### PR TITLE
IGNITE-5838: Unclear exception from BinaryObjectBuilder::build call when builder is reused

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryObjectBuilderImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryObjectBuilderImpl.java
@@ -547,15 +547,16 @@ public class BinaryObjectBuilderImpl implements BinaryObjectBuilder {
 
     /** {@inheritDoc} */
     @Override public BinaryObjectBuilder setField(String name, Object val0) {
-        Object val = val0 == null ? new BinaryValueWithType(BinaryUtils.typeByClass(Object.class), null) : val0;
+        Object val = assignedValues().get(name);
 
-        Object oldVal = assignedValues().put(name, val);
+        if (val instanceof BinaryValueWithType)
+            ((BinaryValueWithType)val).value(val0);
+        else if(val == null)
+            val = val0 == null ? new BinaryValueWithType(BinaryUtils.typeByClass(Object.class), null) : val0;
+        else
+            val = val0 == null ? new BinaryValueWithType(BinaryUtils.typeByClass(val.getClass()), null) : val0;
 
-        if (oldVal instanceof BinaryValueWithType && val0 != null) {
-            ((BinaryValueWithType)oldVal).value(val);
-
-            assignedValues().put(name, oldVal);
-        }
+        assignedValues().put(name, val);
 
         return this;
     }
@@ -579,7 +580,7 @@ public class BinaryObjectBuilderImpl implements BinaryObjectBuilder {
     /** {@inheritDoc} */
     @Override public BinaryObjectBuilder setField(String name, @Nullable BinaryObjectBuilder builder) {
         if (builder == null)
-            return setField(name, null, Object.class);
+            return setField(name, (Object)null);
         else
             return setField(name, (Object)builder);
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryObjectBuilderAdditionalSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryObjectBuilderAdditionalSelfTest.java
@@ -1595,6 +1595,23 @@ public class BinaryObjectBuilderAdditionalSelfTest extends GridCommonAbstractTes
     }
 
     /**
+     * @throws Exception If fails
+     */
+    public void testBuilderReusage() throws Exception {
+        BinaryObjectBuilder builder =  newWrapper("SimpleCls");
+
+        builder.setField("str", "abc");
+
+        assertEquals("abc", builder.build().field("str"));
+
+        builder.setField("str", null);
+        assertNull(builder.build().field("str"));
+
+        builder.setField("str", "def");
+        assertEquals("def", builder.build().field("str"));
+    }
+
+    /**
      *
      */
     private static class TestObjectExternalizable implements Externalizable {


### PR DESCRIPTION
Fix BinaryObjectBuilder reusage issue.