### PR TITLE
IGNITE-2168  Examples should destroy created caches: SpringBeanExample fails after CacheBinaryAutoStoreExample

### DIFF
--- a/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/hibernate/HibernateL2CacheExample.java
+++ b/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/hibernate/HibernateL2CacheExample.java
@@ -92,6 +92,13 @@ public class HibernateL2CacheExample {
     private static final List<String> ENTITY_NAMES =
         Arrays.asList(User.class.getName(), Post.class.getName(), User.class.getName() + ".posts");
 
+    /** Caches' names. */
+    private static final String UPDATE_TIMESTAMPS_CACHE_NAME = "org.hibernate.cache.spi.UpdateTimestampsCache";
+    private static final String STANDART_QUERY_CACHE_NAME = "org.hibernate.cache.internal.StandardQueryCache";
+    private static final String USER_CACHE_NAME = "org.apache.ignite.examples.datagrid.hibernate.User";
+    private static final String USER_POSTS_CACHE_NAME = "org.apache.ignite.examples.datagrid.hibernate.User.posts";
+    private static final String POST_CACHE_NAME = "org.apache.ignite.examples.datagrid.hibernate.Post";
+
     /**
      * Executes example.
      *
@@ -109,11 +116,11 @@ public class HibernateL2CacheExample {
 
             try (
                 // Create all required caches.
-                IgniteCache c1 = createCache("org.hibernate.cache.spi.UpdateTimestampsCache", ATOMIC);
-                IgniteCache c2 = createCache("org.hibernate.cache.internal.StandardQueryCache", ATOMIC);
-                IgniteCache c3 = createCache("org.apache.ignite.examples.datagrid.hibernate.User", TRANSACTIONAL);
-                IgniteCache c4 = createCache("org.apache.ignite.examples.datagrid.hibernate.User.posts", TRANSACTIONAL);
-                IgniteCache c5 = createCache("org.apache.ignite.examples.datagrid.hibernate.Post", TRANSACTIONAL)
+                IgniteCache c1 = createCache(UPDATE_TIMESTAMPS_CACHE_NAME, ATOMIC);
+                IgniteCache c2 = createCache(STANDART_QUERY_CACHE_NAME, ATOMIC);
+                IgniteCache c3 = createCache(USER_CACHE_NAME, TRANSACTIONAL);
+                IgniteCache c4 = createCache(USER_POSTS_CACHE_NAME, TRANSACTIONAL);
+                IgniteCache c5 = createCache(POST_CACHE_NAME, TRANSACTIONAL)
             ) {
                 URL hibernateCfg = ExamplesUtils.url(HIBERNATE_CFG);
 
@@ -182,6 +189,13 @@ public class HibernateL2CacheExample {
                 // The Post is loaded with the collection, so it won't imply
                 // a miss.
                 printStats(sesFactory);
+            }
+            finally {
+                ignite.destroyCache(UPDATE_TIMESTAMPS_CACHE_NAME);
+                ignite.destroyCache(STANDART_QUERY_CACHE_NAME);
+                ignite.destroyCache(USER_CACHE_NAME);
+                ignite.destroyCache(USER_POSTS_CACHE_NAME);
+                ignite.destroyCache(POST_CACHE_NAME);
             }
         }
     }

--- a/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/hibernate/HibernateL2CacheExample.java
+++ b/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/hibernate/HibernateL2CacheExample.java
@@ -114,6 +114,7 @@ public class HibernateL2CacheExample {
             System.out.println();
             System.out.println(">>> Hibernate L2 cache example started.");
 
+            // Auto-close cache at the end of the example.
             try (
                 // Create all required caches.
                 IgniteCache c1 = createCache(UPDATE_TIMESTAMPS_CACHE_NAME, ATOMIC);
@@ -191,6 +192,7 @@ public class HibernateL2CacheExample {
                 printStats(sesFactory);
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(UPDATE_TIMESTAMPS_CACHE_NAME);
                 ignite.destroyCache(STANDART_QUERY_CACHE_NAME);
                 ignite.destroyCache(USER_CACHE_NAME);

--- a/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/store/hibernate/CacheHibernateStoreExample.java
+++ b/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/store/hibernate/CacheHibernateStoreExample.java
@@ -103,6 +103,7 @@ public class CacheHibernateStoreExample {
             cacheCfg.setReadThrough(true);
             cacheCfg.setWriteThrough(true);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Long, Person> cache = ignite.getOrCreateCache(cacheCfg)) {
                 // Make initial cache loading from persistent store. This is a
                 // distributed operation and will call CacheStore.loadCache(...)
@@ -114,6 +115,7 @@ public class CacheHibernateStoreExample {
                 executeTransaction(cache);
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/store/hibernate/CacheHibernateStoreExample.java
+++ b/examples/src/main/java-lgpl/org/apache/ignite/examples/datagrid/store/hibernate/CacheHibernateStoreExample.java
@@ -113,6 +113,9 @@ public class CacheHibernateStoreExample {
                 // read/write-through to persistent store.
                 executeTransaction(cache);
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java/org/apache/ignite/examples/binary/datagrid/store/auto/CacheBinaryAutoStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/binary/datagrid/store/auto/CacheBinaryAutoStoreExample.java
@@ -162,6 +162,7 @@ public class CacheBinaryAutoStoreExample {
                 System.out.println(">>> Loaded cache entries: " + cache.size());
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAffinityExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAffinityExample.java
@@ -69,6 +69,10 @@ public final class CacheAffinityExample {
                 // Co-locates jobs with data using IgniteCluster.mapKeysToNodes(...) method.
                 visitUsingMapKeysToNodes();
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAffinityExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAffinityExample.java
@@ -59,6 +59,8 @@ public final class CacheAffinityExample {
             System.out.println();
             System.out.println(">>> Cache affinity example started.");
 
+
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 for (int i = 0; i < KEY_CNT; i++)
                     cache.put(i, Integer.toString(i));

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheApiExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheApiExample.java
@@ -50,6 +50,7 @@ public class CacheApiExample {
             System.out.println();
             System.out.println(">>> Cache API example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 // Demonstrate atomic map operations.
                 atomicMapOperations(cache);

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheApiExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheApiExample.java
@@ -54,6 +54,10 @@ public class CacheApiExample {
                 // Demonstrate atomic map operations.
                 atomicMapOperations(cache);
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAsyncApiExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAsyncApiExample.java
@@ -51,6 +51,7 @@ public class CacheAsyncApiExample {
             System.out.println();
             System.out.println(">>> Cache asynchronous API example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 // Enable asynchronous mode.
                 IgniteCache<Integer, String> asyncCache = cache.withAsync();

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAsyncApiExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheAsyncApiExample.java
@@ -78,6 +78,10 @@ public class CacheAsyncApiExample {
                     }
                 });
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheContinuousQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheContinuousQueryExample.java
@@ -54,6 +54,7 @@ public class CacheContinuousQueryExample {
             System.out.println();
             System.out.println(">>> Cache continuous query example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 int keyCnt = 20;
 
@@ -99,10 +100,10 @@ public class CacheContinuousQueryExample {
                     // Wait for a while while callback is notified about remaining puts.
                     Thread.sleep(2000);
                 }
-                finally {
-                    // Distributed cache could be removed from cluster only by #destroyCache() call.
-                    ignite.destroyCache(CACHE_NAME);
-                }
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheContinuousQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheContinuousQueryExample.java
@@ -99,6 +99,10 @@ public class CacheContinuousQueryExample {
                     // Wait for a while while callback is notified about remaining puts.
                     Thread.sleep(2000);
                 }
+                finally {
+                    // Distributed cache could be removed from cluster only by #destroyCache() call.
+                    ignite.destroyCache(CACHE_NAME);
+                }
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheDataStreamerExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheDataStreamerExample.java
@@ -81,6 +81,10 @@ public class CacheDataStreamerExample {
 
                 System.out.println(">>> Loaded " + ENTRY_COUNT + " keys in " + (end - start) + "ms.");
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheDataStreamerExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheDataStreamerExample.java
@@ -60,6 +60,7 @@ public class CacheDataStreamerExample {
             System.out.println();
             System.out.println(">>> Cache data streamer example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 long start = System.currentTimeMillis();
 

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEntryProcessorExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEntryProcessorExample.java
@@ -78,6 +78,10 @@ public class CacheEntryProcessorExample {
                 // Demonstrates usage of EntryProcessor.invokeAll(...) method.
                 incrementEntriesWithInvokeAll(cache);
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEntryProcessorExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEntryProcessorExample.java
@@ -71,6 +71,7 @@ public class CacheEntryProcessorExample {
             System.out.println();
             System.out.println(">>> Entry processor example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, Integer> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 // Demonstrates usage of EntryProcessor.invoke(...) method.
                 populateEntriesWithInvoke(cache);

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEventsExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEventsExample.java
@@ -92,6 +92,10 @@ public class CacheEventsExample {
                 // Wait for a while while callback is notified about remaining puts.
                 Thread.sleep(2000);
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEventsExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheEventsExample.java
@@ -56,6 +56,7 @@ public class CacheEventsExample {
             System.out.println();
             System.out.println(">>> Cache events example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 // This optional local callback is called for each event notification
                 // that passed remote predicate listener.

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheQueryExample.java
@@ -89,6 +89,7 @@ public class CacheQueryExample {
             personCacheCfg.setCacheMode(CacheMode.PARTITIONED); // Default.
             personCacheCfg.setIndexedTypes(AffinityKey.class, Person.class);
 
+            // Auto-close cache at the end of the example.
             try (
                 IgniteCache<Long, Organization> orgCache = ignite.getOrCreateCache(orgCacheCfg);
                 IgniteCache<AffinityKey<Long>, Person> personCache = ignite.getOrCreateCache(personCacheCfg)
@@ -119,6 +120,7 @@ public class CacheQueryExample {
                 sqlFieldsQueryWithJoin();
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(PERSON_CACHE);
                 ignite.destroyCache(ORG_CACHE);
             }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheQueryExample.java
@@ -118,6 +118,10 @@ public class CacheQueryExample {
                 // Example for SQL-based fields queries that uses joins.
                 sqlFieldsQueryWithJoin();
             }
+            finally {
+                ignite.destroyCache(PERSON_CACHE);
+                ignite.destroyCache(ORG_CACHE);
+            }
 
             print("Cache query example finished.");
         }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheTransactionExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheTransactionExample.java
@@ -59,6 +59,7 @@ public class CacheTransactionExample {
 
             cfg.setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, Account> cache = ignite.getOrCreateCache(cfg)) {
                 // Initialize.
                 cache.put(1, new Account(1, 100));
@@ -80,6 +81,7 @@ public class CacheTransactionExample {
 
                 System.out.println(">>> Cache transaction example finished.");
             } finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheTransactionExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/CacheTransactionExample.java
@@ -79,6 +79,8 @@ public class CacheTransactionExample {
                 System.out.println(">>> " + cache.get(2));
 
                 System.out.println(">>> Cache transaction example finished.");
+            } finally {
+                ignite.destroyCache(CACHE_NAME);
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/starschema/CacheStarSchemaExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/starschema/CacheStarSchemaExample.java
@@ -93,6 +93,7 @@ public class CacheStarSchemaExample {
                 Integer.class, DimProduct.class
             );
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, FactPurchase> factCache = ignite.getOrCreateCache(factCacheCfg);
                  IgniteCache<Integer, Object> dimCache = ignite.getOrCreateCache(dimCacheCfg)) {
                 populateDimensions(dimCache);
@@ -102,6 +103,7 @@ public class CacheStarSchemaExample {
                 queryProductPurchases();
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(PARTITIONED_CACHE_NAME);
                 ignite.destroyCache(REPLICATED_CACHE_NAME);
             }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/starschema/CacheStarSchemaExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/starschema/CacheStarSchemaExample.java
@@ -78,10 +78,6 @@ public class CacheStarSchemaExample {
             System.out.println();
             System.out.println(">>> Cache star schema example started.");
 
-            // Destroy caches to clean up the data if any left from previous runs.
-            ignite.destroyCache(PARTITIONED_CACHE_NAME);
-            ignite.destroyCache(REPLICATED_CACHE_NAME);
-
             CacheConfiguration<Integer, FactPurchase> factCacheCfg = new CacheConfiguration<>(PARTITIONED_CACHE_NAME);
 
             factCacheCfg.setCacheMode(CacheMode.PARTITIONED);
@@ -104,6 +100,10 @@ public class CacheStarSchemaExample {
 
                 queryStorePurchases();
                 queryProductPurchases();
+            }
+            finally {
+                ignite.destroyCache(PARTITIONED_CACHE_NAME);
+                ignite.destroyCache(REPLICATED_CACHE_NAME);
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/auto/CacheAutoStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/auto/CacheAutoStoreExample.java
@@ -172,7 +172,6 @@ public class CacheAutoStoreExample {
             finally {
                 ignite.destroyCache(CACHE_NAME);
             }
-
         }
     }
 }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/auto/CacheAutoStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/auto/CacheAutoStoreExample.java
@@ -169,6 +169,10 @@ public class CacheAutoStoreExample {
 
                 System.out.println(">>> Loaded cache entries: " + cache.size());
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
+
         }
     }
 }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/auto/CacheAutoStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/auto/CacheAutoStoreExample.java
@@ -126,6 +126,7 @@ public class CacheAutoStoreExample {
             System.out.println();
             System.out.println(">>> Cache auto store example started...");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Long, Person> cache = ignite.getOrCreateCache(cacheConfiguration())) {
                 try (Transaction tx = ignite.transactions().txStart()) {
                     Person val = cache.get(id);
@@ -170,6 +171,7 @@ public class CacheAutoStoreExample {
                 System.out.println(">>> Loaded cache entries: " + cache.size());
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/jdbc/CacheJdbcStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/jdbc/CacheJdbcStoreExample.java
@@ -110,6 +110,9 @@ public class CacheJdbcStoreExample {
                 // read/write-through to persistent store.
                 executeTransaction(cache);
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/jdbc/CacheJdbcStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/jdbc/CacheJdbcStoreExample.java
@@ -100,6 +100,7 @@ public class CacheJdbcStoreExample {
             cacheCfg.setReadThrough(true);
             cacheCfg.setWriteThrough(true);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Long, Person> cache = ignite.getOrCreateCache(cacheCfg)) {
                 // Make initial cache loading from persistent store. This is a
                 // distributed operation and will call CacheStore.loadCache(...)
@@ -111,6 +112,7 @@ public class CacheJdbcStoreExample {
                 executeTransaction(cache);
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/spring/CacheSpringStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/spring/CacheSpringStoreExample.java
@@ -99,6 +99,7 @@ public class CacheSpringStoreExample {
             cacheCfg.setReadThrough(true);
             cacheCfg.setWriteThrough(true);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Long, Person> cache = ignite.getOrCreateCache(cacheCfg)) {
                 // Make initial cache loading from persistent store. This is a
                 // distributed operation and will call CacheStore.loadCache(...)
@@ -110,6 +111,7 @@ public class CacheSpringStoreExample {
                 executeTransaction(cache);
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java/org/apache/ignite/examples/datagrid/store/spring/CacheSpringStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datagrid/store/spring/CacheSpringStoreExample.java
@@ -109,6 +109,9 @@ public class CacheSpringStoreExample {
                 // read/write-through to persistent store.
                 executeTransaction(cache);
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java/org/apache/ignite/examples/streaming/StreamTransformerExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/streaming/StreamTransformerExample.java
@@ -97,6 +97,10 @@ public class StreamTransformerExample {
                 // Print top 10 words.
                 ExamplesUtils.printQueryResults(top10);
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(cfg.getName());
+            }
         }
     }
 }

--- a/examples/src/main/java/org/apache/ignite/examples/streaming/StreamVisitorExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/streaming/StreamVisitorExample.java
@@ -54,6 +54,7 @@ public class StreamVisitorExample {
 
     /** Cache name. */
     private static final String CACHE_NAME = "instCache";
+    private static final String MARKET_TICKET_CACHE_NAME = "marketTicks";
 
     public static void main(String[] args) throws Exception {
         // Mark this cluster member as client.
@@ -72,7 +73,7 @@ public class StreamVisitorExample {
 
             // Auto-close caches at the end of the example.
             try (
-                IgniteCache<String, Double> mktCache = ignite.getOrCreateCache("marketTicks"); // Default config.
+                IgniteCache<String, Double> mktCache = ignite.getOrCreateCache(MARKET_TICKET_CACHE_NAME); // Default config.
                 IgniteCache<String, Instrument> instCache = ignite.getOrCreateCache(instCfg)
             ) {
                 try (IgniteDataStreamer<String, Double> mktStmr = ignite.dataStreamer(mktCache.getName())) {
@@ -146,7 +147,7 @@ public class StreamVisitorExample {
             finally {
                 // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
-                ignite.destroyCache(instCfg.getName());
+                ignite.destroyCache(MARKET_TICKET_CACHE_NAME);
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/streaming/StreamVisitorExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/streaming/StreamVisitorExample.java
@@ -52,6 +52,9 @@ public class StreamVisitorExample {
     /** The list of initial instrument prices. */
     private static final double[] INITIAL_PRICES = {194.9, 893.49, 34.21, 23.24, 57.93, 45.03, 44.41, 28.44, 378.49, 69.50};
 
+    /** Cache name. */
+    private static final String CACHE_NAME = "instCache";
+
     public static void main(String[] args) throws Exception {
         // Mark this cluster member as client.
         Ignition.setClientMode(true);
@@ -61,7 +64,7 @@ public class StreamVisitorExample {
                 return;
 
             // Financial instrument cache configuration.
-            CacheConfiguration<String, Instrument> instCfg = new CacheConfiguration<>("instCache");
+            CacheConfiguration<String, Instrument> instCfg = new CacheConfiguration<>(CACHE_NAME);
 
             // Index key and value for querying financial instruments.
             // Note that Instrument class has @QuerySqlField annotation for secondary field indexing.
@@ -139,6 +142,11 @@ public class StreamVisitorExample {
 
                 // Print top 10 words.
                 ExamplesUtils.printQueryResults(top3);
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+                ignite.destroyCache(instCfg.getName());
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/streaming/wordcount/QueryWords.java
+++ b/examples/src/main/java/org/apache/ignite/examples/streaming/wordcount/QueryWords.java
@@ -23,6 +23,7 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.cache.affinity.AffinityUuid;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.examples.ExampleNodeStartup;
 import org.apache.ignite.examples.ExamplesUtils;
 
@@ -50,35 +51,40 @@ public class QueryWords {
             if (!ExamplesUtils.hasServerNodes(ignite))
                 return;
 
+            CacheConfiguration<AffinityUuid, String> cfg = CacheConfig.wordCache();
+
             // The cache is configured with sliding window holding 1 second of the streaming data.
-            IgniteCache<AffinityUuid, String> stmCache = ignite.getOrCreateCache(CacheConfig.wordCache());
+            try (IgniteCache<AffinityUuid, String> stmCache = ignite.getOrCreateCache(cfg)) {
+                // Select top 10 words.
+                SqlFieldsQuery top10Qry = new SqlFieldsQuery(
+                    "select _val, count(_val) as cnt from String group by _val order by cnt desc limit 10",
+                    true /*collocated*/
+                );
 
-            // Select top 10 words.
-            SqlFieldsQuery top10Qry = new SqlFieldsQuery(
-                "select _val, count(_val) as cnt from String group by _val order by cnt desc limit 10",
-                true /*collocated*/
-            );
+                // Select average, min, and max counts among all the words.
+                SqlFieldsQuery statsQry = new SqlFieldsQuery(
+                    "select avg(cnt), min(cnt), max(cnt) from (select count(_val) as cnt from String group by _val)");
 
-            // Select average, min, and max counts among all the words.
-            SqlFieldsQuery statsQry = new SqlFieldsQuery(
-                "select avg(cnt), min(cnt), max(cnt) from (select count(_val) as cnt from String group by _val)");
+                // Query top 10 popular numbers every 5 seconds.
+                while (true) {
+                    // Execute queries.
+                    List<List<?>> top10 = stmCache.query(top10Qry).getAll();
+                    List<List<?>> stats = stmCache.query(statsQry).getAll();
 
-            // Query top 10 popular numbers every 5 seconds.
-            while (true) {
-                // Execute queries.
-                List<List<?>> top10 = stmCache.query(top10Qry).getAll();
-                List<List<?>> stats = stmCache.query(statsQry).getAll();
+                    // Print average count.
+                    List<?> row = stats.get(0);
 
-                // Print average count.
-                List<?> row = stats.get(0);
+                    if (row.get(0) != null)
+                        System.out.printf("Query results [avg=%.2f, min=%d, max=%d]%n", row.get(0), row.get(1), row.get(2));
 
-                if (row.get(0) != null)
-                    System.out.printf("Query results [avg=%.2f, min=%d, max=%d]%n", row.get(0), row.get(1), row.get(2));
+                    // Print top 10 words.
+                    ExamplesUtils.printQueryResults(top10);
 
-                // Print top 10 words.
-                ExamplesUtils.printQueryResults(top10);
-
-                Thread.sleep(5000);
+                    Thread.sleep(5000);
+                }
+            }
+            finally {
+                ignite.destroyCache(cfg.getName());
             }
         }
     }

--- a/examples/src/main/java/org/apache/ignite/examples/streaming/wordcount/QueryWords.java
+++ b/examples/src/main/java/org/apache/ignite/examples/streaming/wordcount/QueryWords.java
@@ -84,6 +84,7 @@ public class QueryWords {
                 }
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(cfg.getName());
             }
         }

--- a/examples/src/main/java/org/apache/ignite/examples/streaming/wordcount/socket/WordsSocketStreamerServer.java
+++ b/examples/src/main/java/org/apache/ignite/examples/streaming/wordcount/socket/WordsSocketStreamerServer.java
@@ -27,6 +27,7 @@ import org.apache.ignite.IgniteDataStreamer;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.cache.affinity.AffinityUuid;
+import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.examples.ExampleNodeStartup;
 import org.apache.ignite.examples.ExamplesUtils;
 import org.apache.ignite.examples.streaming.wordcount.CacheConfig;
@@ -69,63 +70,64 @@ public class WordsSocketStreamerServer {
         // Mark this cluster member as client.
         Ignition.setClientMode(true);
 
-        Ignite ignite = Ignition.start("examples/config/example-ignite.xml");
+        CacheConfiguration<AffinityUuid, String> cfg = CacheConfig.wordCache();
 
-        if (!ExamplesUtils.hasServerNodes(ignite)) {
-            ignite.close();
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
 
-            return;
-        }
+            if (!ExamplesUtils.hasServerNodes(ignite))
+                return;
 
-        // The cache is configured with sliding window holding 1 second of the streaming data.
-        IgniteCache<AffinityUuid, String> stmCache = ignite.getOrCreateCache(CacheConfig.wordCache());
+            // The cache is configured with sliding window holding 1 second of the streaming data.
+            try (IgniteCache<AffinityUuid, String> stmCache = ignite.getOrCreateCache(cfg)) {
 
-        IgniteDataStreamer<AffinityUuid, String> stmr = ignite.dataStreamer(stmCache.getName());
+                IgniteDataStreamer<AffinityUuid, String> stmr = ignite.dataStreamer(stmCache.getName());
 
-        InetAddress addr = InetAddress.getLocalHost();
+                InetAddress addr = InetAddress.getLocalHost();
 
-        // Configure socket streamer
-        SocketStreamer<String, AffinityUuid, String> sockStmr = new SocketStreamer<>();
+                // Configure socket streamer
+                SocketStreamer<String, AffinityUuid, String> sockStmr = new SocketStreamer<>();
 
-        sockStmr.setAddr(addr);
+                sockStmr.setAddr(addr);
 
-        sockStmr.setPort(PORT);
+                sockStmr.setPort(PORT);
 
-        sockStmr.setDelimiter(DELIM);
+                sockStmr.setDelimiter(DELIM);
 
-        sockStmr.setIgnite(ignite);
+                sockStmr.setIgnite(ignite);
 
-        sockStmr.setStreamer(stmr);
+                sockStmr.setStreamer(stmr);
 
-        // Converter from zero-terminated string to Java strings.
-        sockStmr.setConverter(new SocketMessageConverter<String>() {
-            @Override public String convert(byte[] msg) {
-                try {
-                    return new String(msg, "ASCII");
-                }
-                catch (UnsupportedEncodingException e) {
-                    throw new IgniteException(e);
-                }
+                // Converter from zero-terminated string to Java strings.
+                sockStmr.setConverter(new SocketMessageConverter<String>() {
+                    @Override public String convert(byte[] msg) {
+                        try {
+                            return new String(msg, "ASCII");
+                        }
+                        catch (UnsupportedEncodingException e) {
+                            throw new IgniteException(e);
+                        }
+                    }
+                });
+
+                sockStmr.setSingleTupleExtractor(new StreamSingleTupleExtractor<String, AffinityUuid, String>() {
+                    @Override public Map.Entry<AffinityUuid, String> extract(String word) {
+                        // By using AffinityUuid we ensure that identical
+                        // words are processed on the same cluster node.
+                        return new IgniteBiTuple<>(new AffinityUuid(word), word);
+                    }
+                });
+
+                sockStmr.start();
             }
-        });
+            catch (IgniteException e) {
+                System.err.println("Streaming server didn't start due to an error: ");
 
-        sockStmr.setSingleTupleExtractor(new StreamSingleTupleExtractor<String, AffinityUuid, String>() {
-            @Override public Map.Entry<AffinityUuid, String> extract(String word) {
-                // By using AffinityUuid we ensure that identical
-                // words are processed on the same cluster node.
-                return new IgniteBiTuple<>(new AffinityUuid(word), word);
+                e.printStackTrace();
             }
-        });
-
-        try {
-            sockStmr.start();
-        }
-        catch (IgniteException e) {
-            System.err.println("Streaming server didn't start due to an error: ");
-
-            e.printStackTrace();
-
-            ignite.close();
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(cfg.getName());
+            }
         }
     }
 }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAffinityExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAffinityExample.java
@@ -66,6 +66,7 @@ public final class CacheAffinityExample {
             cfg.setCacheMode(CacheMode.PARTITIONED);
             cfg.setName(CACHE_NAME);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(cfg)) {
                 for (int i = 0; i < KEY_CNT; i++)
                     cache.put(i, Integer.toString(i));
@@ -77,6 +78,7 @@ public final class CacheAffinityExample {
                 visitUsingMapKeysToNodes();
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAffinityExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAffinityExample.java
@@ -76,6 +76,9 @@ public final class CacheAffinityExample {
                 // Co-locates jobs with data using IgniteCluster.mapKeysToNodes(...) method.
                 visitUsingMapKeysToNodes();
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheApiExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheApiExample.java
@@ -55,11 +55,13 @@ public class CacheApiExample {
             cfg.setCacheMode(CacheMode.PARTITIONED);
             cfg.setName(CACHE_NAME);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(cfg)) {
                 // Demonstrate atomic map operations.
                 atomicMapOperations(cache);
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheApiExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheApiExample.java
@@ -59,6 +59,9 @@ public class CacheApiExample {
                 // Demonstrate atomic map operations.
                 atomicMapOperations(cache);
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAsyncApiExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAsyncApiExample.java
@@ -57,6 +57,7 @@ public class CacheAsyncApiExample {
             cfg.setCacheMode(CacheMode.PARTITIONED);
             cfg.setName(CACHE_NAME);
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(cfg)) {
                 // Enable asynchronous mode.
                 IgniteCache<Integer, String> asyncCache = cache.withAsync();
@@ -81,6 +82,7 @@ public class CacheAsyncApiExample {
                     System.out.println("Get operation completed [value=" + fut.get() + ']'));
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAsyncApiExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheAsyncApiExample.java
@@ -80,6 +80,9 @@ public class CacheAsyncApiExample {
                 asyncCache.<String>future().listen(fut ->
                     System.out.println("Get operation completed [value=" + fut.get() + ']'));
             }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheEntryProcessorExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheEntryProcessorExample.java
@@ -76,6 +76,10 @@ public class CacheEntryProcessorExample {
                 // Demonstrates usage of EntryProcessor.invokeAll(...) method.
                 incrementEntriesWithInvokeAll(cache);
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
         }
     }
 

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheEntryProcessorExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/datagrid/CacheEntryProcessorExample.java
@@ -69,6 +69,7 @@ public class CacheEntryProcessorExample {
             System.out.println();
             System.out.println(">>> Entry processor example started.");
 
+            // Auto-close cache at the end of the example.
             try (IgniteCache<Integer, Integer> cache = ignite.getOrCreateCache(CACHE_NAME)) {
                 // Demonstrates usage of EntryProcessor.invoke(...) method.
                 populateEntriesWithInvoke(cache);

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/streaming/StreamTransformerExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/streaming/StreamTransformerExample.java
@@ -100,6 +100,7 @@ public class StreamTransformerExample {
                 ExamplesUtils.printQueryResults(top10);
             }
             finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
                 ignite.destroyCache(CACHE_NAME);
             }
         }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/streaming/StreamTransformerExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/streaming/StreamTransformerExample.java
@@ -46,6 +46,9 @@ public class StreamTransformerExample {
     /** Range within which to generate numbers. */
     private static final int RANGE = 1000;
 
+    /** Cache name. */
+    private static final String CACHE_NAME = "randomNumbers";
+
     public static void main(String[] args) throws Exception {
         // Mark this cluster member as client.
         Ignition.setClientMode(true);
@@ -54,7 +57,7 @@ public class StreamTransformerExample {
             if (!ExamplesUtils.hasServerNodes(ignite))
                 return;
 
-            CacheConfiguration<Integer, Long> cfg = new CacheConfiguration<>("randomNumbers");
+            CacheConfiguration<Integer, Long> cfg = new CacheConfiguration<>(CACHE_NAME);
 
             // Index key and value.
             cfg.setIndexedTypes(Integer.class, Long.class);
@@ -95,6 +98,9 @@ public class StreamTransformerExample {
 
                 // Print top 10 words.
                 ExamplesUtils.printQueryResults(top10);
+            }
+            finally {
+                ignite.destroyCache(CACHE_NAME);
             }
         }
     }

--- a/examples/src/main/java8/org/apache/ignite/examples/java8/streaming/StreamVisitorExample.java
+++ b/examples/src/main/java8/org/apache/ignite/examples/java8/streaming/StreamVisitorExample.java
@@ -121,6 +121,11 @@ public class StreamVisitorExample {
                 // Print top 10 words.
                 ExamplesUtils.printQueryResults(top3);
             }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(mktDataCfg.getName());
+                ignite.destroyCache(instCfg.getName());
+            }
         }
     }
 


### PR DESCRIPTION
    IGNITE-2168
Examples should destroy created caches: SpringBeanExample fails after CacheBinaryAutoStoreExample