### PR TITLE
IGNITE-3196

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1189,9 +1190,12 @@ public class BinaryUtils {
      * @return Value.
      */
     public static BigDecimal doReadDecimal(BinaryInputStream in) {
-        char[] mag = doReadCharArray(in);
+        int scale = in.readInt();
+        byte[] mag = doReadByteArray(in);
 
-        return new BigDecimal(mag);
+        BigInteger intVal = new BigInteger(mag);
+
+        return new BigDecimal(intVal, scale);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,8 +64,8 @@ import org.apache.ignite.lang.IgniteUuid;
 import org.jetbrains.annotations.Nullable;
 import org.jsr166.ConcurrentHashMap8;
 
-import static org.apache.ignite.IgniteSystemProperties.IGNITE_BINARY_MARSHALLER_USE_STRING_SERIALIZATION_VER_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.ignite.IgniteSystemProperties.IGNITE_BINARY_MARSHALLER_USE_STRING_SERIALIZATION_VER_2;
 
 /**
  * Binary utils.
@@ -1190,18 +1189,9 @@ public class BinaryUtils {
      * @return Value.
      */
     public static BigDecimal doReadDecimal(BinaryInputStream in) {
-        int scale = in.readInt();
-        byte[] mag = doReadByteArray(in);
+        char[] mag = doReadCharArray(in);
 
-        BigInteger intVal = new BigInteger(mag);
-
-        if (scale < 0) {
-            scale &= 0x7FFFFFFF;
-
-            intVal = intVal.negate();
-        }
-
-        return new BigDecimal(intVal, scale);
+        return new BigDecimal(mag);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
@@ -1193,7 +1193,15 @@ public class BinaryUtils {
         int scale = in.readInt();
         byte[] mag = doReadByteArray(in);
 
+        boolean negative = mag[0] < 0;
+
+        if (negative)
+            mag[0] &= 0x7F;
+
         BigInteger intVal = new BigInteger(mag);
+
+        if (negative)
+            intVal = intVal.negate();
 
         return new BigDecimal(intVal, scale);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryWriterExImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryWriterExImpl.java
@@ -22,7 +22,6 @@ import java.io.ObjectOutput;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Date;
@@ -403,20 +402,11 @@ public class BinaryWriterExImpl implements BinaryWriter, BinaryRawWriterEx, Obje
 
             out.unsafeWriteByte(GridBinaryMarshaller.DECIMAL);
 
-            BigInteger intVal = val.unscaledValue();
-
-            if (intVal.signum() == -1) {
-                intVal = intVal.negate();
-
-                out.unsafeWriteInt(val.scale() | 0x80000000);
-            }
-            else
-                out.unsafeWriteInt(val.scale());
-
-            byte[] vals = intVal.toByteArray();
+            char[] vals = val.toString().toCharArray();
 
             out.unsafeWriteInt(vals.length);
-            out.writeByteArray(vals);
+
+            out.writeCharArray(vals);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryWriterExImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryWriterExImpl.java
@@ -22,6 +22,7 @@ import java.io.ObjectOutput;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Date;
@@ -402,11 +403,14 @@ public class BinaryWriterExImpl implements BinaryWriter, BinaryRawWriterEx, Obje
 
             out.unsafeWriteByte(GridBinaryMarshaller.DECIMAL);
 
-            char[] vals = val.toString().toCharArray();
+            out.unsafeWriteInt(val.scale());
+
+            BigInteger intVal = val.unscaledValue();
+
+            byte[] vals = intVal.toByteArray();
 
             out.unsafeWriteInt(vals.length);
-
-            out.writeCharArray(vals);
+            out.writeByteArray(vals);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryWriterExImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryWriterExImpl.java
@@ -407,7 +407,15 @@ public class BinaryWriterExImpl implements BinaryWriter, BinaryRawWriterEx, Obje
 
             BigInteger intVal = val.unscaledValue();
 
+            boolean negative = intVal.signum() == -1;
+
+            if (negative)
+                intVal = intVal.negate();
+
             byte[] vals = intVal.toByteArray();
+
+            if (negative)
+                vals[0] |= -0x80;
 
             out.unsafeWriteInt(vals.length);
             out.writeByteArray(vals);

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -186,11 +186,25 @@ public class BinaryMarshallerSelfTest extends GridCommonAbstractTest {
     public void testNegativeScaleDecimal() throws Exception {
         BigDecimal val;
 
+        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE, -1)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE, -2)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE, -3)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE, -4)), marshalUnmarshal(val));
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testNegativeScaleRoundingModeDecimal() throws Exception {
+        BigDecimal val;
+
         assertEquals((val = BigDecimal.ZERO.setScale(-1, RoundingMode.HALF_UP)), marshalUnmarshal(val));
-        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE, 0).setScale(-3, RoundingMode.HALF_UP)), marshalUnmarshal(val));
-        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE, 0).setScale(-5, RoundingMode.HALF_UP)), marshalUnmarshal(val));
-        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE, 8).setScale(-8, RoundingMode.HALF_UP)), marshalUnmarshal(val));
-        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE, 8).setScale(-10, RoundingMode.HALF_UP)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE).setScale(-3, RoundingMode.HALF_DOWN)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE).setScale(-5, RoundingMode.HALF_EVEN)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Integer.MAX_VALUE).setScale(-8, RoundingMode.UP)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Integer.MIN_VALUE).setScale(-10, RoundingMode.DOWN)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Double.MAX_VALUE).setScale(-12, RoundingMode.CEILING)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Double.MIN_VALUE).setScale(-15, RoundingMode.FLOOR)), marshalUnmarshal(val));
     }
 
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.net.InetSocketAddress;
 import java.sql.Timestamp;
 import java.util.AbstractQueue;
@@ -177,6 +178,21 @@ public class BinaryMarshallerSelfTest extends GridCommonAbstractTest {
 
         assertEquals((val = new BigDecimal(new BigInteger("-79228162514264337593543950336"))), marshalUnmarshal(val));
     }
+
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testNegativeScaleDecimal() throws Exception {
+        BigDecimal val;
+
+        assertEquals((val = BigDecimal.ZERO.setScale(-1, RoundingMode.HALF_UP)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE, 0).setScale(-3, RoundingMode.HALF_UP)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE, 0).setScale(-5, RoundingMode.HALF_UP)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MAX_VALUE, 8).setScale(-8, RoundingMode.HALF_UP)), marshalUnmarshal(val));
+        assertEquals((val = BigDecimal.valueOf(Long.MIN_VALUE, 8).setScale(-10, RoundingMode.HALF_UP)), marshalUnmarshal(val));
+    }
+
 
     /**
      * @throws Exception If failed.

--- a/modules/platforms/cpp/odbc/src/utility.cpp
+++ b/modules/platforms/cpp/odbc/src/utility.cpp
@@ -85,12 +85,12 @@ namespace ignite
 
             int32_t sign = 1;
             
-			if (mag[0] < 0)
-			{
-				mag[0] &= 0x7F;
+            if (mag[0] < 0)
+            {
+                mag[0] &= 0x7F;
 
-				sign = -1;
-			}
+                sign = -1;
+            }
 
             common::Decimal res(mag.data(), static_cast<int32_t>(mag.size()), scale, sign);
 
@@ -109,8 +109,8 @@ namespace ignite
 
             unscaled.MagnitudeToBytes(magnitude);
 
-			if (unscaled.GetSign() == -1)
-				magnitude[0] |= -0x80;
+            if (unscaled.GetSign() == -1)
+                magnitude[0] |= -0x80;
 
             writer.WriteInt32(magnitude.GetSize());
 

--- a/modules/platforms/cpp/odbc/src/utility.cpp
+++ b/modules/platforms/cpp/odbc/src/utility.cpp
@@ -83,8 +83,14 @@ namespace ignite
 
             impl::binary::BinaryUtils::ReadInt8Array(reader.GetStream(), mag.data(), static_cast<int32_t>(mag.size()));
 
-            int32_t sign = (scale & 0x80000000) ? -1 : 1;
-            scale = scale & 0x7FFFFFFF;
+            int32_t sign = 1;
+            
+			if (mag[0] < 0)
+			{
+				mag[0] &= 0x7F;
+
+				sign = -1;
+			}
 
             common::Decimal res(mag.data(), static_cast<int32_t>(mag.size()), scale, sign);
 
@@ -97,13 +103,14 @@ namespace ignite
 
             const common::BigInteger &unscaled = decimal.GetUnscaledValue();
 
-            int32_t signFlag = unscaled.GetSign() == -1 ? 0x80000000 : 0;
-
-            writer.WriteInt32(decimal.GetScale() | signFlag);
+            writer.WriteInt32(decimal.GetScale());
 
             common::FixedSizeArray<int8_t> magnitude;
 
             unscaled.MagnitudeToBytes(magnitude);
+
+			if (unscaled.GetSign() == -1)
+				magnitude[0] |= -0x80;
 
             writer.WriteInt32(magnitude.GetSize());
 


### PR DESCRIPTION
Ideally, we shouldn't check sign at serialization, because the used approach:
BigInteger intVal = val.unscaledValue();
byte[] vals = intVal.toByteArray();
#toByteArray() - already including at least one sign bit, which is (ceil((this.bitLength() + 1)/8)). (This representation is compatible with the (byte[]) constructor.)
Therefore, at deserialization we just read  byte[] vals and scale, also we use default constructor which will define a sign from byte[] vals.

But for .NET & C++ compatibility support, we always serialize only positive numbers, also we write a sign in the first byte, because it is always positive.

We can't use the scale for save a sign, because it can be the negative in Java.