### PR TITLE
IGNITE-5119 Append extra message to exception when unable to determine affinity

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/affinity/GridAffinityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/affinity/GridAffinityProcessor.java
@@ -186,7 +186,8 @@ public class GridAffinityProcessor extends GridProcessorAdapter {
             aff = affinityCache(cacheName, ctx.discovery().topologyVersionEx());
 
             if (aff == null)
-                throw new IgniteCheckedException("Failed to get cache affinity.");
+                throw new IgniteCheckedException("Failed to get cache affinity (cache was not started " +
+                        "yet or cache was already stopped): " + cacheName);
         }
 
         return aff.affFunc.partition(aff.affinityKey(key));


### PR DESCRIPTION
Add detail on cache name to exception message when cache is not available and unable to determine affinity.