### PR TITLE
IGNITE-3391 add param tableName for queryEntity

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/QueryEntity.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/QueryEntity.java
@@ -48,6 +48,9 @@ public class QueryEntity implements Serializable {
     /** Collection of query indexes. */
     private Map<String, QueryIndex> idxs = new HashMap<>();
 
+    /** Table name. */
+    private String tableName;
+
     /**
      * Gets key type for this query pair.
      *
@@ -151,6 +154,24 @@ public class QueryEntity implements Serializable {
         }
     }
 
+
+    /**
+     * Gets table name for this query pair.
+     *
+     * @return table name
+     */
+    public String getTableName() {
+        return tableName;
+    }
+
+    /**
+     * Sets table name for this query pair.
+     * @param tableName table name
+     */
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
     /**
      * Utility method for building query entities programmatically.
      */
@@ -183,7 +204,7 @@ public class QueryEntity implements Serializable {
         }
         else
             throw new IllegalArgumentException("An index with the same name and of a different type already exists " +
-                "[idxName=" + idxName + ", existingIdxType=" + idx.getIndexType() + ", newIdxType=" + idxType + ']');
+                    "[idxName=" + idxName + ", existingIdxType=" + idx.getIndexType() + ", newIdxType=" + idxType + ']');
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/cache/QueryEntity.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/QueryEntity.java
@@ -204,7 +204,7 @@ public class QueryEntity implements Serializable {
         }
         else
             throw new IllegalArgumentException("An index with the same name and of a different type already exists " +
-                    "[idxName=" + idxName + ", existingIdxType=" + idx.getIndexType() + ", newIdxType=" + idxType + ']');
+                "[idxName=" + idxName + ", existingIdxType=" + idx.getIndexType() + ", newIdxType=" + idxType + ']');
     }
 
     /**


### PR DESCRIPTION
Currently the SQL table name is always the same as class name. In some cases user may want to override this and use different name in queries.
`tableName` property is added to `QueryEntity`.
