### PR TITLE
IGNITE-5227: StackOverflowError in GridCacheMapEntry#checkOwnerChanged()

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -3727,14 +3727,13 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
             for (int i = 0; i < owners.size(); i++) {
                 GridCacheMvccCandidate owner = owners.candidate(i);
 
-                if(checkingCandidate != null && checkingCandidate.hasCandidate(owner.version()))
-                    continue;
                 boolean locked = prevOwners == null || !prevOwners.hasCandidate(owner.version());
 
                 if (locked) {
                     cctx.mvcc().callback().onOwnerChanged(this, owner);
 
-                    if (owner.local())
+                    if (owner.local()
+                        && (checkingCandidate == null || !checkingCandidate.hasCandidate(owner.version())))
                         checkThreadChain(owner);
 
                     if (cctx.events().isRecordable(EVT_CACHE_OBJECT_LOCKED)) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -3685,6 +3685,18 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
     protected final void checkOwnerChanged(@Nullable CacheLockCandidates prevOwners,
         @Nullable CacheLockCandidates owners,
         CacheObject val) {
+        checkOwnerChanged(prevOwners, owners, val, true);
+    }
+    /**
+     * @param prevOwners Previous owners.
+     * @param owners Current owners.
+     * @param val Entry value.
+     * @param checkCandidateChain flag to enable or disable check of candidate chain
+     */
+    protected final void checkOwnerChanged(@Nullable CacheLockCandidates prevOwners,
+        @Nullable CacheLockCandidates owners,
+        CacheObject val,
+        boolean checkCandidateChain) {
         assert !Thread.holdsLock(this);
 
         if (prevOwners != null && owners == null) {
@@ -3720,7 +3732,7 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
                 if (locked) {
                     cctx.mvcc().callback().onOwnerChanged(this, owner);
 
-                    if (owner.local())
+                    if (owner.local() && checkCandidateChain)
                         checkThreadChain(owner);
 
                     if (cctx.events().isRecordable(EVT_CACHE_OBJECT_LOCKED)) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedCacheEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedCacheEntry.java
@@ -617,7 +617,7 @@ public class GridDistributedCacheEntry extends GridCacheMapEntry {
         }
 
         // This call must be made outside of synchronization.
-        checkOwnerChanged(prev, owner, val);
+        checkOwnerChanged(prev, owner, val, false);
     }
 
     /** {@inheritDoc} */
@@ -702,8 +702,8 @@ public class GridDistributedCacheEntry extends GridCacheMapEntry {
 
                     if (e != null)
                         e.recheck();
-
-                    break;
+                    else
+                        break;
                 }
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedCacheEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedCacheEntry.java
@@ -589,7 +589,7 @@ public class GridDistributedCacheEntry extends GridCacheMapEntry {
     /**
      * Rechecks if lock should be reassigned.
      */
-    public void recheck() {
+    public void recheck(GridCacheMvccCandidate checkingCandidate) {
         CacheLockCandidates prev = null;
         CacheLockCandidates owner = null;
 
@@ -617,7 +617,7 @@ public class GridDistributedCacheEntry extends GridCacheMapEntry {
         }
 
         // This call must be made outside of synchronization.
-        checkOwnerChanged(prev, owner, val, false);
+        checkOwnerChanged(prev, owner, val, checkingCandidate);
     }
 
     /** {@inheritDoc} */
@@ -701,7 +701,7 @@ public class GridDistributedCacheEntry extends GridCacheMapEntry {
                         (GridDistributedCacheEntry)cctx0.cache().peekEx(cand.parent().key());
 
                     if (e != null)
-                        e.recheck();
+                        e.recheck(owner);
                     else
                         break;
                 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalCacheEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalCacheEntry.java
@@ -190,7 +190,7 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
     /**
      * Rechecks if lock should be reassigned.
      */
-    public void recheck() {
+    public void recheck(GridCacheMvccCandidate checkingCandidate) {
         CacheObject val;
         CacheLockCandidates prev = null;
         CacheLockCandidates owner = null;
@@ -210,7 +210,7 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
             val = this.val;
         }
 
-        checkOwnerChanged(prev, owner, val, false);
+        checkOwnerChanged(prev, owner, val, checkingCandidate);
     }
 
     /** {@inheritDoc} */
@@ -234,7 +234,7 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
                     // At this point candidate may have been removed and entry destroyed,
                     // so we check for null.
                     if (e != null)
-                        e.recheck();
+                        e.recheck(owner);
                     else
                         break;
                 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalCacheEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalCacheEntry.java
@@ -210,7 +210,7 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
             val = this.val;
         }
 
-        checkOwnerChanged(prev, owner, val);
+        checkOwnerChanged(prev, owner, val, false);
     }
 
     /** {@inheritDoc} */
@@ -235,8 +235,8 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
                     // so we check for null.
                     if (e != null)
                         e.recheck();
-
-                    break;
+                    else
+                        break;
                 }
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalCacheEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalCacheEntry.java
@@ -189,8 +189,9 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
 
     /**
      * Rechecks if lock should be reassigned.
+     * @return owner
      */
-    public void recheck(GridCacheMvccCandidate checkingCandidate) {
+    public CacheLockCandidates recheck(GridCacheMvccCandidate checkingCandidate) {
         CacheObject val;
         CacheLockCandidates prev = null;
         CacheLockCandidates owner = null;
@@ -211,6 +212,8 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
         }
 
         checkOwnerChanged(prev, owner, val, checkingCandidate);
+
+        return owner;
     }
 
     /** {@inheritDoc} */
@@ -233,8 +236,12 @@ public class GridLocalCacheEntry extends GridCacheMapEntry {
 
                     // At this point candidate may have been removed and entry destroyed,
                     // so we check for null.
-                    if (e != null)
-                        e.recheck(owner);
+                    if (e != null) {
+                        CacheLockCandidates newOwner = e.recheck(owner);
+                        if(newOwner == null || !newOwner.hasCandidate(cand.version()))
+                            // the lock from the chain hasn't been acquired, no sense to check the rest of the chain
+                            break;
+                    }
                     else
                         break;
                 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheBulkUnlockTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheBulkUnlockTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.Lock;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.lang.IgniteFuture;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+
+/**
+ * Tests for ??
+ */
+public class CacheBulkUnlockTest extends GridCommonAbstractTest {
+
+    /** */
+    private static final String DEFAULT_CACHE_NAME = "default";
+
+    /**
+     * @throws Exception if failed.
+     */
+    public void testBatchUnlockForLocalMode() throws Exception {
+        doBulkUnlock(CacheMode.LOCAL);
+    }
+
+    /**
+     * @throws Exception if failed.
+     */
+    public void testBatchUnlockForPartitionedMode() throws Exception {
+        doBulkUnlock(CacheMode.PARTITIONED);
+    }
+
+    private void doBulkUnlock(CacheMode mode) throws Exception {
+        startGrid(0);
+        grid(0).createCache(new CacheConfiguration<Integer, Integer>(DEFAULT_CACHE_NAME)
+            .setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL)
+            .setCacheMode(mode));
+
+        try {
+            final CountDownLatch releaseLatch = new CountDownLatch(1);
+
+            final IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
+            IgniteInternalFuture<Object> future = GridTestUtils.runAsync(new Callable<Object>() {
+                @Override public Object call() throws Exception {
+                    Lock lock = cache.lock("trigger");
+                    try {
+                        lock.lock();
+                        releaseLatch.await();
+                    } finally {
+                        lock.unlock();
+                    }
+
+                    return null;
+                }
+            });
+
+            Map<String, String> putMap = new LinkedHashMap<>();
+            putMap.put("trigger", "trigger-new-val");
+            for (int i = 0; i < 5_000; i++)
+                putMap.put("key-" + i, "value");
+
+            IgniteCache<Object, Object> asyncCache = grid(0).cache(DEFAULT_CACHE_NAME).withAsync();
+            asyncCache.putAll(putMap);
+            IgniteFuture<Object> resFut = asyncCache.future();
+
+            Thread.sleep(500);
+            releaseLatch.countDown();
+
+            future.get();
+            resFut.get();
+        }
+        finally {
+            stopAllGrids();
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheLockCandidatesThreadTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheLockCandidatesThreadTest.java
@@ -32,9 +32,9 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 
 /**
- * Tests for ??
+ * Tests locking of thread of candidates (see IGNITE-5227)
  */
-public class CacheBulkUnlockTest extends GridCommonAbstractTest {
+public class CacheLockCandidatesThreadTest extends GridCommonAbstractTest {
 
     /** */
     private static final String DEFAULT_CACHE_NAME = "default";
@@ -42,18 +42,18 @@ public class CacheBulkUnlockTest extends GridCommonAbstractTest {
     /**
      * @throws Exception if failed.
      */
-    public void testBatchUnlockForLocalMode() throws Exception {
-        doBulkUnlock(CacheMode.LOCAL);
+    public void testLockCandidatesThreadForLocalMode() throws Exception {
+        lockThreadOfCandidates(CacheMode.LOCAL);
     }
 
     /**
      * @throws Exception if failed.
      */
-    public void testBatchUnlockForPartitionedMode() throws Exception {
-        doBulkUnlock(CacheMode.PARTITIONED);
+    public void testLockCandidatesThreadForPartitionedMode() throws Exception {
+        lockThreadOfCandidates(CacheMode.PARTITIONED);
     }
 
-    private void doBulkUnlock(CacheMode mode) throws Exception {
+    private void lockThreadOfCandidates(CacheMode mode) throws Exception {
         startGrid(0);
         grid(0).createCache(new CacheConfiguration<Integer, Integer>(DEFAULT_CACHE_NAME)
             .setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL)


### PR DESCRIPTION
StackOverflowError occurs due recursion in methods:
GridCacheMapEntry.checkOwnerChanged -> GridDistributedCacheEntry.checkThreadChain -> GridDistributedCacheEntry.recheck -> GridCacheMapEntry.checkOwnerChanged

I broke this cycle by passing CacheLockCandidates of current checking thread into GridCacheMapEntry.checkOwnerChanged method, which allow us to miss GridDistributedCacheEntry.checkThreadChain invocation for owner from the current checking thread. 

The check for the whole candidate chain is moved to GridDistributedCacheEntry.checkThreadChain method, as you can see there  already was cycle for this, I've just removed break and added checks in case we don't  acquired  the lock for new candidate in chain.