### PR TITLE
IGNITE-5567

### DIFF
--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.benchmarks.jmh.cache;
 
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.Lock;
 import org.apache.ignite.IgniteLock;
 import org.apache.ignite.cache.CacheAtomicityMode;
@@ -27,9 +26,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.Options;
@@ -45,12 +42,6 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     /** Fixed lock key for Ignite.reentrantLock() and IgniteCache.lock(). */
     private static final String lockKey = "key0";
 
-    /** Fixed key. */
-    private static final String lockKey1 = "key1";
-
-    /** Number of locks for randomly tests. */
-    private static final int N = 128;
-
     /** Parameter for Ignite.reentrantLock(). */
     private static final boolean failoverSafe = false;
 
@@ -63,101 +54,11 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     /** Ignite.reentrantLock() with a fixed lock key. */
     private IgniteLock igniteLock;
 
-    /** Generate a random key for a benchmark. */
-    @State(Scope.Benchmark)
-    public static class Key {
-        /** */
-        final String key;
-
-        /** */
-        public Key() {
-            key = "key" + ThreadLocalRandom.current().nextInt(N);
-        }
-    }
-
-    /** Generate two random keys for a benchmark. */
-    @State(Scope.Benchmark)
-    public static class KeyWithOther {
-        /** */
-        final String key;
-
-        /** */
-        final String otherKey;
-
-        /** */
-        public KeyWithOther() {
-            final int n = ThreadLocalRandom.current().nextInt(N);
-
-            key = "key" + n;
-            otherKey = "key" + (n + 1);
-        }
-    }
-
-    /**
-     * Test IgniteCache.lock() with fixed key and increment operation inside.
-     */
-    @Benchmark
-    public void cacheLocks() {
-        cacheLock.lock();
-
-        try {
-            cache.put(lockKey, (Integer)cache.get(lockKey) + 1);
-        }
-        finally {
-            cacheLock.unlock();
-        }
-    }
-
-    /**
-     * Test Ignite.reentrantLock() with fixed key and increment operation inside.
-     */
-    @Benchmark
-    public void igniteLocks() {
-        igniteLock.lock();
-
-        try {
-            cache.put(lockKey, (Integer)cache.get(lockKey) + 1);
-        }
-        finally {
-            igniteLock.unlock();
-        }
-    }
-
-    /**
-     * Test IgniteCache.lock() with fixed key and increment operation inside.
-     */
-    @Benchmark
-    public void cacheLocksOtherKey() {
-        cacheLock.lock();
-
-        try {
-            cache.put(lockKey1, (Integer)cache.get(lockKey1) + 1);
-        }
-        finally {
-            cacheLock.unlock();
-        }
-    }
-
-    /**
-     * Test Ignite.reentrantLock() with fixed key and increment operation inside.
-     */
-    @Benchmark
-    public void igniteLocksOtherKey() {
-        igniteLock.lock();
-
-        try {
-            cache.put(lockKey1, (Integer)cache.get(lockKey1) + 1);
-        }
-        finally {
-            igniteLock.unlock();
-        }
-    }
-
     /**
      * Test IgniteCache.lock() with fixed key and no-op inside.
      */
     @Benchmark
-    public void cacheNopLocks() {
+    public void cacheLock() {
         cacheLock.lock();
         cacheLock.unlock();
     }
@@ -166,83 +67,9 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
      * Test Ignite.reentrantLock() with fixed key and no-op inside.
      */
     @Benchmark
-    public void igniteNopLocks() {
+    public void igniteLock() {
         igniteLock.lock();
         igniteLock.unlock();
-    }
-
-    /**
-     * Test IgniteCache.lock() with randomly keys.
-     */
-    @Benchmark
-    public void cacheRandomLocks(Key key) {
-        final String k = key.key;
-        final Lock lock = cache.lock(k);
-
-        lock.lock();
-
-        try {
-            cache.put(k, (Integer)cache.get(k) + 1);
-        }
-        finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * Test Ignite.reentrantLock() with randomly keys.
-     */
-    @Benchmark
-    public void igniteRandomLocks(Key key) {
-        final String k = key.key;
-        final IgniteLock lock = node.reentrantLock(k, failoverSafe, fair, true);
-
-        lock.lock();
-
-        try {
-            cache.put(k, (Integer)cache.get(k) + 1);
-        }
-        finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * Test IgniteCache.lock() with randomly keys.
-     */
-    @Benchmark
-    public void cacheRandomLocksOtherKey(KeyWithOther key) {
-        final String k = key.key;
-        final String other = key.otherKey;
-        final Lock lock = cache.lock(k);
-
-        lock.lock();
-
-        try {
-            cache.put(other, (Integer)cache.get(other) + 1);
-        }
-        finally {
-            lock.unlock();
-        }
-    }
-
-    /**
-     * Test Ignite.reentrantLock() with randomly keys.
-     */
-    @Benchmark
-    public void igniteRandomLocksOtherKey(KeyWithOther key) {
-        final String k = key.key;
-        final String other = key.otherKey;
-        final IgniteLock lock = node.reentrantLock(k, failoverSafe, fair, true);
-
-        lock.lock();
-
-        try {
-            cache.put(other, (Integer)cache.get(other) + 1);
-        }
-        finally {
-            lock.unlock();
-        }
     }
 
     /**
@@ -250,9 +77,6 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
      */
     @Setup(Level.Trial)
     public void createLock() {
-        for (int i = 0; i < 2 * N; i++)
-            cache.put("key" + i, new Integer(i));
-
         cacheLock = cache.lock(lockKey);
         igniteLock = node.reentrantLock(lockKey, failoverSafe, fair, true);
     }

--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -49,6 +49,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     @State(Scope.Benchmark)
     public static class Key {
         final String key;
+
         public Key() {
             key = "key"+ThreadLocalRandom.current().nextInt(N);
         }
@@ -58,8 +59,10 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     public static class KeyWithOther {
         final String key;
         final String otherKey;
+
         public KeyWithOther() {
             final int n = ThreadLocalRandom.current().nextInt(N);
+
             key = "key"+n;
             otherKey = "key"+(n+1);
         }
@@ -101,6 +104,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     @Benchmark
     public void cacheLocksOtherKey() {
         cacheLock.lock();
+
         try {
             cache.put(lockKey1, ((Integer)cache.get(lockKey1)) + 1);
         }
@@ -115,6 +119,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     @Benchmark
     public void igniteLocksOtherKey() {
         igniteLock.lock();
+
         try {
             cache.put(lockKey1, ((Integer)cache.get(lockKey1)) + 1);
         }
@@ -206,6 +211,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         final IgniteLock lock = node.reentrantLock(k, failoverSafe, fair, true);
 
         lock.lock();
+
         try {
             cache.put(other, ((Integer)cache.get(other)) + 1);
         }

--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -1,0 +1,148 @@
+package org.apache.ignite.internal.benchmarks.jmh.cache;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.locks.Lock;
+import org.apache.ignite.IgniteLock;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheWriteSynchronizationMode;
+import org.apache.ignite.internal.benchmarks.jmh.runner.JmhIdeBenchmarkRunner;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * IgniteCache.lock() vs Ignite.reentrantLock().
+ */
+@Warmup(iterations = 40)
+@Measurement(iterations = 20)
+@Fork(value = 1)
+public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
+    /** Fixed lock key for IgniteCache.lock(). */
+    final static Integer cacheLockKey = new Integer(0);
+    /** Fixed lock key for Ignite.reentrantLock(). */
+    final static String igniteLockKey = "key";
+    /** Number of locks for randomly tests. */
+    final static int N = 128;
+    /** Parameter for Ignite.reentrantLock(). */
+    final static boolean failoverSafe = false;
+    /** Parameter for Ignite.reentrantLock(). */
+    final static boolean fair = false;
+    /** IgniteCache.lock() with a fixed lock key. */
+    Lock cacheLock;
+    /** Ignite.reentrantLock() with a fixed lock key. */
+    IgniteLock igniteLock;
+
+    /**
+     * Test IgniteCache.lock() with fixed key and increment operation inside.
+     */
+    @Benchmark
+    public void cacheLocks() {
+        cacheLock.lock();
+        cache.put(cacheLockKey, ((Integer)cache.get(cacheLockKey)) + 1);
+        cacheLock.unlock();
+    }
+
+    /**
+     * Test Ignite.reentrantLock() with fixed key and increment operation inside.
+     */
+    @Benchmark
+    public void igniteLocks() {
+        igniteLock.lock();
+        cache.put(cacheLockKey, ((Integer)cache.get(cacheLockKey)) + 1);
+        igniteLock.unlock();
+    }
+
+    /**
+     * Test IgniteCache.lock() with fixed key and no-op inside.
+     */
+    @Benchmark
+    public void cacheNopLocks() {
+        cacheLock.lock();
+        cacheLock.unlock();
+    }
+
+    /**
+     * Test Ignite.reentrantLock() with fixed key and no-op inside.
+     */
+    @Benchmark
+    public void igniteNopLocks() {
+        igniteLock.lock();
+        igniteLock.unlock();
+    }
+
+    /**
+     * Test IgniteCache.lock() with randomly keys.
+     */
+    @Benchmark
+    public void cacheRandomLocks() {
+        final Integer key = ThreadLocalRandom.current().nextInt(N);
+        final Lock lock = cache.lock(key);
+        lock.lock();
+        cache.put(key, ((Integer)cache.get(key)) + 1);
+        lock.unlock();
+    }
+
+    /**
+     * Test Ignite.reentrantLock() with randomly keys.
+     */
+    @Benchmark
+    public void igniteRandomLocks() {
+        final int key = ThreadLocalRandom.current().nextInt(N);
+        final IgniteLock lock = node.reentrantLock(String.valueOf(key), failoverSafe, fair, true);
+        lock.lock();
+        cache.put(key, ((Integer)cache.get(key)) + 1);
+        lock.unlock();
+    }
+
+    /**
+     * Create locks and put values in the cache.
+     */
+    @Setup(Level.Trial)
+    public void createLock() {
+        for (int i = 0; i < N; i++)
+            cache.put(new Integer(i), new Integer(i));
+        cacheLock = cache.lock(cacheLockKey);
+        igniteLock = node.reentrantLock(igniteLockKey, failoverSafe, fair, true);
+    }
+
+    /**
+     * Run benchmarks.
+     *
+     * @param args Arguments.
+     * @throws Exception If failed.
+     */
+    public static void main(String[] args) throws Exception {
+        final String simpleClsName = JmhCacheLocksBenchmark.class.getSimpleName();
+        final int threads = 4;
+        final boolean client = true;
+        final CacheAtomicityMode atomicityMode = CacheAtomicityMode.TRANSACTIONAL;
+        final CacheWriteSynchronizationMode writeSyncMode = CacheWriteSynchronizationMode.FULL_SYNC;
+
+        String output = simpleClsName +
+            "-" + threads + "-threads" +
+            "-" + (client ? "client" : "data") +
+            "-" + atomicityMode +
+            "-" + writeSyncMode;
+
+        Options opt = new OptionsBuilder()
+            .threads(threads)
+            .include(simpleClsName)
+            .output(output + ".jmh.log")
+            .jvmArgs(
+                "-Xms1g",
+                "-Xmx1g",
+                "-XX:+UnlockCommercialFeatures",
+                JmhIdeBenchmarkRunner.createProperty(PROP_ATOMICITY_MODE, atomicityMode),
+                JmhIdeBenchmarkRunner.createProperty(PROP_WRITE_SYNC_MODE, writeSyncMode),
+                JmhIdeBenchmarkRunner.createProperty(PROP_DATA_NODES, 2),
+                JmhIdeBenchmarkRunner.createProperty(PROP_CLIENT_MODE, client)).build();
+
+        new Runner(opt).run();
+    }
+}

--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -40,48 +40,56 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  */
 @Warmup(iterations = 40)
 @Measurement(iterations = 20)
-@Fork(value = 1)
+@Fork(1)
 public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     /** Fixed lock key for Ignite.reentrantLock() and IgniteCache.lock(). */
-    static final String lockKey = "key0";
+    private static final String lockKey = "key0";
 
     /** Fixed key. */
-    static final String lockKey1 = "key1";
+    private static final String lockKey1 = "key1";
 
     /** Number of locks for randomly tests. */
-    static final int N = 128;
+    private static final int N = 128;
 
     /** Parameter for Ignite.reentrantLock(). */
-    static final boolean failoverSafe = false;
+    private static final boolean failoverSafe = false;
 
     /** Parameter for Ignite.reentrantLock(). */
-    static final boolean fair = false;
+    private static final boolean fair = false;
 
     /** IgniteCache.lock() with a fixed lock key. */
-    Lock cacheLock;
+    private Lock cacheLock;
 
     /** Ignite.reentrantLock() with a fixed lock key. */
-    IgniteLock igniteLock;
+    private IgniteLock igniteLock;
 
+    /** Generate a random key for a benchmark. */
     @State(Scope.Benchmark)
     public static class Key {
+        /** */
         final String key;
 
+        /** */
         public Key() {
-            key = "key"+ThreadLocalRandom.current().nextInt(N);
+            key = "key" + ThreadLocalRandom.current().nextInt(N);
         }
     }
 
+    /** Generate two random keys for a benchmark. */
     @State(Scope.Benchmark)
     public static class KeyWithOther {
+        /** */
         final String key;
+
+        /** */
         final String otherKey;
 
+        /** */
         public KeyWithOther() {
             final int n = ThreadLocalRandom.current().nextInt(N);
 
-            key = "key"+n;
-            otherKey = "key"+(n+1);
+            key = "key" + n;
+            otherKey = "key" + (n + 1);
         }
     }
 
@@ -93,7 +101,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         cacheLock.lock();
 
         try {
-            cache.put(lockKey, ((Integer)cache.get(lockKey)) + 1);
+            cache.put(lockKey, (Integer)cache.get(lockKey) + 1);
         }
         finally {
             cacheLock.unlock();
@@ -108,7 +116,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         igniteLock.lock();
 
         try {
-            cache.put(lockKey, ((Integer)cache.get(lockKey)) + 1);
+            cache.put(lockKey, (Integer)cache.get(lockKey) + 1);
         }
         finally {
             igniteLock.unlock();
@@ -123,7 +131,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         cacheLock.lock();
 
         try {
-            cache.put(lockKey1, ((Integer)cache.get(lockKey1)) + 1);
+            cache.put(lockKey1, (Integer)cache.get(lockKey1) + 1);
         }
         finally {
             cacheLock.unlock();
@@ -138,7 +146,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         igniteLock.lock();
 
         try {
-            cache.put(lockKey1, ((Integer)cache.get(lockKey1)) + 1);
+            cache.put(lockKey1, (Integer)cache.get(lockKey1) + 1);
         }
         finally {
             igniteLock.unlock();
@@ -174,7 +182,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         lock.lock();
 
         try {
-            cache.put(k, ((Integer)cache.get(k)) + 1);
+            cache.put(k, (Integer)cache.get(k) + 1);
         }
         finally {
             lock.unlock();
@@ -192,7 +200,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         lock.lock();
 
         try {
-            cache.put(k, ((Integer)cache.get(k)) + 1);
+            cache.put(k, (Integer)cache.get(k) + 1);
         }
         finally {
             lock.unlock();
@@ -211,7 +219,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         lock.lock();
 
         try {
-            cache.put(other, ((Integer)cache.get(other)) + 1);
+            cache.put(other, (Integer)cache.get(other) + 1);
         }
         finally {
             lock.unlock();
@@ -230,7 +238,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
         lock.lock();
 
         try {
-            cache.put(other, ((Integer)cache.get(other)) + 1);
+            cache.put(other, (Integer)cache.get(other) + 1);
         }
         finally {
             lock.unlock();
@@ -242,8 +250,8 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
      */
     @Setup(Level.Trial)
     public void createLock() {
-        for (int i = 0; i < 2*N; i++)
-            cache.put("key"+i, new Integer(i));
+        for (int i = 0; i < 2 * N; i++)
+            cache.put("key" + i, new Integer(i));
 
         cacheLock = cache.lock(lockKey);
         igniteLock = node.reentrantLock(lockKey, failoverSafe, fair, true);
@@ -275,7 +283,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
             .jvmArgs(
                 "-Xms1g",
                 "-Xmx1g",
-                //"-XX:+UnlockCommercialFeatures",
+                "-XX:+UnlockCommercialFeatures",
                 JmhIdeBenchmarkRunner.createProperty(PROP_ATOMICITY_MODE, atomicityMode),
                 JmhIdeBenchmarkRunner.createProperty(PROP_WRITE_SYNC_MODE, writeSyncMode),
                 JmhIdeBenchmarkRunner.createProperty(PROP_DATA_NODES, 4),

--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -78,6 +78,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
     @Setup(Level.Trial)
     public void createLock() {
         cacheLock = cache.lock(lockKey);
+
         igniteLock = node.reentrantLock(lockKey, failoverSafe, fair, true);
     }
 

--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -255,7 +255,7 @@ public class JmhCacheLocksBenchmark extends JmhCacheAbstractBenchmark {
                 //"-XX:+UnlockCommercialFeatures",
                 JmhIdeBenchmarkRunner.createProperty(PROP_ATOMICITY_MODE, atomicityMode),
                 JmhIdeBenchmarkRunner.createProperty(PROP_WRITE_SYNC_MODE, writeSyncMode),
-                JmhIdeBenchmarkRunner.createProperty(PROP_DATA_NODES, 2),
+                JmhIdeBenchmarkRunner.createProperty(PROP_DATA_NODES, 4),
                 JmhIdeBenchmarkRunner.createProperty(PROP_CLIENT_MODE, client)).build();
 
         new Runner(opt).run();

--- a/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
+++ b/modules/benchmarks/src/main/java/org/apache/ignite/internal/benchmarks/jmh/cache/JmhCacheLocksBenchmark.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.internal.benchmarks.jmh.cache;
 
 import java.util.concurrent.ThreadLocalRandom;

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -1,0 +1,71 @@
+package org.apache.ignite.yardstick.cache;
+
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteDataStreamer;
+import org.yardstickframework.BenchmarkConfiguration;
+
+import static org.yardstickframework.BenchmarkUtils.println;
+
+/**
+ * Ignite benchmark that performs IgniteCache.lock operations.
+ */
+public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<String, Integer> {
+    /** {@inheritDoc} */
+    @Override public boolean test(Map<Object, Object> map) throws Exception {
+        final int n = nextRandom(args.range());
+        final String key = "key"+n;
+        final String otherKey = "other_"+key;
+        final IgniteCache<String, Integer> cache = cacheForOperation();
+        final Lock lock = cache.lock(key);
+
+        lock.lock();
+        try {
+            cache.put(otherKey, cache.get(otherKey)+1);
+        }
+        finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteCache<String, Integer> cache() {
+        return ignite().cache("tx");
+    }
+
+    /** {@inheritDoc} */
+    @Override public void setUp(BenchmarkConfiguration cfg) throws Exception {
+        super.setUp(cfg);
+
+        loadCachesData();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void loadCacheData(String cacheName) {
+        loadValues(cacheName, args.preloadAmount());
+    }
+
+    /**
+     * @param cacheName Cache name.
+     * @param cnt Number of entries to load.
+     * */
+    protected void loadValues(String cacheName, int cnt) {
+        try (IgniteDataStreamer<Object, Object> dataLdr = ignite().dataStreamer(cacheName)) {
+            for (int i = 0; i < cnt; i++) {
+                dataLdr.addData("key"+i, new Integer(0));
+                dataLdr.addData("other_key"+i, new Integer(0));
+
+                if (i % 100000 == 0) {
+                    if (Thread.currentThread().isInterrupted())
+                        break;
+
+                    println("Loaded entries [cache=" + cacheName + ", cnt=" + i + ']');
+                }
+            }
+        }
+
+        println("Load entries done [cache=" + cacheName + ", cnt=" + cnt + ']');
+    }
+}

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -47,8 +47,11 @@ public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<Strin
         super.setUp(cfg);
 
         String key = "key";
+
         IgniteCache<String, Integer> cache = cacheForOperation();
+
         cache.put(key, 0);
+
         lock = cache.lock(key);
     }
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -20,31 +20,18 @@ package org.apache.ignite.yardstick.cache;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.IgniteDataStreamer;
 import org.yardstickframework.BenchmarkConfiguration;
-
-import static org.yardstickframework.BenchmarkUtils.println;
 
 /**
  * Ignite benchmark that performs IgniteCache.lock operations.
  */
 public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<String, Integer> {
+    Lock lock;
+
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> map) throws Exception {
-        final int n = nextRandom(args.range());
-        final String key = "key" + n;
-        final String otherKey = "other_" + key;
-        final IgniteCache<String, Integer> cache = cacheForOperation();
-        final Lock lock = cache.lock(key);
-
         lock.lock();
-
-        try {
-            cache.put(otherKey, cache.get(otherKey) + 1);
-        }
-        finally {
-            lock.unlock();
-        }
+        lock.unlock();
 
         return true;
     }
@@ -57,34 +44,10 @@ public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<Strin
     /** {@inheritDoc} */
     @Override public void setUp(BenchmarkConfiguration cfg) throws Exception {
         super.setUp(cfg);
+        String key = "key";
 
-        loadCachesData();
-    }
-
-    /** {@inheritDoc} */
-    @Override protected void loadCacheData(String cacheName) {
-        loadValues(cacheName, args.preloadAmount());
-    }
-
-    /**
-     * @param cacheName Cache name.
-     * @param cnt Number of entries to load.
-     */
-    protected void loadValues(String cacheName, int cnt) {
-        try (IgniteDataStreamer<Object, Object> dataLdr = ignite().dataStreamer(cacheName)) {
-            for (int i = 0; i < cnt; i++) {
-                dataLdr.addData("key" + i, new Integer(0));
-                dataLdr.addData("other_key" + i, new Integer(0));
-
-                if (i % 100000 == 0) {
-                    if (Thread.currentThread().isInterrupted())
-                        break;
-
-                    println("Loaded entries [cache=" + cacheName + ", cnt=" + i + ']');
-                }
-            }
-        }
-
-        println("Load entries done [cache=" + cacheName + ", cnt=" + cnt + ']');
+        IgniteCache<String, Integer> cache = cacheForOperation();
+        cache.put(key, 0);
+        lock = cache.lock(key);
     }
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -27,7 +27,7 @@ import org.yardstickframework.BenchmarkConfiguration;
  */
 public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<String, Integer> {
     /** Cache lock. */
-    Lock lock;
+    private Lock lock;
 
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> map) throws Exception {

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -26,6 +26,7 @@ import org.yardstickframework.BenchmarkConfiguration;
  * Ignite benchmark that performs IgniteCache.lock operations.
  */
 public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<String, Integer> {
+    /** Cache lock. */
     Lock lock;
 
     /** {@inheritDoc} */
@@ -44,8 +45,8 @@ public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<Strin
     /** {@inheritDoc} */
     @Override public void setUp(BenchmarkConfiguration cfg) throws Exception {
         super.setUp(cfg);
-        String key = "key";
 
+        String key = "key";
         IgniteCache<String, Integer> cache = cacheForOperation();
         cache.put(key, 0);
         lock = cache.lock(key);

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -32,18 +32,20 @@ public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<Strin
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> map) throws Exception {
         final int n = nextRandom(args.range());
-        final String key = "key"+n;
-        final String otherKey = "other_"+key;
+        final String key = "key" + n;
+        final String otherKey = "other_" + key;
         final IgniteCache<String, Integer> cache = cacheForOperation();
         final Lock lock = cache.lock(key);
 
         lock.lock();
+
         try {
-            cache.put(otherKey, cache.get(otherKey)+1);
+            cache.put(otherKey, cache.get(otherKey) + 1);
         }
         finally {
             lock.unlock();
         }
+
         return true;
     }
 
@@ -67,12 +69,12 @@ public class IgniteCacheLockBenchmark extends IgniteCacheAbstractBenchmark<Strin
     /**
      * @param cacheName Cache name.
      * @param cnt Number of entries to load.
-     * */
+     */
     protected void loadValues(String cacheName, int cnt) {
         try (IgniteDataStreamer<Object, Object> dataLdr = ignite().dataStreamer(cacheName)) {
             for (int i = 0; i < cnt; i++) {
-                dataLdr.addData("key"+i, new Integer(0));
-                dataLdr.addData("other_key"+i, new Integer(0));
+                dataLdr.addData("key" + i, new Integer(0));
+                dataLdr.addData("other_key" + i, new Integer(0));
 
                 if (i % 100000 == 0) {
                     if (Thread.currentThread().isInterrupted())

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteCacheLockBenchmark.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.yardstick.cache;
 
 import java.util.Map;

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -26,7 +26,7 @@ import org.yardstickframework.BenchmarkConfiguration;
  */
 public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
     /** Reentrant lock. */
-    IgniteLock lock;
+    private IgniteLock lock;
 
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> map) throws Exception {

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -25,6 +25,7 @@ import org.yardstickframework.BenchmarkConfiguration;
  * Ignite benchmark that performs Ignite.reentrantLock operations.
  */
 public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
+    /** Reentrant lock. */
     IgniteLock lock;
 
     /** {@inheritDoc} */
@@ -38,8 +39,8 @@ public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
     /** {@inheritDoc} */
     @Override public void setUp(BenchmarkConfiguration cfg) throws Exception {
         super.setUp(cfg);
-        String key = "key";
 
+        String key = "key";
         lock = ignite().reentrantLock(key, false, false, true);
     }
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -1,0 +1,29 @@
+package org.apache.ignite.yardstick.cache;
+
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteLock;
+
+/**
+ * Ignite benchmark that performs Ignite.reentrantLock operations.
+ */
+public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
+    /** {@inheritDoc} */
+    @Override public boolean test(Map<Object, Object> map) throws Exception {
+        final int n = nextRandom(args.range());
+        final String key = "key"+n;
+        final String otherKey = "other_"+key;
+        final IgniteCache<String, Integer> cache = cacheForOperation();
+        final IgniteLock lock = ignite().reentrantLock(key, false, false, true);
+
+        lock.lock();
+        try {
+            cache.put(otherKey, cache.get(otherKey)+1);
+        }
+        finally {
+            lock.unlock();
+        }
+        return true;
+    }
+}

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -28,18 +28,20 @@ public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> map) throws Exception {
         final int n = nextRandom(args.range());
-        final String key = "key"+n;
-        final String otherKey = "other_"+key;
+        final String key = "key" + n;
+        final String otherKey = "other_" + key;
         final IgniteCache<String, Integer> cache = cacheForOperation();
         final IgniteLock lock = ignite().reentrantLock(key, false, false, true);
 
         lock.lock();
+
         try {
-            cache.put(otherKey, cache.get(otherKey)+1);
+            cache.put(otherKey, cache.get(otherKey) + 1);
         }
         finally {
             lock.unlock();
         }
+
         return true;
     }
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -41,6 +41,7 @@ public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
         super.setUp(cfg);
 
         String key = "key";
+
         lock = ignite().reentrantLock(key, false, false, true);
     }
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -18,30 +18,28 @@
 package org.apache.ignite.yardstick.cache;
 
 import java.util.Map;
-import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteLock;
+import org.yardstickframework.BenchmarkConfiguration;
 
 /**
  * Ignite benchmark that performs Ignite.reentrantLock operations.
  */
 public class IgniteLockBenchmark extends IgniteCacheLockBenchmark {
+    IgniteLock lock;
+
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> map) throws Exception {
-        final int n = nextRandom(args.range());
-        final String key = "key" + n;
-        final String otherKey = "other_" + key;
-        final IgniteCache<String, Integer> cache = cacheForOperation();
-        final IgniteLock lock = ignite().reentrantLock(key, false, false, true);
-
         lock.lock();
-
-        try {
-            cache.put(otherKey, cache.get(otherKey) + 1);
-        }
-        finally {
-            lock.unlock();
-        }
+        lock.unlock();
 
         return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void setUp(BenchmarkConfiguration cfg) throws Exception {
+        super.setUp(cfg);
+        String key = "key";
+
+        lock = ignite().reentrantLock(key, false, false, true);
     }
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/cache/IgniteLockBenchmark.java
@@ -1,7 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.yardstick.cache;
 
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteLock;
 


### PR DESCRIPTION
Added benchmarks which compare a performance of Ignite.reentrantLock and IgniteCache.lock in three use-cases.
1) Atomic increment operation.
2) Only get a lock and immediately unlock.
3) Atomic increment over random keys.