### PR TITLE
Correct cluster misses aggregation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsSnapshot.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsSnapshot.java
@@ -353,7 +353,7 @@ public class CacheMetricsSnapshot implements CacheMetrics, Externalizable {
             reads += e.getCacheGets();
             puts += e.getCachePuts();
             hits += e.getCacheHits();
-            misses += e.getCacheHits();
+            misses += e.getCacheMisses();
             txCommits += e.getCacheTxCommits();
             txRollbacks += e.getCacheTxRollbacks();
             evicts += e.getCacheEvictions();


### PR DESCRIPTION
When merging metrics from a cluster, node hits instead of node misses were being aggregated into merged misses.  Thus for clusters the CacheMetrics were reporting the same value for both hits and misses.