### PR TITLE
IGNITE-4238: example spatial queries fails

### DIFF
--- a/modules/geospatial/src/test/java/org/apache/ignite/internal/processors/query/h2/GridH2IndexingGeoBinarySelfTest.java
+++ b/modules/geospatial/src/test/java/org/apache/ignite/internal/processors/query/h2/GridH2IndexingGeoBinarySelfTest.java
@@ -15,28 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.testsuites;
+package org.apache.ignite.internal.processors.query.h2;
 
-import junit.framework.TestSuite;
-import org.apache.ignite.internal.processors.query.h2.GridH2IndexingGeoBinarySelfTest;
-import org.apache.ignite.internal.processors.query.h2.GridH2IndexingGeoSelfTest;
+import org.apache.ignite.internal.binary.BinaryMarshaller;
+import org.apache.ignite.testframework.config.GridTestProperties;
 
 /**
- * Geospatial indexing tests.
+ *
  */
-public class GeoSpatialIndexingTestSuite extends TestSuite {
-    /**
-     * @return Test suite.
-     * @throws Exception Thrown in case of the failure.
-     */
-    public static TestSuite suite() throws Exception {
-        TestSuite suite = new TestSuite("H2 Geospatial Indexing Test Suite");
+public class GridH2IndexingGeoBinarySelfTest extends GridH2IndexingGeoSelfTest {
 
-        // Geo.
-        suite.addTestSuite(GridH2IndexingGeoSelfTest.class);
+    @Override protected void beforeTestsStarted() throws Exception {
+        GridTestProperties.setProperty(GridTestProperties.MARSH_CLASS_NAME, BinaryMarshaller.class.getName());
 
-        suite.addTestSuite(GridH2IndexingGeoBinarySelfTest.class);
-
-        return suite;
+        super.beforeTestsStarted();
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -57,7 +57,6 @@ import javax.cache.CacheException;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
-import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.cache.CacheMemoryMode;
 import org.apache.ignite.cache.query.QueryCancelledException;
 import org.apache.ignite.cache.query.QueryCursor;
@@ -543,14 +542,6 @@ public class IgniteH2Indexing implements GridQueryIndexing {
         try {
             if (obj == null)
                 stmt.setNull(idx, Types.VARCHAR);
-            if (obj instanceof BinaryObject) {
-                Object obj0 = ((BinaryObject)obj).deserialize();
-
-                if (obj0 == null)
-                    stmt.setNull(idx, Types.VARCHAR);
-                else
-                    stmt.setObject(idx, obj0);
-            }
             else
                 stmt.setObject(idx, obj);
         }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -543,8 +543,14 @@ public class IgniteH2Indexing implements GridQueryIndexing {
         try {
             if (obj == null)
                 stmt.setNull(idx, Types.VARCHAR);
-            if (obj instanceof BinaryObject)
-                stmt.setObject(idx,((BinaryObject)obj).deserialize());
+            if (obj instanceof BinaryObject) {
+                Object obj0 = ((BinaryObject)obj).deserialize();
+
+                if (obj0 == null)
+                    stmt.setNull(idx, Types.VARCHAR);
+                else
+                    stmt.setObject(idx, obj0);
+            }
             else
                 stmt.setObject(idx, obj);
         }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -57,6 +57,7 @@ import javax.cache.CacheException;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.cache.CacheMemoryMode;
 import org.apache.ignite.cache.query.QueryCancelledException;
 import org.apache.ignite.cache.query.QueryCursor;
@@ -542,6 +543,8 @@ public class IgniteH2Indexing implements GridQueryIndexing {
         try {
             if (obj == null)
                 stmt.setNull(idx, Types.VARCHAR);
+            if (obj instanceof BinaryObject)
+                stmt.setObject(idx,((BinaryObject)obj).deserialize());
             else
                 stmt.setObject(idx, obj);
         }


### PR DESCRIPTION
Fixed: deserialize binary sql arguments before binding