### PR TITLE
FIx Log4j2LoggerSelfTest.testLogFilesTwoNodes	test case for Windows.

### DIFF
--- a/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
+++ b/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
@@ -242,10 +242,10 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
                             Appender innerApp = control.getAppender();
 
                             if (innerApp instanceof FileAppender)
-                                return ((FileAppender)innerApp).getFileName();
+                                return normilize(((FileAppender)innerApp).getFileName());
 
                             if (innerApp instanceof RollingFileAppender)
-                                return ((RollingFileAppender)innerApp).getFileName();
+                                return normilize(((RollingFileAppender)innerApp).getFileName());
                         }
                     }
                     catch (IllegalAccessException | NoSuchFieldException e) {
@@ -256,6 +256,20 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
         }
 
         return null;
+    }
+
+    /**
+     * Normalizes given path for windows.
+     * Log4j2 doesn't replace unix directory delimiters which used at 'fileName' to windows.
+     *
+     * @param path Path.
+     * @return Normalized path.
+     */
+    private String normilize(String path) {
+        if (!U.isWindows())
+            return path;
+
+        return path.replace('/', File.separatorChar);
     }
 
     /**


### PR DESCRIPTION
FIx Log4j2LoggerSelfTest.testLogFilesTwoNodes	test case for Windows.

See 

junit.framework.ComparisonFailure: expected:<...ork\871ff4a46e450b13[\work\log\]ignite-65fba17b.log> but was:<...ork\871ff4a46e450b13[/work/log/]ignite-65fba17b.log>
    at junit.framework.Assert.assertEquals(Assert.java:100)
    at junit.framework.Assert.assertEquals(Assert.java:107)
    at junit.framework.TestCase.assertEquals(TestCase.java:269)
    at org.apache.ignite.logger.log4j2.Log4j2LoggerSelfTest.checkOneNode(Log4j2LoggerSelfTest.java:143)
    at org.apache.ignite.logger.log4j2.Log4j2LoggerSelfTest.testLogFilesTwoNodes(Log4j2LoggerSelfTest.java:119)