### PR TITLE
IGNITE-2970 .NET: Fix CompiledQuery parameter validation

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
@@ -855,7 +855,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var cache = GetPersonCache().AsCacheQueryable();
 
             // const args are not allowed
-            Assert.Throws<InvalidOperationException>(()=>CompiledQuery.Compile(() => cache.Where(x => x.Key < 5)));
+            Assert.Throws<InvalidOperationException>(() => CompiledQuery.Compile(() => cache.Where(x => x.Key < 5)));
 
             // 0 arg
             var qry0 = CompiledQuery.Compile(() => cache.Select(x => x.Value.Name));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
@@ -876,6 +876,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 CompiledQuery.Compile((string s, int i) => cache.Where(x => x.Key < i && x.Value.Name.StartsWith(s)));
             Assert.AreEqual(5, qry2R(" Pe", 5).ToArray().Length);
 
+            // Changed param order and constants
+            var qry2Rc = CompiledQuery.Compile(
+                    (string s, int i) => cache.Where(x => x.Key < i && x.Key > -5 && x.Value.Name.StartsWith(s)));
+            Assert.AreEqual(5, qry2Rc(" Pe", 5).ToArray().Length);
+
             // 3 arg
             var qry3 = CompiledQuery.Compile((int i, string s, double d) => 
                 cache.Where(x => x.Value.Address.Zip > d && x.Key < i && x.Value.Name.Contains(s)));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
@@ -856,7 +856,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
             // const args
             var qry = CompiledQuery.Compile(() => cache.Where(x => x.Key < 5 && x.Key > -10));
-            Assert.AreEqual(4, qry().GetAll().Count);
+            Assert.AreEqual(5, qry().GetAll().Count);
 
             // 0 arg
             var qry0 = CompiledQuery.Compile(() => cache.Select(x => x.Value.Name));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
@@ -854,9 +854,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         {
             var cache = GetPersonCache().AsCacheQueryable();
 
-            // const args
-            var qry = CompiledQuery.Compile(() => cache.Where(x => x.Key < 5 && x.Key > -10));
-            Assert.AreEqual(5, qry().GetAll().Count);
+            // const args are not allowed
+            Assert.Throws<InvalidOperationException>(()=>CompiledQuery.Compile(() => cache.Where(x => x.Key < 5)));
 
             // 0 arg
             var qry0 = CompiledQuery.Compile(() => cache.Select(x => x.Value.Name));
@@ -875,11 +874,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var qry2R =
                 CompiledQuery.Compile((string s, int i) => cache.Where(x => x.Key < i && x.Value.Name.StartsWith(s)));
             Assert.AreEqual(5, qry2R(" Pe", 5).ToArray().Length);
-
-            // Changed param order and constants
-            var qry2Rc = CompiledQuery.Compile(
-                    (string s, int i) => cache.Where(x => x.Key < i && x.Key > -5 && x.Value.Name.StartsWith(s)));
-            Assert.AreEqual(5, qry2Rc(" Pe", 5).ToArray().Length);
 
             // 3 arg
             var qry3 = CompiledQuery.Compile((int i, string s, double d) => 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheLinqTest.cs
@@ -854,6 +854,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         {
             var cache = GetPersonCache().AsCacheQueryable();
 
+            // const args
+            var qry = CompiledQuery.Compile(() => cache.Where(x => x.Key < 5 && x.Key > -10));
+            Assert.AreEqual(4, qry().GetAll().Count);
+
             // 0 arg
             var qry0 = CompiledQuery.Compile(() => cache.Select(x => x.Value.Name));
             Assert.AreEqual(PersonCount, qry0().ToArray().Length);

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/CompiledQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/CompiledQuery.cs
@@ -41,7 +41,7 @@ namespace Apache.Ignite.Linq
         {
             IgniteArgumentCheck.NotNull(query, "query");
 
-            var compiledQuery = GetCompiledQuery(query(), null);
+            var compiledQuery = GetCompiledQuery(query(), query);
 
             return () => compiledQuery(new object[0]);
         }
@@ -191,6 +191,7 @@ namespace Apache.Ignite.Linq
         private static Func<object[], IQueryCursor<T>> GetCompiledQuery<T>(IQueryable<T> queryable, 
             Delegate queryCaller)
         {
+            Debug.Assert(queryCaller != null);
             var cacheQueryable = queryable as ICacheQueryableInternal;
 
             if (cacheQueryable == null)

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/CompiledQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/CompiledQuery.cs
@@ -57,7 +57,7 @@ namespace Apache.Ignite.Linq
         {
             IgniteArgumentCheck.NotNull(query, "query");
 
-            var compiledQuery = GetCompiledQuery(query(default(T1)), null);
+            var compiledQuery = GetCompiledQuery(query(default(T1)), query);
 
             return x => compiledQuery(new object[] {x});
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -105,17 +105,13 @@ namespace Apache.Ignite.Linq.Impl
         public Func<object[], IQueryCursor<T>> CompileQuery<T>(QueryModel queryModel, Delegate queryCaller)
         {
             Debug.Assert(queryModel != null);
+            Debug.Assert(queryCaller != null);
 
             var qryData = GetQueryData(queryModel);
 
             var qryText = qryData.QueryText;
 
-            var qryArgs = qryData.Parameters.ToArray();
-
             var selector = GetResultSelector<T>(queryModel.SelectClause.Selector);
-
-            if (queryCaller == null)
-                return args => _cache.QueryFields(new SqlFieldsQuery(qryText, _local, qryArgs), selector);
 
             // Compiled query is a delegate with query parameters
             // Delegate parameters order and query parameters order may differ

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -110,10 +110,12 @@ namespace Apache.Ignite.Linq.Impl
 
             var qryText = qryData.QueryText;
 
+            var qryArgs = qryData.Parameters.ToArray();
+
             var selector = GetResultSelector<T>(queryModel.SelectClause.Selector);
 
             if (queryCaller == null)
-                return args => _cache.QueryFields(new SqlFieldsQuery(qryText, _local, args), selector);
+                return args => _cache.QueryFields(new SqlFieldsQuery(qryText, _local, qryArgs), selector);
 
             // Compiled query is a delegate with query parameters
             // Delegate parameters order and query parameters order may differ

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -126,7 +126,7 @@ namespace Apache.Ignite.Linq.Impl
             if ((qryOrderParams.Count != qryData.Parameters.Count) ||
                 (qryOrderParams.Count != userOrderParams.Count))
                 throw new InvalidOperationException("Error compiling query: all compiled query arguments " +
-                                                    "should come from enclosing lambda expression");
+                                                    "should come from enclosing delegate parameters.");
 
             var indices = qryOrderParams.Select(x => userOrderParams.IndexOf(x)).ToArray();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheQueryExpressionVisitor.cs
@@ -402,7 +402,6 @@ namespace Apache.Ignite.Linq.Impl
         protected override Expression VisitConstant(ConstantExpression expression)
         {
             AppendParameter(expression.Value);
-            _modelVisitor.ParameterExpressions.Add(expression);
 
             return expression;
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheQueryExpressionVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheQueryExpressionVisitor.cs
@@ -402,6 +402,7 @@ namespace Apache.Ignite.Linq.Impl
         protected override Expression VisitConstant(ConstantExpression expression)
         {
             AppendParameter(expression.Value);
+            _modelVisitor.ParameterExpressions.Add(expression);
 
             return expression;
         }


### PR DESCRIPTION
All CompiledQuery parameters must come from the enclosing func arguments.
Constants are not allowed. There was a shortcut for zero and one arg compiled query that excluded the validation.