### PR TITLE
IGNITE-4155 minor fixes to examples

### DIFF
--- a/examples/config/hibernate/example-hibernate-L2-cache.xml
+++ b/examples/config/hibernate/example-hibernate-L2-cache.xml
@@ -32,7 +32,7 @@
         <property name="connection.url">jdbc:h2:mem:example;DB_CLOSE_DELAY=-1</property>
 
         <!-- Drop and re-create the database schema on startup. -->
-        <property name="hbm2ddl.auto">create</property>
+        <property name="hbm2ddl.auto">update</property>
 
         <!-- Enable L2 cache. -->
         <property name="cache.use_second_level_cache">true</property>

--- a/examples/src/main/java/org/apache/ignite/examples/datastructures/IgniteSemaphoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/datastructures/IgniteSemaphoreExample.java
@@ -62,9 +62,6 @@ public class IgniteSemaphoreExample {
             // Make name of semaphore.
             final String semaphoreName = UUID.randomUUID().toString();
 
-            // Initialize semaphore.
-            IgniteSemaphore semaphore = ignite.semaphore(semaphoreName, 0, false, true);
-
             // Start consumers on all cluster nodes.
             for (int i = 0; i < NUM_CONSUMERS; i++)
                 ignite.compute().withAsync().run(new Consumer(semaphoreName));
@@ -126,10 +123,10 @@ public class IgniteSemaphoreExample {
             System.out.println("Producer finished [nodeId=" + Ignition.ignite().cluster().localNode().id() + ']');
 
             // Gets the syncing semaphore
-            IgniteSemaphore sem = Ignition.ignite().semaphore(SEM_NAME, 0, true, true);
+            IgniteSemaphore sync = Ignition.ignite().semaphore(SEM_NAME, 0, true, true);
 
             // Signals the master thread
-            sem.release();
+            sync.release();
         }
     }
 


### PR DESCRIPTION
IgniteSemaphoreExample was fixed: it is possible to rerun example without restarting cluster.

Errors in logs of HibernateL2CacheExample were fixed.