### PR TITLE
IGNITE-3304 Add missing type parameter in serviceProxy

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteServicesImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteServicesImpl.java
@@ -229,7 +229,7 @@ public class IgniteServicesImpl extends AsyncSupportAdapter implements IgniteSer
         guard();
 
         try {
-            return ctx.service().serviceProxy(prj, name, svcItf, sticky);
+            return (T)ctx.service().serviceProxy(prj, name, svcItf, sticky);
         }
         finally {
             unguard();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/service/GridServiceProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/service/GridServiceProcessor.java
@@ -786,7 +786,7 @@ public class GridServiceProcessor extends GridProcessorAdapter {
             }
         }
 
-        return new GridServiceProxy<>(prj, name, svcItf, sticky, ctx).proxy();
+        return new GridServiceProxy<T>(prj, name, svcItf, sticky, ctx).proxy();
     }
 
     /**


### PR DESCRIPTION
Method `serviceProxy` in Class `org.apache.ignite.internal.processors.service.GridServiceProcessor` seems missing type paramter "T", added it. 
Also add a  cast in method `serviceProxy` in  class `org.apache.ignite.internal.IgniteServicesImpl`.
