### PR TITLE
IGNITE-5109 Refactoring for SparseDistributedMatrix:

### DIFF
--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/matrix/AbstractMatrix.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/matrix/AbstractMatrix.java
@@ -840,6 +840,11 @@ public abstract class AbstractMatrix implements Matrix {
     }
 
     /** {@inheritDoc} */
+    @Override public void destroy() {
+        getStorage().destroy();
+    }
+
+    /** {@inheritDoc} */
     @Override public Matrix copy() {
         Matrix cp = like(rowSize(), columnSize());
 

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/matrix/DenseLocalOffHeapMatrix.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/matrix/DenseLocalOffHeapMatrix.java
@@ -71,11 +71,6 @@ public class DenseLocalOffHeapMatrix extends AbstractMatrix {
     }
 
     /** {@inheritDoc} */
-    @Override public void destroy() {
-        getStorage().destroy();
-    }
-
-    /** {@inheritDoc} */
     @Override protected Matrix likeIdentity() {
         int n = rowSize();
         Matrix res = like(n, n);

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrix.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrix.java
@@ -26,6 +26,7 @@
 
 package org.apache.ignite.ml.math.impls.matrix;
 
+import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.ml.math.Matrix;
 import org.apache.ignite.ml.math.StorageConstants;
 import org.apache.ignite.ml.math.Vector;
@@ -119,24 +120,24 @@ public class SparseDistributedMatrix extends AbstractMatrix implements StorageCo
      * @return Matrix with mapped values.
      */
     private Matrix mapOverValues(IgniteFunction<Double, Double> mapper) {
-        CacheUtils.sparseMap(storage().cache().getName(), mapper);
+        CacheUtils.sparseMap(getUUID(), mapper);
 
         return this;
     }
 
     /** {@inheritDoc} */
     @Override public double sum() {
-        return CacheUtils.sparseSum(storage().cache().getName());
+        return CacheUtils.sparseSum(getUUID());
     }
 
     /** {@inheritDoc} */
     @Override public double maxValue() {
-        return CacheUtils.sparseMax(storage().cache().getName());
+        return CacheUtils.sparseMax(getUUID());
     }
 
     /** {@inheritDoc} */
     @Override public double minValue() {
-        return CacheUtils.sparseMin(storage().cache().getName());
+        return CacheUtils.sparseMin(getUUID());
     }
 
     /** {@inheritDoc} */
@@ -146,11 +147,16 @@ public class SparseDistributedMatrix extends AbstractMatrix implements StorageCo
 
     /** {@inheritDoc} */
     @Override public Matrix like(int rows, int cols) {
-        throw new UnsupportedOperationException();
+        return new SparseDistributedMatrix(rows, cols, storage().storageMode(), storage().accessMode());
     }
 
     /** {@inheritDoc} */
     @Override public Vector likeVector(int crd) {
         throw new UnsupportedOperationException();
+    }
+
+    /** */
+    private IgniteUuid getUUID(){
+        return ((SparseDistributedMatrixStorage) getStorage()).getUUID();
     }
 }

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/SparseDistributedMatrixStorage.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/SparseDistributedMatrixStorage.java
@@ -175,6 +175,9 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
             // Local get.
             Map<Integer, Double> map = cache.localPeek(getCacheKey(a), CachePeekMode.PRIMARY);
 
+            if (map == null)
+                map = cache.get(getCacheKey(a));
+
             return (map == null || !map.containsKey(b)) ? 0.0 : map.get(b);
         });
     }
@@ -194,8 +197,13 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
             // Local get.
             Map<Integer, Double> map = cache.localPeek(getCacheKey(a), CachePeekMode.PRIMARY);
 
-            if (map == null)
-                map = acsMode == SEQUENTIAL_ACCESS_MODE ? new Int2DoubleRBTreeMap() : new Int2DoubleOpenHashMap();
+
+            if (map == null) {
+                map = cache.get(getCacheKey(a)); //Remote entry get.
+
+                if (map == null)
+                    map = acsMode == SEQUENTIAL_ACCESS_MODE ? new Int2DoubleRBTreeMap() : new Int2DoubleOpenHashMap();
+            }
 
             if (v != 0.0)
                 map.put(b, v);

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/SparseDistributedMatrixStorage.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/SparseDistributedMatrixStorage.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.ignite.IgniteCache;
@@ -277,7 +278,9 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
 
     /** Delete all data from cache. */
     @Override public void destroy() {
-        cache.clearAll(IntStream.range(0,rows).mapToObj(this::getCacheKey).collect(Collectors.toSet()));
+        Set<IgniteBiTuple<Integer, IgniteUuid>> keyset = IntStream.range(0, rows).mapToObj(this::getCacheKey).collect(Collectors.toSet());
+
+        cache.clearAll(keyset);
     }
 
     /** {@inheritDoc} */

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/SparseDistributedMatrixStorage.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/SparseDistributedMatrixStorage.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.cache.CacheAtomicityMode;
@@ -30,6 +32,7 @@ import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.CachePeekMode;
 import org.apache.ignite.cache.CacheWriteSynchronizationMode;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.ml.math.MatrixStorage;
 import org.apache.ignite.ml.math.StorageConstants;
@@ -40,19 +43,22 @@ import org.apache.ignite.ml.math.impls.matrix.SparseDistributedMatrix;
  * {@link MatrixStorage} implementation for {@link SparseDistributedMatrix}.
  */
 public class SparseDistributedMatrixStorage extends CacheUtils implements MatrixStorage, StorageConstants {
+    /** Cache name used for all instances of {@link SparseDistributedMatrixStorage}.*/
+    public static final String ML_CACHE_NAME = "ML_SPARSE_MATRICES_CONTAINER";
     /** Amount of rows in the matrix. */
     private int rows;
     /** Amount of columns in the matrix. */
     private int cols;
-
     /** Row or column based storage mode. */
     private int stoMode;
     /** Random or sequential access mode. */
     private int acsMode;
+    /** Matrix uuid. */
+    private IgniteUuid uuid;
 
     /** Actual distributed storage. */
     private IgniteCache<
-        Integer /* Row or column index. */,
+        IgniteBiTuple<Integer, IgniteUuid> /* Row or column index with matrix uuid. */,
         Map<Integer, Double> /* Map-based row or column. */
         > cache = null;
 
@@ -81,14 +87,15 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         this.acsMode = acsMode;
 
         cache = newCache();
+
+        uuid = IgniteUuid.randomUuid();
     }
 
     /**
-     *
-     *
+     *  Create new ML cache if needed.
      */
-    private IgniteCache<Integer, Map<Integer, Double>> newCache() {
-        CacheConfiguration<Integer, Map<Integer, Double>> cfg = new CacheConfiguration<>();
+    private IgniteCache<IgniteBiTuple<Integer, IgniteUuid>, Map<Integer, Double>> newCache() {
+        CacheConfiguration<IgniteBiTuple<Integer, IgniteUuid>, Map<Integer, Double>> cfg = new CacheConfiguration<>();
 
         // Write to primary.
         cfg.setWriteSynchronizationMode(CacheWriteSynchronizationMode.PRIMARY_SYNC);
@@ -106,16 +113,18 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         cfg.setCacheMode(CacheMode.PARTITIONED);
 
         // Random cache name.
-        cfg.setName(new IgniteUuid().shortString());
+        cfg.setName(ML_CACHE_NAME);
 
-        return Ignition.localIgnite().getOrCreateCache(cfg);
+        IgniteCache<IgniteBiTuple<Integer, IgniteUuid>, Map<Integer, Double>> cache = Ignition.localIgnite().getOrCreateCache(cfg);
+
+        return cache;
     }
 
     /**
      *
      *
      */
-    public IgniteCache<Integer, Map<Integer, Double>> cache() {
+    public IgniteCache<IgniteBiTuple<Integer, IgniteUuid>, Map<Integer, Double>> cache() {
         return cache;
     }
 
@@ -138,34 +147,33 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
     /** {@inheritDoc} */
     @Override public double get(int x, int y) {
         if (stoMode == ROW_STORAGE_MODE)
-            return matrixGet(cache.getName(), x, y);
+            return matrixGet(x, y);
         else
-            return matrixGet(cache.getName(), y, x);
+            return matrixGet(y, x);
     }
 
     /** {@inheritDoc} */
     @Override public void set(int x, int y, double v) {
         if (stoMode == ROW_STORAGE_MODE)
-            matrixSet(cache.getName(), x, y, v);
+            matrixSet(x, y, v);
         else
-            matrixSet(cache.getName(), y, x, v);
+            matrixSet(y, x, v);
     }
 
     /**
      * Distributed matrix get.
      *
-     * @param cacheName Matrix's cache.
      * @param a Row or column index.
      * @param b Row or column index.
      * @return Matrix value at (a, b) index.
      */
-    private double matrixGet(String cacheName, int a, int b) {
+    private double matrixGet(int a, int b) {
         // Remote get from the primary node (where given row or column is stored locally).
-        return ignite().compute(groupForKey(cacheName, a)).call(() -> {
-            IgniteCache<Integer, Map<Integer, Double>> cache = Ignition.localIgnite().getOrCreateCache(cacheName);
+        return ignite().compute(groupForKey(ML_CACHE_NAME, a)).call(() -> {
+            IgniteCache<IgniteBiTuple<Integer, IgniteUuid>, Map<Integer, Double>> cache = Ignition.localIgnite().getOrCreateCache(ML_CACHE_NAME);
 
             // Local get.
-            Map<Integer, Double> map = cache.localPeek(a, CachePeekMode.PRIMARY);
+            Map<Integer, Double> map = cache.localPeek(getCacheKey(a), CachePeekMode.PRIMARY);
 
             return (map == null || !map.containsKey(b)) ? 0.0 : map.get(b);
         });
@@ -174,18 +182,17 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
     /**
      * Distributed matrix set.
      *
-     * @param cacheName Matrix's cache.
      * @param a Row or column index.
      * @param b Row or column index.
      * @param v New value to set.
      */
-    private void matrixSet(String cacheName, int a, int b, double v) {
+    private void matrixSet(int a, int b, double v) {
         // Remote set on the primary node (where given row or column is stored locally).
-        ignite().compute(groupForKey(cacheName, a)).run(() -> {
-            IgniteCache<Integer, Map<Integer, Double>> cache = Ignition.localIgnite().getOrCreateCache(cacheName);
+        ignite().compute(groupForKey(ML_CACHE_NAME, a)).run(() -> {
+            IgniteCache<IgniteBiTuple<Integer, IgniteUuid>, Map<Integer, Double>> cache = Ignition.localIgnite().getOrCreateCache(ML_CACHE_NAME);
 
             // Local get.
-            Map<Integer, Double> map = cache.localPeek(a, CachePeekMode.PRIMARY);
+            Map<Integer, Double> map = cache.localPeek(getCacheKey(a), CachePeekMode.PRIMARY);
 
             if (map == null)
                 map = acsMode == SEQUENTIAL_ACCESS_MODE ? new Int2DoubleRBTreeMap() : new Int2DoubleOpenHashMap();
@@ -196,8 +203,13 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
                 map.remove(b);
 
             // Local put.
-            cache.put(a, map);
+            cache.put(getCacheKey(a), map);
         });
+    }
+
+    /** Build cache key for row/column. */
+    private IgniteBiTuple<Integer, IgniteUuid> getCacheKey(int idx){
+        return new IgniteBiTuple<>(idx, uuid);
     }
 
     /** {@inheritDoc} */
@@ -216,6 +228,7 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         out.writeInt(cols);
         out.writeInt(acsMode);
         out.writeInt(stoMode);
+        out.writeObject(uuid);
         out.writeUTF(cache.getName());
     }
 
@@ -225,6 +238,7 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         cols = in.readInt();
         acsMode = in.readInt();
         stoMode = in.readInt();
+        uuid = (IgniteUuid)in.readObject();
         cache = ignite().getOrCreateCache(in.readUTF());
     }
 
@@ -253,9 +267,9 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         return false;
     }
 
-    /** Destroy underlying cache. */
+    /** Delete all data from cache. */
     @Override public void destroy() {
-        cache.destroy();
+        cache.clearAll(IntStream.range(0,rows).mapToObj(this::getCacheKey).collect(Collectors.toSet()));
     }
 
     /** {@inheritDoc} */
@@ -266,6 +280,7 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         res = res * 37 + rows;
         res = res * 37 + acsMode;
         res = res * 37 + stoMode;
+        res = res * 37 + uuid.hashCode();
         res = res * 37 + cache.hashCode();
 
         return res;
@@ -282,6 +297,11 @@ public class SparseDistributedMatrixStorage extends CacheUtils implements Matrix
         SparseDistributedMatrixStorage that = (SparseDistributedMatrixStorage)obj;
 
         return rows == that.rows && cols == that.cols && acsMode == that.acsMode && stoMode == that.stoMode
-            && (cache != null ? cache.equals(that.cache) : that.cache == null);
+            && uuid.equals(that.uuid) && (cache != null ? cache.equals(that.cache) : that.cache == null);
+    }
+
+    /** */
+    public IgniteUuid getUUID() {
+        return uuid;
     }
 }

--- a/modules/ml/src/test/java/org/apache/ignite/ml/math/MathImplMainTestSuite.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/math/MathImplMainTestSuite.java
@@ -21,12 +21,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 /**
- * Test suite for local and distributed tests
+ * Test suite for local and distributed tests.
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     MathImplLocalTestSuite.class,
-    MathImplDistributedTestSuite.class
+    MathImplDistributedTestSuite.class,
+    TracerTest.class
 })
 public class MathImplMainTestSuite {
     // No-op.

--- a/modules/ml/src/test/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrixTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrixTest.java
@@ -230,14 +230,7 @@ public class SparseDistributedMatrixTest extends GridCommonAbstractTest {
 
         cacheMatrix = new SparseDistributedMatrix(rows, cols, StorageConstants.ROW_STORAGE_MODE, StorageConstants.RANDOM_ACCESS_MODE);
 
-        try {
-            cacheMatrix.like(1, 1);
-            fail("UnsupportedOperationException expected.");
-        }
-        catch (UnsupportedOperationException e) {
-            return;
-        }
-        fail("UnsupportedOperationException expected.");
+        assertNotNull(cacheMatrix.like(1, 1));
     }
 
     /** */

--- a/modules/ml/src/test/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrixTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrixTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.ml.math.Matrix;
 import org.apache.ignite.ml.math.StorageConstants;
+import org.apache.ignite.ml.math.Tracer;
 import org.apache.ignite.ml.math.exceptions.UnsupportedOperationException;
 import org.apache.ignite.ml.math.impls.MathTestConstants;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
@@ -110,7 +111,7 @@ public class SparseDistributedMatrixTest extends GridCommonAbstractTest {
                 double v = Math.random();
                 cacheMatrix.set(i, j, v);
 
-                assert Double.compare(v, cacheMatrix.get(i, j)) == 0;
+                assertEquals("Unexpected value for matrix element["+ i +" " + j + "]", v, cacheMatrix.get(i, j), PRECISION);
             }
         }
     }
@@ -134,7 +135,7 @@ public class SparseDistributedMatrixTest extends GridCommonAbstractTest {
         SparseDistributedMatrix objRestored = (SparseDistributedMatrix)objInputStream.readObject();
 
         assertTrue(MathTestConstants.VAL_NOT_EQUALS, cacheMatrix.equals(objRestored));
-        assertEquals(MathTestConstants.VAL_NOT_EQUALS, objRestored.get(1, 1), 1.0, 0.0);
+        assertEquals(MathTestConstants.VAL_NOT_EQUALS, objRestored.get(1, 1), 1.0, PRECISION);
     }
 
     /** Test simple math. */

--- a/modules/ml/src/test/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrixTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/math/impls/matrix/SparseDistributedMatrixTest.java
@@ -31,13 +31,19 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
 import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.lang.IgniteBiTuple;
+import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.ml.math.Matrix;
 import org.apache.ignite.ml.math.StorageConstants;
-import org.apache.ignite.ml.math.Tracer;
 import org.apache.ignite.ml.math.exceptions.UnsupportedOperationException;
 import org.apache.ignite.ml.math.impls.MathTestConstants;
+import org.apache.ignite.ml.math.impls.storage.matrix.SparseDistributedMatrixStorage;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.testframework.junits.common.GridCommonTest;
 
@@ -226,6 +232,38 @@ public class SparseDistributedMatrixTest extends GridCommonAbstractTest {
     }
 
     /** */
+    public void testCacheBehaviour(){
+        IgniteUtils.setCurrentIgniteName(ignite.configuration().getIgniteInstanceName());
+
+        SparseDistributedMatrix cacheMatrix1 = new SparseDistributedMatrix(rows, cols, StorageConstants.ROW_STORAGE_MODE, StorageConstants.RANDOM_ACCESS_MODE);
+        SparseDistributedMatrix cacheMatrix2 = new SparseDistributedMatrix(rows, cols, StorageConstants.ROW_STORAGE_MODE, StorageConstants.RANDOM_ACCESS_MODE);
+
+        initMtx(cacheMatrix1);
+        initMtx(cacheMatrix2);
+
+        Collection<String> cacheNames = ignite.cacheNames();
+
+        assert cacheNames.contains(SparseDistributedMatrixStorage.ML_CACHE_NAME);
+
+        IgniteCache<IgniteBiTuple<Integer, IgniteUuid>, Object> cache = ignite.getOrCreateCache(SparseDistributedMatrixStorage.ML_CACHE_NAME);
+
+        Set<IgniteBiTuple<Integer, IgniteUuid>> keySet1 = buildKeySet(cacheMatrix1);
+        Set<IgniteBiTuple<Integer, IgniteUuid>> keySet2 = buildKeySet(cacheMatrix2);
+
+        assert cache.containsKeys(keySet1);
+        assert cache.containsKeys(keySet2);
+
+        cacheMatrix2.destroy();
+
+        assert cache.containsKeys(keySet1);
+        assert !cache.containsKeys(keySet2);
+
+        cacheMatrix1.destroy();
+
+        assert !cache.containsKeys(keySet1);
+    }
+
+    /** */
     public void testLike() {
         IgniteUtils.setCurrentIgniteName(ignite.configuration().getIgniteInstanceName());
 
@@ -255,5 +293,20 @@ public class SparseDistributedMatrixTest extends GridCommonAbstractTest {
         for (int i = 0; i < m.rowSize(); i++)
             for (int j = 0; j < m.columnSize(); j++)
                 m.set(i, j, 1.0);
+    }
+
+    /** Build key set for SparseDistributedMatrix. */
+    private Set<IgniteBiTuple<Integer, IgniteUuid>> buildKeySet(SparseDistributedMatrix m){
+        Set<IgniteBiTuple<Integer, IgniteUuid>> set = new HashSet<>();
+
+        SparseDistributedMatrixStorage storage = (SparseDistributedMatrixStorage)m.getStorage();
+
+        IgniteUuid uuid = storage.getUUID();
+        int size = storage.storageMode() == StorageConstants.ROW_STORAGE_MODE ? storage.rowSize() : storage.columnSize();
+
+        for (int i = 0; i < size; i++)
+            set.add(new IgniteBiTuple<>(i, uuid));
+
+        return set;
     }
 }


### PR DESCRIPTION
Use one cache for all instances of SparseDistributedMatrix.

Also added some tests and fixed get() and destroy() behavior for SparseDistributedMatrix.