### PR TITLE
Filter client nodes when loading caches

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
@@ -3688,14 +3688,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
      */
     IgniteInternalFuture<?> globalLoadCacheAsync(@Nullable IgniteBiPredicate<K, V> p, @Nullable Object... args)
         throws IgniteCheckedException {
-        ClusterGroup oldNodes = ctx.kernalContext().grid().cluster().forCacheNodes(ctx.name())
+        ClusterGroup oldNodes = ctx.kernalContext().grid().cluster().forDataNodes(ctx.name())
             .forPredicate(new IgnitePredicate<ClusterNode>() {
                 @Override public boolean apply(ClusterNode node) {
                     return node.version().compareToIgnoreTimestamp(LOAD_CACHE_JOB_SINCE) < 0;
                 }
             });
 
-        ClusterGroup newNodes = ctx.kernalContext().grid().cluster().forCacheNodes(ctx.name())
+        ClusterGroup newNodes = ctx.kernalContext().grid().cluster().forDataNodes(ctx.name())
             .forPredicate(new IgnitePredicate<ClusterNode>() {
                 @Override public boolean apply(ClusterNode node) {
                     return node.version().compareToIgnoreTimestamp(LOAD_CACHE_JOB_SINCE) >= 0 &&
@@ -3703,7 +3703,7 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
                 }
             });
 
-        ClusterGroup newNodesV2 = ctx.kernalContext().grid().cluster().forCacheNodes(ctx.name())
+        ClusterGroup newNodesV2 = ctx.kernalContext().grid().cluster().forDataNodes(ctx.name())
             .forPredicate(new IgnitePredicate<ClusterNode>() {
                 @Override public boolean apply(ClusterNode node) {
                     return node.version().compareToIgnoreTimestamp(LOAD_CACHE_JOB_V2_SINCE) >= 0;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxy.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxy.java
@@ -374,10 +374,18 @@ public class IgniteCacheProxy<K, V> extends AsyncSupportAdapter<IgniteCache<K, V
             CacheOperationContext prev = onEnter(gate, opCtx);
 
             try {
-                if (isAsync())
-                    setFuture(ctx.cache().globalLoadCacheAsync(p, args));
-                else
-                    ctx.cache().globalLoadCache(p, args);
+                if (isAsync()) {
+                    if (ctx.cache().isLocal())
+                        setFuture(ctx.cache().localLoadCacheAsync(p, args));
+                    else
+                        setFuture(ctx.cache().globalLoadCacheAsync(p, args));
+                }
+                else {
+                    if (ctx.cache().isLocal())
+                        ctx.cache().localLoadCache(p, args);
+                    else
+                        ctx.cache().globalLoadCache(p, args);
+                }
             }
             finally {
                 onLeave(gate, prev);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheClientStoreSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheClientStoreSelfTest.java
@@ -17,17 +17,27 @@
 
 package org.apache.ignite.internal.processors.cache;
 
+import javax.cache.Cache;
 import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriterException;
 import javax.cache.processor.MutableEntry;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteIllegalStateException;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheEntryProcessor;
+import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.store.CacheStore;
+import org.apache.ignite.cache.store.CacheStoreAdapter;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.configuration.IgniteReflectionFactory;
 import org.apache.ignite.configuration.NearCacheConfiguration;
+import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteBiInClosure;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
@@ -36,7 +46,7 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_SKIP_CONFIGURATION_CONSISTENCY_CHECK;
 
 /**
- * Tests for cache client without store.
+ * Tests for cache client with and without store.
  */
 public class CacheClientStoreSelfTest extends GridCommonAbstractTest {
     /** */
@@ -204,6 +214,133 @@ public class CacheClientStoreSelfTest extends GridCommonAbstractTest {
     }
 
     /**
+     * Returns a cache configuration with TestStore as cache store and
+     * read through is enabled based on given params
+     *
+     * @param cacheName Name of the cache that configuration is for
+     * @param cacheMode Cache mode for the configuration
+     * @return
+     * @throws Exception
+     */
+    @SuppressWarnings("unchecked")
+    private  CacheConfiguration cacheConfiguration(String cacheName, CacheMode cacheMode) throws Exception {
+        CacheConfiguration cfg = defaultCacheConfiguration();
+
+        cfg.setName(cacheName);
+        cfg.setCacheMode(cacheMode);
+        cfg.setCacheStoreFactory(new Factory3());
+        cfg.setReadThrough(true);
+
+        return cfg;
+    }
+
+    /**
+     * Checks for if a grid with {clientName} is already exist and
+     * creates a grid as client if not
+     *
+     * @param clientName Name for the client grid
+     * @throws Exception
+     */
+    private void startClientGridIfNot(String clientName) throws Exception {
+        // Try to get grid with name clientName. Otherwise start one.
+        try {
+            grid(clientName);
+        } catch (IgniteIllegalStateException e) {
+            client = true;
+
+            startGrid(clientName);
+        }
+     }
+
+    /**
+     * Load cache created on client as LOCAL and see if it only loaded on client
+     *
+     * @throws Exception
+     */
+    public void testLocalLoadClient() throws Exception {
+        startClientGridIfNot("client-3");
+
+        CacheConfiguration localCache = cacheConfiguration("localCache1", CacheMode.LOCAL);
+        IgniteCache<Object, Object> cache = grid("client-3").createCache(localCache);
+        cache.loadCache(null);
+
+        assertEquals(cache.localSize(), 10) ;
+        assertEquals(grid(0).cache("localCache1").localSize(), 0) ;
+        assertEquals(grid(1).cache("localCache1").localSize(), 0) ;
+    }
+
+    /**
+     * Load cache from server that created on client as LOCAL and see if it only loaded on server
+     *
+     * @throws Exception
+     */
+    public void testLocalLoadServer() throws Exception {
+        startClientGridIfNot("client-3");
+
+        CacheConfiguration localCache = cacheConfiguration("localCache2", CacheMode.LOCAL);
+        grid("client-3").createCache(localCache);
+
+        IgniteCache<Object, Object> cache = grid(0).cache("localCache2");
+        cache.loadCache(null);
+
+        assertEquals(grid("client-3").cache("localCache2").localSize(), 0) ;
+        assertEquals(cache.localSize(), 10) ;
+    }
+
+    /**
+     * Load cache from client that created on server as LOCAL and see if it only loaded on client
+     *
+     * @throws Exception
+     */
+    public void testLocalLoadCreateServer() throws Exception {
+        startClientGridIfNot("client-3");
+
+        CacheConfiguration localCache = cacheConfiguration("localCache3", CacheMode.LOCAL);
+        grid(0).createCache(localCache);
+
+        IgniteCache<Object, Object> cache = grid("client-3").cache("localCache3");
+        cache.loadCache(null);
+
+        assertEquals(grid(0).cache("localCache3").localSize(), 0) ;
+        assertEquals(grid(1).cache("localCache3").localSize(), 0) ;
+        assertEquals(cache.localSize(), 10) ;
+    }
+
+    /**
+     * Load cache created on client as REPLICATED and see if it only loaded on servers
+     */
+    public void testReplicatedLoadFromClient() throws Exception {
+        startClientGridIfNot("client-3");
+
+        CacheConfiguration replicatedCache = cacheConfiguration("replicatedCache1", CacheMode.REPLICATED);
+        IgniteCache<Object, Object> cache = grid("client-3").createCache(replicatedCache);
+        cache.loadCache(null);
+
+        assertEquals(cache.localSize(), 0) ;
+        assertEquals(grid(0).cache("replicatedCache1").localSize()
+                + grid(1).cache("replicatedCache1").localSize(), 10) ;
+    }
+
+    /**
+     * Load cache created on server as REPLICATED and see if it only loaded on servers
+     *
+     * @throws Exception
+     */
+    public void testReplicatedLoadFromServer() throws Exception {
+        startClientGridIfNot("client-3");
+
+        CacheConfiguration replicatedCache = cacheConfiguration("replicatedCache2", CacheMode.REPLICATED);
+        grid(0).createCache(replicatedCache);
+
+        IgniteCache<Object, Object> cache = grid("client-3").cache("replicatedCache2");
+        cache.loadCache(null);
+
+        assertEquals(cache.localSize(), 0) ;
+        assertEquals(grid(0).cache("replicatedCache2").localSize()
+                + grid(1).cache("replicatedCache2").localSize(), 10) ;
+    }
+
+    /**
      */
     private static class Factory1 implements Factory<CacheStore> {
         /** {@inheritDoc} */
@@ -223,9 +360,44 @@ public class CacheClientStoreSelfTest extends GridCommonAbstractTest {
 
     /**
      */
+    private static class Factory3 implements Factory<CacheStore> {
+        /** {@inheritDoc} */
+        @Override public CacheStore create() {
+            return new TestStore();
+        }
+    }
+
+    /**
+     */
     private static class EP implements CacheEntryProcessor {
         @Override public Object process(MutableEntry entry, Object... arguments) {
             return null;
+        }
+    }
+
+    /**
+     * Test store that loads 10 item
+     */
+    public static class TestStore extends CacheStoreAdapter<Object, Object> {
+        @Override
+        public Integer load(Object key) throws CacheLoaderException {
+            return null;
+        }
+
+        @Override
+        public void write(Cache.Entry<? extends Object, ? extends Object> entry) throws CacheWriterException {
+        }
+
+        @Override
+        public void delete(Object key) throws CacheWriterException {
+        }
+
+        @Override
+        public void loadCache(IgniteBiInClosure<Object, Object> clo, Object... args) {
+            U.dumpStack();
+
+            for (int i = 0; i < 10; i++)
+                clo.apply(i, i);
         }
     }
 }


### PR DESCRIPTION
That fixes https://issues.apache.org/jira/browse/IGNITE-2394. If to call
cache.loadCache(...) then the loading from a storage would happen on all
the nodes including client nodes. Now we are only loading to data nodes
instead of all cache nodes.