### PR TITLE
IGNITE-3207 Rename IgniteConfiguration.gridName

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/ClientStartNodeTask.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/ClientStartNodeTask.java
@@ -79,7 +79,7 @@ public class ClientStartNodeTask extends TaskSingleJobSplitAdapter<String, Integ
         IgniteConfiguration cfg = getConfig(type);
 
         // Generate unique for this VM grid name.
-        String gridName = cfg.getGridName() + " (" + UUID.randomUUID() + ")";
+        String gridName = cfg.getLocalInstanceName() + " (" + UUID.randomUUID() + ")";
 
         // Update grid name (required to be unique).
         cfg.setGridName(gridName);

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/ClientStopNodeTask.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/ClientStopNodeTask.java
@@ -106,7 +106,7 @@ public class ClientStopNodeTask extends ComputeTaskSplitAdapter<String, Integer>
         @Override public Object execute() {
             log.info(">>> Stop node [nodeId=" + ignite.cluster().localNode().id() + ", name='" + ignite.name() + "']");
 
-            String prefix = ClientStartNodeTask.getConfig(gridType).getGridName() + " (";
+            String prefix = ClientStartNodeTask.getConfig(gridType).getLocalInstanceName() + " (";
 
             if (!ignite.name().startsWith(prefix)) {
                 int stoppedCnt = 0;

--- a/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
@@ -213,7 +213,11 @@ public class IgniteConfiguration {
     public static final Long DFLT_FAILURE_DETECTION_TIMEOUT = new Long(10_000);
 
     /** Optional grid name. */
+    @Deprecated
     private String gridName;
+
+    /** Optional local instance name. */
+    private String localInstanceName;
 
     /** User attributes. */
     private Map<String, ?> userAttrs;
@@ -503,7 +507,7 @@ public class IgniteConfiguration {
         failureDetectionTimeout = cfg.getFailureDetectionTimeout();
         ggHome = cfg.getIgniteHome();
         ggWork = cfg.getWorkDirectory();
-        gridName = cfg.getGridName();
+        localInstanceName = cfg.getLocalInstanceName();
         igfsCfg = cfg.getFileSystemConfiguration();
         igfsPoolSize = cfg.getIgfsThreadPoolSize();
         hadoopCfg = cfg.getHadoopConfiguration();
@@ -562,9 +566,22 @@ public class IgniteConfiguration {
      * @return Optional grid name. Can be {@code null}, which is default grid name, if
      *      non-default grid name was not provided.
      */
+    @Deprecated
     public String getGridName() {
         return gridName;
     }
+
+    /**
+     * Gets optional local instance name. Returns {@code null} if non-default local instance
+     * name was not provided.
+     *
+     * @return Optional local instance name. Can be {@code null}, which is default local
+     * instance name, if non-default local instance name was not provided.
+     */
+    public String getLocalInstanceName() {
+        return localInstanceName;
+    }
+
 
     /**
      * Whether or not this node should be a daemon node.
@@ -613,10 +630,17 @@ public class IgniteConfiguration {
      *      grid name.
      * @return {@code this} for chaining.
      */
+    @Deprecated
     public IgniteConfiguration setGridName(String gridName) {
         this.gridName = gridName;
 
         return this;
+    }
+
+    public IgniteConfiguration setLocalInstanceName(String localInstanceName) {
+        this.localInstanceName = localInstanceName;
+
+        return  this;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/GridKernalContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/GridKernalContext.java
@@ -93,7 +93,15 @@ public interface GridKernalContext extends Iterable<GridComponent> {
      *
      * @return Grid name.
      */
+    @Deprecated
     public String gridName();
+
+    /**
+     * Gets lcoal instance name.
+     *
+     * @return Local instance name.
+     */
+    public String localInstanceName();
 
     /**
      * Gets logger for given category.

--- a/modules/core/src/main/java/org/apache/ignite/internal/GridKernalContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/GridKernalContextImpl.java
@@ -562,8 +562,14 @@ public class GridKernalContextImpl implements GridKernalContext, Externalizable 
     }
 
     /** {@inheritDoc} */
+    @Deprecated
     @Override public String gridName() {
         return cfg.getGridName();
+    }
+
+    /** {@inheritDoc} */
+    @Override public String localInstanceName() {
+        return cfg.getLocalInstanceName();
     }
 
     /** {@inheritDoc} */
@@ -819,7 +825,7 @@ public class GridKernalContextImpl implements GridKernalContext, Externalizable 
     /** {@inheritDoc} */
     @Override public void printMemoryStats() {
         X.println(">>> ");
-        X.println(">>> Grid memory stats [grid=" + gridName() + ']');
+        X.println(">>> Grid memory stats [grid=" + localInstanceName() + ']');
 
         for (GridComponent comp : comps)
             comp.printMemoryStats();

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -259,7 +259,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
     private GridLoggerProxy log;
 
     /** */
-    private String gridName;
+    private String localInstanceName;
 
     /** */
     @GridToStringExclude
@@ -395,7 +395,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
     /** {@inheritDoc} */
     @Override public String name() {
-        return gridName;
+        return localInstanceName;
     }
 
     /** {@inheritDoc} */
@@ -518,7 +518,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
     /** {@inheritDoc} */
     @Override public String getInstanceName() {
-        return gridName;
+        return localInstanceName;
     }
 
     /** {@inheritDoc} */
@@ -644,7 +644,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         // Catch generic throwable to secure against user assertions.
         catch (Throwable e) {
             U.error(log, "Failed to notify lifecycle bean (safely ignored) [evt=" + evt +
-                (gridName == null ? "" : ", gridName=" + gridName) + ']', e);
+                (localInstanceName == null ? "" : ", localInstanceName=" + localInstanceName) + ']', e);
 
             if (e instanceof Error)
                 throw (Error)e;
@@ -677,7 +677,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         GridAbsClosure errHnd)
         throws IgniteCheckedException
     {
-        gw.compareAndSet(null, new GridKernalGatewayImpl(cfg.getGridName()));
+        gw.compareAndSet(null, new GridKernalGatewayImpl(cfg.getLocalInstanceName()));
 
         GridKernalGateway gw = this.gw.get();
 
@@ -717,12 +717,12 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         // Make sure we got proper configuration.
         validateCommon(cfg);
 
-        gridName = cfg.getGridName();
+        localInstanceName = cfg.getLocalInstanceName();
 
         this.cfg = cfg;
 
         log = (GridLoggerProxy)cfg.getGridLogger().getLogger(
-            getClass().getName() + (gridName != null ? '%' + gridName : ""));
+            getClass().getName() + (localInstanceName != null ? '%' + localInstanceName : ""));
 
         RuntimeMXBean rtBean = ManagementFactory.getRuntimeMXBean();
 
@@ -742,7 +742,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         ackRebalanceConfiguration();
 
         // Run background network diagnostics.
-        GridDiagnostic.runBackgroundCheck(gridName, execSvc, log);
+        GridDiagnostic.runBackgroundCheck(localInstanceName, execSvc, log);
 
         // Ack 3-rd party licenses location.
         if (log.isInfoEnabled() && cfg.getIgniteHome() != null)
@@ -1097,7 +1097,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
             }, metricsLogFreq, metricsLogFreq);
         }
 
-        ctx.performance().logSuggestions(log, gridName);
+        ctx.performance().logSuggestions(log, localInstanceName);
 
         U.quietAndInfo(log, "To start Console Management & Monitoring run ignitevisorcmd.{sh|bat}");
 
@@ -1311,7 +1311,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         }
 
         add(ATTR_USER_NAME, System.getProperty("user.name"));
-        add(ATTR_GRID_NAME, gridName);
+        add(ATTR_GRID_NAME, localInstanceName);
 
         add(ATTR_PEER_CLASSLOADING, cfg.isPeerClassLoadingEnabled());
         add(ATTR_DEPLOYMENT_MODE, cfg.getDeploymentMode());
@@ -1407,7 +1407,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         try {
             kernalMBean = U.registerMBean(
                 cfg.getMBeanServer(),
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 "Kernal",
                 getClass().getSimpleName(),
                 this,
@@ -1430,7 +1430,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         try {
             locNodeMBean = U.registerMBean(
                 cfg.getMBeanServer(),
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 "Kernal",
                 mbean.getClass().getSimpleName(),
                 mbean,
@@ -1475,7 +1475,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         try {
             ObjectName res = U.registerMBean(
                 cfg.getMBeanServer(),
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 "Thread Pools",
                 name,
                 new ThreadPoolMXBeanAdapter(exec),
@@ -1693,7 +1693,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         if (log.isQuiet()) {
             U.quiet(false, "");
             U.quiet(false, "Ignite node started OK (id=" + U.id8(locNode.id()) +
-                (F.isEmpty(gridName) ? "" : ", grid=" + gridName) + ')');
+                (F.isEmpty(localInstanceName) ? "" : ", grid=" + localInstanceName) + ')');
         }
 
         if (log.isInfoEnabled()) {
@@ -1717,7 +1717,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                     ">>> CPU(s): " + locNode.metrics().getTotalCpus() + NL +
                     ">>> Heap: " + U.heapSize(locNode, 2) + "GB" + NL +
                     ">>> VM name: " + rtBean.getName() + NL +
-                    (gridName == null ? "" : ">>> Grid name: " + gridName + NL) +
+                    (localInstanceName == null ? "" : ">>> Grid name: " + localInstanceName + NL) +
                     ">>> Local node [" +
                     "ID=" + locNode.id().toString().toUpperCase() +
                     ", order=" + locNode.order() + ", clientMode=" + ctx.clientNode() +
@@ -1836,7 +1836,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
      * @param cancel Whether or not to cancel running jobs.
      */
     private void stop0(boolean cancel) {
-        gw.compareAndSet(null, new GridKernalGatewayImpl(gridName));
+        gw.compareAndSet(null, new GridKernalGatewayImpl(localInstanceName));
 
         GridKernalGateway gw = this.gw.get();
 
@@ -1915,7 +1915,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                 ctx.cluster().get().clearNodeMap();
 
                 if (log.isDebugEnabled())
-                    log.debug("Grid " + (gridName == null ? "" : '\'' + gridName + "' ") + "is stopping.");
+                    log.debug("Grid " + (localInstanceName == null ? "" : '\'' + localInstanceName + "' ") + "is stopping.");
             }
             finally {
                 gw.writeUnlock();
@@ -1983,7 +1983,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
             // Ack stop.
             if (log.isQuiet()) {
-                String nodeName = gridName == null ? "" : "name=" + gridName + ", ";
+                String nodeName = localInstanceName == null ? "" : "name=" + localInstanceName + ", ";
 
                 if (!errOnStop)
                     U.quiet(false, "Ignite node stopped OK [" + nodeName + "uptime=" +
@@ -2004,7 +2004,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                         ">>> " + dash + NL +
                         ">>> " + ack + NL +
                         ">>> " + dash + NL +
-                        (gridName == null ? "" : ">>> Grid name: " + gridName + NL) +
+                        (localInstanceName == null ? "" : ">>> Grid name: " + localInstanceName + NL) +
                         ">>> Grid uptime: " + X.timeSpan2HMSM(U.currentTimeMillis() - startTime) +
                         NL +
                         NL);
@@ -2018,7 +2018,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                     log.info(NL + NL +
                         ">>> " + ack + NL +
                         ">>> " + dash + NL +
-                        (gridName == null ? "" : ">>> Grid name: " + gridName + NL) +
+                        (localInstanceName == null ? "" : ">>> Grid name: " + localInstanceName + NL) +
                         ">>> Grid uptime: " + X.timeSpan2HMSM(U.currentTimeMillis() - startTime) +
                         NL +
                         ">>> See log above for detailed error message." + NL +
@@ -2927,7 +2927,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
     /** {@inheritDoc} */
     @Override public void close() throws IgniteException {
-        Ignition.stop(gridName, true);
+        Ignition.stop(localInstanceName, true);
     }
 
     /** {@inheritDoc} */
@@ -3307,12 +3307,12 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
     /** {@inheritDoc} */
     @Override public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-        gridName = U.readString(in);
+        localInstanceName = U.readString(in);
     }
 
     /** {@inheritDoc} */
     @Override public void writeExternal(ObjectOutput out) throws IOException {
-        U.writeString(out, gridName);
+        U.writeString(out, localInstanceName);
     }
 
     /**
@@ -3352,7 +3352,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                 UUID routerId = locNode instanceof TcpDiscoveryNode ? ((TcpDiscoveryNode)locNode).clientRouterNodeId() : null;
 
                 U.warn(log, "Dumping debug info for node [id=" + locNode.id() +
-                    ", name=" + ctx.gridName() +
+                    ", name=" + ctx.localInstanceName() +
                     ", order=" + locNode.order() +
                     ", topVer=" + discoMrg.topologyVersion() +
                     ", client=" + client +
@@ -3361,7 +3361,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
                 ctx.cache().context().exchange().dumpDebugInfo();
             }
             else
-                U.warn(log, "Dumping debug info for node, context is not initialized [name=" + gridName + ']');
+                U.warn(log, "Dumping debug info for node, context is not initialized [name=" + localInstanceName + ']');
         }
         catch (Exception e) {
             U.error(log, "Failed to dump debug info for node: " + e, e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -599,24 +599,24 @@ public class IgnitionEx {
      * the Grid configuration bean is ignored.
      *
      * @param springCfgPath Spring XML configuration file path or URL.
-     * @param gridName Grid name that will override default.
+     * @param localInstanceName Grid name that will override default.
      * @return Started grid. If Spring configuration contains multiple grid instances,
      *      then the 1st found instance is returned.
      * @throws IgniteCheckedException If grid could not be started or configuration
      *      read. This exception will be thrown also if grid with given name has already
      *      been started or Spring XML configuration file is invalid.
      */
-    public static Ignite start(@Nullable String springCfgPath, @Nullable String gridName) throws IgniteCheckedException {
+    public static Ignite start(@Nullable String springCfgPath, @Nullable String localInstanceName) throws IgniteCheckedException {
         if (springCfgPath == null) {
             IgniteConfiguration cfg = new IgniteConfiguration();
 
-            if (cfg.getGridName() == null && !F.isEmpty(gridName))
-                cfg.setGridName(gridName);
+            if (cfg.getLocalInstanceName() == null && !F.isEmpty(localInstanceName))
+                cfg.setLocalInstanceName(localInstanceName);
 
             return start(cfg);
         }
         else
-            return start(springCfgPath, gridName, null, null);
+            return start(springCfgPath, localInstanceName, null, null);
     }
 
     /**
@@ -730,7 +730,7 @@ public class IgnitionEx {
      * the Grid configuration bean is ignored.
      *
      * @param springCfgPath Spring XML configuration file path or URL. This cannot be {@code null}.
-     * @param gridName Grid name that will override default.
+     * @param localInstanceName Grid name that will override default.
      * @param springCtx Optional Spring application context, possibly {@code null}.
      * @param ldr Optional class loader that will be used by default.
      *      Spring bean definitions for bean injection are taken from this context.
@@ -742,11 +742,11 @@ public class IgnitionEx {
      *      read. This exception will be thrown also if grid with given name has already
      *      been started or Spring XML configuration file is invalid.
      */
-    public static Ignite start(String springCfgPath, @Nullable String gridName,
+    public static Ignite start(String springCfgPath, @Nullable String localInstanceName,
         @Nullable GridSpringResourceContext springCtx, @Nullable ClassLoader ldr) throws IgniteCheckedException {
         URL url = U.resolveSpringUrl(springCfgPath);
 
-        return start(url, gridName, springCtx, ldr);
+        return start(url, localInstanceName, springCtx, ldr);
     }
 
     /**
@@ -800,7 +800,7 @@ public class IgnitionEx {
      * the Grid configuration bean is ignored.
      *
      * @param springCfgUrl Spring XML configuration file URL. This cannot be {@code null}.
-     * @param gridName Grid name that will override default.
+     * @param localInstanceName Grid name that will override default.
      * @param springCtx Optional Spring application context, possibly {@code null}.
      * @param ldr Optional class loader that will be used by default.
      *      Spring bean definitions for bean injection are taken from this context.
@@ -812,7 +812,7 @@ public class IgnitionEx {
      *      read. This exception will be thrown also if grid with given name has already
      *      been started or Spring XML configuration file is invalid.
      */
-    public static Ignite start(URL springCfgUrl, @Nullable String gridName,
+    public static Ignite start(URL springCfgUrl, @Nullable String localInstanceName,
         @Nullable GridSpringResourceContext springCtx, @Nullable ClassLoader ldr) throws IgniteCheckedException {
         A.notNull(springCfgUrl, "springCfgUrl");
 
@@ -847,7 +847,7 @@ public class IgnitionEx {
                 U.removeJavaNoOpLogger(savedHnds);
         }
 
-        return startConfigurations(cfgMap, springCfgUrl, gridName, springCtx, ldr);
+        return startConfigurations(cfgMap, springCfgUrl, localInstanceName, springCtx, ldr);
     }
 
     /**
@@ -880,7 +880,7 @@ public class IgnitionEx {
      * the Grid configuration bean is ignored.
      *
      * @param springCfgStream Input stream containing Spring XML configuration. This cannot be {@code null}.
-     * @param gridName Grid name that will override default.
+     * @param localInstanceName Grid name that will override default.
      * @param springCtx Optional Spring application context, possibly {@code null}.
      * @param ldr Optional class loader that will be used by default.
      *      Spring bean definitions for bean injection are taken from this context.
@@ -892,7 +892,7 @@ public class IgnitionEx {
      *      read. This exception will be thrown also if grid with given name has already
      *      been started or Spring XML configuration file is invalid.
      */
-    public static Ignite start(InputStream springCfgStream, @Nullable String gridName,
+    public static Ignite start(InputStream springCfgStream, @Nullable String localInstanceName,
         @Nullable GridSpringResourceContext springCtx, @Nullable ClassLoader ldr) throws IgniteCheckedException {
         A.notNull(springCfgStream, "springCfgUrl");
 
@@ -927,7 +927,7 @@ public class IgnitionEx {
                 U.removeJavaNoOpLogger(savedHnds);
         }
 
-        return startConfigurations(cfgMap, null, gridName, springCtx, ldr);
+        return startConfigurations(cfgMap, null, localInstanceName, springCtx, ldr);
     }
 
     /**
@@ -935,7 +935,7 @@ public class IgnitionEx {
      *
      * @param cfgMap Configuration map.
      * @param springCfgUrl Spring XML configuration file URL.
-     * @param gridName Grid name that will override default.
+     * @param localInstanceName Grid name that will override default.
      * @param springCtx Optional Spring application context.
      * @param ldr Optional class loader that will be used by default.
      * @return Started grid.
@@ -944,7 +944,7 @@ public class IgnitionEx {
     private static Ignite startConfigurations(
         IgniteBiTuple<Collection<IgniteConfiguration>, ? extends GridSpringResourceContext> cfgMap,
         URL springCfgUrl,
-        @Nullable String gridName,
+        @Nullable String localInstanceName,
         @Nullable GridSpringResourceContext springCtx,
         @Nullable ClassLoader ldr)
         throws IgniteCheckedException {
@@ -954,8 +954,8 @@ public class IgnitionEx {
             for (IgniteConfiguration cfg : cfgMap.get1()) {
                 assert cfg != null;
 
-                if (cfg.getGridName() == null && !F.isEmpty(gridName))
-                    cfg.setGridName(gridName);
+                if (cfg.getLocalInstanceName() == null && !F.isEmpty(localInstanceName))
+                    cfg.setLocalInstanceName(localInstanceName);
 
                 if (ldr != null && cfg.getClassLoader() == null)
                     cfg.setClassLoader(ldr);
@@ -1000,7 +1000,7 @@ public class IgnitionEx {
     private static IgniteNamedInstance start0(GridStartContext startCtx, boolean failIfStarted ) throws IgniteCheckedException {
         assert startCtx != null;
 
-        String name = startCtx.config().getGridName();
+        String name = startCtx.config().getLocalInstanceName();
 
         if (name != null && name.isEmpty())
             throw new IgniteCheckedException("Non default grid instances cannot have empty string name.");
@@ -1286,7 +1286,7 @@ public class IgnitionEx {
      */
     public static IgniteKernal localIgnite() throws IllegalArgumentException {
         if (Thread.currentThread() instanceof IgniteThread)
-            return gridx(((IgniteThread)Thread.currentThread()).getGridName());
+            return gridx(((IgniteThread)Thread.currentThread()).getLocalInstanceName());
         else
             throw new IllegalArgumentException("This method should be accessed under " + IgniteThread.class.getName());
     }
@@ -1340,17 +1340,17 @@ public class IgnitionEx {
     }
 
     /**
-     * @param gridName Grid instance name.
+     * @param localInstanceName Grid instance name.
      * @param state Factory state.
      */
-    private static void notifyStateChange(@Nullable String gridName, IgniteState state) {
-        if (gridName != null)
-            gridStates.put(gridName, state);
+    private static void notifyStateChange(@Nullable String localInstanceName, IgniteState state) {
+        if (localInstanceName != null)
+            gridStates.put(localInstanceName, state);
         else
             dfltGridState = state;
 
         for (IgnitionListener lsnr : lsnrs)
-            lsnr.onStateChange(gridName, state);
+            lsnr.onStateChange(localInstanceName, state);
     }
 
     /**
@@ -1633,7 +1633,7 @@ public class IgnitionEx {
 
             execSvc = new IgniteThreadPoolExecutor(
                 "pub",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 cfg.getPublicThreadPoolSize(),
                 cfg.getPublicThreadPoolSize(),
                 DFLT_PUBLIC_KEEP_ALIVE_TIME,
@@ -1647,7 +1647,7 @@ public class IgnitionEx {
             // maximum threads has no effect.
             sysExecSvc = new IgniteThreadPoolExecutor(
                 "sys",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 cfg.getSystemThreadPoolSize(),
                 cfg.getSystemThreadPoolSize(),
                 DFLT_SYSTEM_KEEP_ALIVE_TIME,
@@ -1662,7 +1662,7 @@ public class IgnitionEx {
             // not be needed.
             mgmtExecSvc = new IgniteThreadPoolExecutor(
                 "mgmt",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 cfg.getManagementThreadPoolSize(),
                 cfg.getManagementThreadPoolSize(),
                 0,
@@ -1674,7 +1674,7 @@ public class IgnitionEx {
             // not be needed.
             p2pExecSvc = new IgniteThreadPoolExecutor(
                 "p2p",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 cfg.getPeerClassLoadingThreadPoolSize(),
                 cfg.getPeerClassLoadingThreadPoolSize(),
                 0,
@@ -1683,7 +1683,7 @@ public class IgnitionEx {
             // Note that we do not pre-start threads here as igfs pool may not be needed.
             igfsExecSvc = new IgniteThreadPoolExecutor(
                 "igfs",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 cfg.getIgfsThreadPoolSize(),
                 cfg.getIgfsThreadPoolSize(),
                 0,
@@ -1692,13 +1692,13 @@ public class IgnitionEx {
             // Note that we do not pre-start threads here as this pool may not be needed.
             callbackExecSvc = new IgniteStripedThreadPoolExecutor(
                 cfg.getAsyncCallbackPoolSize(),
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 "callback");
 
             if (myCfg.getConnectorConfiguration() != null) {
                 restExecSvc = new IgniteThreadPoolExecutor(
                     "rest",
-                    myCfg.getGridName(),
+                    myCfg.getLocalInstanceName(),
                     myCfg.getConnectorConfiguration().getThreadPoolSize(),
                     myCfg.getConnectorConfiguration().getThreadPoolSize(),
                     ConnectorConfiguration.DFLT_KEEP_ALIVE_TIME,
@@ -1708,7 +1708,7 @@ public class IgnitionEx {
 
             utilityCacheExecSvc = new IgniteThreadPoolExecutor(
                 "utility",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 myCfg.getUtilityCacheThreadPoolSize(),
                 myCfg.getUtilityCacheThreadPoolSize(),
                 myCfg.getUtilityCacheKeepAliveTime(),
@@ -1716,7 +1716,7 @@ public class IgnitionEx {
 
             marshCacheExecSvc = new IgniteThreadPoolExecutor(
                 "marshaller-cache",
-                cfg.getGridName(),
+                cfg.getLocalInstanceName(),
                 myCfg.getMarshallerCacheThreadPoolSize(),
                 myCfg.getMarshallerCacheThreadPoolSize(),
                 myCfg.getMarshallerCacheKeepAliveTime(),
@@ -1819,7 +1819,7 @@ public class IgnitionEx {
             // Ensure invariant.
             // It's a bit dirty - but this is a result of late refactoring
             // and I don't want to reshuffle a lot of code.
-            assert F.eq(name, cfg.getGridName());
+            assert F.eq(name, cfg.getLocalInstanceName());
 
             UUID nodeId = cfg.getNodeId() != null ? cfg.getNodeId() : UUID.randomUUID();
 
@@ -2441,7 +2441,7 @@ public class IgnitionEx {
          */
         private static class GridMBeanServerData {
             /** Set of grid names for selected MBeanServer. */
-            private Collection<String> gridNames = new HashSet<>();
+            private Collection<String> localInstanceNames = new HashSet<>();
 
             /** */
             private ObjectName mbean;
@@ -2463,30 +2463,30 @@ public class IgnitionEx {
             /**
              * Add grid name.
              *
-             * @param gridName Grid name.
+             * @param localInstanceName Grid name.
              */
-            public void addGrid(String gridName) {
-                gridNames.add(gridName);
+            public void addGrid(String localInstanceName) {
+                localInstanceNames.add(localInstanceName);
             }
 
             /**
              * Remove grid name.
              *
-             * @param gridName Grid name.
+             * @param localInstanceName Grid name.
              */
-            public void removeGrid(String gridName) {
-                gridNames.remove(gridName);
+            public void removeGrid(String localInstanceName) {
+                localInstanceNames.remove(localInstanceName);
             }
 
             /**
              * Returns {@code true} if data contains the specified
              * grid name.
              *
-             * @param gridName Grid name.
+             * @param localInstanceName Grid name.
              * @return {@code true} if data contains the specified grid name.
              */
-            public boolean containsGrid(String gridName) {
-                return gridNames.contains(gridName);
+            public boolean containsGrid(String localInstanceName) {
+                return localInstanceNames.contains(localInstanceName);
             }
 
             /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcConnection.java
@@ -211,8 +211,8 @@ public class JdbcConnection implements Connection {
 
             IgniteConfiguration cfg = F.first(cfgMap.get1());
 
-            if (cfg.getGridName() == null)
-                cfg.setGridName("ignite-jdbc-driver-" + UUID.randomUUID().toString());
+            if (cfg.getLocalInstanceName() == null)
+                cfg.setLocalInstanceName("ignite-jdbc-driver-" + UUID.randomUUID().toString());
 
             cfg.setClientMode(true); // Force client mode.
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformIgnition.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformIgnition.java
@@ -45,13 +45,13 @@ public class PlatformIgnition {
      * Start Ignite node in platform mode.
      *
      * @param springCfgPath Spring configuration path.
-     * @param gridName Grid name.
+     * @param localInstanceName Grid name.
      * @param factoryId Factory ID.
      * @param envPtr Environment pointer.
      * @param dataPtr Optional pointer to additional data required for startup.
      * @return Ignite instance.
      */
-    public static synchronized PlatformProcessor start(@Nullable String springCfgPath, @Nullable String gridName,
+    public static synchronized PlatformProcessor start(@Nullable String springCfgPath, @Nullable String localInstanceName,
         int factoryId, long envPtr, long dataPtr) {
         if (envPtr <= 0)
             throw new IgniteException("Environment pointer must be positive.");
@@ -63,16 +63,16 @@ public class PlatformIgnition {
         try {
             IgniteBiTuple<IgniteConfiguration, GridSpringResourceContext> cfg = configuration(springCfgPath);
 
-            if (gridName != null)
-                cfg.get1().setGridName(gridName);
+            if (localInstanceName != null)
+                cfg.get1().setLocalInstanceName(localInstanceName);
             else
-                gridName = cfg.get1().getGridName();
+                localInstanceName = cfg.get1().getLocalInstanceName();
 
             PlatformBootstrap bootstrap = bootstrap(factoryId);
 
             PlatformProcessor proc = bootstrap.start(cfg.get1(), cfg.get2(), envPtr, dataPtr);
 
-            PlatformProcessor old = instances.put(gridName, proc);
+            PlatformProcessor old = instances.put(localInstanceName, proc);
 
             assert old == null;
 
@@ -86,21 +86,21 @@ public class PlatformIgnition {
     /**
      * Get instance by environment pointer.
      *
-     * @param gridName Grid name.
+     * @param localInstanceName Local instance name.
      * @return Instance or {@code null} if it doesn't exist (never started or stopped).
      */
-    @Nullable public static synchronized PlatformProcessor instance(@Nullable String gridName) {
-        return instances.get(gridName);
+    @Nullable public static synchronized PlatformProcessor instance(@Nullable String localInstanceName) {
+        return instances.get(localInstanceName);
     }
 
     /**
      * Get environment pointer of the given instance.
      *
-     * @param gridName Grid name.
+     * @param localInstanceName Local instance name.
      * @return Environment pointer or {@code 0} in case grid with such name doesn't exist.
      */
-    public static synchronized long environmentPointer(@Nullable String gridName) {
-        PlatformProcessor proc = instance(gridName);
+    public static synchronized long environmentPointer(@Nullable String localInstanceName) {
+        PlatformProcessor proc = instance(localInstanceName);
 
         return proc != null ? proc.environmentPointer() : 0;
     }
@@ -108,13 +108,13 @@ public class PlatformIgnition {
     /**
      * Stop single instance.
      *
-     * @param gridName Grid name,
+     * @param localInstanceName Local instance name,
      * @param cancel Cancel flag.
      * @return {@code True} if instance was found and stopped.
      */
-    public static synchronized boolean stop(@Nullable String gridName, boolean cancel) {
-        if (Ignition.stop(gridName, cancel)) {
-            PlatformProcessor old = instances.remove(gridName);
+    public static synchronized boolean stop(@Nullable String localInstanceName, boolean cancel) {
+        if (Ignition.stop(localInstanceName, cancel)) {
+            PlatformProcessor old = instances.remove(localInstanceName);
 
             assert old != null;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/task/GridTaskWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/task/GridTaskWorker.java
@@ -274,7 +274,7 @@ class GridTaskWorker<T, R> extends GridWorker implements GridTimeoutObject {
         GridTaskEventListener evtLsnr,
         @Nullable Map<GridTaskThreadContextKey, Object> thCtx,
         UUID subjId) {
-        super(ctx.config().getGridName(), "grid-task-worker", ctx.log(GridTaskWorker.class));
+        super(ctx.config().getLocalInstanceName(), "grid-task-worker", ctx.log(GridTaskWorker.class));
 
         assert ses != null;
         assert fut != null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/timeout/GridTimeoutProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/timeout/GridTimeoutProcessor.java
@@ -62,7 +62,7 @@ public class GridTimeoutProcessor extends GridProcessorAdapter {
     public GridTimeoutProcessor(GridKernalContext ctx) {
         super(ctx);
 
-        timeoutWorker = new IgniteThread(ctx.config().getGridName(), "grid-timeout-worker",
+        timeoutWorker = new IgniteThread(ctx.config().getLocalInstanceName(), "grid-timeout-worker",
             new TimeoutWorker());
     }
 
@@ -138,7 +138,7 @@ public class GridTimeoutProcessor extends GridProcessorAdapter {
          *
          */
         TimeoutWorker() {
-            super(ctx.config().getGridName(), "grid-timeout-worker", GridTimeoutProcessor.this.log);
+            super(ctx.config().getLocalInstanceName(), "grid-timeout-worker", GridTimeoutProcessor.this.log);
         }
 
         /** {@inheritDoc} */
@@ -196,7 +196,7 @@ public class GridTimeoutProcessor extends GridProcessorAdapter {
     /** {@inheritDoc} */
     @Override public void printMemoryStats() {
         X.println(">>>");
-        X.println(">>> Timeout processor memory stats [grid=" + ctx.gridName() + ']');
+        X.println(">>> Timeout processor memory stats [grid=" + ctx.localInstanceName() + ']');
         X.println(">>>   timeoutObjsSize: " + timeoutObjs.size());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorBasicConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorBasicConfiguration.java
@@ -47,7 +47,11 @@ public class VisorBasicConfiguration implements Serializable {
     private static final long serialVersionUID = 0L;
 
     /** Grid name. */
+    @Deprecated
     private String gridName;
+
+    /** Local instance name*/
+    private String localInstanceName;
 
     /** IGNITE_HOME determined at startup. */
     private String ggHome;
@@ -117,7 +121,7 @@ public class VisorBasicConfiguration implements Serializable {
     public static VisorBasicConfiguration from(IgniteEx ignite, IgniteConfiguration c) {
         VisorBasicConfiguration cfg = new VisorBasicConfiguration();
 
-        cfg.gridName = c.getGridName();
+        cfg.localInstanceName = c.getLocalInstanceName();
         cfg.ggHome = getProperty(IGNITE_HOME, c.getIgniteHome());
         cfg.locHost = getProperty(IGNITE_LOCAL_HOST, c.getLocalHost());
         cfg.nodeId = ignite.localNode().id();
@@ -145,8 +149,13 @@ public class VisorBasicConfiguration implements Serializable {
     /**
      * @return Grid name.
      */
+    @Deprecated
     @Nullable public String gridName() {
         return gridName;
+    }
+
+    @Nullable public String localInstanceName() {
+        return localInstanceName;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/thread/IgniteThread.java
+++ b/modules/core/src/main/java/org/apache/ignite/thread/IgniteThread.java
@@ -42,8 +42,8 @@ public class IgniteThread extends Thread {
     /** Number of all grid threads in the system. */
     private static final AtomicLong cntr = new AtomicLong();
 
-    /** The name of the grid this thread belongs to. */
-    protected final String gridName;
+    /** The name of the lcoal instance this thread belongs to. */
+    protected final String localInstanceName;
 
     /** Group index. */
     private final int grpIdx;
@@ -60,24 +60,24 @@ public class IgniteThread extends Thread {
     /**
      * Creates grid thread with given name for a given grid.
      *
-     * @param gridName Name of grid this thread is created for.
+     * @param localInstanceName Name of grid this thread is created for.
      * @param threadName Name of thread.
      * @param r Runnable to execute.
      */
-    public IgniteThread(String gridName, String threadName, Runnable r) {
-        this(gridName, threadName, r, GRP_IDX_UNASSIGNED);
+    public IgniteThread(String localInstanceName, String threadName, Runnable r) {
+        this(localInstanceName, threadName, r, GRP_IDX_UNASSIGNED);
     }
 
     /**
      * Creates grid thread with given name for a given grid.
      *
-     * @param gridName Name of grid this thread is created for.
+     * @param localInstanceName Name of grid this thread is created for.
      * @param threadName Name of thread.
      * @param r Runnable to execute.
      * @param grpIdx Index within a group.
      */
-    public IgniteThread(String gridName, String threadName, Runnable r, int grpIdx) {
-        this(DFLT_GRP, gridName, threadName, r, grpIdx);
+    public IgniteThread(String localInstanceName, String threadName, Runnable r, int grpIdx) {
+        this(DFLT_GRP, localInstanceName, threadName, r, grpIdx);
     }
 
     /**
@@ -85,27 +85,27 @@ public class IgniteThread extends Thread {
      * thread group.
      *
      * @param grp Thread group.
-     * @param gridName Name of grid this thread is created for.
+     * @param localInstanceName Name of grid this thread is created for.
      * @param threadName Name of thread.
      * @param r Runnable to execute.
      * @param grpIdx Thread index within a group.
      */
-    public IgniteThread(ThreadGroup grp, String gridName, String threadName, Runnable r, int grpIdx) {
-        super(grp, r, createName(cntr.incrementAndGet(), threadName, gridName));
+    public IgniteThread(ThreadGroup grp, String localInstanceName, String threadName, Runnable r, int grpIdx) {
+        super(grp, r, createName(cntr.incrementAndGet(), threadName, localInstanceName));
 
-        this.gridName = gridName;
+        this.localInstanceName = localInstanceName;
         this.grpIdx = grpIdx;
     }
 
     /**
-     * @param gridName Name of grid this thread is created for.
+     * @param localInstanceName Name of grid this thread is created for.
      * @param threadGrp Thread group.
      * @param threadName Name of thread.
      */
-    protected IgniteThread(String gridName, ThreadGroup threadGrp, String threadName) {
+    protected IgniteThread(String localInstanceName, ThreadGroup threadGrp, String threadName) {
         super(threadGrp, threadName);
 
-        this.gridName = gridName;
+        this.localInstanceName = localInstanceName;
         this.grpIdx = GRP_IDX_UNASSIGNED;
     }
 
@@ -114,8 +114,13 @@ public class IgniteThread extends Thread {
      *
      * @return Name of the grid this thread belongs to.
      */
+    @Deprecated
     public String getGridName() {
-        return gridName;
+        return localInstanceName;
+    }
+
+    public String getLocalInstanceName() {
+        return localInstanceName;
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/marshaller/GridMarshallerAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/marshaller/GridMarshallerAbstractTest.java
@@ -89,7 +89,7 @@ public abstract class GridMarshallerAbstractTest extends GridCommonAbstractTest 
     private static Marshaller marsh;
 
     /** */
-    private static String gridName;
+    private static String localInstanceName;
 
     /** Closure job. */
     protected IgniteInClosure<String> c1 = new IgniteInClosure<String>() {
@@ -129,8 +129,8 @@ public abstract class GridMarshallerAbstractTest extends GridCommonAbstractTest 
     }
 
     /** {@inheritDoc} */
-    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
-        IgniteConfiguration cfg = super.getConfiguration(gridName);
+    @Override protected IgniteConfiguration getConfiguration(String localInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(localInstanceName);
 
         CacheConfiguration namedCache = new CacheConfiguration();
 
@@ -151,7 +151,7 @@ public abstract class GridMarshallerAbstractTest extends GridCommonAbstractTest 
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {
         marsh = grid().configuration().getMarshaller();
-        gridName = grid().configuration().getGridName();
+        localInstanceName = grid().configuration().getLocalInstanceName();
     }
 
     /**
@@ -847,7 +847,7 @@ public abstract class GridMarshallerAbstractTest extends GridCommonAbstractTest 
         });
 
         // Any deserialization has to be executed under a thread, that contains the grid name.
-        new IgniteThread(gridName, "unmarshal-thread", f).start();
+        new IgniteThread(localInstanceName, "unmarshal-thread", f).start();
 
         try {
             return f.get();

--- a/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/GridTcpCommunicationSpiConfigSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/GridTcpCommunicationSpiConfigSelfTest.java
@@ -61,7 +61,7 @@ public class GridTcpCommunicationSpiConfigSelfTest extends GridSpiAbstractConfig
             spi.setLocalPortRange(0);
             cfg.setCommunicationSpi(spi);
 
-            startGrid(cfg.getGridName(), cfg);
+            startGrid(cfg.getLocalInstanceName(), cfg);
         }
         finally {
             stopAllGrids();

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpiConfigSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpiConfigSelfTest.java
@@ -59,7 +59,7 @@ public class TcpDiscoverySpiConfigSelfTest extends GridSpiAbstractConfigTest<Tcp
             spi.setLocalPortRange(0);
             cfg.setDiscoverySpi(spi);
 
-            startGrid(cfg.getGridName(), cfg);
+            startGrid(cfg.getLocalInstanceName(), cfg);
         }
         finally {
             stopAllGrids();

--- a/modules/core/src/test/java/org/apache/ignite/testframework/configvariations/ConfigVariationsFactory.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/configvariations/ConfigVariationsFactory.java
@@ -88,7 +88,7 @@ public class ConfigVariationsFactory implements ConfigFactory {
      * @param srcCfg Source config.
      */
     private static void copyDefaultsFromSource(IgniteConfiguration cfg, IgniteConfiguration srcCfg) {
-        cfg.setGridName(srcCfg.getGridName());
+        cfg.setLocalInstanceName(srcCfg.getLocalInstanceName());
         cfg.setGridLogger(srcCfg.getGridLogger());
         cfg.setNodeId(srcCfg.getNodeId());
         cfg.setIgniteHome(srcCfg.getIgniteHome());

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -1240,7 +1240,17 @@ public abstract class GridAbstractTest extends TestCase {
     /**
      * @return Generated unique test grid name.
      */
+    @Deprecated
     public String getTestGridName() {
+        String[] parts = getClass().getName().split("\\.");
+
+        return parts[parts.length - 2] + '.' + parts[parts.length - 1];
+    }
+
+    /**
+     * @return Generated unique test local instance name.
+     */
+    public String getTestLocalInstanceName() {
         String[] parts = getClass().getName().split("\\.");
 
         return parts[parts.length - 2] + '.' + parts[parts.length - 1];

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/multijvm/IgniteProcessProxy.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/multijvm/IgniteProcessProxy.java
@@ -158,12 +158,12 @@ public class IgniteProcessProxy implements IgniteEx {
 
         assert rmtNodeStartedLatch.await(30, TimeUnit.SECONDS): "Remote node has not joined [id=" + id + ']';
 
-        IgniteProcessProxy prevVal = gridProxies.putIfAbsent(cfg.getGridName(), this);
+        IgniteProcessProxy prevVal = gridProxies.putIfAbsent(cfg.getLocalInstanceName(), this);
 
         if (prevVal != null) {
-            remoteCompute().run(new StopGridTask(cfg.getGridName(), true));
+            remoteCompute().run(new StopGridTask(cfg.getLocalInstanceName(), true));
 
-            throw new IllegalStateException("There was found instance assotiated with " + cfg.getGridName() +
+            throw new IllegalStateException("There was found instance assotiated with " + cfg.getLocalInstanceName() +
                 ", instance= " + prevVal + ". New started node was stopped.");
         }
     }
@@ -276,7 +276,7 @@ public class IgniteProcessProxy implements IgniteEx {
 
     /** {@inheritDoc} */
     @Override public String name() {
-        return cfg.getGridName();
+        return cfg.getLocalInstanceName();
     }
 
     /** {@inheritDoc} */

--- a/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteContext.scala
+++ b/modules/spark/src/main/scala/org/apache/ignite/spark/IgniteContext.scala
@@ -176,7 +176,7 @@ class IgniteContext[K, V](
     private def doClose() = {
         val igniteCfg = cfgClo()
 
-        Ignition.stop(igniteCfg.getGridName, false)
+        Ignition.stop(igniteCfg.getLocalInstanceName, false)
     }
 }
 

--- a/modules/spring/src/test/java/org/apache/ignite/internal/GridFactorySelfTest.java
+++ b/modules/spring/src/test/java/org/apache/ignite/internal/GridFactorySelfTest.java
@@ -114,8 +114,8 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
     }
 
     /** {@inheritDoc} */
-    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
-        IgniteConfiguration cfg = super.getConfiguration(gridName);
+    @Override protected IgniteConfiguration getConfiguration(String localInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(localInstanceName);
 
         ((TcpDiscoverySpi)cfg.getDiscoverySpi()).setIpFinder(IP_FINDER);
 
@@ -167,7 +167,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
      */
     public void testStartGridWithConfigUrlString() throws Exception {
         GridEmbeddedHttpServer srv = null;
-        String gridName = "grid_with_url_config";
+        String localInstanceName = "grid_with_url_config";
 
         try {
             srv = GridEmbeddedHttpServer.startHttpServer().withFileDownloadingHandler(null,
@@ -175,13 +175,13 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
 
             Ignite ignite = G.start(srv.getBaseUrl());
 
-            assert gridName.equals(ignite.name()) : "Unexpected grid name: " + ignite.name();
+            assert localInstanceName.equals(ignite.name()) : "Unexpected grid name: " + ignite.name();
         }
         finally {
             if (srv != null)
                 srv.stop(1);
 
-            G.stop(gridName, false);
+            G.stop(localInstanceName, false);
         }
     }
 
@@ -190,7 +190,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
      */
     public void testStartGridWithConfigUrl() throws Exception {
         GridEmbeddedHttpServer srv = null;
-        String gridName = "grid_with_url_config";
+        String localInstanceName = "grid_with_url_config";
 
         try {
             srv = GridEmbeddedHttpServer.startHttpServer().withFileDownloadingHandler(null,
@@ -198,13 +198,13 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
 
             Ignite ignite = G.start(new URL(srv.getBaseUrl()));
 
-            assert gridName.equals(ignite.name()) : "Unexpected grid name: " + ignite.name();
+            assert localInstanceName.equals(ignite.name()) : "Unexpected grid name: " + ignite.name();
         }
         finally {
             if (srv != null)
                 srv.stop(1);
 
-            G.stop(gridName, false);
+            G.stop(localInstanceName, false);
         }
     }
 
@@ -293,71 +293,71 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
     /**
      * @throws Exception If failed.
      */
-    public void testLifecycleBeansNullGridName() throws Exception {
+    public void testLifecycleBeansNullLocalInstanceName() throws Exception {
         checkLifecycleBeans(null);
     }
 
     /**
      * @throws Exception If failed.
      */
-    public void testLifecycleBeansNotNullGridName() throws Exception {
+    public void testLifecycleBeansNotNullLocalInstanceName() throws Exception {
         checkLifecycleBeans("testGrid");
     }
 
     /**
-     * @param gridName Grid name.
+     * @param localInstanceName Grid name.
      * @throws Exception If test failed.
      */
-    private void checkLifecycleBeans(@Nullable String gridName) throws Exception {
+    private void checkLifecycleBeans(@Nullable String localInstanceName) throws Exception {
         TestLifecycleBean bean1 = new TestLifecycleBean();
         TestLifecycleBean bean2 = new TestLifecycleBean();
 
         IgniteConfiguration cfg = new IgniteConfiguration();
 
         cfg.setLifecycleBeans(bean1, bean2);
-        cfg.setGridName(gridName);
+        cfg.setLocalInstanceName(localInstanceName);
 
         cfg.setConnectorConfiguration(null);
 
         try (Ignite g = IgniteSpring.start(cfg, new GenericApplicationContext())) {
-            bean1.checkState(gridName, true);
-            bean2.checkState(gridName, true);
+            bean1.checkState(localInstanceName, true);
+            bean2.checkState(localInstanceName, true);
         }
 
-        bean1.checkState(gridName, false);
-        bean2.checkState(gridName, false);
+        bean1.checkState(localInstanceName, false);
+        bean2.checkState(localInstanceName, false);
 
-        checkLifecycleBean(bean1, gridName);
-        checkLifecycleBean(bean2, gridName);
+        checkLifecycleBean(bean1, localInstanceName);
+        checkLifecycleBean(bean2, localInstanceName);
     }
 
     /**
      * @param bean Bean to check.
-     * @param gridName Grid name to check for.
+     * @param localInstanceName Grid name to check for.
      */
-    private void checkLifecycleBean(TestLifecycleBean bean, String gridName) {
+    private void checkLifecycleBean(TestLifecycleBean bean, String localInstanceName) {
         bean.checkErrors();
 
         List<LifecycleEventType> evts = bean.getLifecycleEvents();
 
-        List<String> gridNames = bean.getGridNames();
+        List<String> localInstanceNames = bean.getLocalInstanceNames();
 
         assert evts.get(0) == LifecycleEventType.BEFORE_NODE_START : "Invalid lifecycle event: " + evts.get(0);
         assert evts.get(1) == LifecycleEventType.AFTER_NODE_START : "Invalid lifecycle event: " + evts.get(1);
         assert evts.get(2) == LifecycleEventType.BEFORE_NODE_STOP : "Invalid lifecycle event: " + evts.get(2);
         assert evts.get(3) == LifecycleEventType.AFTER_NODE_STOP : "Invalid lifecycle event: " + evts.get(3);
 
-        checkGridNameEquals(gridNames.get(0), gridName);
-        checkGridNameEquals(gridNames.get(1), gridName);
-        checkGridNameEquals(gridNames.get(2), gridName);
-        checkGridNameEquals(gridNames.get(3), gridName);
+        checkLocalInstanceNameEquals(localInstanceNames.get(0), localInstanceName);
+        checkLocalInstanceNameEquals(localInstanceNames.get(1), localInstanceName);
+        checkLocalInstanceNameEquals(localInstanceNames.get(2), localInstanceName);
+        checkLocalInstanceNameEquals(localInstanceNames.get(3), localInstanceName);
     }
 
     /**
      * @param n1 First name.
      * @param n2 Second name.
      */
-    private void checkGridNameEquals(String n1, String n2) {
+    private void checkLocalInstanceNameEquals(String n1, String n2) {
         if (n1 == null) {
             assert n2 == null;
 
@@ -470,7 +470,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
                         try {
                             IgniteConfiguration cfg = new IgniteConfiguration();
 
-                            cfg.setGridName("TEST_NAME");
+                            cfg.setLocalInstanceName("TEST_NAME");
                             cfg.setConnectorConfiguration(null);
 
                             G.start(cfg);
@@ -512,17 +512,17 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
     }
 
     /**
-     * @param gridName Grid name ({@code null} for default grid).
+     * @param localInstanceName Grid name ({@code null} for default grid).
      * @throws Exception If failed.
      */
-    private void checkConcurrentStartStop(@Nullable final String gridName) throws Exception {
+    private void checkConcurrentStartStop(@Nullable final String localInstanceName) throws Exception {
         final AtomicInteger startedCnt = new AtomicInteger();
         final AtomicInteger stoppedCnt = new AtomicInteger();
 
         IgnitionListener lsnr = new IgnitionListener() {
             @SuppressWarnings("StringEquality")
             @Override public void onStateChange(@Nullable String name, IgniteState state) {
-                assert name == gridName;
+                assert name == localInstanceName;
 
                 info("On state change fired: " + state);
 
@@ -546,7 +546,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
                     @Nullable @Override public Object call() throws Exception {
                         for (int i = 0; i < iterCnt; i++) {
                             try {
-                                IgniteConfiguration cfg = getConfiguration(gridName);
+                                IgniteConfiguration cfg = getConfiguration(localInstanceName);
 
                                 G.start(cfg);
                             }
@@ -561,7 +561,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
                                     throw e; // Unexpected exception.
                             }
                             finally {
-                                stopGrid(gridName);
+                                stopGrid(localInstanceName);
                             }
                         }
 
@@ -599,7 +599,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
                     cfg.setConnectorConfiguration(null);
 
                     cfg.setDiscoverySpi(new TcpDiscoverySpi() {
-                        @Override public void spiStart(String gridName) throws IgniteSpiException {
+                        @Override public void spiStart(String localInstanceName) throws IgniteSpiException {
                             throw new IgniteSpiException("This SPI will never start.");
                         }
                     });
@@ -628,38 +628,38 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
 
         G.start(cfg1);
 
-        assert G.state(cfg1.getGridName()) == STARTED;
-        assert G.state(getTestGridName() + '1') == STOPPED;
+        assert G.state(cfg1.getLocalInstanceName()) == STARTED;
+        assert G.state(getTestLocalInstanceName() + '1') == STOPPED;
 
-        G.stop(cfg1.getGridName(), false);
+        G.stop(cfg1.getLocalInstanceName(), false);
 
-        assert G.state(cfg1.getGridName()) == STOPPED;
-        assert G.state(getTestGridName() + '1') == STOPPED;
+        assert G.state(cfg1.getLocalInstanceName()) == STOPPED;
+        assert G.state(getTestLocalInstanceName() + '1') == STOPPED;
 
-        cfg2.setGridName(getTestGridName() + '1');
-
-        G.start(cfg2);
-
-        assert G.state(cfg1.getGridName()) == STOPPED;
-        assert G.state(getTestGridName() + '1') == STARTED;
-
-        G.stop(getTestGridName() + '1', false);
-
-        assert G.state(cfg1.getGridName()) == STOPPED;
-        assert G.state(getTestGridName() + '1') == STOPPED;
-
-        cfg2.setGridName(getTestGridName() + '1');
+        cfg2.setLocalInstanceName(getTestLocalInstanceName() + '1');
 
         G.start(cfg2);
 
-        assert G.state(getTestGridName() + '1') == STARTED;
-        assert G.state(getTestGridName()) == STOPPED;
+        assert G.state(cfg1.getLocalInstanceName()) == STOPPED;
+        assert G.state(getTestLocalInstanceName() + '1') == STARTED;
 
-        G.stop(getTestGridName() + '1', false);
-        G.stop(getTestGridName(), false);
+        G.stop(getTestLocalInstanceName() + '1', false);
 
-        assert G.state(getTestGridName() + '1') == STOPPED;
-        assert G.state(getTestGridName()) == STOPPED;
+        assert G.state(cfg1.getLocalInstanceName()) == STOPPED;
+        assert G.state(getTestLocalInstanceName() + '1') == STOPPED;
+
+        cfg2.setLocalInstanceName(getTestLocalInstanceName() + '1');
+
+        G.start(cfg2);
+
+        assert G.state(getTestLocalInstanceName() + '1') == STARTED;
+        assert G.state(getTestLocalInstanceName()) == STOPPED;
+
+        G.stop(getTestLocalInstanceName() + '1', false);
+        G.stop(getTestLocalInstanceName(), false);
+
+        assert G.state(getTestLocalInstanceName() + '1') == STOPPED;
+        assert G.state(getTestLocalInstanceName()) == STOPPED;
     }
 
     /**
@@ -674,27 +674,27 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         cfg2.setCollisionSpi(new TestMultipleInstancesCollisionSpi());
         cfg3.setCollisionSpi(new TestMultipleInstancesCollisionSpi());
 
-        cfg2.setGridName(getTestGridName() + '1');
+        cfg2.setLocalInstanceName(getTestLocalInstanceName() + '1');
 
         G.start(cfg2);
 
         G.start(cfg1);
 
-        cfg3.setGridName(getTestGridName() + '2');
+        cfg3.setLocalInstanceName(getTestLocalInstanceName() + '2');
 
         G.start(cfg3);
 
-        assert G.state(cfg1.getGridName()) == STARTED;
-        assert G.state(getTestGridName() + '1') == STARTED;
-        assert G.state(getTestGridName() + '2') == STARTED;
+        assert G.state(cfg1.getLocalInstanceName()) == STARTED;
+        assert G.state(getTestLocalInstanceName() + '1') == STARTED;
+        assert G.state(getTestLocalInstanceName() + '2') == STARTED;
 
-        G.stop(getTestGridName() + '2', false);
-        G.stop(cfg1.getGridName(), false);
-        G.stop(getTestGridName() + '1', false);
+        G.stop(getTestLocalInstanceName() + '2', false);
+        G.stop(cfg1.getLocalInstanceName(), false);
+        G.stop(getTestLocalInstanceName() + '1', false);
 
-        assert G.state(cfg1.getGridName()) == STOPPED;
-        assert G.state(getTestGridName() + '1') == STOPPED;
-        assert G.state(getTestGridName() + '2') == STOPPED;
+        assert G.state(cfg1.getLocalInstanceName()) == STOPPED;
+        assert G.state(getTestLocalInstanceName() + '1') == STOPPED;
+        assert G.state(getTestLocalInstanceName() + '2') == STOPPED;
     }
 
     /**
@@ -741,7 +741,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         }
 
         /** {@inheritDoc} */
-        @Override public void spiStart(String gridName) throws IgniteSpiException {
+        @Override public void spiStart(String localInstanceName) throws IgniteSpiException {
             // Start SPI start stopwatch.
             startStopwatch();
 
@@ -779,7 +779,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         }
 
         /** {@inheritDoc} */
-        @Override public void spiStart(String gridName) throws IgniteSpiException {
+        @Override public void spiStart(String localInstanceName) throws IgniteSpiException {
             // Start SPI start stopwatch.
             startStopwatch();
 
@@ -820,8 +820,8 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         /** Lifecycle events. */
         private final List<LifecycleEventType> evts = new ArrayList<>();
 
-        /** Grid names. */
-        private final List<String> gridNames = new ArrayList<>();
+        /** Local instance names. */
+        private final List<String> localInstanceNames = new ArrayList<>();
 
         /** */
         private final AtomicReference<Throwable> err = new AtomicReference<>();
@@ -830,7 +830,7 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         @Override public void onLifecycleEvent(LifecycleEventType evt) {
             evts.add(evt);
 
-            gridNames.add(ignite.name());
+            localInstanceNames.add(ignite.name());
 
             try {
                 checkState(ignite.name(),
@@ -846,18 +846,18 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         /**
          * Checks state of the bean.
          *
-         * @param gridName Grid name.
+         * @param localInstanceName Grid name.
          * @param exec Try to execute something on the grid.
          */
-        void checkState(String gridName, boolean exec) {
+        void checkState(String localInstanceName, boolean exec) {
             assert log != null;
             assert appCtx != null;
 
-            assert F.eq(gridName, ignite.name());
+            assert F.eq(localInstanceName, ignite.name());
 
             if (exec)
                 // Execute any grid method.
-                G.ignite(gridName).events().localQuery(F.<Event>alwaysTrue());
+                G.ignite(localInstanceName).events().localQuery(F.<Event>alwaysTrue());
         }
 
         /**
@@ -870,12 +870,12 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         }
 
         /**
-         * Gets ordered list of grid names.
+         * Gets oedered list of local instance names.
          *
-         * @return Ordered list of grid names.
+         * @return Ordered list of local instance names.
          */
-        List<String> getGridNames() {
-            return gridNames;
+        List<String> getLocalInstanceNames() {
+            return localInstanceNames;
         }
 
         /**

--- a/modules/web/src/main/java/org/apache/ignite/startup/servlet/ServletContextListenerStartup.java
+++ b/modules/web/src/main/java/org/apache/ignite/startup/servlet/ServletContextListenerStartup.java
@@ -154,7 +154,7 @@ public class ServletContextListenerStartup implements ServletContextListener {
 
                 synchronized (ServletContextListenerStartup.class) {
                     try {
-                        ignite = G.ignite(cfg.getGridName());
+                        ignite = G.ignite(cfg.getLocalInstanceName());
                     }
                     catch (IgniteIllegalStateException ignored) {
                         ignite = IgnitionEx.start(new IgniteConfiguration(cfg), rsrcCtx);


### PR DESCRIPTION
Deprecate IgniteConfiguration.gridName
Add IgniteConfiguration.localInstanceName
Rename related parameters in Ignition class (and other places, if present)
Update Javadoc: clearly state that this name only works locally and has no effect on topology.