### PR TITLE
IGNITE-4920 Fixed.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
@@ -70,7 +70,7 @@ import org.jsr166.ConcurrentLinkedHashMap;
 @IgnoreIfPeerClassLoadingDisabled
 public class LocalDeploymentSpi extends IgniteSpiAdapter implements DeploymentSpi {
     /** Enables additional check for resource name on resources removal. */
-    public static final String IGNITE_DEPLOYMENT_ADDITIONAL_CHECK = "ignite.deployment.additional.check";
+    public static final String IGNITE_DEPLOYMENT_ADDITIONAL_CHECK = "IGNITE.DEPLOYMENT.ADDITIONAL.CHECK";
 
     /** Value for additional check on resources removal. */
     private static final boolean ENABLE_IGNITE_DEPLOYMENT_ADDITIONAL_CHECK =

--- a/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
@@ -334,7 +334,8 @@ public class LocalDeploymentSpi extends IgniteSpiAdapter implements DeploymentSp
                     // Check classes with class loader only when classes points to classes to avoid redundant check.
                     // Resources map contains two entries for class with task name(alias).
                     if (entry.getKey().equals(entry.getValue()) && isResourceExist(ldr, entry.getKey()) &&
-                        !U.hasParent(clsLdrToIgnore, ldr) && ldrRsrcs.remove(ldr, clsLdrRsrcs)) {
+                            !U.hasParent(clsLdrToIgnore, ldr) && clsLdrRsrcs.containsKey(entry.getKey()) &&
+                            ldrRsrcs.remove(ldr, clsLdrRsrcs)) {
                         // Add class loaders in collection to notify listener outside synchronization block.
                         rmvClsLdrs.add(ldr);
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.compute.ComputeTask;
 import org.apache.ignite.compute.ComputeTaskName;
 import org.apache.ignite.internal.util.GridAnnotationsCache;
@@ -68,6 +69,13 @@ import org.jsr166.ConcurrentLinkedHashMap;
 @IgniteSpiConsistencyChecked(optional = false)
 @IgnoreIfPeerClassLoadingDisabled
 public class LocalDeploymentSpi extends IgniteSpiAdapter implements DeploymentSpi {
+    /** Enables additional check for resource name on resources removal. */
+    public static final String IGNITE_DEPLOYMENT_ADDITIONAL_CHECK = "ignite.deployment.additional.check";
+
+    /** Value for additional check on resources removal. */
+    private static final boolean ENABLE_IGNITE_DEPLOYMENT_ADDITIONAL_CHECK =
+        IgniteSystemProperties.getBoolean(IGNITE_DEPLOYMENT_ADDITIONAL_CHECK);
+
     /** */
     @SuppressWarnings({"FieldAccessedSynchronizedAndUnsynchronized"})
     @LoggerResource
@@ -334,7 +342,8 @@ public class LocalDeploymentSpi extends IgniteSpiAdapter implements DeploymentSp
                     // Check classes with class loader only when classes points to classes to avoid redundant check.
                     // Resources map contains two entries for class with task name(alias).
                     if (entry.getKey().equals(entry.getValue()) && isResourceExist(ldr, entry.getKey()) &&
-                            !U.hasParent(clsLdrToIgnore, ldr) && clsLdrRsrcs.containsKey(entry.getKey()) &&
+                            !U.hasParent(clsLdrToIgnore, ldr) &&
+                            (!ENABLE_IGNITE_DEPLOYMENT_ADDITIONAL_CHECK || clsLdrRsrcs.containsKey(entry.getKey())) &&
                             ldrRsrcs.remove(ldr, clsLdrRsrcs)) {
                         // Add class loaders in collection to notify listener outside synchronization block.
                         rmvClsLdrs.add(ldr);

--- a/modules/core/src/test/java/org/apache/ignite/p2p/GridP2PLocalDeploymentSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/p2p/GridP2PLocalDeploymentSelfTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_CACHE_REMOVED_ENTRIES_TTL;
+import static org.apache.ignite.spi.deployment.local.LocalDeploymentSpi.IGNITE_DEPLOYMENT_ADDITIONAL_CHECK;
 
 /**
  * Test to make sure that if job executes on the same node, it reuses the same class loader as task.
@@ -221,6 +222,7 @@ public class GridP2PLocalDeploymentSelfTest extends GridCommonAbstractTest {
 
         // Force rmvQueue removal task to run very often.
         System.setProperty(IGNITE_CACHE_REMOVED_ENTRIES_TTL, "1");
+        System.setProperty(IGNITE_DEPLOYMENT_ADDITIONAL_CHECK, "true");
 
         try {
             final Ignite ignite = startGrid();
@@ -255,6 +257,7 @@ public class GridP2PLocalDeploymentSelfTest extends GridCommonAbstractTest {
             stopAllGrids();
 
             System.clearProperty(IGNITE_CACHE_REMOVED_ENTRIES_TTL);
+            System.clearProperty(IGNITE_DEPLOYMENT_ADDITIONAL_CHECK);
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/p2p/GridP2PLocalDeploymentSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/p2p/GridP2PLocalDeploymentSelfTest.java
@@ -234,7 +234,7 @@ public class GridP2PLocalDeploymentSelfTest extends GridCommonAbstractTest {
             IgniteInternalFuture<?> fut = multithreadedAsync(new Callable<Void>() {
                 @Override public Void call() throws Exception {
                     while (!stop.get()) {
-                        final Class<?> clazz = root.loadClass("org.apache.ignite.p2p.GridP2PLocalDeploymentSelfTest$CallFunction");
+                        final Class<?> clazz = root.loadClass("org.apache.ignite.p2p.GridP2PLocalDeploymentSelfTest$TestClosure");
 
                         ignite.compute().
                                 call((IgniteCallable) clazz.getDeclaredConstructor(ClassLoader.class).newInstance(root));
@@ -258,40 +258,56 @@ public class GridP2PLocalDeploymentSelfTest extends GridCommonAbstractTest {
         }
     }
 
-    public static class CallFunction implements IgniteCallable, GridPeerDeployAware {
-        transient ClassLoader classLoader;
+    /** */
+    private static class TestClosure implements IgniteCallable, GridPeerDeployAware {
+        /** */
+        transient ClassLoader clsLdr;
 
-        public CallFunction(ClassLoader cls) {
-            this.classLoader = cls;
+        /**
+         * @param cls Class.
+         */
+        public TestClosure(ClassLoader cls) {
+            this.clsLdr = cls;
         }
 
+        /** {@inheritDoc} */
         public Object call() throws Exception {
             return null;
         }
 
+        /** {@inheritDoc} */
         public Class<?> deployClass() {
             return this.getClass();
         }
 
+        /** {@inheritDoc} */
         public ClassLoader classLoader() {
-            return classLoader;
+            return clsLdr;
         }
     }
 
-    public static class DelegateClassLoader extends ClassLoader {
-        private ClassLoader delegateCL;
+    /** */
+    private static class DelegateClassLoader extends ClassLoader {
+        /** Delegate class loader. */
+        private ClassLoader delegateClsLdr;
 
-        public DelegateClassLoader(ClassLoader parent, ClassLoader delegateCL) {
+        /**
+         * @param parent Parent.
+         * @param delegateClsLdr Delegate class loader.
+         */
+        public DelegateClassLoader(ClassLoader parent, ClassLoader delegateClsLdr) {
             super(parent); // Parent doesn't matter.
-            this.delegateCL = delegateCL;
+            this.delegateClsLdr = delegateClsLdr;
         }
 
+        /** {@inheritDoc} */
         @Override public URL getResource(String name) {
-            return delegateCL.getResource(name);
+            return delegateClsLdr.getResource(name);
         }
 
+        /** {@inheritDoc} */
         @Override public Class<?> loadClass(String name) throws ClassNotFoundException {
-            return delegateCL.loadClass(name);
+            return delegateClsLdr.loadClass(name);
         }
     }
 


### PR DESCRIPTION
LocalDeploymentSpi resources cleanup on spi.register() might clean resources from other tasks using delegating classloader.