### PR TITLE
IGNITE-4917: BinaryObjectBuilder field value access failed if its serialized with optimal marshaller

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryBuilderReader.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryBuilderReader.java
@@ -485,6 +485,14 @@ public class BinaryBuilderReader implements BinaryPositionReadable {
                 return new BinaryPlainBinaryObject(binaryObj);
             }
 
+            case GridBinaryMarshaller.OPTM_MARSH: {
+                final BinaryHeapInputStream bin = BinaryHeapInputStream.create(arr, pos + 1);
+
+                final Object obj = BinaryUtils.doReadOptimized(bin, ctx, U.resolveClassLoader(ctx.configuration()));
+
+                return obj;
+            }
+
             default:
                 throw new BinaryObjectException("Invalid flag value: " + type);
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/mutabletest/GridBinaryTestClasses.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/mutabletest/GridBinaryTestClasses.java
@@ -24,6 +24,7 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
@@ -142,6 +143,9 @@ public class GridBinaryTestClasses {
         public Integer i_;
 
         /** */
+        public BigInteger bi_;
+
+        /** */
         public Long l_;
 
         /** */
@@ -149,6 +153,9 @@ public class GridBinaryTestClasses {
 
         /** */
         public Double d_;
+
+        /** */
+        public BigDecimal bd_;
 
         /** */
         public Character c_;
@@ -267,9 +274,11 @@ public class GridBinaryTestClasses {
             b_ = 11;
             s_ = 22;
             i_ = 33;
+            bi_ = new BigInteger("33000000000000");
             l_ = 44L;
             f_ = 55f;
             d_ = 66d;
+            bd_ = new BigDecimal("33000000000000.123456789");
             c_ = 'e';
             z_ = true;
 


### PR DESCRIPTION
Fixed failure when accessing BinaryObjectBuilder field value serialized with OptimizedMarshaller.