### PR TITLE
When multiple addresses resolve to same name, TcpDiscoverySharedFsIpFinder fails on unregister

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/sharedfs/TcpDiscoverySharedFsIpFinder.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/sharedfs/TcpDiscoverySharedFsIpFinder.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -225,8 +227,8 @@ public class TcpDiscoverySharedFsIpFinder extends TcpDiscoveryIpFinderAdapter {
         initFolder();
 
         try {
-            for (InetSocketAddress addr : addrs) {
-                File file = new File(folder, name(addr));
+            for (String name : distinctNames(addrs)) {
+                File file = new File(folder, name);
 
                 file.createNewFile();
             }
@@ -243,8 +245,8 @@ public class TcpDiscoverySharedFsIpFinder extends TcpDiscoveryIpFinderAdapter {
         initFolder();
 
         try {
-            for (InetSocketAddress addr : addrs) {
-                File file = new File(folder, name(addr));
+            for (String name : distinctNames(addrs)) {
+                File file = new File(folder, name);
 
                 if (!file.delete())
                     throw new IgniteSpiException("Failed to delete file " + file.getName());
@@ -253,6 +255,14 @@ public class TcpDiscoverySharedFsIpFinder extends TcpDiscoveryIpFinderAdapter {
         catch (SecurityException e) {
             throw new IgniteSpiException("Failed to delete file.", e);
         }
+    }
+
+    private Iterable<String> distinctNames(Iterable<InetSocketAddress> addresses ){
+        Set<String> result = new HashSet<>();
+        for (InetSocketAddress address : addresses) {
+            result.add(name(address));
+        }
+        return result;
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/sharedfs/TcpDiscoverySharedFsIpFinderSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/sharedfs/TcpDiscoverySharedFsIpFinderSelfTest.java
@@ -18,6 +18,10 @@
 package org.apache.ignite.spi.discovery.tcp.ipfinder.sharedfs;
 
 import java.io.File;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinderAbstractSelfTest;
 
@@ -51,5 +55,27 @@ public class TcpDiscoverySharedFsIpFinderSelfTest
         finder.setPath(tmpFile.getAbsolutePath());
 
         return finder;
+    }
+
+    /**
+     * @throws Exception If any error occurs.
+     */
+    public void test_multiple_addresses_that_merge_to_1() throws Exception {
+
+        InetSocketAddress node1 = new InetSocketAddress("10.7.7.7", 4343);
+        InetAddress ia =   InetAddress.getByAddress("localhost", new byte[]{10, 7,7,7 });
+        InetSocketAddress node2 = new InetSocketAddress(ia, 4343);
+
+        List<InetSocketAddress> initAddrs = Arrays.asList(node1, node2);
+
+        finder.registerAddresses(initAddrs);
+
+        assertEquals("Wrong collection size", 1, finder.getRegisteredAddresses().size());
+
+        finder.unregisterAddresses(initAddrs);
+
+        assertEquals("Wrong collection size", 0, finder.getRegisteredAddresses().size());
+
+        finder.close();
     }
 }


### PR DESCRIPTION
On my mac, I will have an address that reads <hostname>/ip:port as well as ip:port. These will resolve
to the same filename and subsequently give a stacktrace upon unregister.

Fixed with testcase
