### PR TITLE
Ignite 1277 main

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/igfs/IgfsProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/igfs/IgfsProcessor.java
@@ -311,14 +311,6 @@ public class IgfsProcessor extends IgfsProcessorAdapter {
                         ", maxIgfsSpaceSize=" + maxSpaceSize + ']');
             }
 
-            if (dataCacheCfg.getCacheMode() == PARTITIONED) {
-                int backups = dataCacheCfg.getBackups();
-
-                if (backups != 0)
-                    throw new IgniteCheckedException("IGFS data cache cannot be used with backups (set backup count " +
-                        "to 0 and restart the grid): " + cfg.getDataCacheName());
-            }
-
             if (cfg.getMaxSpaceSize() == 0 && dataCacheCfg.getMemoryMode() == OFFHEAP_VALUES)
                 U.warn(log, "IGFS max space size is not specified but data cache values are stored off-heap (max " +
                     "space will be limited to 80% of max JVM heap size): " + cfg.getName());

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/future/GridFutureAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/future/GridFutureAdapter.java
@@ -247,6 +247,8 @@ public class GridFutureAdapter<R> extends AbstractQueuedSynchronizer implements 
         }
         catch (final RuntimeException | Error e) {
             if (e instanceof StackOverflowError) {
+                // TODO: this is investigation code, remove it.
+                // Start a separate thread to avoid another SOE while printing:
                 new Thread(new Runnable() {
                     @Override public void run() {
                         StackTraceElement[] els = e.getStackTrace();
@@ -257,16 +259,12 @@ public class GridFutureAdapter<R> extends AbstractQueuedSynchronizer implements 
                             sb.append(i).append(":  ").append(els[i]).append('\n');
 
                         System.out.println(sb);
-
-                        System.exit(1);
-                        Runtime.getRuntime().halt(1);
                     }
                 }).start();
-            } else {
+            } else
                 U.error(null, "Failed to notify listener: " + lsnr, e);
 
-                throw e;
-            }
+            throw e;
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/future/GridFutureAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/future/GridFutureAdapter.java
@@ -195,15 +195,6 @@ public class GridFutureAdapter<R> extends AbstractQueuedSynchronizer implements 
                         lsnr = (IgniteInClosure)new ArrayListener<IgniteInternalFuture>(lsnr, lsnr0);
                     }
 
-                    int depth = new Throwable().getStackTrace().length;
-
-                    if (depth >= 1000) {
-                        X.println(" -------------- ");
-                        X.println("depth: " + depth);
-                        X.println("this : " + this);
-                        X.println("lsnr : " + lsnr);
-                    }
-
                     return;
                 }
             }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsAbstractSelfTest.java
@@ -146,6 +146,12 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
         this(mode, ONHEAP_TIERED);
     }
 
+    /**
+     * Constructor.
+     *
+     * @param mode
+     * @param memoryMode
+     */
     protected IgfsAbstractSelfTest(IgfsMode mode, CacheMemoryMode memoryMode) {
         assert mode != null && mode != PROXY;
 
@@ -155,7 +161,12 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
         dual = mode != PRIMARY;
     }
 
-    private static byte[] createChunk(int length) {
+    /**
+     *
+     * @param length
+     * @return
+     */
+    static byte[] createChunk(int length) {
         byte[] chunk = new byte[length];
 
         for (int i = 0; i < chunk.length; i++)
@@ -246,6 +257,8 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
 
         discoSpi.setIpFinder(new TcpDiscoveryVmIpFinder(true));
 
+        prepareCacheConfigurations(dataCacheCfg, metaCacheCfg);
+
         cfg.setDiscoverySpi(discoSpi);
         cfg.setCacheConfiguration(dataCacheCfg, metaCacheCfg);
         cfg.setFileSystemConfiguration(igfsCfg);
@@ -254,6 +267,15 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
         cfg.setConnectorConfiguration(null);
 
         return G.start(cfg);
+    }
+
+    /**
+     *
+     * @param dataCacheCfg
+     * @param metaCacheCfg
+     */
+    protected void prepareCacheConfigurations(CacheConfiguration dataCacheCfg, CacheConfiguration metaCacheCfg) {
+        // Noop
     }
 
     /**
@@ -2263,7 +2285,7 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
      * @param chunks Data chunks.
      * @throws Exception If failed.
      */
-    protected void createFile(IgfsImpl igfs, IgfsPath file, boolean overwrite, long blockSize,
+    protected static void createFile(IgfsImpl igfs, IgfsPath file, boolean overwrite, long blockSize,
         @Nullable byte[]... chunks) throws Exception {
         IgfsOutputStream os = null;
 
@@ -2287,7 +2309,7 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
      * @param chunks Data chunks.
      * @throws Exception If failed.
      */
-    protected void appendFile(IgfsImpl igfs, IgfsPath file, @Nullable byte[]... chunks)
+    protected static void appendFile(IgfsImpl igfs, IgfsPath file, @Nullable byte[]... chunks)
         throws Exception {
         IgfsOutputStream os = null;
 
@@ -2354,7 +2376,7 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
      * @param paths Paths.
      * @throws IgniteCheckedException If failed.
      */
-    protected void checkExist(IgfsImpl igfs, IgfsPath... paths) throws IgniteCheckedException {
+    protected static void checkExist(IgfsImpl igfs, IgfsPath... paths) throws IgniteCheckedException {
         for (IgfsPath path : paths) {
             assert igfs.context().meta().fileId(path) != null : "Path doesn't exist [igfs=" + igfs.name() +
                 ", path=" + path + ']';
@@ -2463,7 +2485,7 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
      * @throws IOException In case of IO exception.
      * @throws IgniteCheckedException In case of Grid exception.
      */
-    protected void checkFileContent(IgfsImpl igfs, IgfsPath file, @Nullable byte[]... chunks)
+    protected static void checkFileContent(IgfsImpl igfs, IgfsPath file, @Nullable byte[]... chunks)
         throws IOException, IgniteCheckedException {
         if (chunks != null && chunks.length > 0) {
             IgfsInputStream is = null;
@@ -2562,7 +2584,7 @@ public abstract class IgfsAbstractSelfTest extends IgfsCommonAbstractTest {
      * @param paths Paths to group.
      * @return Paths as array.
      */
-    protected IgfsPath[] paths(IgfsPath... paths) {
+    protected static IgfsPath[] paths(IgfsPath... paths) {
         return paths;
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupFailoverSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupFailoverSelfTest.java
@@ -58,6 +58,9 @@ public class IgfsBackupFailoverSelfTest extends IgfsCommonAbstractTest {
     /** Number of backup copies of data (aka replication). */
     protected int numBackups = numIgfsNodes - 1;
 
+    /** */
+    protected final boolean fragmentizerEnabled = false;
+
     /** File block size. */
     protected int igfsBlockSize = 31; // Use Very small blocks.
 
@@ -154,6 +157,7 @@ public class IgfsBackupFailoverSelfTest extends IgfsCommonAbstractTest {
         igfsCfg.setBlockSize(igfsBlockSize);
         igfsCfg.setDefaultMode(mode);
         igfsCfg.setIpcEndpointConfiguration(restCfg);
+        igfsCfg.setFragmentizerEnabled(fragmentizerEnabled);
         igfsCfg.setSecondaryFileSystem(secondaryFs);
         igfsCfg.setPrefetchBlocks(DFLT_PREFETCH_BLOCKS);
         igfsCfg.setSequentialReadsBeforePrefetch(DFLT_SEQ_READS_BEFORE_PREFETCH);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupFailoverSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupFailoverSelfTest.java
@@ -1,0 +1,545 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.igfs;
+
+import org.apache.ignite.*;
+import org.apache.ignite.cache.*;
+import org.apache.ignite.configuration.*;
+import org.apache.ignite.igfs.*;
+import org.apache.ignite.igfs.secondary.*;
+import org.apache.ignite.internal.*;
+import org.apache.ignite.internal.util.typedef.*;
+import org.apache.ignite.internal.util.typedef.internal.*;
+import org.apache.ignite.internal.util.worker.*;
+import org.jetbrains.annotations.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.*;
+import static org.apache.ignite.cache.CacheMode.*;
+import static org.apache.ignite.internal.processors.igfs.IgfsAbstractSelfTest.*;
+
+/**
+ *
+ */
+public class IgfsBackupFailoverSelfTest extends IgfsCommonAbstractTest {
+    /** */
+    protected static final IgfsPath DIR = new IgfsPath("/dir");
+
+    /** Sub-directory. */
+    protected static final IgfsPath SUBDIR = new IgfsPath(DIR, "subdir");
+
+    /** Amount of blocks to prefetch. */
+    protected static final int DFLT_PREFETCH_BLOCKS = 1;
+
+    /** Amount of sequential block reads before prefetch is triggered. */
+    protected static final int DFLT_SEQ_READS_BEFORE_PREFETCH = 2;
+
+    /** Number of Ignite nodes. */
+    protected int numIgfsNodes = 2;
+
+    /** Number of backup copies of data (aka replication). */
+    protected int numBackups = numIgfsNodes - 1;
+
+    /** File block size. */
+    protected int igfsBlockSize = 31; // Use Very small blocks.
+
+    /**  */
+    protected int affGrpSize = 1;
+
+    /**  */
+    protected IgfsMode igfsMode = IgfsMode.PRIMARY;
+
+    /** Memory mode. */
+    protected final CacheMemoryMode memoryMode;
+
+    /**  */
+    protected NodeFsData[] nodeDatas;
+
+    /**
+     * Structure to hold Ignite IGFS node data.
+     */
+    static class NodeFsData {
+        /**  */
+        int idx;
+
+        /**  */
+        Ignite ignite;
+
+        /**  */
+        IgfsImpl igfsImpl;
+    }
+
+    /**
+     * Constructor.
+     */
+    public IgfsBackupFailoverSelfTest() {
+
+        memoryMode = CacheMemoryMode.ONHEAP_TIERED;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        nodeDatas = new NodeFsData[numIgfsNodes];
+
+        for (int i = 0; i<numIgfsNodes; i++) {
+            NodeFsData data = new NodeFsData();
+
+            data.idx = i;
+
+            IgfsIpcEndpointConfiguration igfsIpcCfg = createIgfsRestConfig(10500 + i);
+
+            data.ignite = startGridWithIgfs(getTestGridName(i), "igfs", igfsMode, null, igfsIpcCfg);
+
+            data.igfsImpl = (IgfsImpl) data.ignite.fileSystem("igfs");
+
+            nodeDatas[i] = data;
+        }
+
+        // Ensure all the nodes are started and discovered each other.
+        checkTopology(numIgfsNodes);
+    }
+
+    /**
+     *
+     * @param port
+     * @return
+     */
+    protected IgfsIpcEndpointConfiguration createIgfsRestConfig(int port) {
+        IgfsIpcEndpointConfiguration cfg = new IgfsIpcEndpointConfiguration();
+
+        cfg.setType(IgfsIpcEndpointType.TCP);
+        cfg.setPort(port);
+
+        return cfg;
+    }
+
+    /**
+     * Start grid with IGFS.
+     *
+     * @param gridName Grid name.
+     * @param igfsName IGFS name
+     * @param mode IGFS mode.
+     * @param secondaryFs Secondary file system (optional).
+     * @param restCfg Rest configuration string (optional).
+     * @return Started grid instance.
+     * @throws Exception If failed.
+     */
+    protected Ignite startGridWithIgfs(String gridName, String igfsName, IgfsMode mode,
+        @Nullable IgfsSecondaryFileSystem secondaryFs, @Nullable IgfsIpcEndpointConfiguration restCfg) throws Exception {
+        final FileSystemConfiguration igfsCfg = new FileSystemConfiguration();
+
+        igfsCfg.setDataCacheName("dataCache");
+        igfsCfg.setMetaCacheName("metaCache");
+        igfsCfg.setName(igfsName);
+        igfsCfg.setBlockSize(igfsBlockSize);
+        igfsCfg.setDefaultMode(mode);
+        igfsCfg.setIpcEndpointConfiguration(restCfg);
+        igfsCfg.setSecondaryFileSystem(secondaryFs);
+        igfsCfg.setPrefetchBlocks(DFLT_PREFETCH_BLOCKS);
+        igfsCfg.setSequentialReadsBeforePrefetch(DFLT_SEQ_READS_BEFORE_PREFETCH);
+
+        CacheConfiguration dataCacheCfg = defaultCacheConfiguration();
+
+        dataCacheCfg.setName("dataCache");
+        dataCacheCfg.setCacheMode(PARTITIONED);
+        dataCacheCfg.setNearConfiguration(null);
+        dataCacheCfg.setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC);
+        dataCacheCfg.setAffinityMapper(new IgfsGroupDataBlocksKeyMapper(affGrpSize));
+        dataCacheCfg.setBackups(numBackups);
+        dataCacheCfg.setAtomicityMode(TRANSACTIONAL);
+        dataCacheCfg.setMemoryMode(memoryMode);
+        dataCacheCfg.setOffHeapMaxMemory(0);
+
+        CacheConfiguration metaCacheCfg = defaultCacheConfiguration();
+
+        metaCacheCfg.setName("metaCache");
+        metaCacheCfg.setCacheMode(REPLICATED);
+        metaCacheCfg.setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC);
+        metaCacheCfg.setAtomicityMode(TRANSACTIONAL);
+
+        IgniteConfiguration cfg = new IgniteConfiguration();
+
+        cfg.setGridName(gridName);
+
+        cfg.setCacheConfiguration(dataCacheCfg, metaCacheCfg);
+        cfg.setFileSystemConfiguration(igfsCfg);
+
+        cfg.setLocalHost("127.0.0.1");
+
+        return startGrid(gridName, cfg);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        G.stopAll(false);
+
+        Arrays.fill(nodeDatas, null);
+    }
+
+    /**
+     *
+     * @param length
+     * @return
+     */
+    static byte[] createChunk(int length, int j) {
+        byte[] chunk = new byte[length];
+
+        for (int i = 0; i < chunk.length; i++)
+            chunk[i] = (byte)(i ^ j);
+
+        return chunk;
+    }
+
+    /** */
+    private IgfsPath filePath(int j) {
+        return new IgfsPath(SUBDIR, "file" + j);
+    }
+
+    /**
+     *
+     * @throws Exception
+     */
+    public void testFailoverMultipleNodes() throws Exception {
+        final IgfsImpl igfs0 = nodeDatas[0].igfsImpl;
+
+        clear(igfs0);
+
+        IgfsAbstractSelfTest.create(igfs0, paths(DIR, SUBDIR), null);
+
+        final int files = 500;
+
+        final int fileSize = 16 * 1024;
+
+        // Create files:
+        for (int f=0; f<files; f++) {
+            final byte[] data = createChunk(fileSize, f);
+
+            createFile(igfs0, filePath(f), true, -1/*block size unused*/, data);
+        }
+
+        // Check files:
+        for (int f=0; f<files; f++) {
+            IgfsPath path = filePath(f);
+            byte[] data = createChunk(fileSize, f);
+
+            // Check through 1st node:
+            checkExist(igfs0, path);
+            checkFileContent(igfs0, path, data);
+
+            // Check the same file through other nodes:
+            for (int n=1; n<numIgfsNodes; n++) {
+                checkExist(nodeDatas[n].igfsImpl, path);
+                checkFileContent(nodeDatas[n].igfsImpl, path, data);
+            }
+        }
+
+        // Now stop all the nodes but the 1st:
+        for (int n=1; n<numIgfsNodes; n++)
+            stopGrid(n);
+
+        // Check files again:
+        for (int f=0; f<files; f++) {
+            IgfsPath path = filePath(f);
+
+            byte[] data = createChunk(fileSize, f);
+
+            // Check through 1st node:
+            checkExist(igfs0, path);
+            checkFileContent(igfs0, path, data);
+        }
+    }
+
+    /**
+     *
+     * @throws Exception
+     */
+    public void testFailoverMultipleNodesReadWhileShuttingDown() throws Exception {
+        final IgfsImpl igfs0 = nodeDatas[0].igfsImpl;
+
+        clear(igfs0);
+
+        IgfsAbstractSelfTest.create(igfs0, paths(DIR, SUBDIR), null);
+
+        final int files = 500;
+
+        final int fileSize = 16 * 1024;
+
+        // Create files:
+        for (int f = 0; f < files; f++) {
+            final byte[] data = createChunk(fileSize, f);
+
+            createFile(igfs0, filePath(f), true, -1/*block size unused*/, data);
+        }
+
+        // Check files:
+        for (int f = 0; f < files; f++) {
+            IgfsPath path = filePath(f);
+            byte[] data = createChunk(fileSize, f);
+
+            // Check through 1st node:
+            checkExist(igfs0, path);
+            checkFileContent(igfs0, path, data);
+
+            // Check the same file through other nodes:
+            for (int n = 1; n < numIgfsNodes; n++) {
+                checkExist(nodeDatas[n].igfsImpl, path);
+                checkFileContent(nodeDatas[n].igfsImpl, path, data);
+            }
+        }
+
+        GridWorker gw = new GridWorker("grid-name", "shutdown-worker", log(), null) {
+            @Override protected void body() throws InterruptedException, IgniteInterruptedCheckedException {
+                Thread.sleep(5_000);
+
+                // Now stop all the nodes but the 1st:
+                for (int n = 1; n < numIgfsNodes; n++) {
+                    stopGrid(n);
+
+                    X.println("grid " + n + " stopped.");
+                }
+            }
+        };
+        new Thread(gw).start();
+
+        // Read files repeatedly, while the nodes are being stopped:
+        int readCnt = 0;
+
+        while (readCnt < 40) {
+            X.println("read " + readCnt);
+
+            // Check files while the nodes are being stopped:
+            for (int f = 0; f < files; f++) {
+                IgfsPath path = filePath(f);
+
+                byte[] data = createChunk(fileSize, f);
+
+                // Check through 1st node:
+                checkExist(igfs0, path);
+                checkFileContent(igfs0, path, data);
+            }
+
+            readCnt++;
+        }
+
+        gw.join();
+    }
+
+    // files = 30, size = 2 * 1024 -- passes.
+    // files = 30, size = 4 * 1024 -- corrupted file?.
+
+    /** */
+    private final int fileSize = 16 * 1024; // 16 * 1024
+
+    /** */
+    private final int files = 100; //500;
+
+    /**
+     *
+     * @throws Exception
+     */
+    public void testFailoverMultipleNodesWriteReadWhileShuttingDown() throws Exception {
+        final IgfsImpl igfs0 = nodeDatas[0].igfsImpl;
+
+        clear(igfs0);
+
+        IgfsAbstractSelfTest.create(igfs0, paths(DIR, SUBDIR), null);
+
+        final IgfsOutputStream[] outStreams = new IgfsOutputStream[files];
+
+        // Create files:
+        for (int f = 0; f < files; f++) {
+            final byte[] data = createChunk(fileSize, f);
+
+            IgfsOutputStream os = null;
+
+            try {
+                os = igfs0.create(filePath(f), 256, true, null, 0, -1, null);
+
+                assert os != null;
+
+                writeFileChunks(os, data);
+            }
+            finally {
+                os.flush();
+            }
+
+            outStreams[f] = os;
+
+            X.println("write #1 completed: " + f);
+        }
+
+        // Now stop all the nodes but the 1st:
+        for (int n = 1; n < numIgfsNodes; n++) {
+            stopGrid(n);
+
+            X.println("#### grid " + n + " stopped.");
+        }
+
+        // Create files:
+        for (int f0 = 0; f0 < files; f0++) {
+            final IgfsOutputStream os = outStreams[f0];
+
+            assert os != null;
+
+            final int f = f0;
+
+            int att = doWithRetries(2, new Callable<Void>() {
+                @Override public Void call() throws Exception {
+                    IgfsOutputStream ios = os;
+
+                    try {
+                        writeChunks0(igfs0, ios, f);
+                    }
+                    catch (IOException ioe) {
+//                        try {
+                            //ios = igfs0.create(filePath(f), 256, true, null, 0, -1, null);
+                            ios = igfs0.append(filePath(f), false);
+
+                            assert ios != null;
+
+                            writeChunks0(igfs0, ios, f);
+//                        }
+//                        finally {
+//                            ios.flush();
+//                        }
+                    }
+
+                    return null;
+                }
+            });
+
+            X.println("write #2 completed: " + f0 + " in " + att + " attempts.");
+        }
+
+        // Check files:
+        for (int f = 0; f < files; f++) {
+            IgfsPath path = filePath(f);
+
+            byte[] data = createChunk(fileSize, f);
+
+            // Check through 1st node:
+            checkExist(igfs0, path);
+
+            checkFileContent(igfs0, path, data, data);
+
+            X.println("Read test completed: " + f);
+        }
+    }
+
+    void writeChunks0(IgfsEx igfs0, IgfsOutputStream ios, int fileIndex) throws IOException {
+        try {
+            byte[] data = createChunk(fileSize, fileIndex);
+
+            writeFileChunks(ios, data);
+        }
+        finally {
+            ios.flush();
+
+            U.closeQuiet(ios);
+
+            //X.println("waiting for file to close: " + filePath(f));
+
+            awaitFileClose(igfs0.asSecondary(), filePath(fileIndex));
+        }
+    }
+
+//    protected void checkFileContentWithRetries(IgfsImpl igfs, IgfsPath file, int retries, @Nullable byte[]... chunks)
+//        throws IOException , IgniteCheckedException {
+//        int failureCnt = 0;
+//
+//        while (true) {
+//            try {
+//                checkFileContent(igfs, file, chunks);
+//
+//                break;
+//            }
+//            catch (IOException | IgniteCheckedException ie) {
+//                failureCnt++;
+//
+//                if (failureCnt >= retries)
+//                    throw ie;
+//                else
+//                    log().info("Failed to check file [" + file + "] content. Failure count = " + failureCnt);
+//            }
+//        }
+//    }
+
+//    /**
+//     * Create the file in the given IGFS and write provided data chunks to it.
+//     *
+//     * @param igfs IGFS.
+//     * @param file File.
+//     * @param chunks Data chunks.
+//     * @throws Exception If failed.
+//     */
+//    protected static void rewriteFile(IgfsImpl igfs, IgfsPath file,
+//        @Nullable byte[]... chunks) throws Exception {
+//        IgfsOutputStream os = null;
+//
+//        try {
+//            os = igfs.append(file, true); //open(file, 256);
+//
+//            writeFileChunks(os, chunks);
+//
+//            assert igfs.size(file) == chunks[0].length;
+//        }
+//        finally {
+//            U.closeQuiet(os);
+//
+//            awaitFileClose(igfs.asSecondary(), file);
+//        }
+//    }
+
+    /**
+     *
+     * @param attempts
+     * @param clo
+     * @throws Exception
+     */
+    protected int doWithRetries(int attempts, Callable<Void> clo) throws Exception {
+        int attemptCnt = 0;
+
+        while (true) {
+            try {
+                attemptCnt++;
+
+                clo.call();
+
+                return attemptCnt;
+            }
+            catch (Exception e) {
+                if (attemptCnt >= attempts)
+                    throw e;
+                else
+                    X.println("Failed to execute closure in " + attempts + " attempts.");
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected long getTestTimeout() {
+        return 20 * 60 * 1000;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupsDualAsyncSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupsDualAsyncSelfTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.igfs;
+
+import org.apache.ignite.configuration.*;
+
+import static org.apache.ignite.igfs.IgfsMode.*;
+
+/**
+ * Tests for DUAL_ASYNC mode.
+ */
+public class IgfsBackupsDualAsyncSelfTest extends IgfsDualAbstractSelfTest {
+    /**
+     * Constructor.
+     */
+    public IgfsBackupsDualAsyncSelfTest() {
+        super(DUAL_ASYNC);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void prepareCacheConfigurations(CacheConfiguration dataCacheCfg,
+        CacheConfiguration metaCacheCfg) {
+        dataCacheCfg.setBackups(1);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupsDualSyncSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupsDualSyncSelfTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.igfs;
+
+import org.apache.ignite.configuration.*;
+
+import static org.apache.ignite.igfs.IgfsMode.*;
+
+/**
+ * Tests for DUAL_SYNC mode.
+ */
+public class IgfsBackupsDualSyncSelfTest extends IgfsDualAbstractSelfTest {
+    /**
+     * Constructor.
+     */
+    public IgfsBackupsDualSyncSelfTest() {
+        super(DUAL_SYNC);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void prepareCacheConfigurations(CacheConfiguration dataCacheCfg,
+        CacheConfiguration metaCacheCfg) {
+        dataCacheCfg.setBackups(1);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupsPrimarySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/igfs/IgfsBackupsPrimarySelfTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.igfs;
+
+import org.apache.ignite.configuration.*;
+
+import static org.apache.ignite.igfs.IgfsMode.*;
+
+/**
+ * Tests for PRIMARY mode.
+ */
+public class IgfsBackupsPrimarySelfTest extends IgfsAbstractSelfTest {
+    /**
+     * Constructor.
+     */
+    public IgfsBackupsPrimarySelfTest() {
+        super(PRIMARY);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void prepareCacheConfigurations(CacheConfiguration dataCacheCfg,
+            CacheConfiguration metaCacheCfg) {
+        dataCacheCfg.setBackups(1);
+    }
+}


### PR DESCRIPTION
1) enabled data cache backups for IGFS to provide data resilience.
2) added tests to check the failovers with backups. 