### PR TITLE
IGNITE-2929 IgniteContext should not have type parameters

### DIFF
--- a/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteContext.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteContext.scala
@@ -29,10 +29,8 @@ import org.apache.spark.{Logging, SparkContext}
  *
  * @param sparkContext Spark context.
  * @param cfgF Configuration factory.
- * @tparam K Key type.
- * @tparam V Value type.
  */
-class IgniteContext[K, V](
+class IgniteContext(
     @transient val sparkContext: SparkContext,
     cfgF: () ⇒ IgniteConfiguration,
     standalone: Boolean = true
@@ -105,7 +103,7 @@ class IgniteContext[K, V](
      * @param cacheName Cache name.
      * @return `IgniteRDD` instance.
      */
-    def fromCache(cacheName: String): IgniteRDD[K, V] = {
+    def fromCache[K, V](cacheName: String): IgniteRDD[K, V] = {
         new IgniteRDD[K, V](this, cacheName, null)
     }
 
@@ -116,7 +114,7 @@ class IgniteContext[K, V](
      * @param cacheCfg Cache configuration to use.
      * @return `IgniteRDD` instance.
      */
-    def fromCache(cacheCfg: CacheConfiguration[K, V]) = {
+    def fromCache[K, V](cacheCfg: CacheConfiguration[K, V]) = {
         new IgniteRDD[K, V](this, cacheCfg.getName, cacheCfg)
     }
 

--- a/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteRDD.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteRDD.scala
@@ -43,7 +43,7 @@ import scala.collection.JavaConversions._
  * @tparam V Value type.
  */
 class IgniteRDD[K, V] (
-    val ic: IgniteContext[K, V],
+    val ic: IgniteContext,
     val cacheName: String,
     val cacheCfg: CacheConfiguration[K, V]
 ) extends IgniteAbstractRDD[(K, V), K, V] (ic, cacheName, cacheCfg) {

--- a/modules/spark/src/main/scala/org/apache/ignite/spark/JavaIgniteContext.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/JavaIgniteContext.scala
@@ -39,7 +39,7 @@ class JavaIgniteContext[K, V](
     standalone: Boolean = true
     ) extends Serializable {
 
-    @transient val ic: IgniteContext[K, V] = new IgniteContext[K, V](sc.sc, () => cfgF.apply(), standalone)
+    @transient val ic: IgniteContext = new IgniteContext(sc.sc, () => cfgF.apply(), standalone)
 
     def this(sc: JavaSparkContext, cfgF: IgniteOutClosure[IgniteConfiguration]) {
         this(sc, cfgF, true)

--- a/modules/spark/src/main/scala/org/apache/ignite/spark/impl/IgniteAbstractRDD.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/impl/IgniteAbstractRDD.scala
@@ -25,7 +25,7 @@ import org.apache.spark.rdd.RDD
 import scala.reflect.ClassTag
 
 abstract class IgniteAbstractRDD[R:ClassTag, K, V] (
-    ic: IgniteContext[K, V],
+    ic: IgniteContext,
     cacheName: String,
     cacheCfg: CacheConfiguration[K, V]
 ) extends RDD[R] (ic.sparkContext, deps = Nil) {

--- a/modules/spark/src/main/scala/org/apache/ignite/spark/impl/IgniteSqlRDD.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/impl/IgniteSqlRDD.scala
@@ -25,7 +25,7 @@ import org.apache.spark.{TaskContext, Partition}
 import scala.reflect.ClassTag
 
 class IgniteSqlRDD[R: ClassTag, T, K, V](
-    ic: IgniteContext[K, V],
+    ic: IgniteContext,
     cacheName: String,
     cacheCfg: CacheConfiguration[K, V],
     qry: Query[T],

--- a/modules/spark/src/test/scala/org/apache/ignite/spark/IgniteRDDSpec.scala
+++ b/modules/spark/src/test/scala/org/apache/ignite/spark/IgniteRDDSpec.scala
@@ -38,11 +38,11 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
             val sc = new SparkContext("local[*]", "test")
 
             try {
-                val ic = new IgniteContext[String, String](sc,
+                val ic = new IgniteContext(sc,
                     () ⇒ configuration("client", client = true))
 
                 // Save pairs ("0", "val0"), ("1", "val1"), ... to Ignite cache.
-                ic.fromCache(PARTITIONED_CACHE_NAME).savePairs(sc.parallelize(0 to 10000, 2).map(i ⇒ (String.valueOf(i), "val" + i)))
+                ic.fromCache[String, String](PARTITIONED_CACHE_NAME).savePairs(sc.parallelize(0 to 10000, 2).map(i ⇒ (String.valueOf(i), "val" + i)))
 
                 // Check cache contents.
                 val ignite = Ignition.ignite("grid-0")
@@ -63,7 +63,7 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
             val sc = new SparkContext("local[*]", "test")
 
             try {
-                val cache = Ignition.ignite("grid-0").cache[String, Int](PARTITIONED_CACHE_NAME)
+                val cache = Ignition.ignite("grid-0").cache(PARTITIONED_CACHE_NAME)
 
                 val num = 10000
 
@@ -71,10 +71,10 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
                     cache.put(String.valueOf(i), i)
                 }
 
-                val ic = new IgniteContext[String, Int](sc,
+                val ic = new IgniteContext(sc,
                     () ⇒ configuration("client", client = true))
 
-                val res = ic.fromCache(PARTITIONED_CACHE_NAME).map(_._2).sum()
+                val res = ic.fromCache[String, Int](PARTITIONED_CACHE_NAME).map(_._2).sum()
 
                 assert(res == (0 to num).sum)
             }
@@ -87,10 +87,10 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
             val sc = new SparkContext("local[*]", "test")
 
             try {
-                val ic = new IgniteContext[String, Entity](sc,
+                val ic = new IgniteContext(sc,
                     () ⇒ configuration("client", client = true))
 
-                val cache: IgniteRDD[String, Entity] = ic.fromCache(PARTITIONED_CACHE_NAME)
+                val cache: IgniteRDD[String, Entity] = ic.fromCache[String, Entity](PARTITIONED_CACHE_NAME)
 
                 cache.savePairs(sc.parallelize(0 to 1000, 2).map(i ⇒ (String.valueOf(i), new Entity(i, "name" + i, i * 100))))
 
@@ -112,7 +112,7 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
             val sc = new SparkContext("local[*]", "test")
 
             try {
-                val ic = new IgniteContext[String, Entity](sc,
+                val ic = new IgniteContext(sc,
                     () ⇒ configuration("client", client = true))
 
                 val cache: IgniteRDD[String, Entity] = ic.fromCache(PARTITIONED_CACHE_NAME)
@@ -152,10 +152,10 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
             val sc = new SparkContext("local[*]", "test")
 
             try {
-                val ic = new IgniteContext[String, String](sc,
+                val ic = new IgniteContext(sc,
                     "modules/core/src/test/config/spark/spark-config.xml")
 
-                val cache: IgniteRDD[String, String] = ic.fromCache(PARTITIONED_CACHE_NAME)
+                val cache: IgniteRDD[String, String] = ic.fromCache[String, String](PARTITIONED_CACHE_NAME)
 
                 cache.savePairs(sc.parallelize(1 to 1000, 2).map(i ⇒ (String.valueOf(i), "val" + i)))
 
@@ -172,10 +172,10 @@ class IgniteRDDSpec extends FunSpec with Matchers with BeforeAndAfterAll with Be
             val sc = new SparkContext("local[*]", "test")
 
             try {
-                val ic = new IgniteContext[Integer, WithObjectField](sc,
+                val ic = new IgniteContext(sc,
                     () ⇒ configuration("client", client = true))
 
-                val cache: IgniteRDD[Integer, WithObjectField] = ic.fromCache(PARTITIONED_CACHE_NAME)
+                val cache: IgniteRDD[Integer, WithObjectField] = ic.fromCache[Integer, WithObjectField](PARTITIONED_CACHE_NAME)
 
                 cache.savePairs(sc.parallelize(0 to 1000, 2).map(i ⇒ (i:java.lang.Integer, new WithObjectField(i, new Entity(i, "", i)))))
 


### PR DESCRIPTION
Currently implementation of `SparkContext` has type parameters `[K, V]` which means that all the RDDs that are created by a particular instance of context have to be of the same type.
Type parameters on`IgniteContext` is removed.`fromCache` method is parameterized instead.