### PR TITLE
IGNITE-3229 un existing link in Class GridCacheStoreValueBytesSelfTest

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheStoreValueBytesSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheStoreValueBytesSelfTest.java
@@ -31,7 +31,7 @@ import static org.apache.ignite.cache.CacheMode.REPLICATED;
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
 
 /**
- * Test for {@link org.apache.ignite.configuration.CacheConfiguration#isStoreValueBytes()}.
+ * Test for {@link org.apache.ignite.configuration.CacheConfiguration#isStoreKeepBinary()}.
  */
 public class GridCacheStoreValueBytesSelfTest extends GridCommonAbstractTest {
     /** */


### PR DESCRIPTION
Class GridCacheStoreValueBytesSelfTest' s annotation has linked to an un existing  method  `org.apache.ignite.configuration.CacheConfiguration#isStoreValueBytes()`. Change it to `org.apache.ignite.configuration.CacheConfiguration#isStoreKeepBinary()`