### PR TITLE
automatically detect IGNITE_HOME in service.sh

### DIFF
--- a/bin/include/service.sh
+++ b/bin/include/service.sh
@@ -34,6 +34,10 @@ SERVICE=$2
 # Name of PID file.
 PIDFILE=${IGNITE_PID_DIR}/${SERVICE}.pid
 
+if [ "${IGNITE_HOME}" = "" ];
+    then IGNITE_HOME="$(cd $(dirname $0); cd ../../; pwd)";
+fi
+
 case "$1" in
     start)
         #


### PR DESCRIPTION
it would be handy to have service.sh detect IGNITE_HOME, without relying on other files to be sourced before calling it