### PR TITLE
IGNITE-5607: HttpSessionBindingListener is not supported for clustere…

### DIFF
--- a/modules/web/src/main/java/org/apache/ignite/cache/websession/WebSessionV2.java
+++ b/modules/web/src/main/java/org/apache/ignite/cache/websession/WebSessionV2.java
@@ -168,6 +168,8 @@ class WebSessionV2 implements HttpSession {
         maxInactiveInterval = interval;
 
         maxInactiveIntervalChanged = true;
+        
+        genuineSes.setMaxInactiveInterval(interval);
     }
 
     /**
@@ -224,6 +226,8 @@ class WebSessionV2 implements HttpSession {
     /** {@inheritDoc} */
     @Override public void setAttribute(final String name, final Object val) {
         assertValid();
+        
+        genuineSes.setAttribute(name, val);
 
         if (val == null)
             removeAttribute(name);


### PR DESCRIPTION
Ignite WebSessionV2 uses genuineSes as the original HttpSession.

Therefore, when setting an attribute or setting the maxInactiveInterval, Ignite should tell the original HttpSession about it.

Otherwise, when the web container (such as Tomcat) thinks that a session expires, or is invalidated, or a session attribute gets removed, etc., session attributes' HttpSessionBindingListener's valueUnbound callback function will not get fired.

So once the original HttpSession gets updated with the session attributes and the maxInactiveInterval, the web container will transitively trigger the session attributes' HttpSessionBindingListener's valueUnbound callback function when a session expires, etc.

(By the way, tested with our app, and our issue is fixed:
http://apache-ignite-developers.2346864.n4.nabble.com/It-seems-WebSession-s-removeAttribute-does-not-support-HttpSessionBindingListener-td19184.html)