### PR TITLE
fix IGNITE-2650

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -97,6 +97,7 @@ import org.apache.ignite.internal.processors.cache.store.CacheStoreManager;
 import org.apache.ignite.internal.processors.cache.transactions.IgniteTransactionsImpl;
 import org.apache.ignite.internal.processors.cache.transactions.IgniteTxManager;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersionManager;
+import org.apache.ignite.internal.processors.cache.GridCacheUtils;
 import org.apache.ignite.internal.processors.cacheobject.IgniteCacheObjectProcessor;
 import org.apache.ignite.internal.processors.plugin.CachePluginManager;
 import org.apache.ignite.internal.processors.query.GridQueryProcessor;
@@ -2264,6 +2265,17 @@ public class GridCacheProcessor extends GridProcessorAdapter {
             req.deploymentId(desc.deploymentId());
             req.startCacheConfiguration(ccfg);
         }
+
+        /**
+         * Fail cache with swap enabled creation on grid without swap space SPI.
+         */
+        if( ccfg.isSwapEnabled())
+            for (ClusterNode n : ctx.discovery().allNodes())
+                if(!GridCacheUtils.clientNode(n))
+                    if(!GridCacheUtils.isSwapEnabled(n))
+                        return new GridFinishedFuture<>(new IgniteCheckedException("Failed to start cache " +
+                            cacheName + " with swap enabled: Remote Node with ID " + n.id().toString().toUpperCase() +
+                            " has not swap SPI configured"));
 
         if (nearCfg != null)
             req.nearCacheConfiguration(nearCfg);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
@@ -90,6 +90,7 @@ import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.lang.IgniteReducer;
 import org.apache.ignite.lifecycle.LifecycleAware;
 import org.apache.ignite.plugin.CachePluginConfiguration;
+import org.apache.ignite.spi.swapspace.noop.NoopSwapSpaceSpi;
 import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionConcurrency;
 import org.apache.ignite.transactions.TransactionIsolation;
@@ -282,6 +283,9 @@ public class GridCacheUtils {
             return "Cache extended entry to key converter.";
         }
     };
+
+    private static final String NOOP_SWAP_SPACE_SPI_ATTR_NAME = U.spiAttribute(new NoopSwapSpaceSpi(),
+        IgniteNodeAttributes.ATTR_SPI_CLASS);
 
     /**
      * Ensure singleton.
@@ -1835,5 +1839,15 @@ public class GridCacheUtils {
         }
 
         return res;
+    }
+
+    /**
+     * Checks if swap is enabled on node.
+     *
+     * @param node Node
+     * @return {@code true} if swap is enabled, {@code false} otherwise.
+     */
+    public static boolean isSwapEnabled(ClusterNode node) {
+        return !node.attributes().containsKey(NOOP_SWAP_SPACE_SPI_ATTR_NAME);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/IgniteSpiConsistencyChecked.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/IgniteSpiConsistencyChecked.java
@@ -40,4 +40,12 @@ public @interface IgniteSpiConsistencyChecked {
      */
     @SuppressWarnings("JavaDoc")
     public boolean optional();
+
+    /**
+     * If false, skip consistency checks for client cluster nodes. Could be useful
+     * for SwapSpaceSpi for example, since client nodes has no data at all, so they
+     * don't need to be consistent with server nodes.
+     */
+    @SuppressWarnings("JavaDoc")
+    public boolean checkClient() default true;
 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/swapspace/file/FileSwapSpaceSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/swapspace/file/FileSwapSpaceSpi.java
@@ -61,6 +61,7 @@ import org.apache.ignite.resources.LoggerResource;
 import org.apache.ignite.spi.IgniteSpiAdapter;
 import org.apache.ignite.spi.IgniteSpiCloseableIterator;
 import org.apache.ignite.spi.IgniteSpiConfiguration;
+import org.apache.ignite.spi.IgniteSpiConsistencyChecked;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.IgniteSpiMultipleInstancesSupport;
 import org.apache.ignite.spi.IgniteSpiThread;
@@ -137,6 +138,7 @@ import static org.apache.ignite.events.EventType.EVT_SWAP_SPACE_DATA_STORED;
  * @see org.apache.ignite.spi.swapspace.SwapSpaceSpi
  */
 @IgniteSpiMultipleInstancesSupport(true)
+@IgniteSpiConsistencyChecked(optional = false, checkClient = false)
 @SuppressWarnings({"PackageVisibleInnerClass", "PackageVisibleField"})
 public class FileSwapSpaceSpi extends IgniteSpiAdapter implements SwapSpaceSpi, FileSwapSpaceSpiMBean {
     /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/swapspace/noop/NoopSwapSpaceSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/swapspace/noop/NoopSwapSpaceSpi.java
@@ -30,6 +30,7 @@ import org.apache.ignite.lang.IgniteInClosure;
 import org.apache.ignite.resources.LoggerResource;
 import org.apache.ignite.spi.IgniteSpiAdapter;
 import org.apache.ignite.spi.IgniteSpiCloseableIterator;
+import org.apache.ignite.spi.IgniteSpiConsistencyChecked;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.IgniteSpiMultipleInstancesSupport;
 import org.apache.ignite.spi.IgniteSpiNoop;
@@ -44,6 +45,7 @@ import org.jetbrains.annotations.Nullable;
  */
 @IgniteSpiNoop
 @IgniteSpiMultipleInstancesSupport(true)
+@IgniteSpiConsistencyChecked(optional = false, checkClient = false)
 public class NoopSwapSpaceSpi extends IgniteSpiAdapter implements SwapSpaceSpi {
     /** Logger. */
     @LoggerResource

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheSwapSpaceSpiConsistencySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheSwapSpaceSpiConsistencySelfTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+
+import java.util.concurrent.Callable;
+import javax.cache.CacheException;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.spi.swapspace.file.FileSwapSpaceSpi;
+import org.apache.ignite.spi.swapspace.noop.NoopSwapSpaceSpi;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.apache.ignite.testframework.junits.common.GridCommonTest;
+
+/**
+ * Check creation of cache with swap space enabled on grids with and without swap space spi
+ */
+@SuppressWarnings({"ProhibitedExceptionDeclared"})
+@GridCommonTest(group = "Kernal")
+public class GridCacheSwapSpaceSpiConsistencySelfTest extends GridCommonAbstractTest {
+
+    protected static final String GRID_WITHOUT_SWAP_SPACE = "grid-without-swap-space";
+
+    protected static final String GRID_WITH_SWAP_SPACE = "grid-with-swap-space";
+
+    protected static final String GRID_CLIENT = "grid-client";
+
+    protected static final String CACHE_NAME = "TestCache";
+
+    public GridCacheSwapSpaceSpiConsistencySelfTest() {
+        super(false);
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings({"unchecked"})
+    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(gridName);
+
+        if (GRID_WITHOUT_SWAP_SPACE.equals(gridName))
+            cfg.setSwapSpaceSpi(new NoopSwapSpaceSpi());
+
+        if (GRID_WITH_SWAP_SPACE.equals(gridName))
+            cfg.setSwapSpaceSpi(new FileSwapSpaceSpi());
+
+        if (GRID_CLIENT.equals(gridName))
+            cfg.setClientMode(true);
+
+        return cfg;
+    }
+
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+    }
+
+    /**
+     * It should be impossible to create cache with swap enabled on grid without swap
+     */
+    public void testInconsistentCacheCreation() throws Exception {
+        startGrid(GRID_WITHOUT_SWAP_SPACE);
+
+        final Ignite gclnt = startGrid(GRID_CLIENT);
+
+        final CacheConfiguration<Integer, String> ccfg = new CacheConfiguration<>();
+
+        ccfg.setSwapEnabled(true);
+        ccfg.setName(CACHE_NAME);
+
+        GridTestUtils.assertThrows(log, new Callable<Object>() {
+            @Override public Object call() throws Exception {
+                return gclnt.createCache(ccfg);
+            }
+        }, CacheException.class, "Failed to start cache " + CACHE_NAME + " with swap enabled:");
+    }
+
+    /**
+     * It should ok to create cache with swap enabled on grid with swap
+     */
+    public void testConsistentCacheCreation() throws Exception {
+        startGrid(GRID_WITH_SWAP_SPACE);
+
+        final Ignite gclnt = startGrid(GRID_CLIENT);
+
+        final CacheConfiguration<Integer, String> ccfg = new CacheConfiguration<>();
+
+        ccfg.setSwapEnabled(true);
+        ccfg.setName(CACHE_NAME);
+
+        IgniteCache<Integer,String> cache = gclnt.createCache(ccfg);
+
+        cache.put(1, "one");
+
+        assert cache.get(1).equals("one");
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/spi/swapspace/GridSwapSpaceSpiConsistencySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/swapspace/GridSwapSpaceSpiConsistencySelfTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.spi.swapspace;
+
+
+import java.io.StringWriter;
+import java.util.concurrent.Callable;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.spi.swapspace.file.FileSwapSpaceSpi;
+import org.apache.ignite.spi.swapspace.noop.NoopSwapSpaceSpi;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.apache.ignite.testframework.junits.common.GridCommonTest;
+import org.apache.log4j.Layout;
+import org.apache.log4j.Logger;
+import org.apache.log4j.SimpleLayout;
+import org.apache.log4j.WriterAppender;
+
+/**
+ * Check that all server nodes in grid have configured the same swap space spi.
+ * Check that client nodes could have any swap space spi.
+ */
+@SuppressWarnings({"ProhibitedExceptionDeclared"})
+public class GridSwapSpaceSpiConsistencySelfTest extends GridCommonAbstractTest {
+
+    protected static final String GRID_WITHOUT_SWAP_SPACE = "grid-without-swap-space";
+
+    protected static final String GRID_WITH_SWAP_SPACE = "grid-with-swap-space";
+
+    protected static final String GRID_CLIENT_WITHOUT_SWAP_SPACE = "grid-client-without-swap-space";
+
+    protected static final String GRID_CLIENT_WITH_SWAP_SPACE = "grid-client-with-swap-space";
+
+    protected static final String CACHE_NAME = "TestCache";
+
+    public GridSwapSpaceSpiConsistencySelfTest() {
+        super(false);
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings({"unchecked"})
+    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(gridName);
+
+        if (GRID_WITHOUT_SWAP_SPACE.equals(gridName))
+            cfg.setSwapSpaceSpi(new NoopSwapSpaceSpi());
+
+        if (GRID_WITH_SWAP_SPACE.equals(gridName))
+            cfg.setSwapSpaceSpi(new FileSwapSpaceSpi());
+
+        if (GRID_CLIENT_WITHOUT_SWAP_SPACE.equals(gridName)) {
+            cfg.setClientMode(true);
+            cfg.setSwapSpaceSpi(new NoopSwapSpaceSpi());
+        }
+
+        if (GRID_CLIENT_WITH_SWAP_SPACE.equals(gridName)) {
+            cfg.setClientMode(true);
+            cfg.setSwapSpaceSpi(new FileSwapSpaceSpi());
+        }
+
+        return cfg;
+    }
+
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+    }
+
+    /**
+     * Node with swap enabled should not start after node without swap
+     */
+    public void testServerNodeIncompatibleSwapSpaceSpi1() throws Exception {
+        startGrid(GRID_WITHOUT_SWAP_SPACE);
+
+        GridTestUtils.assertThrows(log, new Callable<Object>() {
+            @Override public Object call() throws Exception {
+                return startGrid(GRID_WITH_SWAP_SPACE);
+            }
+        }, IgniteCheckedException.class, "Failed to initialize SPI context");
+    }
+
+    /**
+     * Node without swap should not start after node with swap enabled
+     */
+    public void testServerNodeIncompatibleSwapSpaceSpi2() throws Exception {
+        startGrid(GRID_WITH_SWAP_SPACE);
+
+        GridTestUtils.assertThrows(log, new Callable<Object>() {
+            @Override public Object call() throws Exception {
+                return startGrid(GRID_WITHOUT_SWAP_SPACE);
+            }
+        }, IgniteCheckedException.class, "Failed to initialize SPI context");
+    }
+
+    /**
+     * Client nodes should join to grid with any swap policy
+     */
+    public void testClientNodeAnySwapSpaceSpi() throws Exception {
+        startGrid(GRID_WITHOUT_SWAP_SPACE);
+
+        Ignite gclnt1 = startGrid(GRID_CLIENT_WITH_SWAP_SPACE);
+
+        Ignite gclnt2 = startGrid(GRID_CLIENT_WITHOUT_SWAP_SPACE);
+
+        IgniteCache<Integer,String> cache1 = gclnt1.createCache("TestCache");
+
+        cache1.put(1, "one");
+
+        IgniteCache<Integer,String> cache2 = gclnt2.getOrCreateCache("TestCache");
+
+        assert cache2.get(1).equals("one");
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite5.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite5.java
@@ -20,6 +20,7 @@ package org.apache.ignite.testsuites;
 import junit.framework.TestSuite;
 import org.apache.ignite.internal.processors.cache.CacheNearReaderUpdateTest;
 import org.apache.ignite.internal.processors.cache.CacheSerializableTransactionsTest;
+import org.apache.ignite.internal.processors.cache.GridCacheSwapSpaceSpiConsistencySelfTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheStoreCollectionTest;
 import org.apache.ignite.internal.processors.cache.store.IgniteCacheWriteBehindNoUpdateSelfTest;
 
@@ -38,6 +39,7 @@ public class IgniteCacheTestSuite5 extends TestSuite {
         suite.addTestSuite(CacheNearReaderUpdateTest.class);
         suite.addTestSuite(IgniteCacheStoreCollectionTest.class);
         suite.addTestSuite(IgniteCacheWriteBehindNoUpdateSelfTest.class);
+        suite.addTestSuite(GridCacheSwapSpaceSpiConsistencySelfTest.class);
 
         return suite;
     }

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiSwapSpaceSelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiSwapSpaceSelfTestSuite.java
@@ -21,6 +21,7 @@ import junit.framework.TestSuite;
 import org.apache.ignite.spi.swapspace.file.GridFileSwapCompactionSelfTest;
 import org.apache.ignite.spi.swapspace.file.GridFileSwapSpaceSpiSelfTest;
 import org.apache.ignite.spi.swapspace.noop.GridNoopSwapSpaceSpiSelfTest;
+import org.apache.ignite.spi.swapspace.GridSwapSpaceSpiConsistencySelfTest;
 
 /**
  *
@@ -36,6 +37,7 @@ public class IgniteSpiSwapSpaceSelfTestSuite {
         suite.addTest(new TestSuite(GridFileSwapCompactionSelfTest.class));
         suite.addTest(new TestSuite(GridFileSwapSpaceSpiSelfTest.class));
         suite.addTest(new TestSuite(GridNoopSwapSpaceSpiSelfTest.class));
+        suite.addTest(new TestSuite(GridSwapSpaceSpiConsistencySelfTest.class));
 
         return suite;
     }


### PR DESCRIPTION
- Added checkClient to to IgniteSpiConsistencyChecked annotation with default value true.
  If it's false, than spi consistency will not be checked for client nodes.
- Added IgniteSpiConsistencyChecked to NoopSwapSpaceSpi and FileSwapSpaceSpi. That guaranties, that all nodes in grid will have the same swap space provider. Client nodes ignore this check, because clients don't have any data.
- Cache with swap creation will fail, if nodes in grid have NoopSwapSpaceSpi 
