### PR TITLE
IGNITE-3793: Need to fix dependencies and it's licenses

### DIFF
--- a/assembly/LICENSE_FABRIC
+++ b/assembly/LICENSE_FABRIC
@@ -229,7 +229,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
 This product bundles JSR107 API and SPI which is available under a:
-JSR-000107 JCACHE 2.9 Public Review - Updated Specification License. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
+The Apache Software License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50
@@ -250,10 +250,10 @@ This product bundles Scala Library which is available under a:
 BSD 3-Clause. For details, see http://www.scala-lang.org/license.html.
 
 ==============================================================================
-For H2 Database Engine (http://www.h2database.com) com.h2database:h2:jar:1.3.175
+For H2 Database Engine (http://www.h2database.com) com.h2database:h2:jar:1.4.191
 ==============================================================================
 This product bundles H2 Database Engine which is available under a:
-The H2 License, Version 1.0. For details, see http://h2database.com/html/license.html.
+MPL 2.0, and EPL 1.0. For details, see http://h2database.com/html/license.html.
 
 ==============================================================================
 For JTidy (http://jtidy.sourceforge.net) net.sf.jtidy:jtidy:jar:r938

--- a/assembly/LICENSE_FABRIC
+++ b/assembly/LICENSE_FABRIC
@@ -229,7 +229,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
 This product bundles JSR107 API and SPI which is available under a:
-The Apache Software License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
+Apache License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50

--- a/assembly/LICENSE_FABRIC
+++ b/assembly/LICENSE_FABRIC
@@ -214,9 +214,8 @@ licenses.
 ==============================================================================
 For SnapTree:
 ==============================================================================
-This product bundles SnapTree, which is available under a
-"3-clause BSD" license.  For details, see
-https://github.com/nbronson/snaptree/blob/master/LICENSE.
+This product bundles SnapTree, which is available under the following:
+"3-clause BSD" license. For details, see https://github.com/nbronson/snaptree/blob/master/LICENSE.
 
 ==============================================================================
 For JSR 166 classes in "org.jsr166" package
@@ -228,55 +227,55 @@ http://creativecommons.org/publicdomain/zero/1.0/
 ==============================================================================
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
-This product bundles JSR107 API and SPI which is available under a:
+This product bundles JSR107 API and SPI which is available under the following:
 Apache License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50
 ==============================================================================
-This product bundles JSch which is available under a:
+This product bundles JSch which is available under the following:
 Revised BSD. For details, see http://www.jcraft.com/jsch/LICENSE.txt.
 
 ==============================================================================
 For JLine (http://nexus.sonatype.org/oss-repository-hosting.html/jline) jline:jline:jar:2.12.1
 ==============================================================================
-This product bundles JLine which is available under a:
+This product bundles JLine which is available under the following:
 The BSD License. For details, see http://www.opensource.org/licenses/bsd-license.php.
 
 ==============================================================================
 For Scala Library (http://www.scala-lang.org/) org.scala-lang:scala-library:jar:2.*
 ==============================================================================
-This product bundles Scala Library which is available under a:
+This product bundles Scala Library which is available under the following:
 BSD 3-Clause. For details, see http://www.scala-lang.org/license.html.
 
 ==============================================================================
 For H2 Database Engine (http://www.h2database.com) com.h2database:h2:jar:1.4.191
 ==============================================================================
-This product bundles H2 Database Engine which is available under a:
+This product bundles H2 Database Engine which is available under the following:
 MPL 2.0, and EPL 1.0. For details, see http://h2database.com/html/license.html.
 
 ==============================================================================
 For JTidy (http://jtidy.sourceforge.net) net.sf.jtidy:jtidy:jar:r938
 ==============================================================================
-This product bundles JTidy which is available under a:
+This product bundles JTidy which is available under the following:
 Java HTML Tidy License. For details, see http://jtidy.svn.sourceforge.net/viewvc/jtidy/trunk/jtidy/LICENSE.txt?revision=95.
 
 ==============================================================================
 For tomcat-servlet-api (http://tomcat.apache.org/) org.apache.tomcat:tomcat-servlet-api:jar:8.0.23
 ==============================================================================
-This product bundles tomcat-servlet-api which is available under a:
+This product bundles tomcat-servlet-api which is available under the following:
 Apache License, Version 2.0 and Common Development And Distribution License (CDDL) Version 1.0. For details, see http://www.apache.org/licenses/LICENSE-2.0.txt and http://www.opensource.org/licenses/cddl1.txt.
 
 ==============================================================================
 For AOP alliance (http://aopalliance.sourceforge.net) aopalliance:aopalliance:jar:1.0
 ==============================================================================
-This product bundles AOP alliance which is available under a:
+This product bundles AOP alliance which is available under the following:
 Public Domain.
 
 ==============================================================================
 For AspectJ (http://www.aspectj.org) org.aspectj:*:jar:1.7.2
 ==============================================================================
-This product bundles AspectJ which is available under a:
+This product bundles AspectJ which is available under the following:
 Eclipse Public License - v 1.0. For details, see http://www.eclipse.org/legal/epl-v10.html.
 
 ==============================================================================
@@ -288,18 +287,18 @@ See http://download.oracle.com/otndocs/jcp/jta-1.1-classes-oth-JSpec/jta-1.1-cla
 ==============================================================================
 For ASM All (http://asm.objectweb.org/asm-all/) org.ow2.asm:asm-all:jar:4.2
 ==============================================================================
-This product bundles ASM All which is available under a:
+This product bundles ASM All which is available under the following:
 BSD. For details, see http://asm.objectweb.org/license.html.
 
 ==============================================================================
 For Jetty (http://www.eclipse.org/jetty) org.eclipse.jetty:*:jar:9.2.11.v20150529
 ==============================================================================
-This product bundles Jetty which is available under a:
+This product bundles Jetty which is available under the following:
 Apache Software License - Version 2.0. For details, see http://www.apache.org/licenses/LICENSE-2.0.
 Eclipse Public License - Version 1.0. For details, see http://www.eclipse.org/org/documents/epl-v10.php.
 
 ==============================================================================
 For SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:1.6.4
 ==============================================================================
-This product bundles SLF4J API Module which is available under a:
+This product bundles SLF4J API Module which is available under the following:
 MIT License. For details, see http://www.opensource.org/licenses/mit-license.php.

--- a/assembly/LICENSE_FABRIC
+++ b/assembly/LICENSE_FABRIC
@@ -228,7 +228,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
 This product bundles JSR107 API and SPI which is available under the following:
-Apache License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
+JSR-000107 JCACHE 2.9 Public Review - Updated Specification License. https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50

--- a/assembly/LICENSE_HADOOP
+++ b/assembly/LICENSE_HADOOP
@@ -214,9 +214,8 @@ licenses.
 ==============================================================================
 For SnapTree:
 ==============================================================================
-This product bundles SnapTree, which is available under a
-"3-clause BSD" license.  For details, see
-https://github.com/nbronson/snaptree/blob/master/LICENSE.
+This product bundles SnapTree, which is available under the following:
+"3-clause BSD" license. For details, see https://github.com/nbronson/snaptree/blob/master/LICENSE.
 
 ==============================================================================
 For JSR 166 classes in "org.jsr166" package
@@ -228,31 +227,31 @@ http://creativecommons.org/publicdomain/zero/1.0/
 ==============================================================================
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
-This product bundles JSR107 API and SPI which is available under a:
+This product bundles JSR107 API and SPI which is available under the following:
 Apache License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50
 ==============================================================================
-This product bundles JSch which is available under a:
+This product bundles JSch which is available under the following:
 Revised BSD. For details, see http://www.jcraft.com/jsch/LICENSE.txt.
 
 ==============================================================================
 For JLine (http://nexus.sonatype.org/oss-repository-hosting.html/jline) jline:jline:jar:2.12.1
 ==============================================================================
-This product bundles JLine which is available under a:
+This product bundles JLine which is available under the following:
 The BSD License. For details, see http://www.opensource.org/licenses/bsd-license.php.
 
 ==============================================================================
 For Scala Library (http://www.scala-lang.org/) org.scala-lang:scala-library:jar:2.11.2
 ==============================================================================
-This product bundles Scala Library which is available under a:
+This product bundles Scala Library which is available under the following:
 BSD 3-Clause. For details, see http://www.scala-lang.org/license.html.
 
 ==============================================================================
 For ASM All (http://asm.objectweb.org/asm-all/) org.ow2.asm:asm-all:jar:4.2
 ==============================================================================
-This product bundles ASM All which is available under a:
+This product bundles ASM All which is available under the following:
 BSD. For details, see http://asm.objectweb.org/license.html.
 
 

--- a/assembly/LICENSE_HADOOP
+++ b/assembly/LICENSE_HADOOP
@@ -229,7 +229,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
 This product bundles JSR107 API and SPI which is available under a:
-JSR-000107 JCACHE 2.9 Public Review - Updated Specification License. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
+The Apache Software License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50

--- a/assembly/LICENSE_HADOOP
+++ b/assembly/LICENSE_HADOOP
@@ -229,7 +229,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
 This product bundles JSR107 API and SPI which is available under a:
-The Apache Software License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
+Apache License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50

--- a/assembly/LICENSE_HADOOP
+++ b/assembly/LICENSE_HADOOP
@@ -228,7 +228,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 For JSR107 API and SPI (https://github.com/jsr107/jsr107spec) javax.cache:cache-api:jar:1.0.0
 ==============================================================================
 This product bundles JSR107 API and SPI which is available under the following:
-Apache License, Version 2.0. For details, see https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt.
+JSR-000107 JCACHE 2.9 Public Review - Updated Specification License. https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt
 
 ==============================================================================
 For JSch (http://www.jcraft.com/jsch/) com.jcraft:jsch:jar:0.1.50

--- a/examples/schema-import/bin/h2-server.bat
+++ b/examples/schema-import/bin/h2-server.bat
@@ -75,6 +75,6 @@ if exist "%IGNITE_HOME%\config" goto run
 :run
 
 :: Starts H2 server and console.
-"%JAVA_HOME%\bin\java.exe" -cp "%IGNITE_HOME%\libs\ignite-indexing\h2-1.3.175.jar" org.h2.tools.Console %*
+"%JAVA_HOME%\bin\java.exe" -cp "%IGNITE_HOME%\libs\ignite-indexing\h2-1.4.191.jar" org.h2.tools.Console %*
 
 :error_finish

--- a/examples/schema-import/bin/h2-server.sh
+++ b/examples/schema-import/bin/h2-server.sh
@@ -58,9 +58,9 @@ fi
 # Starts H2 server and console.
 case $osname in
     Darwin*)
-        "${JAVA}" "${DOCK_OPTS}" -cp "${IGNITE_HOME}/libs/ignite-indexing/h2-1.3.175.jar" org.h2.tools.Console ${ARGS}
+        "${JAVA}" "${DOCK_OPTS}" -cp "${IGNITE_HOME}/libs/ignite-indexing/h2-1.4.191.jar" org.h2.tools.Console ${ARGS}
         ;;
    *)
-        "${JAVA}" -cp "${IGNITE_HOME}/libs/ignite-indexing/h2-1.3.175.jar" org.h2.tools.Console ${ARGS}
+        "${JAVA}" -cp "${IGNITE_HOME}/libs/ignite-indexing/h2-1.4.191.jar" org.h2.tools.Console ${ARGS}
         ;;
 esac

--- a/examples/schema-import/bin/schema-import.properties
+++ b/examples/schema-import/bin/schema-import.properties
@@ -19,7 +19,7 @@
 #  Predefined properties for Ignite Schema Import Demo
 #
 jdbc.db.preset=0
-jdbc.driver.jar=libs/ignite-indexing/h2-1.3.175.jar
+jdbc.driver.jar=libs/ignite-indexing/h2-1.4.191.jar
 jdbc.driver.class=org.h2.Driver
 jdbc.url=jdbc:h2:tcp://localhost/~/schema-import/demo
 jdbc.user=sa

--- a/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
+++ b/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
@@ -19,8 +19,7 @@
 ## $Id$
 ##
 // ------------------------------------------------------------------
-// List of #if ($projectName)$projectName#else${project.name}#end module's dependencies provided as a part of this distribution
-// which licenses differ from Apache Software License.
+// List of #if ($projectName)$projectName#else${project.name}#end module's dependencies provided as a part of this distribution.
 // ------------------------------------------------------------------
 
 #foreach ( $organizationName in $projectsSortedByOrganization.keySet() )
@@ -31,12 +30,11 @@ For $project.name #if ($project.url)($project.url)#end $project.artifact
 ==============================================================================
 This product bundles $project.name which is available under a:
 #foreach ( $license in $project.licenses )
-## Despite the license for javax.cache:cache-api:jar:1.0.0 was changed to
-## The Apache Software License, Version 2.0, the license name in the POM
-## remains unchanged. As a workaround, explicitly replace the license name
-## to the proper one.
+## JSR 107 updated the license to Apache License, Version 2.0
+## (https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt) but the JSR's POM
+## still remains unchanged. Handling this with the instructions below.
 #if ( $license.name.contains("JSR-000107 JCACHE 2.9 Public Review") )
-	#set( $licenseName = "The Apache Software License, Version 2.0" )
+	#set( $licenseName = "Apache License, Version 2.0" )
 #else
 	#set( $licenseName = $license.name.replaceAll("[ ]{2,}"," ").replaceAll("\n","") )
 #end

--- a/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
+++ b/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
@@ -25,13 +25,22 @@
 
 #foreach ( $organizationName in $projectsSortedByOrganization.keySet() )
 #foreach ( $project in $projectsSortedByOrganization.get( $organizationName ) )
-#if((!($project.licenses.size() == 1 && $project.licenses.get(0).url.contains("www.apache.org/licenses/LICENSE-2.0") && !$project.licenses.get(0).url.contains("and"))) && $project.licenses.size() > 0)
+#if($project.licenses.size() > 0)
 ==============================================================================
 For $project.name #if ($project.url)($project.url)#end $project.artifact
 ==============================================================================
 This product bundles $project.name which is available under a:
 #foreach ( $license in $project.licenses )
-$license.name.replaceAll("[ ]{2,}"," ").replaceAll("\n",""). #if ($license.url)For details, see $license.url.replaceAll("[ ]{2,}"," ").replaceAll("\n","").#end
+## Despite the license for javax.cache:cache-api:jar:1.0.0 was changed to
+## The Apache Software License, Version 2.0, the license name in the POM
+## remains unchanged. As a workaround, explicitly replace the license name
+## to the proper one.
+#if ( $license.name.contains("JSR-000107 JCACHE 2.9 Public Review") )
+	#set( $licenseName = "The Apache Software License, Version 2.0" )
+#else
+	#set( $licenseName = $license.name.replaceAll("[ ]{2,}"," ").replaceAll("\n","") )
+#end
+$licenseName. #if ($license.url)For details, see $license.url.replaceAll("[ ]{2,}"," ").replaceAll("\n","").#end
 
 #end
 

--- a/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
+++ b/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
@@ -28,7 +28,7 @@
 ==============================================================================
 For $project.name #if ($project.url)($project.url)#end $project.artifact
 ==============================================================================
-This product bundles $project.name which is available under a:
+This product bundles $project.name which is available under the following:
 #foreach ( $license in $project.licenses )
 ## JSR 107 updated the license to Apache License, Version 2.0
 ## (https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt) but the JSR's POM

--- a/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
+++ b/modules/apache-license-gen/src/main/resources/META-INF/licenses.txt.vm
@@ -30,15 +30,7 @@ For $project.name #if ($project.url)($project.url)#end $project.artifact
 ==============================================================================
 This product bundles $project.name which is available under the following:
 #foreach ( $license in $project.licenses )
-## JSR 107 updated the license to Apache License, Version 2.0
-## (https://raw.github.com/jsr107/jsr107spec/master/LICENSE.txt) but the JSR's POM
-## still remains unchanged. Handling this with the instructions below.
-#if ( $license.name.contains("JSR-000107 JCACHE 2.9 Public Review") )
-	#set( $licenseName = "Apache License, Version 2.0" )
-#else
-	#set( $licenseName = $license.name.replaceAll("[ ]{2,}"," ").replaceAll("\n","") )
-#end
-$licenseName. #if ($license.url)For details, see $license.url.replaceAll("[ ]{2,}"," ").replaceAll("\n","").#end
+$license.name.replaceAll("[ ]{2,}"," ").replaceAll("\n",""). #if ($license.url)For details, see $license.url.replaceAll("[ ]{2,}"," ").replaceAll("\n","").#end
 
 #end
 


### PR DESCRIPTION
1) Fix H2 license listed at LICENSE_FABRIC.
2) Fix invalid H2 version in examples.
3) Fix incorrect JCache the license generation after the license changed to Apache 2.0 
4) Enable Apache licenses to be shown at ignite-*-licenses.txt.
