### PR TITLE
ignite-4797: Added API for system allocated size in CacheMetrics

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/CacheMetrics.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/CacheMetrics.java
@@ -244,6 +244,13 @@ public interface CacheMetrics {
     public long getOffHeapMaxSize();
 
     /**
+     * Gets the offheap memory allocated for internal data structures
+     *
+     * @return offHeap allocated for internal data structures
+     */
+    public long getSystemAllocatedSize();
+
+    /**
      * The total number of get requests to the swap.
      *
      * @return The number of gets.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheClusterMetricsMXBeanImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheClusterMetricsMXBeanImpl.java
@@ -114,6 +114,9 @@ class CacheClusterMetricsMXBeanImpl implements CacheMetricsMXBean {
     }
 
     /** {@inheritDoc} */
+    @Override public long getSystemAllocatedSize() { return cache.metrics0().getSystemAllocatedSize(); }
+
+    /** {@inheritDoc} */
     @Override public long getSwapGets() {
         return cache.clusterMetrics().getSwapGets();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheLocalMetricsMXBeanImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheLocalMetricsMXBeanImpl.java
@@ -114,6 +114,9 @@ class CacheLocalMetricsMXBeanImpl implements CacheMetricsMXBean {
     }
 
     /** {@inheritDoc} */
+    @Override public long getSystemAllocatedSize() { return cache.metrics0().getSystemAllocatedSize(); }
+
+    /** {@inheritDoc} */
     @Override public long getSwapGets() {
         return cache.metrics0().getSwapGets();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsImpl.java
@@ -252,6 +252,9 @@ public class CacheMetricsImpl implements CacheMetrics {
     }
 
     /** {@inheritDoc} */
+    @Override public long getSystemAllocatedSize() { return cctx.unsafeMemory().systemAllocatedSize(); }
+
+    /** {@inheritDoc} */
     @Override public long getSwapGets() {
         return swapGets.get();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsSnapshot.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheMetricsSnapshot.java
@@ -110,6 +110,9 @@ public class CacheMetricsSnapshot implements CacheMetrics, Externalizable {
     /** Off-heap memory maximum size*/
     private long offHeapMaxSize;
 
+    /** Off-heap memory allocated for internal data structures. */
+    private long systemAllocatedSize;
+
     /** Number of reads from swap. */
     private long swapGets;
 
@@ -275,6 +278,7 @@ public class CacheMetricsSnapshot implements CacheMetrics, Externalizable {
         offHeapBackupEntriesCnt = m.getOffHeapBackupEntriesCount();
         offHeapAllocatedSize = m.getOffHeapAllocatedSize();
         offHeapMaxSize = m.getOffHeapMaxSize();
+        systemAllocatedSize = m.getSystemAllocatedSize();
 
         swapGets = m.getSwapGets();
         swapPuts = m.getSwapPuts();
@@ -624,6 +628,9 @@ public class CacheMetricsSnapshot implements CacheMetrics, Externalizable {
     @Override public long getOffHeapMaxSize() {
         return offHeapMaxSize;
     }
+
+    /** {@inheritDoc} */
+    @Override public long getSystemAllocatedSize() { return systemAllocatedSize; }
 
     /** {@inheritDoc} */
     @Override public long getSwapGets() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
@@ -1370,6 +1370,7 @@ public class PlatformCache extends PlatformAbstractTarget {
         writer.writeLong(metrics.getOffHeapBackupEntriesCount());
         writer.writeLong(metrics.getOffHeapAllocatedSize());
         writer.writeLong(metrics.getOffHeapMaxSize());
+        writer.writeLong(metrics.getSystemAllocatedSize());
         writer.writeLong(metrics.getSwapGets());
         writer.writeLong(metrics.getSwapPuts());
         writer.writeLong(metrics.getSwapRemovals());
@@ -1413,6 +1414,7 @@ public class PlatformCache extends PlatformAbstractTarget {
         writer.writeBoolean(metrics.isManagementEnabled());
         writer.writeBoolean(metrics.isReadThrough());
         writer.writeBoolean(metrics.isWriteThrough());
+        writer.writeLong(metrics.getSystemAllocatedSize());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformCacheWriteMetricsTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformCacheWriteMetricsTask.java
@@ -425,6 +425,9 @@ public class PlatformCacheWriteMetricsTask extends ComputeTaskAdapter<Long, Obje
         }
 
         /** {@inheritDoc} */
+        @Override public long getSystemAllocatedSize() { return 64; }
+
+        /** {@inheritDoc} */
         @Override public String getKeyType() {
             return "foo";
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheMetricsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheMetricsTest.cs
@@ -204,6 +204,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 Assert.AreEqual(61, metrics.WriteBehindCriticalOverflowCount);
                 Assert.AreEqual(62, metrics.WriteBehindErrorRetryCount);
                 Assert.AreEqual(63, metrics.WriteBehindBufferSize);
+                Assert.AreEqual(64,metrics.SystemAllocatedSize)
                 Assert.AreEqual("foo", metrics.KeyType);
                 Assert.AreEqual("bar", metrics.ValueType);
                 Assert.AreEqual(true, metrics.IsStoreByValue);


### PR DESCRIPTION
Added getSystemAllocatedSize API (https://issues.apache.org/jira/browse/IGNITE-4797) to expose offHeap memory allocated for internal data structures.