### PR TITLE
IGNITE-2668

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -4323,7 +4323,7 @@ public abstract class IgniteUtils {
 
         cacheName = maskName(cacheName);
 
-        sb.a("group=").a(cacheName).a(',');
+        sb.a("group=").a('"').a(cacheName).a('"').a(',');
 
         sb.a("name=").a(name);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -253,6 +253,9 @@ import static org.apache.ignite.internal.util.GridUnsafe.staticFieldOffset;
  */
 @SuppressWarnings({"UnusedReturnValue", "UnnecessaryFullyQualifiedName"})
 public abstract class IgniteUtils {
+    /** Correct identifier pattern */
+    private static Pattern correctIdentifier = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
+
     /** {@code True} if {@code unsafe} should be used for array copy. */
     private static final boolean UNSAFE_BYTE_ARR_CP = unsafeByteArrayCopyAvailable();
 
@@ -4323,7 +4326,10 @@ public abstract class IgniteUtils {
 
         cacheName = maskName(cacheName);
 
-        sb.a("group=").a('"').a(cacheName).a('"').a(',');
+        if (!correctIdentifier.matcher(cacheName).matches())
+            cacheName = ObjectName.quote(cacheName);
+
+        sb.a("group=").a(cacheName).a(',');
 
         sb.a("name=").a(name);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheNamesWithSpecialCharactersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheNamesWithSpecialCharactersTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+
+import java.util.Collection;
+
+/**
+ * Test that validates {@link Ignite#cacheNames()} implementation.
+ */
+public class CacheNamesWithSpecialCharactersTest extends GridCommonAbstractTest {
+
+    public static final String CACHE_NAME_1 = "--№=+:(replicated)";
+    public static final String CACHE_NAME_2 = ":_&:: (partitioned)";
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(gridName);
+
+        CacheConfiguration cacheCfg1 = new CacheConfiguration();
+        cacheCfg1.setCacheMode(CacheMode.REPLICATED);
+        cacheCfg1.setName(CACHE_NAME_1);
+
+        CacheConfiguration cacheCfg2 = new CacheConfiguration();
+        cacheCfg2.setCacheMode(CacheMode.PARTITIONED);
+        cacheCfg2.setName(CACHE_NAME_2);
+
+        cfg.setCacheConfiguration(cacheCfg1, cacheCfg2);
+
+        return cfg;
+    }
+
+    /**
+     * @throws Exception In case of failure.
+     */
+    public void testCacheNames() throws Exception {
+        try {
+            startGridsMultiThreaded(2);
+
+            Collection<String> names = grid(0).cacheNames();
+
+            assertEquals(2, names.size());
+
+            for (String name : names)
+                assertTrue(name.equals(CACHE_NAME_1) || name.equals(CACHE_NAME_2));
+        }
+        finally {
+            stopAllGrids();
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite.java
@@ -40,6 +40,7 @@ import org.apache.ignite.internal.processors.cache.CacheDeferredDeleteSanitySelf
 import org.apache.ignite.internal.processors.cache.CacheEntryProcessorCopySelfTest;
 import org.apache.ignite.internal.processors.cache.CacheFutureExceptionSelfTest;
 import org.apache.ignite.internal.processors.cache.CacheNamesSelfTest;
+import org.apache.ignite.internal.processors.cache.CacheNamesWithSpecialCharactersTest;
 import org.apache.ignite.internal.processors.cache.CachePutEventListenerErrorSelfTest;
 import org.apache.ignite.internal.processors.cache.GridCacheAffinityApiSelfTest;
 import org.apache.ignite.internal.processors.cache.GridCacheAffinityMapperSelfTest;
@@ -216,6 +217,7 @@ public class IgniteCacheTestSuite extends TestSuite {
 
         // Common tests.
         suite.addTestSuite(CacheNamesSelfTest.class);
+        suite.addTestSuite(CacheNamesWithSpecialCharactersTest.class);
         suite.addTestSuite(GridCacheConcurrentMapSelfTest.class);
         suite.addTestSuite(GridCacheAffinityMapperSelfTest.class);
         suite.addTestSuite(CacheAffinityCallSelfTest.class);


### PR DESCRIPTION
MBean creation fails if cache name contains ':' character
Write attribute, which contains cache name, in quote