### PR TITLE
IGNITE-6179: fixed tests with client reconnect

### DIFF
--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/index/DynamicIndexAbstractConcurrentSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/index/DynamicIndexAbstractConcurrentSelfTest.java
@@ -699,7 +699,7 @@ public abstract class DynamicIndexAbstractConcurrentSelfTest extends DynamicInde
 
                 final QueryIndex idx = index(IDX_NAME_2, field(FIELD_NAME_1), field(aliasUnescaped(FIELD_NAME_2)));
 
-                queryProcessor(srv).dynamicIndexCreate(CACHE_NAME, CACHE_NAME, TBL_NAME, idx, false);
+                queryProcessor(srv).dynamicIndexCreate(CACHE_NAME, CACHE_NAME, TBL_NAME, idx, false).get();
             }
         });
 


### PR DESCRIPTION
Affects:
DynamicIndexPartitionedAtomicConcurrentSelfTest.testClientReconnectWithCacheRestart()
DynamicIndexPartitionedTransactionalConcurrentSelfTest.testClientReconnectWithCacheRestart()
DynamicIndexReplicatedTransactionalConcurrentSelfTest.testClientReconnectWithCacheRestart()
DynamicIndexReplicatedAtomicConcurrentSelfTest.testClientReconnectWithCacheRestart()