### PR TITLE
Cluster metrics should merge remote size and key size

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsSnapshot.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsSnapshot.java
@@ -354,6 +354,8 @@ public class CacheMetricsSnapshot implements CacheMetrics, Externalizable {
             puts += e.getCachePuts();
             hits += e.getCacheHits();
             misses += e.getCacheHits();
+            size += e.getSize();
+            keySize += e.getKeySize();
             txCommits += e.getCacheTxCommits();
             txRollbacks += e.getCacheTxRollbacks();
             evicts += e.getCacheEvictions();


### PR DESCRIPTION
CacheMetric for a cluster was not aggregating remote getSize() and getKeySize() values.  Thus the aggregate CacheMetric would report only the local node's values.  When local node is in client mode, this would always be zero.
