### PR TITLE
IGNITE 2135 ClassNotFoundException for CacheContinuousQueryExample

### DIFF
--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheContinuousQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheContinuousQueryExample.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.examples.datagrid;
 
 import javax.cache.Cache;
+import javax.cache.CacheException;
 import javax.cache.event.CacheEntryEvent;
 import javax.cache.event.CacheEntryUpdatedListener;
 import org.apache.ignite.Ignite;
@@ -89,15 +90,19 @@ public class CacheContinuousQueryExample {
                 // Execute query.
                 try (QueryCursor<Cache.Entry<Integer, String>> cur = cache.query(qry)) {
                     // Iterate through existing data.
-                    for (Cache.Entry<Integer, String> e : cur)
-                        System.out.println("Queried existing entry [key=" + e.getKey() + ", val=" + e.getValue() + ']');
+                    try {
+                        for (Cache.Entry<Integer, String> e : cur)
+                            System.out.println("Queried existing entry [key=" + e.getKey() + ", val=" + e.getValue() + ']');
 
-                    // Add a few more keys and watch more query notifications.
-                    for (int i = keyCnt; i < keyCnt + 10; i++)
-                        cache.put(i, Integer.toString(i));
+                        // Add a few more keys and watch more query notifications.
+                        for (int i = keyCnt; i < keyCnt + 10; i++)
+                            cache.put(i, Integer.toString(i));
 
-                    // Wait for a while while callback is notified about remaining puts.
-                    Thread.sleep(2000);
+                        // Wait for a while while callback is notified about remaining puts.
+                        Thread.sleep(2000);
+                    } catch (CacheException e){
+                        System.out.println("Failed to run continuous query examples.");
+                    }
                 }
             }
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/GridCacheAbstractDataStructuresFailoverSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/GridCacheAbstractDataStructuresFailoverSelfTest.java
@@ -455,28 +455,28 @@ public abstract class GridCacheAbstractDataStructuresFailoverSelfTest extends Ig
      * @throws Exception If failed.
      */
     public void testSemaphoreConstantTopologyChangeFailoverSafe() throws Exception {
-        doTestSemaphore(new ConstantTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), true);
+        doTestSemaphore(new ConstantTopologyChangeWorker(), true);
     }
 
     /**
      * @throws Exception If failed.
      */
     public void testSemaphoreConstantTopologyChangeNonFailoverSafe() throws Exception {
-        doTestSemaphore(new ConstantTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), false);
+        doTestSemaphore(new ConstantTopologyChangeWorker(), false);
     }
 
     /**
      * @throws Exception If failed.
      */
     public void testSemaphoreMultipleTopologyChangeFailoverSafe() throws Exception {
-        doTestSemaphore(multipleTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), true);
+        doTestSemaphore(multipleTopologyChangeWorker(), true);
     }
 
     /**
      * @throws Exception If failed.
      */
     public void testSemaphoreMultipleTopologyChangeNonFailoverSafe() throws Exception {
-        doTestSemaphore(multipleTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), false);
+        doTestSemaphore(multipleTopologyChangeWorker(), false);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/GridCacheAbstractDataStructuresFailoverSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/GridCacheAbstractDataStructuresFailoverSelfTest.java
@@ -455,28 +455,28 @@ public abstract class GridCacheAbstractDataStructuresFailoverSelfTest extends Ig
      * @throws Exception If failed.
      */
     public void testSemaphoreConstantTopologyChangeFailoverSafe() throws Exception {
-        doTestSemaphore(new ConstantTopologyChangeWorker(), true);
+        doTestSemaphore(new ConstantTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), true);
     }
 
     /**
      * @throws Exception If failed.
      */
     public void testSemaphoreConstantTopologyChangeNonFailoverSafe() throws Exception {
-        doTestSemaphore(new ConstantTopologyChangeWorker(), false);
+        doTestSemaphore(new ConstantTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), false);
     }
 
     /**
      * @throws Exception If failed.
      */
     public void testSemaphoreMultipleTopologyChangeFailoverSafe() throws Exception {
-        doTestSemaphore(multipleTopologyChangeWorker(), true);
+        doTestSemaphore(multipleTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), true);
     }
 
     /**
      * @throws Exception If failed.
      */
     public void testSemaphoreMultipleTopologyChangeNonFailoverSafe() throws Exception {
-        doTestSemaphore(multipleTopologyChangeWorker(), false);
+        doTestSemaphore(multipleTopologyChangeWorker(TOP_CHANGE_THREAD_CNT), false);
     }
 
     /**


### PR DESCRIPTION
I am able to reproduce this issue and I think it is due to lack of enough memory in the system. If number of nodes started = number of GB of RAM this issue is reproducible.
Tested on a system with 4GB ram.
output from node 1
[20:20:31] Topology snapshot [ver=20, servers=4, clients=0, CPUs=4, heap=3.9GB]
output from node 2
[20:20:31] Topology snapshot [ver=20, servers=4, clients=0, CPUs=4, heap=3.9GB]
output from node 3
[20:20:31] Topology snapshot [ver=20, servers=4, clients=0, CPUs=4, heap=3.9GB]
To fix the issue added a try /catch for CacheException.
output from node 4

> > > Cache continuous query example started.
> > > Failed to run continuous query example.
> > > [20:37:32] Ignite node stopped OK [uptime=00:00:03:584]
