### PR TITLE
IGNITE-2538 RDD.isEmpty method should be overriden in IgniteRDD to use IgniteCache API

### DIFF
--- a/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteRDD.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteRDD.scala
@@ -246,4 +246,5 @@ class IgniteRDD[K, V] (
         val cache = ensureCache()
         return cache.size() == 0
     }
+
 }

--- a/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteRDD.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteRDD.scala
@@ -241,4 +241,9 @@ class IgniteRDD[K, V] (
         Stream.from(1, 1000).map(_ ⇒ IgniteUuid.randomUuid()).find(node == null || aff.mapKeyToNode(_).eq(node))
             .getOrElse(IgniteUuid.randomUuid())
     }
+
+    override def isEmpty(): Boolean = {
+        val cache = ensureCache()
+        return cache.size() == 0
+    }
 }


### PR DESCRIPTION
Currently calling `IgniteRDD.isEmpty` ends up in execution of 1024 Spark jobs, which is not fast. We should override this method and use native IgniteCache API there.