### PR TITLE
Created a property to create the caches automatically for hibernate

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
@@ -960,7 +960,8 @@ public class BinaryContext {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public static String typeName(String clsName) {
         assert clsName != null;
-
+        return clsName;
+        /*
         int idx = clsName.lastIndexOf('$');
 
         if (idx == clsName.length() - 1)
@@ -988,6 +989,7 @@ public class BinaryContext {
             idx = clsName.lastIndexOf('.');
 
         return idx >= 0 ? clsName.substring(idx + 1) : clsName;
+        */
     }
 
     /**

--- a/modules/hibernate/src/main/java/org/apache/ignite/cache/hibernate/HibernateRegionFactory.java
+++ b/modules/hibernate/src/main/java/org/apache/ignite/cache/hibernate/HibernateRegionFactory.java
@@ -84,6 +84,9 @@ public class HibernateRegionFactory implements RegionFactory {
     /** */
     public static final String GRID_CONFIG_PROPERTY = "org.apache.ignite.hibernate.grid_config";
 
+    /** */
+    public static final String AUTO_CREATE_CACHE_PROPERTY = "org.apache.ignite.hibernate.auto_create_cache";
+
     /** Grid providing caches. */
     private Ignite ignite;
 
@@ -95,6 +98,8 @@ public class HibernateRegionFactory implements RegionFactory {
 
     /** Region name to cache name mapping. */
     private final Map<String, String> regionCaches = new HashMap<>();
+
+    private boolean autoCreateCache = true;
 
     /** Map needed to provide the same transaction context for different regions. */
     private final ThreadLocal threadLoc = new ThreadLocal();
@@ -143,6 +148,9 @@ public class HibernateRegionFactory implements RegionFactory {
             if (dfltCache == null)
                 throw new CacheException("Cache specified as default is not configured: " + dfltCacheName);
         }
+
+        if (props.get(AUTO_CREATE_CACHE_PROPERTY) != null)
+            autoCreateCache = (boolean) props.get(AUTO_CREATE_CACHE_PROPERTY);
 
         IgniteLogger log = ignite.log().getLogger(HibernateRegionFactory.class);
 
@@ -222,6 +230,9 @@ public class HibernateRegionFactory implements RegionFactory {
 
             cacheName = regionName;
         }
+
+        if ((autoCreateCache) && (ignite.cache(cacheName) == null))
+            ignite.createCache(cacheName);
 
         IgniteInternalCache<Object, Object> cache = ((IgniteKernal)ignite).getCache(cacheName);
 


### PR DESCRIPTION
Created a property to create the caches automatically for hibernate, default is true. This is the default behavior for ehCache, Hazelcast and others.

In BinaryContext.typeName(String) returning the complete class name, this avoid duplicated names and errors such as org.apache.ignite.IgniteCheckedException: Duplicate ID [id=1199319121, oldCls=org.hibernate.type.descriptor.sql.BooleanTypeDescriptor, newCls=org.hibernate.type.descriptor.java.BooleanTypeDescriptor.

I made the same change for branch 1.5.1-2 too https://github.com/apache/ignite/pull/388, which I'm testing.
