### PR TITLE
IGNITE-1863: Fix IgniteAtomicReference.compareAndSet for nulls

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheAtomicReferenceImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheAtomicReferenceImpl.java
@@ -204,7 +204,7 @@ public final class GridCacheAtomicReferenceImpl<T> implements GridCacheAtomicRef
     private IgnitePredicate<T> wrapperPredicate(final T val) {
         return new IgnitePredicate<T>() {
             @Override public boolean apply(T e) {
-                return val != null && val.equals(e);
+                return F.eq(val, e);
             }
         };
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/GridCacheAtomicReferenceApiSelfAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/GridCacheAtomicReferenceApiSelfAbstractTest.java
@@ -109,4 +109,22 @@ public abstract class GridCacheAtomicReferenceApiSelfAbstractTest extends Ignite
 
         assertEquals(null, atomic.get());
     }
+
+    /**
+     * JUnit.
+     *
+     * @throws Exception If failed.
+     */
+    public void testCompareAndSetNullValue() throws Exception {
+        String atomicName = UUID.randomUUID().toString();
+
+        IgniteAtomicReference<String> atomic = grid(0).atomicReference(atomicName, null, true);
+
+        assertEquals(null, atomic.get());
+
+        boolean success = atomic.compareAndSet(null, "newVal");
+
+        assertTrue(success);
+        assertEquals("newVal", atomic.get());
+    }
 }


### PR DESCRIPTION
IGNITE-1863: Fix IgniteAtomicReference.compareAndSet for nulls

https://issues.apache.org/jira/browse/IGNITE-1863
