### PR TITLE
IGNITE-3231 add the unimplement method

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCachePartitionedNearDisabledFairAffinityMultiNodeFullApiSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCachePartitionedNearDisabledFairAffinityMultiNodeFullApiSelfTest.java
@@ -33,4 +33,9 @@ public class GridCachePartitionedNearDisabledFairAffinityMultiNodeFullApiSelfTes
 
         return cfg;
     }
+
+    /** {@inheritDoc} */
+    @Override protected int gridCount() {
+        return 1;
+    }
 }


### PR DESCRIPTION
`GridCachePartitionedNearDisabledFairAffinityMultiNodeFullApiSelfTest` must either be declared abstract or implement method `gridCount()`

