### PR TITLE
IGNITE-5790 SQL: Append UUID to names of Ignite instances opened by JDBC

### DIFF
--- a/modules/clients/src/test/config/jdbc-config.xml
+++ b/modules/clients/src/test/config/jdbc-config.xml
@@ -29,6 +29,7 @@
         <!-- JDBC driver should force true value -->
         <property name="clientMode" value="false"/>
 
+        <property name="igniteInstanceName" value="SqlGrid"/>
         <property name="localHost" value="127.0.0.1"/>
 
         <property name="discoverySpi">

--- a/modules/clients/src/test/java/org/apache/ignite/internal/jdbc2/JdbcConnectionReopenTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/jdbc2/JdbcConnectionReopenTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.jdbc2;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.internal.IgnitionEx;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+
+import static org.apache.ignite.IgniteJdbcDriver.CFG_URL_PREFIX;
+
+/**
+ * Connection test.
+ */
+public class JdbcConnectionReopenTest extends GridCommonAbstractTest {
+    /**
+     * @return Config URL to use in test.
+     */
+    private String configURL() {
+        return "modules/clients/src/test/config/jdbc-config.xml";
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testReopenSameInstanceName() throws Exception {
+        String url = CFG_URL_PREFIX + configURL();
+
+        try (Ignite ignite = IgnitionEx.start(configURL())) {
+            try (Connection conn = DriverManager.getConnection(url)) {
+                assertNotNull(conn);
+            }
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcConnection.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.jdbc2;
 
+import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -50,7 +51,6 @@ import org.apache.ignite.IgniteClientDisconnectedException;
 import org.apache.ignite.IgniteDataStreamer;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteJdbcDriver;
-import org.apache.ignite.Ignition;
 import org.apache.ignite.cluster.ClusterGroup;
 import org.apache.ignite.compute.ComputeTaskTimeoutException;
 import org.apache.ignite.configuration.IgniteConfiguration;
@@ -64,6 +64,7 @@ import org.apache.ignite.internal.processors.query.QueryUtils;
 import org.apache.ignite.internal.processors.resource.GridSpringResourceContext;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteCallable;
 import org.apache.ignite.resources.IgniteInstanceResource;
@@ -229,6 +230,8 @@ public class JdbcConnection implements Connection {
      * @param cfgUrl Config url.
      */
     private Ignite getIgnite(String cfgUrl) throws IgniteCheckedException {
+        String jdbcName = "ignite-jdbc-driver-" + UUID.randomUUID().toString();
+
         while (true) {
             IgniteNodeFuture fut = NODES.get(cfg);
 
@@ -241,21 +244,28 @@ public class JdbcConnection implements Connection {
                     fut = old;
                 else {
                     try {
-                        Ignite ignite;
+                        final IgniteBiTuple<IgniteConfiguration, ? extends GridSpringResourceContext> cfgAndCtx;
 
                         if (NULL.equals(cfg)) {
-                            Ignition.setClientMode(true);
+                            URL url = U.resolveIgniteUrl(IgnitionEx.DFLT_CFG);
 
-                            ignite = Ignition.start();
+                            if (url != null)
+                                cfgAndCtx = loadConfiguration(IgnitionEx.DFLT_CFG, jdbcName);
+                            else {
+                                U.warn(null, "Default Spring XML file not found (is IGNITE_HOME set?): "
+                                    + IgnitionEx.DFLT_CFG);
+
+                                IgniteConfiguration cfg = new IgniteConfiguration()
+                                    .setIgniteInstanceName(jdbcName)
+                                    .setClientMode(true);
+
+                                cfgAndCtx = new IgniteBiTuple<>(cfg, null);
+                            }
                         }
-                        else {
-                            IgniteBiTuple<IgniteConfiguration, ? extends GridSpringResourceContext> cfgAndCtx =
-                                loadConfiguration(cfgUrl);
+                        else
+                            cfgAndCtx = loadConfiguration(cfgUrl, jdbcName);
 
-                            ignite = IgnitionEx.start(cfgAndCtx.get1(), cfgAndCtx.get2());
-                        }
-
-                        fut.onDone(ignite);
+                        fut.onDone(IgnitionEx.start(cfgAndCtx.get1(), cfgAndCtx.get2()));
                     }
                     catch (IgniteException e) {
                         fut.onDone(e);
@@ -274,9 +284,11 @@ public class JdbcConnection implements Connection {
 
     /**
      * @param cfgUrl Config URL.
+     * @param jdbcName Appended to instance name or used as default.
      * @return Ignite config and Spring context.
      */
-    private IgniteBiTuple<IgniteConfiguration, ? extends GridSpringResourceContext> loadConfiguration(String cfgUrl) {
+    private IgniteBiTuple<IgniteConfiguration, ? extends GridSpringResourceContext> loadConfiguration(String cfgUrl,
+        String jdbcName) {
         try {
             IgniteBiTuple<Collection<IgniteConfiguration>, ? extends GridSpringResourceContext> cfgMap =
                 IgnitionEx.loadConfigurations(cfgUrl);
@@ -284,7 +296,9 @@ public class JdbcConnection implements Connection {
             IgniteConfiguration cfg = F.first(cfgMap.get1());
 
             if (cfg.getIgniteInstanceName() == null)
-                cfg.setIgniteInstanceName("ignite-jdbc-driver-" + UUID.randomUUID().toString());
+                cfg.setIgniteInstanceName(jdbcName);
+            else
+                cfg.setIgniteInstanceName(cfg.getIgniteInstanceName() + "-" + jdbcName);
 
             cfg.setClientMode(true); // Force client mode.
 


### PR DESCRIPTION
All Ignite instances created by Jdbc driver should now be either named or appended with ignite-jdbc-driver-UUID to avoid conflicting with instances created in other places.

Had to inline parts of IgnitionEx.start() to apply changes to every decision branch.