### PR TITLE
IGNITE-3516

### DIFF
--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -1675,6 +1675,12 @@ public class IgniteH2Indexing implements GridQueryIndexing {
                 if (F.eq(e.getKey().get1(), ccfg.getName()))
                     it.remove();
             }
+
+            for (TableDescriptor desc : rmv.tbls.values()) {
+                desc.tbl.close();
+                if (desc.luceneIdx != null)
+                    U.closeQuiet(desc.luceneIdx);
+            }
         }
     }
 


### PR DESCRIPTION
H2 Indexing unregister cache does not call TableDescriptor's GridH2Table close and optionally GridLuceneIndex close, which causes OFFHEAP_TIERED cache to leak memory.
