### PR TITLE
GG-11005 - NPE on start sender hub. Fix.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -895,10 +895,6 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
             // Notify IO manager the second so further components can send and receive messages.
             ctx.io().onKernalStart();
 
-            // Start plugins.
-            for (PluginProvider provider : ctx.plugins().allProviders())
-                provider.onIgniteStart();
-
             // Callbacks.
             for (GridComponent comp : ctx) {
                 // Skip discovery manager.
@@ -915,6 +911,10 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                 if (!skipDaemon(comp))
                     comp.onKernalStart();
             }
+
+            // Start plugins.
+            for (PluginProvider provider : ctx.plugins().allProviders())
+                provider.onIgniteStart();
 
             // Register MBeans.
             registerKernalMBean();


### PR DESCRIPTION
Changed initialization order of plugins and components. Plugins inited after component, because they depend on components.
