### PR TITLE
Fixed putIfAbsent() return error

### DIFF
--- a/modules/spring/src/main/java/org/apache/ignite/cache/spring/SpringCache.java
+++ b/modules/spring/src/main/java/org/apache/ignite/cache/spring/SpringCache.java
@@ -74,7 +74,6 @@ class SpringCache implements Cache {
     /** {@inheritDoc} */
     @Override public ValueWrapper putIfAbsent(Object key, Object val) {
         boolean res = cache.putIfAbsent(key, val);
-
         return res ? new SimpleValueWrapper(val) : null;
     }
 

--- a/modules/spring/src/main/java/org/apache/ignite/cache/spring/SpringCache.java
+++ b/modules/spring/src/main/java/org/apache/ignite/cache/spring/SpringCache.java
@@ -73,9 +73,9 @@ class SpringCache implements Cache {
 
     /** {@inheritDoc} */
     @Override public ValueWrapper putIfAbsent(Object key, Object val) {
-        Object old = cache.putIfAbsent(key, val);
+        boolean res = cache.putIfAbsent(key, val);
 
-        return old != null ? new SimpleValueWrapper(old) : null;
+        return res ? new SimpleValueWrapper(val) : null;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
cache.putIfAbsent(key, val) return a boolean value, not the object.
