### PR TITLE
IGNITE-530 development of Twitter data streamer

### DIFF
--- a/modules/twitter/pom.xml
+++ b/modules/twitter/pom.xml
@@ -34,10 +34,6 @@
     <version>1.5.0-SNAPSHOT</version>
     <url>http://ignite.apache.org</url>
 
-    <properties>
-        <!--<activemq.version>5.11.1</activemq.version>-->
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.ignite</groupId>
@@ -68,22 +64,61 @@
 
         <dependency>
             <groupId>com.twitter</groupId>
-            <artifactId>hbc-twitter4j</artifactId> <!-- or hbc-twitter4j -->
-            <version>2.2.0</version> <!-- or whatever the latest version is -->
+            <artifactId>hbc-twitter4j</artifactId>
+            <version>2.2.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.57</version>
+
+            <!-- Include everything below here if you have dependency conflicts -->
+            <classifier>standalone</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xmlunit</groupId>
+                    <artifactId>xmlunit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.sf.jopt-simple</groupId>
+                    <artifactId>jopt-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.4.2</version>
-                <configuration>
-                    <!-- configuration to skip test for this module as this requires Twitter login (OAuth and BasicAuth  credentials -->
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/modules/twitter/pom.xml
+++ b/modules/twitter/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    POM file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.ignite</groupId>
+        <artifactId>ignite-parent</artifactId>
+        <version>1</version>
+        <relativePath>../../parent</relativePath>
+    </parent>
+
+    <artifactId>ignite-twitter</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+    <url>http://ignite.apache.org</url>
+
+    <properties>
+        <!--<activemq.version>5.11.1</activemq.version>-->
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-log4j</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-spring</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>hbc-twitter4j</artifactId> <!-- or hbc-twitter4j -->
+            <version>2.2.0</version> <!-- or whatever the latest version is -->
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.4.2</version>
+                <configuration>
+                    <!-- configuration to skip test for this module as this requires Twitter login (OAuth and BasicAuth  credentials -->
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/OAuthSettings.java
+++ b/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/OAuthSettings.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.stream.twitter;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * OAuth keys holder.
+ */
+public class OAuthSettings {
+
+    @NotNull private String consumerKey;
+    @NotNull private String consumerSecret;
+    @NotNull private String accessToken;
+    @NotNull private String accessTokenSecret;
+
+    public OAuthSettings(String consumerKey, String consumerSecret, String accessToken, String accessTokenSecret) {
+        this.consumerKey = consumerKey;
+        this.consumerSecret = consumerSecret;
+        this.accessToken = accessToken;
+        this.accessTokenSecret = accessTokenSecret;
+    }
+
+    @NotNull
+    public String getConsumerKey() {
+        return consumerKey;
+    }
+
+    @NotNull
+    public String getConsumerSecret() {
+        return consumerSecret;
+    }
+
+    @NotNull
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    @NotNull
+    public String getAccessTokenSecret() {
+        return accessTokenSecret;
+    }
+}

--- a/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/TweetTransformer.java
+++ b/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/TweetTransformer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.stream.twitter;
+
+import java.util.Map;
+
+/**
+ * Implement this interface to transform from a Tweet JSON to a set of cache entries in the form of a {@link Map}.
+ *
+ * @param <K> The type of the cache key.
+ * @param <V> The type of the cache value.
+ * @author Lalit Jha
+ */
+public interface TweetTransformer<K, V> {
+
+    /**
+     * Transformation function.
+     *
+     * @param tweet The message (Tweet JSON String) received from the Twitter Streaming API.
+     * @return Set of cache entries to add to the cache. It could be empty or null if the message should be skipped.
+     */
+    Map<K, V> apply(String tweet);
+
+}

--- a/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/TweetTransformer.java
+++ b/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/TweetTransformer.java
@@ -24,7 +24,6 @@ import java.util.Map;
  *
  * @param <K> The type of the cache key.
  * @param <V> The type of the cache value.
- * @author Lalit Jha
  */
 public interface TweetTransformer<K, V> {
 

--- a/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/TwitterStreamer.java
+++ b/modules/twitter/src/main/java/org/apache/ignite/stream/twitter/TwitterStreamer.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.stream.twitter;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.twitter.hbc.ClientBuilder;
+import com.twitter.hbc.core.*;
+import com.twitter.hbc.core.endpoint.*;
+import com.twitter.hbc.core.processor.StringDelimitedProcessor;
+import com.twitter.hbc.httpclient.auth.Authentication;
+import com.twitter.hbc.httpclient.auth.OAuth1;
+import org.apache.ignite.IgniteDataStreamer;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.internal.util.typedef.internal.A;
+import org.apache.ignite.stream.StreamAdapter;
+import twitter4j.Status;
+import twitter4j.TwitterObjectFactory;
+
+/**
+ * Streamer that consumes from a Twitter Streaming API and feeds transformed key-value pairs, by default < tweetId, text>,
+ * into an {@link IgniteDataStreamer} instance.
+ * <p>
+ * This streamer uses https://dev.twitter.com/streaming API and supports Public API, User Streams, Site Streams and Firehose.
+ * <p>
+ * You can also provide a {@link TweetTransformer} to convert the incoming message into cache entries to override
+ * default transformer.
+ * <p>
+ * This Streamer features:
+ *
+ * <ul>
+ *     <li>Supports OAuth1 authentication scheme. <br/> BasicAuth not supported by Streaming API https://dev.twitter.com/streaming/overview/connecting</li>
+ *     <li>Provide all params in apiParams map. https://dev.twitter.com/streaming/overview/request-parameters</li>
+ * </ul>
+ *
+ * @author Lalit Jha
+ */
+public class TwitterStreamer<K, V> extends StreamAdapter<String, K, V> {
+
+    /** Logger. */
+    private IgniteLogger log;
+
+    /**
+     * The message transformer that converts an incoming Tweet into cache entries.
+     * If not provided default transformer will be used.
+     */
+    private TweetTransformer<K, V> transformer;
+
+    /** Twitter Streaming API params. See https://dev.twitter.com/streaming/overview/request-parameters */
+    private Map<String, String> apiParams = new HashMap<String, String>();
+
+    /** Twitter streaming API endpoint example, '/statuses/filter.json' or '/statuses/firehose.json' */
+    private String endpointUrl;
+
+    /** BasicAuth not supported by Streaming API https://dev.twitter.com/streaming/overview/connecting */
+    private Class<? extends Authentication> authenticationScheme = OAuth1.class;
+
+    /** OAuth params */
+    private String consumerKey;
+    private String consumerSecret;
+    private String accessToken;
+    private String accessTokenSecret;
+
+    private volatile boolean stopped;
+    private Integer bufferCapacity = 100000;
+    private Client client;
+
+    /** Process stream asynchronously */
+    private ExecutorService tweetStreamProcesser = Executors.newSingleThreadExecutor();
+
+    private String SITE_USER_ID_KEY = "follow";
+
+    /**
+     * Starts streamer.
+     *
+     * @throws IgniteException If failed.
+     */
+    public void start() throws IgniteException {
+        if (stopped)
+            throw new IgniteException("Attempted to start an already started Twitter Streamer");
+
+        try {
+            validate();
+
+            log = getIgnite().log();
+
+            BlockingQueue<String> tweetQueue = new LinkedBlockingQueue<String>(bufferCapacity);
+            client = getStreamingEndpoint(tweetQueue);
+
+            client.connect();
+
+            if(transformer == null){
+                transformer = new DefaultTweetTransformer();
+            }
+            Callable<Boolean> task = new Callable<Boolean>() {
+
+                @Override
+                public Boolean call() throws Exception {
+                    while (!client.isDone() && !stopped) {
+                        String tweet = tweetQueue.take();
+                        Map<K, V> value = transformer.apply(tweet);
+                        if (value != null){
+                            getStreamer().addData(value);
+                        }
+                    }
+                    return stopped;
+                }
+            };
+            tweetStreamProcesser.submit(task);
+        }catch (Throwable t) {
+            throw new IgniteException("Exception while initializing TwitterStreamer", t);
+        }
+
+    }
+
+    /**
+     * Stops streamer.
+     */
+    public void stop() throws IgniteException {
+
+        try {
+            stopped = true;
+            client.stop();
+        }catch (Throwable t) {
+            throw new IgniteException("Exception while stopping TwitterStreamer", t);
+        }finally {
+            /** Even if client.stop() fails, this need to be executed */
+            if (tweetStreamProcesser != null) {
+                tweetStreamProcesser.shutdown();
+
+                try {
+                    if (!tweetStreamProcesser.awaitTermination(5000, TimeUnit.MILLISECONDS))
+                        if (log.isDebugEnabled())
+                            log.debug("Timed out waiting for consumer threads to shut down, exiting uncleanly.");
+                } catch (InterruptedException e) {
+                    if (log.isDebugEnabled())
+                        log.debug("Interrupted during shutdown, exiting uncleanly.");
+                }
+            }
+        }
+    }
+
+    private void validate(){
+        A.notNull(getStreamer(), "streamer");
+        A.notNull(getIgnite(), "ignite");
+
+        A.notNull(endpointUrl, "Twitter Streaming API endpoint");
+        A.notNull(authenticationScheme, "twitter Streaming API authentication scheme");
+        A.ensure(authenticationScheme.isAssignableFrom(OAuth1.class),
+                "twitter Streaming API authentication scheme must be OAuth1");
+        if(authenticationScheme.isAssignableFrom(OAuth1.class)){
+            A.notNull(consumerKey, "OAuth consumer key");
+            A.notNull(consumerSecret, "OAuth consumer secret");
+            A.notNull(accessToken, "OAuth access token");
+            A.notNull(accessTokenSecret, "OAuth access token secret");
+        }
+
+        if(endpointUrl.equalsIgnoreCase(SitestreamEndpoint.PATH)){
+            String followParam = apiParams.get(SITE_USER_ID_KEY);
+            A.ensure(followParam != null && followParam.matches("^(\\d+,? ?)+$"),
+                    "Site streaming endpoint must provide 'follow' param with value as comma separated numbers");
+        }
+    }
+
+    private Client getStreamingEndpoint(BlockingQueue<String> tweetQueue){
+        StreamingEndpoint endpoint;
+        Authentication authentication = null;
+
+        if(this.endpointUrl.equalsIgnoreCase(StatusesFilterEndpoint.PATH)){
+            endpoint = new StatusesFilterEndpoint();
+        }else if(this.endpointUrl.equalsIgnoreCase(StatusesFirehoseEndpoint.PATH)){
+            endpoint = new StatusesFirehoseEndpoint();
+        }else if(this.endpointUrl.equalsIgnoreCase(StatusesSampleEndpoint.PATH)){
+            endpoint = new StatusesSampleEndpoint(); //for testing
+        }else if(this.endpointUrl.equalsIgnoreCase(UserstreamEndpoint.PATH)){
+            endpoint = new UserstreamEndpoint();
+        }else if(this.endpointUrl.equalsIgnoreCase(SitestreamEndpoint.PATH)){
+            String follow = apiParams.remove(SITE_USER_ID_KEY);
+            List<Long> followers = Lists.newArrayList();
+            for(String follower : Splitter.on(',').trimResults().omitEmptyStrings().split(follow)){
+                followers.add(Long.valueOf(follower));
+            }
+            endpoint = new SitestreamEndpoint(followers);
+        }else {
+            endpoint = new DefaultStreamingEndpoint(this.endpointUrl, HttpConstants.HTTP_GET, false);
+        }
+
+        for(Map.Entry<String, String> entry : apiParams.entrySet()){
+            endpoint.addPostParameter(entry.getKey(), entry.getValue());
+        }
+
+        if(authenticationScheme.isAssignableFrom(OAuth1.class)){
+            authentication = new OAuth1(consumerKey, consumerSecret, accessToken, accessTokenSecret);
+        }
+        Hosts hosts = new HttpHosts(Constants.STREAM_HOST);
+        ClientBuilder builder = new ClientBuilder()
+                .name("Ignite-Twitter-Client")
+                .hosts(hosts)
+                .authentication(authentication)
+                .endpoint(endpoint)
+                .processor(new StringDelimitedProcessor(tweetQueue));
+
+        Client client = builder.build();
+
+        return client;
+    }
+
+    private static class DefaultTweetTransformer implements TweetTransformer {
+
+        @Override
+        public Map<String, String> apply(String tweet) {
+            try{
+                Status status = TwitterObjectFactory.createStatus(tweet);
+                Map<String, String> value = Maps.newHashMap();
+                value.put(String.valueOf(status.getId()), status.getText());
+                return value;
+            }catch (Exception e){
+                //no op
+            }
+            return Collections.EMPTY_MAP;
+        }
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void setAccessTokenSecret(String accessTokenSecret) {
+        this.accessTokenSecret = accessTokenSecret;
+    }
+
+    public void setConsumerKey(String consumerKey) {
+        this.consumerKey = consumerKey;
+    }
+
+    public void setConsumerSecret(String consumerSecret) {
+        this.consumerSecret = consumerSecret;
+    }
+
+    public void setTransformer(TweetTransformer<K, V> transformer) {
+        this.transformer = transformer;
+    }
+
+    public void setApiParams(Map<String, String> apiParams) {
+        this.apiParams = apiParams;
+    }
+
+    public void setEndpointUrl(String endpointUrl) {
+        this.endpointUrl = endpointUrl;
+    }
+
+    public void setBufferCapacity(Integer bufferCapacity) {
+        this.bufferCapacity = bufferCapacity;
+    }
+}

--- a/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTest.java
+++ b/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.stream.twitter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.twitter.hbc.core.endpoint.*;
+import com.twitter.hbc.httpclient.auth.Authentication;
+import com.twitter.hbc.httpclient.auth.OAuth1;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteDataStreamer;
+import org.apache.ignite.events.CacheEvent;
+import org.apache.ignite.lang.IgnitePredicate;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.After;
+import org.junit.Before;
+
+
+import static org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_PUT;
+
+/**
+ * Test for {@link TwitterStreamer}. Tests Public Status streaming API https://dev.twitter.com/streaming/public.
+ *
+ * @author Lalit Jha
+ */
+public class IgniteTwitterStreamerTest extends GridCommonAbstractTest {
+
+    private static final int CACHE_ENTRY_COUNT = 100;
+
+    private ResourceBundle twitterLogin;
+
+    /** Constructor. */
+    public IgniteTwitterStreamerTest() {
+        super(true);
+    }
+
+    @Before @SuppressWarnings("unchecked")
+    public void beforeTest() throws Exception {
+        grid().<Integer, String>getOrCreateCache(defaultCacheConfiguration());
+        twitterLogin = ResourceBundle.getBundle("twitter");
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        grid().cache(null).clear();
+
+    }
+
+    public void testStatusesFilterEndpointOAuth1() throws Exception {
+        try (IgniteDataStreamer<String, String> dataStreamer = grid().dataStreamer(null)) {
+            TwitterStreamer<String, String> streamer = newStreamerInstance(dataStreamer);
+            setAuthProperties(streamer, OAuth1.class);
+            streamer.setEndpointUrl(StatusesFilterEndpoint.PATH);
+            Map<String, String> params = new HashMap<>();
+            params.put("track", "apache, twitter");
+            streamer.setApiParams(params);
+            executeStreamer(streamer);
+        }
+    }
+
+    private void executeStreamer(TwitterStreamer streamer) throws Exception{
+        CacheListener listener = subscribeToPutEvents();
+
+        streamer.start();
+
+        // all cache PUT events received in 10 seconds, wait 10 more seconds as Twitter API can take time
+        CountDownLatch latch = listener.getLatch();
+        latch.await(10, TimeUnit.SECONDS);
+        if(latch.getCount() == CACHE_ENTRY_COUNT){
+            latch.await(10, TimeUnit.SECONDS);
+        }
+        unsubscribeToPutEvents(listener);
+        assertTrue(latch.getCount() < CACHE_ENTRY_COUNT);
+        streamer.stop();
+    }
+
+    private CacheListener subscribeToPutEvents() {
+        Ignite ignite = grid();
+
+        // Listen to cache PUT events and expect as many as messages as test data items
+        CacheListener listener = new CacheListener();
+        ignite.events(ignite.cluster().forCacheNodes(null)).localListen(listener, EVT_CACHE_OBJECT_PUT);
+        return listener;
+    }
+
+    private void unsubscribeToPutEvents(CacheListener listener) {
+        Ignite ignite = grid();
+
+        ignite.events(ignite.cluster().forCacheNodes(null)).stopLocalListen(listener, EVT_CACHE_OBJECT_PUT);
+    }
+
+    private TwitterStreamer<String, String> newStreamerInstance(IgniteDataStreamer<String, String> dataStreamer) {
+
+        TwitterStreamer<String, String> streamer = new TwitterStreamer<>();
+        streamer.setIgnite(grid());
+        streamer.setStreamer(dataStreamer);
+
+        dataStreamer.allowOverwrite(true);
+        dataStreamer.autoFlushFrequency(10);
+        return streamer;
+    }
+
+    private void setAuthProperties(TwitterStreamer streamer, Class<? extends Authentication> authScheme){
+        if(authScheme.isAssignableFrom(OAuth1.class)){
+            streamer.setConsumerKey(twitterLogin.getString("consumerKey"));
+            streamer.setConsumerSecret(twitterLogin.getString("consumerSecret"));
+            streamer.setAccessToken(twitterLogin.getString("accessToken"));
+            streamer.setAccessTokenSecret(twitterLogin.getString("accessTokenSecret"));
+        }
+    }
+
+
+    private class CacheListener implements IgnitePredicate<CacheEvent> {
+
+        private CountDownLatch latch;
+
+        public CacheListener(){
+            latch = new CountDownLatch(CACHE_ENTRY_COUNT);
+        }
+
+        public CountDownLatch getLatch() {
+            return latch;
+        }
+
+        @Override
+        public boolean apply(CacheEvent evt) {
+            latch.countDown();
+            log.debug(String.valueOf(latch.getCount()));
+            return true;
+        }
+
+    }
+
+}

--- a/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTest.java
+++ b/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTest.java
@@ -17,15 +17,9 @@
 
 package org.apache.ignite.stream.twitter;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import com.twitter.hbc.core.endpoint.*;
-import com.twitter.hbc.httpclient.auth.Authentication;
-import com.twitter.hbc.httpclient.auth.OAuth1;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.twitter.hbc.core.HttpHosts;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteDataStreamer;
 import org.apache.ignite.events.CacheEvent;
@@ -33,43 +27,65 @@ import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import twitter4j.Status;
+import twitter4j.TwitterObjectFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_PUT;
 
 /**
  * Test for {@link TwitterStreamer}. Tests Public Status streaming API https://dev.twitter.com/streaming/public.
- *
- * @author Lalit Jha
  */
 public class IgniteTwitterStreamerTest extends GridCommonAbstractTest {
 
     private static final int CACHE_ENTRY_COUNT = 100;
 
-    private ResourceBundle twitterLogin;
+    /** mocked api in embedded server */
+    private static final String MOCK_TWEET_PATH = "/tweet/mock";
+
+    /** sample tweet */
+    String tweet = "{\"created_at\":\"Fri Sep 25 11:43:20 +0000 2015\",\"id\":647375831971590144,\"id_str\":\"647375831971590144\",\"text\":\"\\u041f\\u044f\\u0442\\u043d\\u0438\\u0446\\u0430 \\u0442\\u0430\\u043a \\u043f\\u044f\\u0442\\u043d\\u0438\\u0446\\u0430\\ud83d\\udc4d\\ud83c\\udffc\\ud83d\\udc4d\\ud83c\\udffc\\ud83d\\udc4d\\ud83c\\udffc\\ud83d\\ude04 (@ \\u041f\\u0440\\u043e\\u0441\\u043f\\u0435\\u043a\\u0442 \\u041b\\u044e\\u0431\\u0438\\u043c\\u043e\\u0432\\u0430 in Minsk) https:\\/\\/t.co\\/JcQrQtQcV6\",\"source\":\"\\u003ca href=\\\"http:\\/\\/foursquare.com\\\" rel=\\\"nofollow\\\"\\u003eFoursquare\\u003c\\/a\\u003e\",\"truncated\":false,\"in_reply_to_status_id\":null,\"in_reply_to_status_id_str\":null,\"in_reply_to_user_id\":null,\"in_reply_to_user_id_str\":null,\"in_reply_to_screen_name\":null,\"user\":{\"id\":953599657,\"id_str\":\"953599657\",\"name\":\"K A T Y A\",\"screen_name\":\"Lady_Kolber\",\"location\":\"\\u041c\\u0438\\u043d\\u0441\\u043a\",\"url\":null,\"description\":null,\"protected\":false,\"verified\":false,\"followers_count\":98,\"friends_count\":62,\"listed_count\":8,\"favourites_count\":818,\"statuses_count\":7667,\"created_at\":\"Sat Nov 17 13:41:18 +0000 2012\",\"utc_offset\":10800,\"time_zone\":\"Baghdad\",\"geo_enabled\":true,\"lang\":\"ru\",\"contributors_enabled\":false,\"is_translator\":false,\"profile_background_color\":\"0099B9\",\"profile_background_image_url\":\"http:\\/\\/pbs.twimg.com\\/profile_background_images\\/378800000159769086\\/x2fWF2nQ.jpeg\",\"profile_background_image_url_https\":\"https:\\/\\/pbs.twimg.com\\/profile_background_images\\/378800000159769086\\/x2fWF2nQ.jpeg\",\"profile_background_tile\":true,\"profile_link_color\":\"0099B9\",\"profile_sidebar_border_color\":\"FFFFFF\",\"profile_sidebar_fill_color\":\"95E8EC\",\"profile_text_color\":\"3C3940\",\"profile_use_background_image\":true,\"profile_image_url\":\"http:\\/\\/pbs.twimg.com\\/profile_images\\/636313079224139776\\/z93GNw7-_normal.jpg\",\"profile_image_url_https\":\"https:\\/\\/pbs.twimg.com\\/profile_images\\/636313079224139776\\/z93GNw7-_normal.jpg\",\"profile_banner_url\":\"https:\\/\\/pbs.twimg.com\\/profile_banners\\/953599657\\/1440236650\",\"default_profile\":false,\"default_profile_image\":false,\"following\":null,\"follow_request_sent\":null,\"notifications\":null},\"geo\":{\"type\":\"Point\",\"coordinates\":[53.863376,27.458605]},\"coordinates\":{\"type\":\"Point\",\"coordinates\":[27.458605,53.863376]},\"place\":{\"id\":\"333a5811d6b0c1cb\",\"url\":\"https:\\/\\/api.twitter.com\\/1.1\\/geo\\/id\\/333a5811d6b0c1cb.json\",\"place_type\":\"country\",\"name\":\"\\u0411\\u0435\\u043b\\u0430\\u0440\\u0443\\u0441\\u044c\",\"full_name\":\"\\u0411\\u0435\\u043b\\u0430\\u0440\\u0443\\u0441\\u044c\",\"country_code\":\"BY\",\"country\":\"Belarus'\",\"bounding_box\":{\"type\":\"Polygon\",\"coordinates\":[[[23.179217,51.2626423],[23.179217,56.1717339],[32.7769812,56.1717339],[32.7769812,51.2626423]]]},\"attributes\":{}},\"contributors\":null,\"retweet_count\":0,\"favorite_count\":0,\"entities\":{\"hashtags\":[],\"trends\":[],\"urls\":[{\"url\":\"https:\\/\\/t.co\\/JcQrQtQcV6\",\"expanded_url\":\"https:\\/\\/www.swarmapp.com\\/c\\/jAFkmVxZnFQ\",\"display_url\":\"swarmapp.com\\/c\\/jAFkmVxZnFQ\",\"indices\":[58,81]}],\"user_mentions\":[],\"symbols\":[]},\"favorited\":false,\"retweeted\":false,\"possibly_sensitive\":false,\"filter_level\":\"low\",\"lang\":\"ru\",\"timestamp_ms\":\"1443181400660\"}\n";
 
     /** Constructor. */
     public IgniteTwitterStreamerTest() {
         super(true);
     }
 
+    @Rule
+    /** embedded mock HTTP server for Twitter API */
+    public WireMockRule wireMockRule = new WireMockRule();
+    WireMockServer mockServer = new WireMockServer(); //starts server on 8080 port
+
     @Before @SuppressWarnings("unchecked")
     public void beforeTest() throws Exception {
-        grid().<Integer, String>getOrCreateCache(defaultCacheConfiguration());
-        twitterLogin = ResourceBundle.getBundle("twitter");
+        grid().<String, String>getOrCreateCache(defaultCacheConfiguration());
+
+        mockServer.start();
+
+        stubFor(get(urlMatching("/1.1" + MOCK_TWEET_PATH + ".*")).willReturn(aResponse().
+                withHeader("Content-Type", "text/plain").withBody(tweet.length() + "\n" + tweet)));
     }
 
     @After
     public void afterTest() throws Exception {
         grid().cache(null).clear();
-
+        mockServer.stop();
     }
 
     public void testStatusesFilterEndpointOAuth1() throws Exception {
         try (IgniteDataStreamer<String, String> dataStreamer = grid().dataStreamer(null)) {
             TwitterStreamer<String, String> streamer = newStreamerInstance(dataStreamer);
-            setAuthProperties(streamer, OAuth1.class);
-            streamer.setEndpointUrl(StatusesFilterEndpoint.PATH);
+            streamer.setHosts(new HttpHosts("http://localhost:8080"));
+            streamer.setEndpointUrl(MOCK_TWEET_PATH);
             Map<String, String> params = new HashMap<>();
             params.put("track", "apache, twitter");
             streamer.setApiParams(params);
@@ -84,12 +100,15 @@ public class IgniteTwitterStreamerTest extends GridCommonAbstractTest {
 
         // all cache PUT events received in 10 seconds, wait 10 more seconds as Twitter API can take time
         CountDownLatch latch = listener.getLatch();
-        latch.await(10, TimeUnit.SECONDS);
-        if(latch.getCount() == CACHE_ENTRY_COUNT){
-            latch.await(10, TimeUnit.SECONDS);
+        for(int i = 0; i < 10 || latch.getCount() == CACHE_ENTRY_COUNT; i++){
+            latch.await(1, TimeUnit.SECONDS);
         }
         unsubscribeToPutEvents(listener);
         assertTrue(latch.getCount() < CACHE_ENTRY_COUNT);
+        Status status = TwitterObjectFactory.createStatus(tweet);
+        String cachedValue = grid().<String, String>cache(null).get(String.valueOf(status.getId()));
+        assertTrue(cachedValue != null);
+        assertTrue(cachedValue.equals(status.getText()));
         streamer.stop();
     }
 
@@ -109,8 +128,8 @@ public class IgniteTwitterStreamerTest extends GridCommonAbstractTest {
     }
 
     private TwitterStreamer<String, String> newStreamerInstance(IgniteDataStreamer<String, String> dataStreamer) {
-
-        TwitterStreamer<String, String> streamer = new TwitterStreamer<>();
+        OAuthSettings oAuthSettings = new OAuthSettings("<dummy>", "<dummy>", "<dummy>", "<dummy>");
+        TwitterStreamer<String, String> streamer = new TwitterStreamer<>(oAuthSettings);
         streamer.setIgnite(grid());
         streamer.setStreamer(dataStreamer);
 
@@ -118,16 +137,6 @@ public class IgniteTwitterStreamerTest extends GridCommonAbstractTest {
         dataStreamer.autoFlushFrequency(10);
         return streamer;
     }
-
-    private void setAuthProperties(TwitterStreamer streamer, Class<? extends Authentication> authScheme){
-        if(authScheme.isAssignableFrom(OAuth1.class)){
-            streamer.setConsumerKey(twitterLogin.getString("consumerKey"));
-            streamer.setConsumerSecret(twitterLogin.getString("consumerSecret"));
-            streamer.setAccessToken(twitterLogin.getString("accessToken"));
-            streamer.setAccessTokenSecret(twitterLogin.getString("accessTokenSecret"));
-        }
-    }
-
 
     private class CacheListener implements IgnitePredicate<CacheEvent> {
 
@@ -144,7 +153,6 @@ public class IgniteTwitterStreamerTest extends GridCommonAbstractTest {
         @Override
         public boolean apply(CacheEvent evt) {
             latch.countDown();
-            log.debug(String.valueOf(latch.getCount()));
             return true;
         }
 

--- a/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTestSuite.java
+++ b/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTestSuite.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.stream.twitter;
+
+import org.junit.runner.*;
+import org.junit.runners.*;
+
+/**
+ * Twitter streamer tests.
+ *
+ * @author Lalit Jha
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    IgniteTwitterStreamerTest.class
+})
+public class IgniteTwitterStreamerTestSuite {
+
+}

--- a/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTestSuite.java
+++ b/modules/twitter/src/test/java/org/apache/ignite/stream/twitter/IgniteTwitterStreamerTestSuite.java
@@ -17,13 +17,12 @@
 
 package org.apache.ignite.stream.twitter;
 
-import org.junit.runner.*;
-import org.junit.runners.*;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * Twitter streamer tests.
- *
- * @author Lalit Jha
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({

--- a/modules/twitter/src/test/resources/twitter.properties
+++ b/modules/twitter/src/test/resources/twitter.properties
@@ -1,0 +1,4 @@
+consumerKey=
+consumerSecret=
+accessToken=
+accessTokenSecret=

--- a/modules/twitter/src/test/resources/twitter.properties
+++ b/modules/twitter/src/test/resources/twitter.properties
@@ -1,4 +1,0 @@
-consumerKey=
-consumerSecret=
-accessToken=
-accessTokenSecret=

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <module>modules/kafka</module>
         <module>modules/yarn</module>
         <module>modules/jms11</module>
+        <module>modules/twitter</module>
         <module>modules/zookeeper</module>
         <module>modules/platform</module>
     </modules>


### PR DESCRIPTION
IGNITE-530 development of Twitter data streamer based on Twitter Streaming API (public statuses).

This data streamer requires valid Twitter OAuth credentials, so tests are skipped by default (in this module's pom.xml).
Need to set these OAuth keys in test/resources/twitter.properties and enable tests.

Test covers only statuses filter API endpoint as firehose and site stream requires special permissions.