### PR TITLE
FIx Log4j2LoggerSelfTest.testLogFilesTwoNodes test case for Windows.

### DIFF
--- a/examples/config/example-default.xml
+++ b/examples/config/example-default.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite configuration with all defaults and enabled p2p deployment and enabled events.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean abstract="true" id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <!-- Set to true to enable distributed class loading for examples, default is false. -->
+        <property name="peerClassLoadingEnabled" value="true"/>
+
+        <!-- Enable task execution events for examples. -->
+        <property name="includeEventTypes">
+            <list>
+                <!--Task execution events-->
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_STARTED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FINISHED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_TIMEDOUT"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_SESSION_ATTR_SET"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_REDUCED"/>
+
+                <!--Cache events-->
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_PUT"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_READ"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_REMOVED"/>
+            </list>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <!--
+                        Ignite provides several options for automatic discovery that can be used
+                        instead os static IP based discovery. For information on all options refer
+                        to our documentation: http://apacheignite.readme.io/docs/cluster-config
+                    -->
+                    <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/examples/config/portable/example-ignite-portable.xml
+++ b/examples/config/portable/example-ignite-portable.xml
@@ -18,22 +18,27 @@
 -->
 
 <!--
-    Ignite configuration with all defaults and enabled p2p deployment and enabled events.
+    Ignite configuration with all defaults and enabled p2p deployment, events and portable marshaller.
+
+    Use this configuration file when running HTTP REST examples (see 'examples/rest' folder).
+
+    When starting a standalone node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/portable/example-ignite-portable.xml
+
+    When starting Ignite from Java IDE, pass path to this file to Ignition:
+    Ignition.start("examples/config/portable/example-ignite-portable.xml");
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
     <!-- Imports default Ignite configuration -->
-    <import resource="example-default.xml"/>
+    <import resource="../example-default.xml"/>
 
     <bean parent="ignite.cfg">
-        <!-- Enabled optimized marshaller -->
+        <!-- Enables portable marshaller -->
         <property name="marshaller">
-            <bean class="org.apache.ignite.marshaller.optimized.OptimizedMarshaller">
-                <!-- Set to false to allow non-serializable objects in examples, default is true. -->
-                <property name="requireSerializable" value="false"/>
-            </bean>
+            <bean class="org.apache.ignite.marshaller.portable.PortableMarshaller"/>
         </property>
     </bean>
 </beans>

--- a/examples/src/main/java/org/apache/ignite/examples/portable/Address.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/Address.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable;
+
+import org.apache.ignite.portable.PortableException;
+import org.apache.ignite.portable.PortableMarshalAware;
+import org.apache.ignite.portable.PortableReader;
+import org.apache.ignite.portable.PortableWriter;
+
+/**
+ * Employee address.
+ * <p>
+ * This class implements {@link PortableMarshalAware} only for example purposes,
+ * in order to show how to customize serialization and deserialization of
+ * portable objects.
+ */
+public class Address implements PortableMarshalAware {
+    /** Street. */
+    private String street;
+
+    /** ZIP code. */
+    private int zip;
+
+    /**
+     * Required for portable deserialization.
+     */
+    public Address() {
+        // No-op.
+    }
+
+    /**
+     * @param street Street.
+     * @param zip ZIP code.
+     */
+    public Address(String street, int zip) {
+        this.street = street;
+        this.zip = zip;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void writePortable(PortableWriter writer) throws PortableException {
+        writer.writeString("street", street);
+        writer.writeInt("zip", zip);
+    }
+
+    /** {@inheritDoc} */
+    @Override public void readPortable(PortableReader reader) throws PortableException {
+        street = reader.readString("street");
+        zip = reader.readInt("zip");
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "Address [street=" + street +
+            ", zip=" + zip + ']';
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/Employee.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/Employee.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable;
+
+import java.util.Collection;
+
+/**
+ * This class represents employee object.
+ */
+public class Employee {
+    /** Name. */
+    private String name;
+
+    /** Salary. */
+    private long salary;
+
+    /** Address. */
+    private Address address;
+
+    /** Departments. */
+    private Collection<String> departments;
+
+    /**
+     * Required for portable deserialization.
+     */
+    public Employee() {
+        // No-op.
+    }
+
+    /**
+     * @param name Name.
+     * @param salary Salary.
+     * @param address Address.
+     * @param departments Departments.
+     */
+    public Employee(String name, long salary, Address address, Collection<String> departments) {
+        this.name = name;
+        this.salary = salary;
+        this.address = address;
+        this.departments = departments;
+    }
+
+    /**
+     * @return Name.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return Salary.
+     */
+    public long salary() {
+        return salary;
+    }
+
+    /**
+     * @return Address.
+     */
+    public Address address() {
+        return address;
+    }
+
+    /**
+     * @return Departments.
+     */
+    public Collection<String> departments() {
+        return departments;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "Employee [name=" + name +
+            ", salary=" + salary +
+            ", address=" + address +
+            ", departments=" + departments + ']';
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/EmployeeKey.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/EmployeeKey.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable;
+
+/**
+ * This class represents key for employee object.
+ * <p>
+ * Used in query example to collocate employees
+ * with their organizations.
+ */
+public class EmployeeKey {
+    /** ID. */
+    private int id;
+
+    /** Organization ID. */
+    private int organizationId;
+
+    /**
+     * Required for portable deserialization.
+     */
+    public EmployeeKey() {
+        // No-op.
+    }
+
+    /**
+     * @param id ID.
+     * @param organizationId Organization ID.
+     */
+    public EmployeeKey(int id, int organizationId) {
+        this.id = id;
+        this.organizationId = organizationId;
+    }
+
+    /**
+     * @return ID.
+     */
+    public int id() {
+        return id;
+    }
+
+    /**
+     * @return Organization ID.
+     */
+    public int organizationId() {
+        return organizationId;
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        EmployeeKey key = (EmployeeKey)o;
+
+        return id == key.id && organizationId == key.organizationId;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int hashCode() {
+        int res = id;
+
+        res = 31 * res + organizationId;
+
+        return res;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "EmployeeKey [id=" + id +
+            ", organizationId=" + organizationId + ']';
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/ExamplePortableNodeStartup.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/ExamplePortableNodeStartup.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable;
+
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+
+/**
+ * Starts up an empty node with example configuration and portable marshaller enabled.
+ */
+public class ExamplePortableNodeStartup {
+    /**
+     * Start up an empty node with example configuration and portable marshaller enabled.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+        Ignition.start("examples/config/portable/example-ignite-portable.xml");
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/Organization.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/Organization.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable;
+
+import java.sql.Timestamp;
+
+/**
+ * This class represents organization object.
+ */
+public class Organization {
+    /** Name. */
+    private String name;
+
+    /** Address. */
+    private Address address;
+
+    /** Type. */
+    private OrganizationType type;
+
+    /** Last update time. */
+    private Timestamp lastUpdated;
+
+    /**
+     * Required for portable deserialization.
+     */
+    public Organization() {
+        // No-op.
+    }
+
+    /**
+     * @param name Name.
+     * @param address Address.
+     * @param type Type.
+     * @param lastUpdated Last update time.
+     */
+    public Organization(String name, Address address, OrganizationType type, Timestamp lastUpdated) {
+        this.name = name;
+        this.address = address;
+        this.type = type;
+        this.lastUpdated = lastUpdated;
+    }
+
+    /**
+     * @return Name.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return Address.
+     */
+    public Address address() {
+        return address;
+    }
+
+    /**
+     * @return Type.
+     */
+    public OrganizationType type() {
+        return type;
+    }
+
+    /**
+     * @return Last update time.
+     */
+    public Timestamp lastUpdated() {
+        return lastUpdated;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "Organization [name=" + name +
+            ", address=" + address +
+            ", type=" + type +
+            ", lastUpdated=" + lastUpdated + ']';
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/OrganizationType.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/OrganizationType.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable;
+
+/**
+ * Organization type enum.
+ */
+public enum OrganizationType {
+    /** Non-profit organization. */
+    NON_PROFIT,
+
+    /** Private organization. */
+    PRIVATE,
+
+    /** Government organization. */
+    GOVERNMENT
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/computegrid/ComputeClientPortableTaskExecutionExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/computegrid/ComputeClientPortableTaskExecutionExample.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable.computegrid;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.examples.portable.Address;
+import org.apache.ignite.examples.portable.Employee;
+import org.apache.ignite.examples.portable.ExamplePortableNodeStartup;
+import org.apache.ignite.portable.PortableObject;
+
+/**
+ * This example demonstrates use of portable objects with task execution.
+ * Specifically it shows that portable objects are simple Java POJOs and do not require any special treatment.
+ * <p>
+ * The example executes map-reduce task that accepts collection of portable objects as an argument.
+ * Since these objects are never deserialized on remote nodes, classes are not required on classpath
+ * of these nodes.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables the portable marshaller: {@code 'ignite.{sh|bat} examples/config/portable/example-ignite-portable.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExamplePortableNodeStartup} in another JVM which will
+ * start node with {@code examples/config/portable/example-ignite-portable.xml} configuration.
+ */
+public class ComputeClientPortableTaskExecutionExample {
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     */
+    public static void main(String[] args) {
+        try (Ignite ignite = Ignition.start("examples/config/portable/example-ignite-portable.xml")) {
+            System.out.println();
+            System.out.println(">>> Portable objects task execution example started.");
+
+            if (ignite.cluster().forRemotes().nodes().isEmpty()) {
+                System.out.println();
+                System.out.println(">>> This example requires remote nodes to be started.");
+                System.out.println(">>> Please start at least 1 remote node.");
+                System.out.println(">>> Refer to example's javadoc for details on configuration.");
+                System.out.println();
+
+                return;
+            }
+
+            // Generate employees to calculate average salary for.
+            Collection<Employee> employees = employees();
+
+            System.out.println();
+            System.out.println(">>> Calculating average salary for employees:");
+
+            for (Employee employee : employees)
+                System.out.println(">>>     " + employee);
+
+            // Convert collection of employees to collection of portable objects.
+            // This allows to send objects across nodes without requiring to have
+            // Employee class on classpath of these nodes.
+            Collection<PortableObject> portables = ignite.portables().toPortable(employees);
+
+            // Execute task and get average salary.
+            Long avgSalary = ignite.compute(ignite.cluster().forRemotes()).execute(new ComputeClientTask(), portables);
+
+            System.out.println();
+            System.out.println(">>> Average salary for all employees: " + avgSalary);
+            System.out.println();
+        }
+    }
+
+    /**
+     * Creates collection of employees.
+     *
+     * @return Collection of employees.
+     */
+    private static Collection<Employee> employees() {
+        Collection<Employee> employees = new ArrayList<>();
+
+        employees.add(new Employee(
+            "James Wilson",
+            12500,
+            new Address("1096 Eddy Street, San Francisco, CA", 94109),
+            Arrays.asList("Human Resources", "Customer Service")
+        ));
+
+        employees.add(new Employee(
+            "Daniel Adams",
+            11000,
+            new Address("184 Fidler Drive, San Antonio, TX", 78205),
+            Arrays.asList("Development", "QA")
+        ));
+
+        employees.add(new Employee(
+            "Cristian Moss",
+            12500,
+            new Address("667 Jerry Dove Drive, Florence, SC", 29501),
+            Arrays.asList("Logistics")
+        ));
+
+        employees.add(new Employee(
+            "Allison Mathis",
+            25300,
+            new Address("2702 Freedom Lane, Hornitos, CA", 95325),
+            Arrays.asList("Development")
+        ));
+
+        employees.add(new Employee(
+            "Breana Robbin",
+            6500,
+            new Address("3960 Sundown Lane, Austin, TX", 78758),
+            Arrays.asList("Sales")
+        ));
+
+        employees.add(new Employee(
+            "Philip Horsley",
+            19800,
+            new Address("2803 Elsie Drive, Sioux Falls, SD", 57104),
+            Arrays.asList("Sales")
+        ));
+
+        employees.add(new Employee(
+            "Brian Peters",
+            10600,
+            new Address("1407 Pearlman Avenue, Boston, MA", 12110),
+            Arrays.asList("Development", "QA")
+        ));
+
+        employees.add(new Employee(
+            "Jack Yang",
+            12900,
+            new Address("4425 Parrish Avenue Smithsons Valley, TX", 78130),
+            Arrays.asList("Sales")
+        ));
+
+        return employees;
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/computegrid/ComputeClientTask.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/computegrid/ComputeClientTask.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable.computegrid;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobAdapter;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeTaskSplitAdapter;
+import org.apache.ignite.lang.IgniteBiTuple;
+import org.apache.ignite.portable.PortableObject;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Task that is used for {@link ComputeClientPortableTaskExecutionExample} and
+ * similar examples in .NET and C++.
+ * <p>
+ * This task calculates average salary for provided collection of employees.
+ * It splits the collection into batches of size {@code 3} and creates a job
+ * for each batch. After all jobs are executed, there results are reduced to
+ * get the average salary.
+ */
+public class ComputeClientTask extends ComputeTaskSplitAdapter<Collection<PortableObject>, Long> {
+    /** {@inheritDoc} */
+    @Override protected Collection<? extends ComputeJob> split(
+        int gridSize,
+        Collection<PortableObject> arg
+    ) {
+        Collection<ComputeClientJob> jobs = new ArrayList<>();
+
+        Collection<PortableObject> employees = new ArrayList<>();
+
+        // Split provided collection into batches and
+        // create a job for each batch.
+        for (PortableObject employee : arg) {
+            employees.add(employee);
+
+            if (employees.size() == 3) {
+                jobs.add(new ComputeClientJob(employees));
+
+                employees = new ArrayList<>(3);
+            }
+        }
+
+        if (!employees.isEmpty())
+            jobs.add(new ComputeClientJob(employees));
+
+        return jobs;
+    }
+
+    /** {@inheritDoc} */
+    @Nullable @Override public Long reduce(List<ComputeJobResult> results) {
+        long sum = 0;
+        int cnt = 0;
+
+        for (ComputeJobResult res : results) {
+            IgniteBiTuple<Long, Integer> t = res.getData();
+
+            sum += t.get1();
+            cnt += t.get2();
+        }
+
+        return sum / cnt;
+    }
+
+    /**
+     * Remote job for {@link ComputeClientTask}.
+     */
+    private static class ComputeClientJob extends ComputeJobAdapter {
+        /** Collection of employees. */
+        private final Collection<PortableObject> employees;
+
+        /**
+         * @param employees Collection of employees.
+         */
+        private ComputeClientJob(Collection<PortableObject> employees) {
+            this.employees = employees;
+        }
+
+        /** {@inheritDoc} */
+        @Nullable @Override public Object execute() {
+            long sum = 0;
+            int cnt = 0;
+
+            for (PortableObject employee : employees) {
+                System.out.println(">>> Processing employee: " + employee.field("name"));
+
+                // Get salary from portable object. Note that object
+                // doesn't need to be fully deserialized.
+                long salary = employee.field("salary");
+
+                sum += salary;
+                cnt++;
+            }
+
+            return new IgniteBiTuple<>(sum, cnt);
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/computegrid/package-info.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/computegrid/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Demonstrates the usage of portable objects with task execution.
+ */
+package org.apache.ignite.examples.portable.computegrid;

--- a/examples/src/main/java/org/apache/ignite/examples/portable/datagrid/CacheClientPortablePutGetExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/datagrid/CacheClientPortablePutGetExample.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable.datagrid;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.portable.Address;
+import org.apache.ignite.examples.portable.ExamplePortableNodeStartup;
+import org.apache.ignite.examples.portable.Organization;
+import org.apache.ignite.examples.portable.OrganizationType;
+import org.apache.ignite.portable.PortableObject;
+
+/**
+ * This example demonstrates use of portable objects with Ignite cache.
+ * Specifically it shows that portable objects are simple Java POJOs and do not require any special treatment.
+ * <p>
+ * The example executes several put-get operations on Ignite cache with portable values. Note that
+ * it demonstrates how portable object can be retrieved in fully-deserialized form or in portable object
+ * format using special cache projection.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables the portable marshaller: {@code 'ignite.{sh|bat} examples/config/portable/example-ignite-portable.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExamplePortableNodeStartup} in another JVM which will
+ * start node with {@code examples/config/portable/example-ignite-portable.xml} configuration.
+ */
+public class CacheClientPortablePutGetExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheClientPortablePutGetExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     */
+    public static void main(String[] args) {
+        try (Ignite ignite = Ignition.start("examples/config/portable/example-ignite-portable.xml")) {
+            System.out.println();
+            System.out.println(">>> Portable objects cache put-get example started.");
+
+            CacheConfiguration<Integer, Organization> cfg = new CacheConfiguration<>();
+
+            cfg.setCacheMode(CacheMode.PARTITIONED);
+            cfg.setName(CACHE_NAME);
+            cfg.setAtomicityMode(CacheAtomicityMode.ATOMIC);
+
+            try (IgniteCache<Integer, Organization> cache = ignite.createCache(cfg)) {
+                if (ignite.cluster().forDataNodes(cache.getName()).nodes().isEmpty()) {
+                    System.out.println();
+                    System.out.println(">>> This example requires remote cache node nodes to be started.");
+                    System.out.println(">>> Please start at least 1 remote cache node.");
+                    System.out.println(">>> Refer to example's javadoc for details on configuration.");
+                    System.out.println();
+
+                    return;
+                }
+
+                putGet(cache);
+                putGetPortable(cache);
+                putGetAll(cache);
+                putGetAllPortable(cache);
+
+                System.out.println();
+            }
+        }
+    }
+
+    /**
+     * Execute individual put and get.
+     *
+     * @param cache Cache.
+     */
+    private static void putGet(IgniteCache<Integer, Organization> cache) {
+        // Create new Organization portable object to store in cache.
+        Organization org = new Organization(
+            "Microsoft", // Name.
+            new Address("1096 Eddy Street, San Francisco, CA", 94109), // Address.
+            OrganizationType.PRIVATE, // Type.
+            new Timestamp(System.currentTimeMillis())); // Last update time.
+
+        // Put created data entry to cache.
+        cache.put(1, org);
+
+        // Get recently created organization as a strongly-typed fully de-serialized instance.
+        Organization orgFromCache = cache.get(1);
+
+        System.out.println();
+        System.out.println(">>> Retrieved organization instance from cache: " + orgFromCache);
+    }
+
+    /**
+     * Execute individual put and get, getting value in portable format, without de-serializing it.
+     *
+     * @param cache Cache.
+     */
+    private static void putGetPortable(IgniteCache<Integer, Organization> cache) {
+        // Create new Organization portable object to store in cache.
+        Organization org = new Organization(
+            "Microsoft", // Name.
+            new Address("1096 Eddy Street, San Francisco, CA", 94109), // Address.
+            OrganizationType.PRIVATE, // Type.
+            new Timestamp(System.currentTimeMillis())); // Last update time.
+
+        // Put created data entry to cache.
+        cache.put(1, org);
+
+        // Get cache that will get values as portable objects.
+        IgniteCache<Integer, PortableObject> portableCache = cache.withKeepPortable();
+
+        // Get recently created organization as a portable object.
+        PortableObject po = portableCache.get(1);
+
+        // Get organization's name from portable object (note that
+        // object doesn't need to be fully deserialized).
+        String name = po.field("name");
+
+        System.out.println();
+        System.out.println(">>> Retrieved organization name from portable object: " + name);
+    }
+
+    /**
+     * Execute bulk {@code putAll(...)} and {@code getAll(...)} operations.
+     *
+     * @param cache Cache.
+     */
+    private static void putGetAll(IgniteCache<Integer, Organization> cache) {
+        // Create new Organization portable objects to store in cache.
+        Organization org1 = new Organization(
+            "Microsoft", // Name.
+            new Address("1096 Eddy Street, San Francisco, CA", 94109), // Address.
+            OrganizationType.PRIVATE, // Type.
+            new Timestamp(System.currentTimeMillis())); // Last update time.
+
+        Organization org2 = new Organization(
+            "Red Cross", // Name.
+            new Address("184 Fidler Drive, San Antonio, TX", 78205), // Address.
+            OrganizationType.NON_PROFIT, // Type.
+            new Timestamp(System.currentTimeMillis())); // Last update time.
+
+        Map<Integer, Organization> map = new HashMap<>();
+
+        map.put(1, org1);
+        map.put(2, org2);
+
+        // Put created data entries to cache.
+        cache.putAll(map);
+
+        // Get recently created organizations as a strongly-typed fully de-serialized instances.
+        Map<Integer, Organization> mapFromCache = cache.getAll(map.keySet());
+
+        System.out.println();
+        System.out.println(">>> Retrieved organization instances from cache:");
+
+        for (Organization org : mapFromCache.values())
+            System.out.println(">>>     " + org);
+    }
+
+    /**
+     * Execute bulk {@code putAll(...)} and {@code getAll(...)} operations,
+     * getting values in portable format, without de-serializing it.
+     *
+     * @param cache Cache.
+     */
+    private static void putGetAllPortable(IgniteCache<Integer, Organization> cache) {
+        // Create new Organization portable objects to store in cache.
+        Organization org1 = new Organization(
+            "Microsoft", // Name.
+            new Address("1096 Eddy Street, San Francisco, CA", 94109), // Address.
+            OrganizationType.PRIVATE, // Type.
+            new Timestamp(System.currentTimeMillis())); // Last update time.
+
+        Organization org2 = new Organization(
+            "Red Cross", // Name.
+            new Address("184 Fidler Drive, San Antonio, TX", 78205), // Address.
+            OrganizationType.NON_PROFIT, // Type.
+            new Timestamp(System.currentTimeMillis())); // Last update time.
+
+        Map<Integer, Organization> map = new HashMap<>();
+
+        map.put(1, org1);
+        map.put(2, org2);
+
+        // Put created data entries to cache.
+        cache.putAll(map);
+
+        // Get cache that will get values as portable objects.
+        IgniteCache<Integer, PortableObject> portableCache = cache.withKeepPortable();
+
+        // Get recently created organizations as portable objects.
+        Map<Integer, PortableObject> poMap = portableCache.getAll(map.keySet());
+
+        Collection<String> names = new ArrayList<>();
+
+        // Get organizations' names from portable objects (note that
+        // objects don't need to be fully deserialized).
+        for (PortableObject po : poMap.values())
+            names.add(po.<String>field("name"));
+
+        System.out.println();
+        System.out.println(">>> Retrieved organization names from portable objects: " + names);
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/portable/datagrid/CacheClientPortableQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/datagrid/CacheClientPortableQueryExample.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.portable.datagrid;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.cache.Cache;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.cache.CacheTypeMetadata;
+import org.apache.ignite.cache.query.QueryCursor;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.cache.query.SqlQuery;
+import org.apache.ignite.cache.query.TextQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.portable.Address;
+import org.apache.ignite.examples.portable.Employee;
+import org.apache.ignite.examples.portable.EmployeeKey;
+import org.apache.ignite.examples.portable.ExamplePortableNodeStartup;
+import org.apache.ignite.examples.portable.Organization;
+import org.apache.ignite.examples.portable.OrganizationType;
+import org.apache.ignite.portable.PortableObject;
+
+/**
+ * This example demonstrates use of portable objects with cache queries.
+ * The example populates cache with sample data and runs several SQL and full text queries over this data.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables the portable marshaller: {@code 'ignite.{sh|bat} examples/config/portable/example-ignite-portable.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExamplePortableNodeStartup} in another JVM which will
+ * start node with {@code examples/config/portable/example-ignite-portable.xml} configuration.
+ */
+public class CacheClientPortableQueryExample {
+    /** Organization cache name. */
+    private static final String ORGANIZATION_CACHE_NAME = CacheClientPortableQueryExample.class.getSimpleName()
+        + "Organizations";
+
+    /** Employee cache name. */
+    private static final String EMPLOYEE_CACHE_NAME = CacheClientPortableQueryExample.class.getSimpleName()
+        + "Employees";
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     */
+    public static void main(String[] args) {
+        try (Ignite ignite = Ignition.start("examples/config/portable/example-ignite-portable.xml")) {
+            System.out.println();
+            System.out.println(">>> Portable objects cache query example started.");
+
+            CacheConfiguration<Integer, Organization> orgCacheCfg = new CacheConfiguration<>();
+
+            orgCacheCfg.setCacheMode(CacheMode.PARTITIONED);
+            orgCacheCfg.setName(ORGANIZATION_CACHE_NAME);
+
+            orgCacheCfg.setTypeMetadata(Arrays.asList(createOrganizationTypeMetadata()));
+
+            CacheConfiguration<EmployeeKey, Employee> employeeCacheCfg = new CacheConfiguration<>();
+
+            employeeCacheCfg.setCacheMode(CacheMode.PARTITIONED);
+            employeeCacheCfg.setName(EMPLOYEE_CACHE_NAME);
+
+            employeeCacheCfg.setTypeMetadata(Arrays.asList(createEmployeeTypeMetadata()));
+
+            try (IgniteCache<Integer, Organization> orgCache = ignite.createCache(orgCacheCfg);
+                 IgniteCache<EmployeeKey, Employee> employeeCache = ignite.createCache(employeeCacheCfg)
+            ) {
+                if (ignite.cluster().forDataNodes(orgCache.getName()).nodes().isEmpty()) {
+                    System.out.println();
+                    System.out.println(">>> This example requires remote cache nodes to be started.");
+                    System.out.println(">>> Please start at least 1 remote cache node.");
+                    System.out.println(">>> Refer to example's javadoc for details on configuration.");
+                    System.out.println();
+
+                    return;
+                }
+
+                // Populate cache with sample data entries.
+                populateCache(orgCache, employeeCache);
+
+                // Get cache that will work with portable objects.
+                IgniteCache<PortableObject, PortableObject> portableCache = employeeCache.withKeepPortable();
+
+                // Run SQL query example.
+                sqlQuery(portableCache);
+
+                // Run SQL query with join example.
+                sqlJoinQuery(portableCache);
+
+                // Run SQL fields query example.
+                sqlFieldsQuery(portableCache);
+
+                // Run full text query example.
+                textQuery(portableCache);
+
+                System.out.println();
+            }
+        }
+    }
+
+    /**
+     * Create cache type metadata for {@link Employee}.
+     *
+     * @return Cache type metadata.
+     */
+    private static CacheTypeMetadata createEmployeeTypeMetadata() {
+        CacheTypeMetadata employeeTypeMeta = new CacheTypeMetadata();
+
+        employeeTypeMeta.setValueType(Employee.class);
+
+        employeeTypeMeta.setKeyType(EmployeeKey.class);
+
+        Map<String, Class<?>> ascFields = new HashMap<>();
+
+        ascFields.put("name", String.class);
+        ascFields.put("salary", Long.class);
+        ascFields.put("address.zip", Integer.class);
+        ascFields.put("organizationId", Integer.class);
+
+        employeeTypeMeta.setAscendingFields(ascFields);
+
+        employeeTypeMeta.setTextFields(Arrays.asList("address.street"));
+
+        return employeeTypeMeta;
+    }
+
+    /**
+     * Create cache type metadata for {@link Organization}.
+     *
+     * @return Cache type metadata.
+     */
+    private static CacheTypeMetadata createOrganizationTypeMetadata() {
+        CacheTypeMetadata organizationTypeMeta = new CacheTypeMetadata();
+
+        organizationTypeMeta.setValueType(Organization.class);
+
+        organizationTypeMeta.setKeyType(Integer.class);
+
+        Map<String, Class<?>> ascFields = new HashMap<>();
+
+        ascFields.put("name", String.class);
+
+        Map<String, Class<?>> queryFields = new HashMap<>();
+
+        queryFields.put("address.street", String.class);
+
+        organizationTypeMeta.setAscendingFields(ascFields);
+
+        organizationTypeMeta.setQueryFields(queryFields);
+
+        return organizationTypeMeta;
+    }
+
+    /**
+     * Queries employees that have provided ZIP code in address.
+     *
+     * @param cache Ignite cache.
+     */
+    private static void sqlQuery(IgniteCache<PortableObject, PortableObject> cache) {
+        SqlQuery<PortableObject, PortableObject> query = new SqlQuery<>(Employee.class, "zip = ?");
+
+        int zip = 94109;
+
+        QueryCursor<Cache.Entry<PortableObject, PortableObject>> employees = cache.query(query.setArgs(zip));
+
+        System.out.println();
+        System.out.println(">>> Employees with zip " + zip + ':');
+
+        for (Cache.Entry<PortableObject, PortableObject> e : employees.getAll())
+            System.out.println(">>>     " + e.getValue().deserialize());
+    }
+
+    /**
+     * Queries employees that work for organization with provided name.
+     *
+     * @param cache Ignite cache.
+     */
+    private static void sqlJoinQuery(IgniteCache<PortableObject, PortableObject> cache) {
+        SqlQuery<PortableObject, PortableObject> query = new SqlQuery<>(Employee.class,
+            "from Employee, \"" + ORGANIZATION_CACHE_NAME + "\".Organization as org " +
+                "where Employee.organizationId = org._key and org.name = ?");
+
+        String organizationName = "GridGain";
+
+        QueryCursor<Cache.Entry<PortableObject, PortableObject>> employees =
+            cache.query(query.setArgs(organizationName));
+
+        System.out.println();
+        System.out.println(">>> Employees working for " + organizationName + ':');
+
+        for (Cache.Entry<PortableObject, PortableObject> e : employees.getAll())
+            System.out.println(">>>     " + e.getValue());
+    }
+
+    /**
+     * Queries names and salaries for all employees.
+     *
+     * @param cache Ignite cache.
+     */
+    private static void sqlFieldsQuery(IgniteCache<PortableObject, PortableObject> cache) {
+        SqlFieldsQuery query = new SqlFieldsQuery("select name, salary from Employee");
+
+        QueryCursor<List<?>> employees = cache.query(query);
+
+        System.out.println();
+        System.out.println(">>> Employee names and their salaries:");
+
+        for (List<?> row : employees.getAll())
+            System.out.println(">>>     [Name=" + row.get(0) + ", salary=" + row.get(1) + ']');
+    }
+
+    /**
+     * Queries employees that live in Texas using full-text query API.
+     *
+     * @param cache Ignite cache.
+     */
+    private static void textQuery(IgniteCache<PortableObject, PortableObject> cache) {
+        TextQuery<PortableObject, PortableObject> query = new TextQuery<>(Employee.class, "TX");
+
+        QueryCursor<Cache.Entry<PortableObject, PortableObject>> employees = cache.query(query);
+
+        System.out.println();
+        System.out.println(">>> Employees living in Texas:");
+
+        for (Cache.Entry<PortableObject, PortableObject> e : employees.getAll())
+            System.out.println(">>>     " + e.getValue().deserialize());
+    }
+
+    /**
+     * Populates cache with data.
+     *
+     * @param orgCache Organization cache.
+     * @param employeeCache Employee cache.
+     */
+    private static void populateCache(IgniteCache<Integer, Organization> orgCache,
+        IgniteCache<EmployeeKey, Employee> employeeCache) {
+        orgCache.put(1, new Organization(
+            "GridGain",
+            new Address("1065 East Hillsdale Blvd, Foster City, CA", 94404),
+            OrganizationType.PRIVATE,
+            new Timestamp(System.currentTimeMillis())
+        ));
+
+        orgCache.put(2, new Organization(
+            "Microsoft",
+            new Address("1096 Eddy Street, San Francisco, CA", 94109),
+            OrganizationType.PRIVATE,
+            new Timestamp(System.currentTimeMillis())
+        ));
+
+        employeeCache.put(new EmployeeKey(1, 1), new Employee(
+            "James Wilson",
+            12500,
+            new Address("1096 Eddy Street, San Francisco, CA", 94109),
+            Arrays.asList("Human Resources", "Customer Service")
+        ));
+
+        employeeCache.put(new EmployeeKey(2, 1), new Employee(
+            "Daniel Adams",
+            11000,
+            new Address("184 Fidler Drive, San Antonio, TX", 78130),
+            Arrays.asList("Development", "QA")
+        ));
+
+        employeeCache.put(new EmployeeKey(3, 1), new Employee(
+            "Cristian Moss",
+            12500,
+            new Address("667 Jerry Dove Drive, Florence, SC", 29501),
+            Arrays.asList("Logistics")
+        ));
+
+        employeeCache.put(new EmployeeKey(4, 2), new Employee(
+            "Allison Mathis",
+            25300,
+            new Address("2702 Freedom Lane, San Francisco, CA", 94109),
+            Arrays.asList("Development")
+        ));
+
+        employeeCache.put(new EmployeeKey(5, 2), new Employee(
+            "Breana Robbin",
+            6500,
+            new Address("3960 Sundown Lane, Austin, TX", 78130),
+            Arrays.asList("Sales")
+        ));
+
+        employeeCache.put(new EmployeeKey(6, 2), new Employee(
+            "Philip Horsley",
+            19800,
+            new Address("2803 Elsie Drive, Sioux Falls, SD", 57104),
+            Arrays.asList("Sales")
+        ));
+
+        employeeCache.put(new EmployeeKey(7, 2), new Employee(
+            "Brian Peters",
+            10600,
+            new Address("1407 Pearlman Avenue, Boston, MA", 12110),
+            Arrays.asList("Development", "QA")
+        ));
+    }
+}
+

--- a/examples/src/main/java/org/apache/ignite/examples/portable/datagrid/package-info.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/datagrid/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Demonstrates the usage of portable objects with cache.
+ */
+package org.apache.ignite.examples.portable.datagrid;

--- a/examples/src/main/java/org/apache/ignite/examples/portable/package-info.java
+++ b/examples/src/main/java/org/apache/ignite/examples/portable/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains portable classes and examples.
+ */
+package org.apache.ignite.examples.portable;

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAffinityExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAffinityExample.java
@@ -17,6 +17,21 @@
 
 package org.apache.ignite.examples.java8.datagrid;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCluster;
+import org.apache.ignite.IgniteCompute;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.lang.IgniteRunnable;
+
 /**
  * This example demonstrates the simplest code that populates the distributed cache
  * and co-locates simple closure execution with each key. The goal of this particular

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/messaging/MessagingExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/messaging/MessagingExample.java
@@ -17,6 +17,15 @@
 
 package org.apache.ignite.examples.java8.messaging;
 
+import java.util.concurrent.CountDownLatch;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.IgniteMessaging;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cluster.ClusterGroup;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.examples.ExamplesUtils;
+
 /**
  * Example that demonstrates how to exchange messages between nodes. Use such
  * functionality for cases when you need to communicate to other nodes outside

--- a/examples/src/test/java/org/apache/ignite/examples/CacheClientPortableExampleTest.java
+++ b/examples/src/test/java/org/apache/ignite/examples/CacheClientPortableExampleTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples;
+
+import org.apache.ignite.examples.portable.datagrid.CacheClientPortablePutGetExample;
+import org.apache.ignite.examples.portable.datagrid.CacheClientPortableQueryExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
+/**
+ *
+ */
+public class CacheClientPortableExampleTest extends GridAbstractExamplesTest {
+    /** {@inheritDoc} */
+    @Override protected String defaultConfig() {
+        return "examples/config/portable/example-ignite-portable.xml";
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testPortablePutGetExample() throws Exception {
+        CacheClientPortablePutGetExample.main(new String[] {});
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testPortableQueryExample() throws Exception {
+        CacheClientPortableQueryExample.main(new String[] {});
+    }
+}

--- a/examples/src/test/java/org/apache/ignite/examples/ComputeClientPortableExampleTest.java
+++ b/examples/src/test/java/org/apache/ignite/examples/ComputeClientPortableExampleTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.examples;
+
+import org.apache.ignite.examples.portable.computegrid.ComputeClientPortableTaskExecutionExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
+/**
+ *
+ */
+public class ComputeClientPortableExampleTest extends GridAbstractExamplesTest {
+    /** {@inheritDoc} */
+    @Override protected String defaultConfig() {
+        return "examples/config/portable/example-ignite-portable.xml";
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testPortableTaskExecutionExample() throws Exception {
+        ComputeClientPortableTaskExecutionExample.main(new String[] {});
+    }
+}

--- a/examples/src/test/java/org/apache/ignite/testsuites/IgniteExamplesSelfTestSuite.java
+++ b/examples/src/test/java/org/apache/ignite/testsuites/IgniteExamplesSelfTestSuite.java
@@ -20,10 +20,12 @@ package org.apache.ignite.testsuites;
 import junit.framework.TestSuite;
 import org.apache.ignite.examples.BasicExamplesMultiNodeSelfTest;
 import org.apache.ignite.examples.BasicExamplesSelfTest;
+import org.apache.ignite.examples.CacheClientPortableExampleTest;
 import org.apache.ignite.examples.CacheExamplesMultiNodeSelfTest;
 import org.apache.ignite.examples.CacheExamplesSelfTest;
 import org.apache.ignite.examples.CheckpointExamplesSelfTest;
 import org.apache.ignite.examples.ClusterGroupExampleSelfTest;
+import org.apache.ignite.examples.ComputeClientPortableExampleTest;
 import org.apache.ignite.examples.ContinuationExamplesMultiNodeSelfTest;
 import org.apache.ignite.examples.ContinuationExamplesSelfTest;
 import org.apache.ignite.examples.ContinuousMapperExamplesMultiNodeSelfTest;
@@ -92,6 +94,10 @@ public class IgniteExamplesSelfTestSuite extends TestSuite {
         suite.addTest(new TestSuite(MemcacheRestExamplesMultiNodeSelfTest.class));
         suite.addTest(new TestSuite(MonteCarloExamplesMultiNodeSelfTest.class));
         suite.addTest(new TestSuite(HibernateL2CacheExampleMultiNodeSelfTest.class));
+
+        // Portable.
+        suite.addTest(new TestSuite(CacheClientPortableExampleTest.class));
+        suite.addTest(new TestSuite(ComputeClientPortableExampleTest.class));
 
         return suite;
     }

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/BasicExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/BasicExamplesSelfTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.ignite.java8.examples;
 
-import org.apache.ignite.examples.java8.computegrid.*;
-import org.apache.ignite.examples.java8.datastructures.*;
+import org.apache.ignite.examples.java8.computegrid.ComputeBroadcastExample;
+import org.apache.ignite.examples.java8.computegrid.ComputeCallableExample;
+import org.apache.ignite.examples.java8.computegrid.ComputeClosureExample;
+import org.apache.ignite.examples.java8.computegrid.ComputeRunnableExample;
+import org.apache.ignite.examples.java8.datastructures.IgniteExecutorServiceExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
 
 /**
  * Closure examples self test.

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/CacheExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/CacheExamplesSelfTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.ignite.java8.examples;
 
-import org.apache.ignite.examples.java8.datagrid.*;
+import org.apache.ignite.examples.java8.datagrid.CacheAffinityExample;
+import org.apache.ignite.examples.java8.datagrid.CacheApiExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
 
 //import org.apache.ignite.examples.java8.datagrid.starschema.*;
 //import org.apache.ignite.examples.java8.datagrid.store.dummy.*;
@@ -34,7 +36,7 @@ public class CacheExamplesSelfTest extends GridAbstractExamplesTest {
         CacheAffinityExample.main(EMPTY_ARGS);
     }
 
-//    TODO: IGNITE-711 next example(s) should be implemented for java 8 
+//    TODO: IGNITE-711 next example(s) should be implemented for java 8
 //    or testing method(s) should be removed if example(s) does not applicable for java 8.
 //    /**
 //     * @throws Exception If failed.

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/CheckpointExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/CheckpointExamplesSelfTest.java
@@ -17,16 +17,16 @@
 
 package org.apache.ignite.java8.examples;
 
-//import org.apache.ignite.examples.java8.computegrid.failover.*;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
 
 /**
  * Checkpoint examples self test.
  */
 public class CheckpointExamplesSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     *  
+     *
      * Starts remote nodes before each test.
      *
      * Note: using beforeTestsStarted() to start nodes only once won't work.

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/ClusterGroupExampleSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/ClusterGroupExampleSelfTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.java8.examples;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  *
  */

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/ContinuationExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/ContinuationExamplesSelfTest.java
@@ -19,14 +19,16 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.computegrid.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * Continuation example self test.
  */
 public class ContinuationExamplesSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     *  
+     *
      * @throws Exception If failed.
      */
 //    public void testContinuationExample() throws Exception {

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/ContinuousMapperExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/ContinuousMapperExamplesSelfTest.java
@@ -17,14 +17,16 @@
 
 package org.apache.ignite.java8.examples;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * ContinuousMapperExample self test.
  */
 public class ContinuousMapperExamplesSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     *  
+     *
      * @throws Exception If failed.
      */
 //    public void testContinuousMapperExample() throws Exception {

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/DeploymentExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/DeploymentExamplesSelfTest.java
@@ -19,11 +19,13 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.misc.deployment.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * Deployment examples self test.
  */
 public class DeploymentExamplesSelfTest extends GridAbstractExamplesTest {
-    // TODO: IGNITE-711 next example(s) should be implemented for java 8 
+    // TODO: IGNITE-711 next example(s) should be implemented for java 8
     // or testing method(s) should be removed if example(s) does not applicable for java 8.
     /**
      * @throws Exception If failed.

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/HibernateL2CacheExampleSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/HibernateL2CacheExampleSelfTest.java
@@ -19,14 +19,16 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.datagrid.hibernate.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * Tests the {@link org.apache.ignite.examples.java8.datagrid.hibernate.HibernateL2CacheExample}.
  */
 public class HibernateL2CacheExampleSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     * 
+     *
      * @throws Exception If failed.
      */
 //    public void testHibernateL2CacheExample() throws Exception {

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/IgfsExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/IgfsExamplesSelfTest.java
@@ -20,6 +20,8 @@ package org.apache.ignite.java8.examples;
 //import org.apache.ignite.examples.java8.igfs.*;
 //import org.apache.ignite.internal.util.typedef.internal.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * IGFS examples self test.
  */
@@ -31,7 +33,7 @@ public class IgfsExamplesSelfTest extends GridAbstractExamplesTest {
     private static final String IGFS_LOOPBACK_CFG = "modules/core/src/test/config/igfs-loopback.xml";
 
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
      *
      * @throws Exception If failed.

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/LifecycleExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/LifecycleExamplesSelfTest.java
@@ -19,14 +19,16 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.misc.lifecycle.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * LifecycleExample self test.
  */
 public class LifecycleExamplesSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     * 
+     *
      * @throws Exception If failed.
      */
 //    public void testLifecycleExample() throws Exception {

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/MemcacheRestExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/MemcacheRestExamplesSelfTest.java
@@ -19,6 +19,8 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.misc.client.memcache.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * MemcacheRestExample self test.
  */

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/MessagingExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/MessagingExamplesSelfTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.ignite.java8.examples;
 
-import org.apache.ignite.examples.java8.messaging.*;
+import org.apache.ignite.examples.java8.messaging.MessagingExample;
+import org.apache.ignite.examples.java8.messaging.MessagingPingPongExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
 
 /**
  * Messaging examples self test.

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/MonteCarloExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/MonteCarloExamplesSelfTest.java
@@ -19,6 +19,8 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.computegrid.montecarlo.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * Ignite examples self test. Excludes Ignite Spring tests.
  *
@@ -65,9 +67,9 @@ package org.apache.ignite.java8.examples;
  */
 public class MonteCarloExamplesSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     *  
+     *
      * @throws Exception If failed.
      */
 //    public void testCreditRiskExample() throws Exception {

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/SpringBeanExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/SpringBeanExamplesSelfTest.java
@@ -19,14 +19,16 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.misc.springbean.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * Spring bean examples self test.
  */
 public class SpringBeanExamplesSelfTest extends GridAbstractExamplesTest {
     /**
-     * TODO: IGNITE-711 next example(s) should be implemented for java 8 
+     * TODO: IGNITE-711 next example(s) should be implemented for java 8
      * or testing method(s) should be removed if example(s) does not applicable for java 8.
-     *  
+     *
      * @throws Exception If failed.
      */
 //    public void testSpringBeanHelloWorldExample() throws Exception {

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/TaskExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/TaskExamplesSelfTest.java
@@ -19,6 +19,8 @@ package org.apache.ignite.java8.examples;
 
 //import org.apache.ignite.examples.java8.computegrid.*;
 
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
+
 /**
  * Hello world examples self test.
  */

--- a/examples/src/test/java8/org/apache/ignite/java8/testsuites/IgniteExamplesJ8SelfTestSuite.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/testsuites/IgniteExamplesJ8SelfTestSuite.java
@@ -17,7 +17,15 @@
 
 package org.apache.ignite.java8.testsuites;
 
-import org.apache.ignite.java8.examples.*;
+import junit.framework.TestSuite;
+import org.apache.ignite.java8.examples.BasicExamplesMultiNodeSelfTest;
+import org.apache.ignite.java8.examples.BasicExamplesSelfTest;
+import org.apache.ignite.java8.examples.CacheExamplesMultiNodeSelfTest;
+import org.apache.ignite.java8.examples.CacheExamplesSelfTest;
+import org.apache.ignite.java8.examples.EventsExamplesMultiNodeSelfTest;
+import org.apache.ignite.java8.examples.EventsExamplesSelfTest;
+import org.apache.ignite.java8.examples.MessagingExamplesSelfTest;
+import org.apache.ignite.testframework.GridTestUtils;
 
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_OVERRIDE_MCAST_GRP;
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheP2pUnmarshallingErrorTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheP2pUnmarshallingErrorTest.java
@@ -42,6 +42,11 @@ public class IgniteCacheP2pUnmarshallingErrorTest extends IgniteCacheAbstractTes
     protected static int key = 0;
 
     /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        fail("https://issues.apache.org/jira/browse/IGNITE-1366");
+    }
+
+    /** {@inheritDoc} */
     @Override protected int gridCount() {
         return 3;
     }

--- a/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
+++ b/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
@@ -242,10 +242,10 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
                             Appender innerApp = control.getAppender();
 
                             if (innerApp instanceof FileAppender)
-                                return ((FileAppender)innerApp).getFileName();
+                                return normilize(((FileAppender)innerApp).getFileName());
 
                             if (innerApp instanceof RollingFileAppender)
-                                return ((RollingFileAppender)innerApp).getFileName();
+                                return normilize(((RollingFileAppender)innerApp).getFileName());
                         }
                     }
                     catch (IllegalAccessException | NoSuchFieldException e) {
@@ -256,6 +256,20 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
         }
 
         return null;
+    }
+
+    /**
+     * Normalizes given path for windows.
+     * Log4j2 doesn't replace unix directory delimiters which used at 'fileName' to windows.
+     *
+     * @param path Path.
+     * @return Normalized path.
+     */
+    private String normilize(String path) {
+        if (!U.isWindows())
+            return path;
+
+        return path.replace('/', File.separatorChar);
     }
 
     /**

--- a/modules/platform/src/main/java/org/apache/ignite/platform/cpp/package-info.java
+++ b/modules/platform/src/main/java/org/apache/ignite/platform/cpp/package-info.java
@@ -15,19 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.java8.examples;
-
-import org.apache.ignite.examples.java8.events.EventsExample;
-import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
-
 /**
- * Events examples self test.
+ * <!-- Package description. -->
+ * Contains C++ platform-related classes.
  */
-public class EventsExamplesSelfTest extends GridAbstractExamplesTest {
-    /**
-     * @throws Exception If failed.
-     */
-    public void testEventsExample() throws Exception {
-        EventsExample.main(EMPTY_ARGS);
-    }
-}
+package org.apache.ignite.platform.cpp;

--- a/modules/platform/src/main/java/org/apache/ignite/platform/dotnet/package-info.java
+++ b/modules/platform/src/main/java/org/apache/ignite/platform/dotnet/package-info.java
@@ -15,19 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.java8.examples;
-
-import org.apache.ignite.examples.java8.events.EventsExample;
-import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
-
 /**
- * Events examples self test.
+ * <!-- Package description. -->
+ * Contains .Net platform-related classes.
  */
-public class EventsExamplesSelfTest extends GridAbstractExamplesTest {
-    /**
-     * @throws Exception If failed.
-     */
-    public void testEventsExample() throws Exception {
-        EventsExample.main(EMPTY_ARGS);
-    }
-}
+package org.apache.ignite.platform.dotnet;

--- a/modules/platform/src/main/java/org/apache/ignite/platform/package-info.java
+++ b/modules/platform/src/main/java/org/apache/ignite/platform/package-info.java
@@ -15,19 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.java8.examples;
-
-import org.apache.ignite.examples.java8.events.EventsExample;
-import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
-
 /**
- * Events examples self test.
+ * <!-- Package description. -->
+ * Contains platform-related classes.
  */
-public class EventsExamplesSelfTest extends GridAbstractExamplesTest {
-    /**
-     * @throws Exception If failed.
-     */
-    public void testEventsExample() throws Exception {
-        EventsExample.main(EMPTY_ARGS);
-    }
-}
+package org.apache.ignite.platform;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -339,6 +339,10 @@
                                 <packages>org.apache.ignite.yarn*</packages>
                             </group>
                             <group>
+                                <title>Platforms</title>
+                                <packages>org.apache.ignite.platform*</packages>
+                            </group>
+                            <group>
                                 <title>Spark Integration</title>
                                 <packages>org.apache.ignite.spark.examples.java</packages>
                             </group>


### PR DESCRIPTION
FIx Log4j2LoggerSelfTest.testLogFilesTwoNodes test case for Windows.

See

junit.framework.ComparisonFailure: expected:<...ork\871ff4a46e450b13[\work\log]ignite-65fba17b.log> but was:<...ork\871ff4a46e450b13[/work/log/]ignite-65fba17b.log>
at junit.framework.Assert.assertEquals(Assert.java:100)
at junit.framework.Assert.assertEquals(Assert.java:107)
at junit.framework.TestCase.assertEquals(TestCase.java:269)
at org.apache.ignite.logger.log4j2.Log4j2LoggerSelfTest.checkOneNode(Log4j2LoggerSelfTest.java:143)
at org.apache.ignite.logger.log4j2.Log4j2LoggerSelfTest.testLogFilesTwoNodes(Log4j2LoggerSelfTest.java:119)