### PR TITLE
IGNITE-3035 Postgres mssql JDBC discovery fix

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/jdbc/TcpDiscoveryJdbcIpFinder.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/jdbc/TcpDiscoveryJdbcIpFinder.java
@@ -76,8 +76,10 @@ public class TcpDiscoveryJdbcIpFinder extends TcpDiscoveryIpFinderAdapter {
             + "\" where hostname = ? and port = ?";
 
     /** Query to create addresses table. */
-    public static final String CREATE_ADDRS_TABLE_QRY = "create table \"" + ADDRS_TABLE_NAME
-            + "\" (hostname VARCHAR(1024), port INT)";
+    public static final String CREATE_ADDRS_TABLE_QRY =
+        "create table \"" + ADDRS_TABLE_NAME + "\" (" +
+        "hostname VARCHAR(1024), " +
+        "port INT)";
 
     /** Query to check database validity. */
     public static final String CHK_QRY = "select count(*) from \"" + ADDRS_TABLE_NAME + "\"";

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/jdbc/TcpDiscoveryJdbcIpFinder.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/jdbc/TcpDiscoveryJdbcIpFinder.java
@@ -64,22 +64,23 @@ public class TcpDiscoveryJdbcIpFinder extends TcpDiscoveryIpFinderAdapter {
     public static final String ADDRS_TABLE_NAME = "TBL_ADDRS";
     
     /** Query to get addresses. */
-    public static final String GET_ADDRS_QRY = "select hostname, port from tbl_addrs";
+    public static final String GET_ADDRS_QRY = "select hostname, port from \"" + ADDRS_TABLE_NAME
+            + "\"";
 
     /** Query to register address. */
-    public static final String REG_ADDR_QRY = "insert into tbl_addrs values (?, ?)";
+    public static final String REG_ADDR_QRY = "insert into \"" + ADDRS_TABLE_NAME
+            + "\" values (?, ?)";
 
     /** Query to unregister address. */
-    public static final String UNREG_ADDR_QRY = "delete from tbl_addrs where hostname = ? and port = ?";
+    public static final String UNREG_ADDR_QRY = "delete from \"" + ADDRS_TABLE_NAME
+            + "\" where hostname = ? and port = ?";
 
     /** Query to create addresses table. */
-    public static final String CREATE_ADDRS_TABLE_QRY =
-        "create table tbl_addrs (" +
-        "hostname VARCHAR(1024), " +
-        "port INT)";
+    public static final String CREATE_ADDRS_TABLE_QRY = "create table \"" + ADDRS_TABLE_NAME
+            + "\" (hostname VARCHAR(1024), port INT)";
 
     /** Query to check database validity. */
-    public static final String CHK_QRY = "select count(*) from tbl_addrs";
+    public static final String CHK_QRY = "select count(*) from \"" + ADDRS_TABLE_NAME + "\"";
 
     /** Grid logger. */
     @LoggerResource


### PR DESCRIPTION
Updated the TcpDiscoveryJdbcIpFinder class to work with Postgres and Microsoft SQL Server while maintaining the fix for Oracle databases introduced with IGNITE-1993.  

The issue stemmed from the fact that the DatabaseMetaData.getTables(...) table name value has to be upper case for Oracle, but ran case sensitively for other databases such as Postgres.  This meant the TcpDiscoveryJdbcIpFinder  always failed to correctly determine if the "TBL_ADDRS" table already existed before trying and failing to create it again.  The table creation failures caused an aborted transaction and subsequent SQL queries to fail with "ERROR: current transaction is aborted, commands ignored until end of transaction block". 

The fix is to create the and table in the database in upper case.