### PR TITLE
IGNITE-3649 IGFS: Local secondary: "create" flag is not used for appe…

### DIFF
--- a/modules/hadoop/src/main/java/org/apache/ignite/hadoop/fs/LocalIgfsSecondaryFileSystem.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/hadoop/fs/LocalIgfsSecondaryFileSystem.java
@@ -411,14 +411,17 @@ public class LocalIgfsSecondaryFileSystem implements IgfsSecondaryFileSystem, Li
     @Override public OutputStream append(IgfsPath path, int bufSize, boolean create,
         @Nullable Map<String, String> props) {
         // TODO: IGNITE-3648.
-        // TODO: IGNITE-3649.
         try {
             File file = fileForPath(path);
 
             boolean exists = file.exists();
 
-            if (!exists)
-                throw new IOException("File not found.");
+            if (!exists) {
+                if(!create)
+                    throw new IOException("File not found.");
+                else
+                    return create0(path, false, bufSize);
+            }
 
             return new BufferedOutputStream(new FileOutputStream(file, true), bufSize);
         }


### PR DESCRIPTION
…nd() operation.