### PR TITLE
jdkMarshaller(String nodeName) didn't set nodeName

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/marshaller/MarshallerUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/marshaller/MarshallerUtils.java
@@ -48,7 +48,7 @@ public class MarshallerUtils {
     public static JdkMarshaller jdkMarshaller(@Nullable String nodeName) {
         JdkMarshaller marsh = new JdkMarshaller();
 
-        setNodeName(new JdkMarshaller(), nodeName);
+        setNodeName(marsh, nodeName);
 
         return marsh;
     }


### PR DESCRIPTION
Node name was being set on a new instance of JdkMarshaller, not the one being returned