### PR TITLE
IGNITE-5468

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
@@ -442,12 +442,14 @@ public final class IgniteSystemProperties {
      * Property controlling maximum number of SQL result rows which can be fetched into a merge table.
      * If there are less rows than this threshold then multiple passes throw a table will be possible,
      * otherwise only one pass (e.g. only result streaming is possible).
+     * Will work if the Query parameter is not set.
      */
     public static final String IGNITE_SQL_MERGE_TABLE_MAX_SIZE = "IGNITE_SQL_MERGE_TABLE_MAX_SIZE";
 
     /**
      * Property controlling number of SQL result rows that will be fetched into a merge table at once before
      * applying binary search for the bounds.
+     * Will work if the Query parameter is not set.
      */
     public static final String IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE = "IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE";
 

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/MergeQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/MergeQuery.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.query;
+
+/**
+ * Base class for Ignite cache queries which can merge tables.
+ */
+public abstract class MergeQuery<R> extends Query<R> {
+    /** Maximum number of SQL result rows which can be fetched into a merge table. */
+    private int sqlMergeTblMaxSize;
+
+    /**
+     * Number of SQL result rows that will be fetched into a merge table at once before applying binary search for the
+     * bounds.
+     */
+    private int sqlMergeTblPrefetchSize;
+
+    /**
+     * Gets property controlling maximum number of SQL result rows which can be fetched into a merge table. If there are
+     * less rows than this threshold then multiple passes throw a table will be possible, otherwise only one pass (e.g.
+     * only result streaming is possible).
+     *
+     * @return Maximum number of SQL result rows which can be fetched into a merge table.
+     */
+    public int getSqlMergeTableMaxSize() {
+        return sqlMergeTblMaxSize;
+    }
+
+    /**
+     * Sets property controlling maximum number of SQL result rows which can be fetched into a merge table. If there are
+     * less rows than this threshold then multiple passes throw a table will be possible, otherwise only one pass (e.g.
+     * only result streaming is possible).
+     *
+     * @param sqlMergeTblMaxSize Maximum number of SQL result rows which can be fetched into a merge table. Must be
+     * positive and greater than {@link MergeQuery#sqlMergeTblPrefetchSize}.
+     * @return {@code this} for chaining.
+     */
+    public MergeQuery<R> setSqlMergeTableMaxSize(int sqlMergeTblMaxSize) {
+        this.sqlMergeTblMaxSize = sqlMergeTblMaxSize;
+
+        return this;
+    }
+
+    /**
+     * Gets number of SQL result rows that will be fetched into a merge table at once before applying binary search for
+     * the bounds.
+     *
+     * @return Number of SQL result rows that will be fetched into a merge table.
+     */
+    public int getSqlMergeTablePrefetchSize() {
+        return sqlMergeTblPrefetchSize;
+    }
+
+    /**
+     * Sets number of SQL result rows that will be fetched into a merge table at once before applying binary search for
+     * the bounds.
+     *
+     * @param sqlMergeTblPrefetchSize Number of SQL result rows that will be fetched into a merge table. Must be
+     * positive and power of 2 and less than {@link MergeQuery#sqlMergeTblMaxSize}.
+     * @return {@code this} for chaining.
+     */
+    public MergeQuery<R> setSqlMergeTablePrefetchSize(int sqlMergeTblPrefetchSize) {
+        this.sqlMergeTblPrefetchSize = sqlMergeTblPrefetchSize;
+
+        return this;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @see IgniteCache#query(Query)
  */
-public class SqlFieldsQuery extends Query<List<?>> {
+public class SqlFieldsQuery extends MergeQuery<List<?>> {
     /** */
     private static final long serialVersionUID = 0L;
 
@@ -247,6 +247,16 @@ public class SqlFieldsQuery extends Query<List<?>> {
     /** {@inheritDoc} */
     @Override public SqlFieldsQuery setLocal(boolean loc) {
         return (SqlFieldsQuery)super.setLocal(loc);
+    }
+
+    /** {@inheritDoc} */
+    @Override public SqlFieldsQuery setSqlMergeTableMaxSize(int sqlMergeTableMaxSize) {
+        return (SqlFieldsQuery)super.setSqlMergeTableMaxSize(sqlMergeTableMaxSize);
+    }
+
+    /** {@inheritDoc} */
+    @Override public SqlFieldsQuery setSqlMergeTablePrefetchSize(int sqlMergeTablePrefetchSize) {
+        return (SqlFieldsQuery)super.setSqlMergeTablePrefetchSize(sqlMergeTablePrefetchSize);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/SqlQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/SqlQuery.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @see IgniteCache#query(Query)
  */
-public final class SqlQuery<K, V> extends Query<Cache.Entry<K, V>> {
+public final class SqlQuery<K, V> extends MergeQuery<Cache.Entry<K, V>> {
     /** */
     private static final long serialVersionUID = 0L;
 
@@ -198,6 +198,16 @@ public final class SqlQuery<K, V> extends Query<Cache.Entry<K, V>> {
     /** {@inheritDoc} */
     @Override public SqlQuery<K, V> setLocal(boolean loc) {
         return (SqlQuery<K, V>)super.setLocal(loc);
+    }
+
+    /** {@inheritDoc} */
+    @Override public SqlQuery<K, V> setSqlMergeTableMaxSize(int sqlMergeTableMaxSize) {
+        return (SqlQuery<K, V>)super.setSqlMergeTableMaxSize(sqlMergeTableMaxSize);
+    }
+
+    /** {@inheritDoc} */
+    @Override public SqlQuery<K, V> setSqlMergeTablePrefetchSize(int sqlMergeTablePrefetchSize) {
+        return (SqlQuery<K, V>)super.setSqlMergeTablePrefetchSize(sqlMergeTablePrefetchSize);
     }
 
     /**

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheTwoStepQuery.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheTwoStepQuery.java
@@ -23,6 +23,9 @@ import java.util.Set;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
 
+import static org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing.DFLT_SQL_MERGE_TABLE_MAX_SIZE;
+import static org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing.DFLT_SQL_MERGE_TABLE_PREFETCH_SIZE;
+
 /**
  * Two step map-reduce style query.
  */
@@ -40,6 +43,15 @@ public class GridCacheTwoStepQuery {
 
     /** */
     private int pageSize = DFLT_PAGE_SIZE;
+
+    /** Maximum number of SQL result rows which can be fetched into a merge table. */
+    private int sqlMergeTblMaxSize = DFLT_SQL_MERGE_TABLE_MAX_SIZE;
+
+    /**
+     * Number of SQL result rows that will be fetched into a merge table at once before applying binary search for the
+     * bounds.
+     */
+    private int sqlMergeTblPrefetchSize = DFLT_SQL_MERGE_TABLE_PREFETCH_SIZE;
 
     /** */
     private boolean explain;
@@ -92,7 +104,6 @@ public class GridCacheTwoStepQuery {
         return distributedJoins;
     }
 
-
     /**
      * @return {@code True} if reduce query can skip merge table creation and get data directly from merge index.
      */
@@ -133,6 +144,38 @@ public class GridCacheTwoStepQuery {
      */
     public int pageSize() {
         return pageSize;
+    }
+
+    /**
+     * @return Maximum number of SQL result rows which can be fetched into a merge table.
+     */
+    public int sqlMergeTableMaxSize() {
+        return sqlMergeTblMaxSize;
+    }
+
+    /**
+     * @param sqlMergeTblMaxSize New maximum number of SQL result rows which can be fetched into a merge table. Must be
+     * positive and greater than {@link GridCacheTwoStepQuery#sqlMergeTblPrefetchSize}.
+     */
+    public void sqlMergeTableMaxSize(int sqlMergeTblMaxSize) {
+        this.sqlMergeTblMaxSize = sqlMergeTblMaxSize;
+    }
+
+    /**
+     * @return Number of SQL result rows that will be fetched into a merge table at once before applying binary search
+     * for the bounds.
+     */
+    public int sqlMergeTablePrefetchSize() {
+        return sqlMergeTblPrefetchSize;
+    }
+
+    /**
+     * @param sqlMergeTblPrefetchSize New number of SQL result rows that will be fetched into a merge table at once
+     * before applying binary search for the bounds. Must be positive and power of 2 and less than {@link
+     * GridCacheTwoStepQuery#sqlMergeTblMaxSize}.
+     */
+    public void sqlMergeTablePrefetchSize(int sqlMergeTblPrefetchSize) {
+        this.sqlMergeTblPrefetchSize = sqlMergeTblPrefetchSize;
     }
 
     /**

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/twostep/GridMergeIndexSorted.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/twostep/GridMergeIndexSorted.java
@@ -92,14 +92,19 @@ public final class GridMergeIndexSorted extends GridMergeIndex {
      * @param tbl Table.
      * @param name Index name,
      * @param cols Columns.
+     * @param maxFetchSize Maximum number of SQL result rows which can be fetched into a merge table.
+     * @param prefetchSize Number of SQL result rows that will be fetched into a merge table
+     * at once before applying binary search for the bounds.
      */
     public GridMergeIndexSorted(
         GridKernalContext ctx,
         GridMergeTable tbl,
         String name,
-        IndexColumn[] cols
+        IndexColumn[] cols,
+        int maxFetchSize,
+        int prefetchSize
     ) {
-        super(ctx, tbl, name, TYPE, cols);
+        super(ctx, tbl, name, TYPE, cols, maxFetchSize, prefetchSize);
     }
 
     /** {@inheritDoc} */

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/twostep/GridMergeIndexUnsorted.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/twostep/GridMergeIndexUnsorted.java
@@ -59,24 +59,34 @@ public final class GridMergeIndexUnsorted extends GridMergeIndex {
      * @param ctx Context.
      * @param tbl  Table.
      * @param name Index name.
+     * @param maxFetchSize Maximum number of SQL result rows which can be fetched into a merge table.
+     * @param prefetchSize Number of SQL result rows that will be fetched into a merge table
+     * at once before applying binary search for the bounds.
      */
-    public GridMergeIndexUnsorted(GridKernalContext ctx, GridMergeTable tbl, String name) {
-        super(ctx, tbl, name, TYPE, IndexColumn.wrap(tbl.getColumns()));
+    public GridMergeIndexUnsorted(GridKernalContext ctx,
+        GridMergeTable tbl,
+        String name,
+        int maxFetchSize,
+        int prefetchSize) {
+        super(ctx, tbl, name, TYPE, IndexColumn.wrap(tbl.getColumns()), maxFetchSize, prefetchSize);
     }
 
     /**
      * @param ctx Context.
+     * @param maxFetchSize Maximum number of SQL result rows which can be fetched into a merge table.
+     * @param prefetchSize Number of SQL result rows that will be fetched into a merge table
+     * at once before applying binary search for the bounds.
      * @return Dummy index instance.
      */
-    public static GridMergeIndexUnsorted createDummy(GridKernalContext ctx) {
-        return new GridMergeIndexUnsorted(ctx);
+    public static GridMergeIndexUnsorted createDummy(GridKernalContext ctx, int maxFetchSize, int prefetchSize) {
+        return new GridMergeIndexUnsorted(ctx, maxFetchSize, prefetchSize);
     }
 
     /**
      * @param ctx Context.
      */
-    private GridMergeIndexUnsorted(GridKernalContext ctx) {
-        super(ctx);
+    private GridMergeIndexUnsorted(GridKernalContext ctx, int maxFetchSize, int prefetchSize) {
+        super(ctx, maxFetchSize, prefetchSize);
     }
 
     /** {@inheritDoc} */

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlMergeQueryInvalidParametersTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlMergeQueryInvalidParametersTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.ignite.internal.processors.query;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.apache.ignite.internal.processors.cache.query.GridCacheTwoStepQuery;
 import org.apache.ignite.internal.processors.cache.query.QueryTable;
@@ -227,7 +228,7 @@ public class IgniteSqlMergeQueryInvalidParametersTest extends GridCommonAbstract
     /**
      * @return Log4j {@link Hashtable}.
      */
-    private Hashtable getLog4jHashable() {
+    private Hashtable<Object, Object> getLog4jHashable() {
         GridTestLog4jLogger log = (GridTestLog4jLogger)log();
 
         Object impl = GridTestUtils.getFieldValue(log, GridTestLog4jLogger.class, "impl");
@@ -241,15 +242,21 @@ public class IgniteSqlMergeQueryInvalidParametersTest extends GridCommonAbstract
      *
      */
     private Object getLoggerKey() throws Exception {
-        if (logKey != null)
-            return logKey;
+        if (logKey == null) {
+            IgniteLogger log = log().getLogger(IgniteH2Indexing.class);
 
-        Class<?> keyCls = ClassLoader.getSystemClassLoader().loadClass("org.apache.log4j.CategoryKey");
+            Object impl = GridTestUtils.getFieldValue(log, GridTestLog4jLogger.class, "impl");
 
-        Constructor<?> keyConstructor = keyCls.getDeclaredConstructor(String.class);
-        keyConstructor.setAccessible(true);
+            for (Map.Entry<Object, Object> entry : getLog4jHashable().entrySet()) {
+                if (entry.getValue().equals(impl)) {
+                    logKey = entry.getKey();
 
-        return logKey = keyConstructor.newInstance(IgniteH2Indexing.class.getName());
+                    break;
+                }
+            }
+        }
+
+        return logKey;
     }
 
     /**

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlMergeQueryInvalidParametersTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlMergeQueryInvalidParametersTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.internal.processors.cache.query.GridCacheTwoStepQuery;
+import org.apache.ignite.internal.processors.cache.query.QueryTable;
+import org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing;
+import org.apache.ignite.internal.util.GridSpinBusyLock;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.apache.ignite.testframework.junits.logger.GridTestLog4jLogger;
+import org.apache.log4j.Category;
+import org.apache.log4j.Hierarchy;
+import org.apache.log4j.Logger;
+
+import static org.apache.ignite.IgniteSystemProperties.IGNITE_SQL_MERGE_TABLE_MAX_SIZE;
+import static org.apache.ignite.IgniteSystemProperties.IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE;
+import static org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing.DFLT_SQL_MERGE_TABLE_MAX_SIZE;
+import static org.apache.ignite.internal.processors.query.h2.IgniteH2Indexing.DFLT_SQL_MERGE_TABLE_PREFETCH_SIZE;
+
+/**
+ * Tests behavior with invalid Query parameters.
+ */
+@SuppressWarnings("unchecked")
+public class IgniteSqlMergeQueryInvalidParametersTest extends GridCommonAbstractTest {
+    /** Warn logs. */
+    private static Set<String> warnLogs = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+    /** Logger key. */
+    private static Object logKey;
+
+    /** Ignite H2 index. */
+    private static IgniteH2Indexing h2Idx;
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        System.clearProperty(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE);
+        System.clearProperty(IGNITE_SQL_MERGE_TABLE_MAX_SIZE);
+
+        warnLogs.clear();
+
+        h2Idx.start(grid(0).context(), new GridSpinBusyLock());
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        super.beforeTestsStarted();
+
+        getLog4jHashable().put(getLoggerKey(), new TestLoggerDecorator());
+
+        startGrid(0);
+
+        for (String warnLog : warnLogs)
+            assertTrue(!warnLog.contains(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE));
+
+        GridQueryProcessor qryProcessor = grid(0).context().query();
+        h2Idx = GridTestUtils.getFieldValue(qryProcessor, GridQueryProcessor.class, "idx");
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        System.clearProperty(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE);
+        System.clearProperty(IGNITE_SQL_MERGE_TABLE_MAX_SIZE);
+
+        getLog4jHashable().remove(getLoggerKey());
+
+        stopAllGrids();
+    }
+
+    /**
+     *
+     */
+    public void testParametersValidationDuringMerge() throws Exception {
+        SqlFieldsQuery qry = new SqlFieldsQuery("");
+        GridCacheTwoStepQuery twoStepQry = new GridCacheTwoStepQuery("", Collections.<QueryTable>emptySet());
+
+        Method mtd = IgniteH2Indexing.class
+            .getDeclaredMethod("copyParamsToTwoStepQuery", SqlFieldsQuery.class, GridCacheTwoStepQuery.class);
+        mtd.setAccessible(true);
+
+        qry.setSqlMergeTablePrefetchSize(-10)
+            .setSqlMergeTableMaxSize(5_000);
+
+        mtd.invoke(h2Idx, qry, twoStepQry);
+
+        assertEquals(1024, twoStepQry.sqlMergeTablePrefetchSize());
+        assertEquals(5_000, twoStepQry.sqlMergeTableMaxSize());
+
+        assertTrue(warnLogs.contains("Query parameter sqlMergeTablePrefetchSize (-10) must be positive." +
+            " It remains defaulted (1024)"));
+        warnLogs.clear();
+
+        qry.setSqlMergeTablePrefetchSize(500)
+            .setSqlMergeTableMaxSize(7_000);
+
+        mtd.invoke(h2Idx, qry, twoStepQry);
+
+        assertEquals(256, twoStepQry.sqlMergeTablePrefetchSize());
+        assertEquals(7_000, twoStepQry.sqlMergeTableMaxSize());
+
+        assertTrue(warnLogs.contains("Query parameter sqlMergeTablePrefetchSize (500) must be a power of 2." +
+            " The value was changed to nearest power of 2 (256)."));
+        warnLogs.clear();
+
+        qry.setSqlMergeTablePrefetchSize(-1)
+            .setSqlMergeTableMaxSize(200);
+
+        mtd.invoke(h2Idx, qry, twoStepQry);
+
+        assertEquals(1024, twoStepQry.sqlMergeTablePrefetchSize());
+        assertEquals(10_000, twoStepQry.sqlMergeTableMaxSize());
+
+        assertTrue(warnLogs.contains("Query parameter sqlMergeTablePrefetchSize (-1) must be positive." +
+            " It remains defaulted (1024)"));
+        assertTrue(warnLogs.contains("Query parameter sqlMergeTblMaxSize (200) must be greater than " +
+            "sqlMergeTablePrefetchSize (1024). It remains defaulted (10000)"));
+        warnLogs.clear();
+
+        qry.setSqlMergeTablePrefetchSize(0)
+            .setSqlMergeTableMaxSize(0);
+
+        mtd.invoke(h2Idx, qry, twoStepQry);
+
+        assertEquals(1024, twoStepQry.sqlMergeTablePrefetchSize());
+        assertEquals(10_000, twoStepQry.sqlMergeTableMaxSize());
+
+        for (String warnLog : warnLogs)
+            assertTrue(!warnLog.contains("Query parameter "));
+    }
+
+    /**
+     *
+     */
+    public void testParametersValidationDuringStart() throws Exception {
+        assertPrefetchSizeEquals(DFLT_SQL_MERGE_TABLE_PREFETCH_SIZE);
+        assertMaxSizeEquals(DFLT_SQL_MERGE_TABLE_MAX_SIZE);
+
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE, "500");
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_MAX_SIZE, "5000");
+
+        h2Idx.start(grid(0).context(), new GridSpinBusyLock());
+
+        assertPrefetchSizeEquals(256);
+        assertMaxSizeEquals(5_000);
+
+        assertTrue(warnLogs.contains(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE + " (500) must be a power of 2. " +
+            "The value was changed to nearest power of 2 (256)."));
+        warnLogs.clear();
+
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE, "-1");
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_MAX_SIZE, "10000");
+
+        h2Idx.start(grid(0).context(), new GridSpinBusyLock());
+
+        assertPrefetchSizeEquals(256);
+        assertMaxSizeEquals(10_000);
+
+        assertTrue(warnLogs.contains(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE + " (-1) must be positive and less than " +
+            IGNITE_SQL_MERGE_TABLE_MAX_SIZE + " (10000). " + IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE +
+            " remains defaulted (256)."));
+        warnLogs.clear();
+
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE, "-1");
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_MAX_SIZE, "200");
+
+        h2Idx.start(grid(0).context(), new GridSpinBusyLock());
+
+        assertPrefetchSizeEquals(256);
+        assertMaxSizeEquals(10_000);
+
+        assertTrue(warnLogs.contains(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE + " (-1) must be positive and less than " +
+            IGNITE_SQL_MERGE_TABLE_MAX_SIZE + " (200). The values remains defaulted (256) and (10000)."));
+        warnLogs.clear();
+
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE, "10000");
+        System.setProperty(IGNITE_SQL_MERGE_TABLE_MAX_SIZE, "5000");
+
+        h2Idx.start(grid(0).context(), new GridSpinBusyLock());
+
+        assertPrefetchSizeEquals(256);
+        assertMaxSizeEquals(5000);
+
+        assertTrue(warnLogs.contains(IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE + " (10000) must be positive and less than " +
+            IGNITE_SQL_MERGE_TABLE_MAX_SIZE + " (5000). " + IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE +
+            " remains defaulted (256)."));
+        warnLogs.clear();
+    }
+
+    /**
+     * @param exp Expected.
+     */
+    private void assertMaxSizeEquals(int exp) {
+        assertEquals(exp,
+            GridTestUtils.getFieldValue(h2Idx, IgniteH2Indexing.class, "sqlMergeTblMaxSize"));
+    }
+
+    /**
+     * @param exp Expected.
+     */
+    private void assertPrefetchSizeEquals(int exp) {
+        assertEquals(exp,
+            GridTestUtils.getFieldValue(h2Idx, IgniteH2Indexing.class, "sqlMergeTblPrefetchSize"));
+    }
+
+    /**
+     * @return Log4j {@link Hashtable}.
+     */
+    private Hashtable getLog4jHashable() {
+        GridTestLog4jLogger log = (GridTestLog4jLogger)log();
+
+        Object impl = GridTestUtils.getFieldValue(log, GridTestLog4jLogger.class, "impl");
+
+        Object repo = GridTestUtils.getFieldValue(impl, Category.class, "repository");
+
+        return GridTestUtils.getFieldValue(repo, Hierarchy.class, "ht");
+    }
+
+    /**
+     *
+     */
+    private Object getLoggerKey() throws Exception {
+        if (logKey != null)
+            return logKey;
+
+        Class<?> keyCls = ClassLoader.getSystemClassLoader().loadClass("org.apache.log4j.CategoryKey");
+
+        Constructor<?> keyConstructor = keyCls.getDeclaredConstructor(String.class);
+        keyConstructor.setAccessible(true);
+
+        return logKey = keyConstructor.newInstance(IgniteH2Indexing.class.getName());
+    }
+
+    /**
+     * Add warning logs to set.
+     */
+    private class TestLoggerDecorator extends Logger {
+        /**
+         * Default constructor.
+         */
+        TestLoggerDecorator() {
+            super(IgniteH2Indexing.class.getName());
+
+            parent = Logger.getRootLogger();
+            repository = Logger.getRootLogger().getLoggerRepository();
+        }
+
+        /** {@inheritDoc} */
+        @Override public void warn(Object msg) {
+            super.warn(msg);
+            warnLogs.add((String)msg);
+        }
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlMergeQueryInvalidParametersTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlMergeQueryInvalidParametersTest.java
@@ -214,7 +214,7 @@ public class IgniteSqlMergeQueryInvalidParametersTest extends GridCommonAbstract
      */
     private void assertMaxSizeEquals(int exp) {
         assertEquals(exp,
-            GridTestUtils.getFieldValue(h2Idx, IgniteH2Indexing.class, "sqlMergeTblMaxSize"));
+            (int) GridTestUtils.getFieldValue(h2Idx, IgniteH2Indexing.class, "sqlMergeTblMaxSize"));
     }
 
     /**
@@ -222,7 +222,7 @@ public class IgniteSqlMergeQueryInvalidParametersTest extends GridCommonAbstract
      */
     private void assertPrefetchSizeEquals(int exp) {
         assertEquals(exp,
-            GridTestUtils.getFieldValue(h2Idx, IgniteH2Indexing.class, "sqlMergeTblPrefetchSize"));
+            (int) GridTestUtils.getFieldValue(h2Idx, IgniteH2Indexing.class, "sqlMergeTblPrefetchSize"));
     }
 
     /**

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheQuerySelfTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheQuerySelfTestSuite.java
@@ -122,6 +122,7 @@ import org.apache.ignite.internal.processors.cache.query.IndexingSpiQueryTxSelfT
 import org.apache.ignite.internal.processors.query.IgniteQueryDedicatedPoolTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlEntryCacheModeAgnosticTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlKeyValueFieldsTest;
+import org.apache.ignite.internal.processors.query.IgniteSqlMergeQueryInvalidParametersTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlRoutingTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlSchemaIndexingTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlSegmentedIndexMultiNodeSelfTest;
@@ -201,6 +202,7 @@ public class IgniteCacheQuerySelfTestSuite extends TestSuite {
         suite.addTestSuite(IgniteCacheAtomicQuerySelfTest.class);
         suite.addTestSuite(IgniteCacheAtomicNearEnabledQuerySelfTest.class);
         suite.addTestSuite(IgniteCachePartitionedQueryP2PDisabledSelfTest.class);
+        suite.addTestSuite(IgniteSqlMergeQueryInvalidParametersTest.class);
 
         suite.addTestSuite(IgniteCacheQueryIndexSelfTest.class);
         suite.addTestSuite(IgniteCacheCollocatedQuerySelfTest.class);


### PR DESCRIPTION
IGNITE-5468: Added the ability to set IGNITE_SQL_MERGE_TABLE_MAX_SIZE and IGNITE_SQL_MERGE_TABLE_PREFETCH_SIZE via cache configuration