### PR TITLE
Ignite 5562 Assertions in TCP discovery SPI when NTP is moving time backwards

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryStatistics.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryStatistics.java
@@ -314,7 +314,9 @@ public class TcpDiscoveryStatistics {
      */
     public synchronized void onMessageSent(TcpDiscoveryAbstractMessage msg, long time) {
         assert msg != null;
-        assert time >= 0 : time;
+
+        if (time < 0)
+            time = 0;
 
         if (crdSinceTs.get() > 0 &&
             (msg instanceof TcpDiscoveryCustomEventMessage) ||

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryStatistics.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryStatistics.java
@@ -435,7 +435,8 @@ public class TcpDiscoveryStatistics {
      * @param initTime Time socket was initialized in.
      */
     public synchronized void onServerSocketInitialized(long initTime) {
-        assert initTime >= 0;
+        if (initTime < 0)
+            initTime = 0;
 
         if (maxSrvSockInitTime < initTime)
             maxSrvSockInitTime = initTime;
@@ -447,7 +448,8 @@ public class TcpDiscoveryStatistics {
      * @param initTime Time socket was initialized in.
      */
     public synchronized void onClientSocketInitialized(long initTime) {
-        assert initTime >= 0;
+        if (initTime < 0)
+            initTime = 0;
 
         clientSockCreatedCnt++;
 


### PR DESCRIPTION
The `assert` statements were changed due to the fact `System.currentTimeMillis()` is not monotonic.