### PR TITLE
IGNITE-6260 rename setDistributedJoins to setNonCollocatedJoins

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
@@ -66,7 +66,7 @@ public class SqlFieldsQuery extends Query<List<?>> {
     private boolean enforceJoinOrder;
 
     /** */
-    private boolean distributedJoins;
+    private boolean nonCollocatedJoins;
 
     /** */
     private boolean replicatedOnly;
@@ -219,25 +219,48 @@ public class SqlFieldsQuery extends Query<List<?>> {
     }
 
     /**
-     * Specify if distributed joins are enabled for this query.
+     * Specify if distributed joins are enabled for this query.<br><br>
+     * The method is deprecated  due to the confusing naming (to be deleted in v3.0).
+     * Use instead {@link #setNonCollocatedJoins(boolean)} which sets the same value.
      *
      * @param distributedJoins Distributed joins enabled.
      * @return {@code this} For chaining.
      */
+    @Deprecated
     public SqlFieldsQuery setDistributedJoins(boolean distributedJoins) {
-        this.distributedJoins = distributedJoins;
-
+        this.nonCollocatedJoins = distributedJoins;
         return this;
     }
 
     /**
-     * Check if distributed joins are enabled for this query.
+     * Check if distributed joins are enabled for this query.<br><br>
+     * The method is deprecated  due to the confusing naming (to be deleted in v3.0).
+     * Use instead {@link #isNonCollocatedJoins()} which returns same value.
      *
      * @return {@code true} If distributed joins enabled.
      */
+    @Deprecated
     public boolean isDistributedJoins() {
-        return distributedJoins;
+        return nonCollocatedJoins;
     }
+
+    /**
+     * Specify if non collocated joins are enabled for this query.
+     *
+     * @param nonCollocatedJoins Non collocated joins enabled.
+     * @return {@code this} For chaining.
+     */
+    public SqlFieldsQuery setNonCollocatedJoins(boolean nonCollocatedJoins) {
+        this.nonCollocatedJoins = nonCollocatedJoins;
+        return this;
+    }
+
+    /**
+     * Check if non collocated joins are enabled for this query.
+     *
+     * @return {@code true} If non collocated joins enabled.
+     */
+    public boolean isNonCollocatedJoins() { return nonCollocatedJoins; }
 
     /** {@inheritDoc} */
     @Override public SqlFieldsQuery setPageSize(int pageSize) {

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/SqlQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/SqlQuery.java
@@ -52,7 +52,7 @@ public final class SqlQuery<K, V> extends Query<Cache.Entry<K, V>> {
     private int timeout;
 
     /** */
-    private boolean distributedJoins;
+    private boolean nonCollocatedJoins;
 
     /** */
     private boolean replicatedOnly;
@@ -212,25 +212,51 @@ public final class SqlQuery<K, V> extends Query<Cache.Entry<K, V>> {
      * Specify if distributed joins are enabled for this query.
      *
      * When disabled, join results will only contain colocated data (joins work locally).
-     * When enabled, joins work as expected, no matter how the data is distributed.
+     * When enabled, joins work as expected, no matter how the data is distributed.<br><br>
+     *
+     * The method is deprecated  due to the confusing naming (to be deleted in v3.0).
+     * Use instead {@link #setNonCollocatedJoins(boolean)} which returns same value.
      *
      * @param distributedJoins Distributed joins enabled.
      * @return {@code this} For chaining.
      */
+    @Deprecated
     public SqlQuery<K, V> setDistributedJoins(boolean distributedJoins) {
-        this.distributedJoins = distributedJoins;
+        this.nonCollocatedJoins = distributedJoins;
 
         return this;
     }
 
     /**
-     * Check if distributed joins are enabled for this query.
+     * Check if distributed joins are enabled for this query.<br><br>
+     *
+     * The method is deprecated  due to the confusing naming (to be deleted in v3.0).
+     * Use instead {@link #isNonCollocatedJoins()} which returns same value.
      *
      * @return {@code true} If distributed joins enabled.
      */
+    @Deprecated
     public boolean isDistributedJoins() {
-        return distributedJoins;
+        return nonCollocatedJoins;
     }
+
+    /**
+     * Specify if non collocated joins are enabled for this query.
+     *
+     * @param nonCollocatedJoins Non collocated joins enabled.
+     * @return {@code this} For chaining.
+     */
+    public SqlQuery<K, V> setNonCollocatedJoins(boolean nonCollocatedJoins) {
+        this.nonCollocatedJoins = nonCollocatedJoins;
+        return this;
+    }
+
+    /**
+     * Check if non collocated joins are enabled for this query.
+     *
+     * @return {@code true} If non collocated joins enabled.
+     */
+    public boolean isNonCollocatedJoins() { return nonCollocatedJoins; }
 
     /**
      * Specify if the query contains only replicated tables.

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcBatchUpdateTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcBatchUpdateTask.java
@@ -161,7 +161,7 @@ class JdbcBatchUpdateTask implements IgniteCallable<int[]> {
         qry.setPageSize(fetchSize);
         qry.setLocal(locQry);
         qry.setCollocated(collocatedQry);
-        qry.setDistributedJoins(distributedJoins);
+        qry.setNonCollocatedJoins(distributedJoins);
         qry.setSchema(schemaName);
         qry.setArgs(args == null ? null : args.toArray());
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcQueryTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcQueryTask.java
@@ -163,7 +163,7 @@ class JdbcQueryTask implements IgniteCallable<JdbcQueryTask.QueryResult> {
             qry.setPageSize(fetchSize);
             qry.setLocal(locQry);
             qry.setCollocated(collocatedQry);
-            qry.setDistributedJoins(distributedJoins);
+            qry.setNonCollocatedJoins(distributedJoins);
             qry.setEnforceJoinOrder(enforceJoinOrder());
             qry.setLazy(lazy());
             qry.setSchema(schemaName);

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcSqlFieldsQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcSqlFieldsQuery.java
@@ -90,6 +90,13 @@ public final class JdbcSqlFieldsQuery extends SqlFieldsQuery {
     }
 
     /** {@inheritDoc} */
+    @Override public JdbcSqlFieldsQuery setNonCollocatedJoins(boolean nonCollocatedJoins) {
+        super.setNonCollocatedJoins(nonCollocatedJoins);
+
+        return this;
+    }
+
+    /** {@inheritDoc} */
     @Override public JdbcSqlFieldsQuery setPageSize(int pageSize) {
         super.setPageSize(pageSize);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/jdbc/JdbcRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/jdbc/JdbcRequestHandler.java
@@ -244,7 +244,7 @@ public class JdbcRequestHandler implements SqlListenerRequestHandler {
 
             qry.setArgs(req.arguments());
 
-            qry.setDistributedJoins(distributedJoins);
+            qry.setNonCollocatedJoins(distributedJoins);
             qry.setEnforceJoinOrder(enforceJoinOrder);
             qry.setCollocated(collocated);
             qry.setReplicatedOnly(replicatedOnly);
@@ -410,7 +410,7 @@ public class JdbcRequestHandler implements SqlListenerRequestHandler {
 
                 qry.setArgs(q.args());
 
-                qry.setDistributedJoins(distributedJoins);
+                qry.setNonCollocatedJoins(distributedJoins);
                 qry.setEnforceJoinOrder(enforceJoinOrder);
                 qry.setCollocated(collocated);
                 qry.setReplicatedOnly(replicatedOnly);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcRequestHandler.java
@@ -181,7 +181,7 @@ public class OdbcRequestHandler implements SqlListenerRequestHandler {
 
         qry.setArgs(args);
 
-        qry.setDistributedJoins(distributedJoins);
+        qry.setNonCollocatedJoins(distributedJoins);
         qry.setEnforceJoinOrder(enforceJoinOrder);
         qry.setReplicatedOnly(replicatedOnly);
         qry.setCollocated(collocated);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
@@ -1290,7 +1290,7 @@ public class PlatformCache extends PlatformAbstractTarget {
                 .setPageSize(pageSize)
                 .setArgs(args)
                 .setLocal(loc)
-                .setDistributedJoins(distrJoins)
+                .setNonCollocatedJoins(distrJoins)
                 .setTimeout(timeout, TimeUnit.MILLISECONDS)
                 .setReplicatedOnly(replicated);
     }
@@ -1320,7 +1320,7 @@ public class PlatformCache extends PlatformAbstractTarget {
                 .setPageSize(pageSize)
                 .setArgs(args)
                 .setLocal(loc)
-                .setDistributedJoins(distrJoins)
+                .setNonCollocatedJoins(distrJoins)
                 .setEnforceJoinOrder(enforceJoinOrder)
                 .setLazy(lazy)
                 .setTimeout(timeout, TimeUnit.MILLISECONDS)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -1865,7 +1865,7 @@ private IgniteInternalFuture<Object> rebuildIndexesFromHash(@Nullable final Stri
                         FieldsQueryCursor<List<?>> cur;
 
                         if (cctx.config().getQueryParallelism() > 1) {
-                            qry.setDistributedJoins(true);
+                            qry.setNonCollocatedJoins(true);
 
                             cur = idx.queryDistributedSqlFields(schemaName, qry, keepBinary, cancel, mainCacheId);
                         }
@@ -1948,8 +1948,8 @@ private IgniteInternalFuture<Object> rebuildIndexesFromHash(@Nullable final Stri
         if (qry.isReplicatedOnly() && qry.getPartitions() != null)
             throw new CacheException("Partitions are not supported in replicated only mode.");
 
-        if (qry.isDistributedJoins() && qry.getPartitions() != null)
-            throw new CacheException("Using both partitions and distributed JOINs is not supported for the same query");
+        if (qry.isNonCollocatedJoins() && qry.getPartitions() != null)
+            throw new CacheException("Using both partitions and non collocated JOINs is not supported for the same query");
     }
 
     /**
@@ -1996,9 +1996,9 @@ private IgniteInternalFuture<Object> rebuildIndexesFromHash(@Nullable final Stri
         if (qry.isReplicatedOnly() && qry.getPartitions() != null)
             throw new CacheException("Partitions are not supported in replicated only mode.");
 
-        if (qry.isDistributedJoins() && qry.getPartitions() != null)
+        if (qry.isNonCollocatedJoins() && qry.getPartitions() != null)
             throw new CacheException(
-                "Using both partitions and distributed JOINs is not supported for the same query");
+                "Using both partitions and non collocated JOINs is not supported for the same query");
 
         if ((qry.isReplicatedOnly() && cctx.isReplicatedAffinityNode()) || cctx.isLocal() || qry.isLocal())
             return queryLocalSql(cctx, qry, keepBinary);
@@ -2068,7 +2068,7 @@ private IgniteInternalFuture<Object> rebuildIndexesFromHash(@Nullable final Stri
                             cctx.name());
 
                         if (cctx.config().getQueryParallelism() > 1) {
-                            qry.setDistributedJoins(true);
+                            qry.setNonCollocatedJoins(true);
 
                             return idx.queryDistributedSql(schemaName, qry, keepBinary, mainCacheId);
                         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/query/QueryCommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/query/QueryCommandHandler.java
@@ -288,7 +288,7 @@ public class QueryCommandHandler extends GridRestCommandHandlerAdapter {
 
                         ((SqlQuery)qry).setArgs(req.arguments());
 
-                        ((SqlQuery)qry).setDistributedJoins(req.distributedJoins());
+                        ((SqlQuery)qry).setNonCollocatedJoins(req.distributedJoins());
 
                         break;
 
@@ -297,7 +297,7 @@ public class QueryCommandHandler extends GridRestCommandHandlerAdapter {
 
                         ((SqlFieldsQuery)qry).setArgs(req.arguments());
 
-                        ((SqlFieldsQuery)qry).setDistributedJoins(req.distributedJoins());
+                        ((SqlFieldsQuery)qry).setNonCollocatedJoins(req.distributedJoins());
 
                         break;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/query/VisorQueryTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/query/VisorQueryTask.java
@@ -76,7 +76,7 @@ public class VisorQueryTask extends VisorOneNodeTask<VisorQueryTaskArg, VisorEit
                 SqlFieldsQuery qry = new SqlFieldsQuery(arg.getQueryText());
                 qry.setPageSize(arg.getPageSize());
                 qry.setLocal(arg.isLocal());
-                qry.setDistributedJoins(arg.isDistributedJoins());
+                qry.setNonCollocatedJoins(arg.isDistributedJoins());
                 qry.setEnforceJoinOrder(arg.isEnforceJoinOrder());
                 qry.setReplicatedOnly(arg.isReplicatedOnly());
                 qry.setLazy(arg.getLazy());

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
@@ -1682,7 +1682,7 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
             .setLocal(qry.isLocal())
             .setCollocated(qry.isCollocated())
             .setPageSize(qry.getPageSize())
-            .setDistributedJoins(qry.isDistributedJoins())
+            .setNonCollocatedJoins(qry.isNonCollocatedJoins())
             .setEnforceJoinOrder(qry.isEnforceJoinOrder()))
             .getAll().get(0).get(0);
     }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/DmlStatementsProcessor.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/DmlStatementsProcessor.java
@@ -371,7 +371,7 @@ public class DmlStatementsProcessor {
         if (!loc && !plan.isLocSubqry) {
             SqlFieldsQuery newFieldsQry = new SqlFieldsQuery(plan.selectQry, fieldsQry.isCollocated())
                 .setArgs(fieldsQry.getArgs())
-                .setDistributedJoins(fieldsQry.isDistributedJoins())
+                .setNonCollocatedJoins(fieldsQry.isNonCollocatedJoins())
                 .setEnforceJoinOrder(fieldsQry.isEnforceJoinOrder())
                 .setLocal(fieldsQry.isLocal())
                 .setPageSize(fieldsQry.getPageSize())

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -1240,7 +1240,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
         fqry.setArgs(qry.getArgs());
         fqry.setPageSize(qry.getPageSize());
-        fqry.setDistributedJoins(qry.isDistributedJoins());
+        fqry.setNonCollocatedJoins(qry.isNonCollocatedJoins());
         fqry.setPartitions(qry.getPartitions());
         fqry.setLocal(qry.isLocal());
 
@@ -1287,16 +1287,16 @@ public class IgniteH2Indexing implements GridQueryIndexing {
         Connection c = connectionForSchema(schemaName);
 
         final boolean enforceJoinOrder = qry.isEnforceJoinOrder();
-        final boolean distributedJoins = qry.isDistributedJoins();
+        final boolean nonCollocatedJoins = qry.isNonCollocatedJoins();
         final boolean grpByCollocated = qry.isCollocated();
 
-        final DistributedJoinMode distributedJoinMode = distributedJoinMode(qry.isLocal(), distributedJoins);
+        final DistributedJoinMode distributedJoinMode = distributedJoinMode(qry.isLocal(), nonCollocatedJoins);
 
         GridCacheTwoStepQuery twoStepQry = null;
         List<GridQueryFieldMetadata> meta;
 
         final H2TwoStepCachedQueryKey cachedQryKey = new H2TwoStepCachedQueryKey(schemaName, sqlQry, grpByCollocated,
-            distributedJoins, enforceJoinOrder, qry.isLocal());
+            nonCollocatedJoins, enforceJoinOrder, qry.isLocal());
         H2TwoStepCachedQuery cachedQry = twoStepCache.get(cachedQryKey);
 
         if (cachedQry != null) {
@@ -1357,7 +1357,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
                         bindParameters(stmt, F.asList(qry.getArgs()));
 
                         twoStepQry = GridSqlQuerySplitter.split((JdbcPreparedStatement)stmt, qry.getArgs(),
-                            grpByCollocated, distributedJoins, enforceJoinOrder, this);
+                            grpByCollocated, nonCollocatedJoins, enforceJoinOrder, this);
 
                         assert twoStepQry != null;
                     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheAbstractQuerySelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheAbstractQuerySelfTest.java
@@ -719,13 +719,13 @@ public abstract class IgniteCacheAbstractQuerySelfTest extends GridCommonAbstrac
 
         QueryCursor<List<?>> query = cache.query(
             new SqlFieldsQuery("SELECT t2.name, t1.name FROM Type2 as t2 LEFT JOIN Type1 as t1 ON t1.id = t2.id")
-                .setDistributedJoins(cacheMode() == PARTITIONED));
+                .setNonCollocatedJoins(cacheMode() == PARTITIONED));
 
         assertEquals(2, query.getAll().size());
 
         query = cache.query(
             new SqlFieldsQuery("SELECT t2.name, t1.name FROM Type2 as t2 RIGHT JOIN Type1 as t1 ON t1.id = t2.id")
-                .setDistributedJoins(cacheMode() == PARTITIONED));
+                .setNonCollocatedJoins(cacheMode() == PARTITIONED));
 
         assertEquals(3, query.getAll().size());
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCollocatedAndNotTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCollocatedAndNotTest.java
@@ -216,7 +216,7 @@ public class IgniteCacheDistributedJoinCollocatedAndNotTest extends GridCommonAb
         IgniteCache<?, ?> cache,
         boolean enforceJoinOrder) {
         return (String)cache.query(new SqlFieldsQuery("explain " + sql)
-            .setDistributedJoins(true)
+            .setNonCollocatedJoins(true)
             .setEnforceJoinOrder(enforceJoinOrder))
             .getAll().get(0).get(0);
     }
@@ -232,7 +232,7 @@ public class IgniteCacheDistributedJoinCollocatedAndNotTest extends GridCommonAb
         boolean enforceJoinOrder,
         int expSize) {
         String plan = (String)cache.query(new SqlFieldsQuery("explain " + sql)
-            .setDistributedJoins(true)
+            .setNonCollocatedJoins(true)
             .setEnforceJoinOrder(enforceJoinOrder))
             .getAll().get(0).get(0);
 
@@ -240,7 +240,7 @@ public class IgniteCacheDistributedJoinCollocatedAndNotTest extends GridCommonAb
 
         SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
         qry.setEnforceJoinOrder(enforceJoinOrder);
 
         QueryCursor<List<?>> cur = cache.query(qry);

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCustomAffinityMapper.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinCustomAffinityMapper.java
@@ -202,7 +202,7 @@ public class IgniteCacheDistributedJoinCustomAffinityMapper extends GridCommonAb
         boolean enforceJoinOrder) {
         final SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
         qry.setEnforceJoinOrder(enforceJoinOrder);
 
         Throwable err = GridTestUtils.assertThrows(log, new Callable<Void>() {

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinNoIndexTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinNoIndexTest.java
@@ -206,7 +206,7 @@ public class IgniteCacheDistributedJoinNoIndexTest extends GridCommonAbstractTes
             @Override public Void call() throws Exception {
                 SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-                qry.setDistributedJoins(true);
+                qry.setNonCollocatedJoins(true);
 
                 cache.query(qry).getAll();
 
@@ -233,7 +233,7 @@ public class IgniteCacheDistributedJoinNoIndexTest extends GridCommonAbstractTes
         Object... args) {
         SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
         qry.setArgs(args);
 
         log.info("Plan: " + queryPlan(cache, qry));

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinPartitionedAndReplicatedTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinPartitionedAndReplicatedTest.java
@@ -382,7 +382,7 @@ public class IgniteCacheDistributedJoinPartitionedAndReplicatedTest extends Grid
         Object... args) {
         SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
         qry.setEnforceJoinOrder(enforceJoinOrder);
         qry.setArgs(args);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinQueryConditionsTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinQueryConditionsTest.java
@@ -446,7 +446,7 @@ public class IgniteCacheDistributedJoinQueryConditionsTest extends GridCommonAbs
         Object... args) {
         SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
         qry.setEnforceJoinOrder(enforceJoinOrder);
         qry.setArgs(args);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheDistributedJoinTest.java
@@ -158,7 +158,7 @@ public class IgniteCacheDistributedJoinTest extends GridCommonAbstractTest {
 
         try (
             ResultSet rs1 = s.executeQuery(qry);
-            QueryCursor<List<?>> rs2 = c.query(new SqlFieldsQuery(qry).setDistributedJoins(true))
+            QueryCursor<List<?>> rs2 = c.query(new SqlFieldsQuery(qry).setNonCollocatedJoins(true))
         ) {
             Iterator<List<?>> iter = rs2.iterator();
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheJoinPartitionedAndReplicatedCollocationTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheJoinPartitionedAndReplicatedCollocationTest.java
@@ -340,7 +340,7 @@ public class IgniteCacheJoinPartitionedAndReplicatedCollocationTest extends Abst
         Object... args) throws Exception {
         String plan = (String)cache.query(new SqlFieldsQuery("explain " + sql)
             .setArgs(args)
-            .setDistributedJoins(true)
+            .setNonCollocatedJoins(true)
             .setEnforceJoinOrder(enforceJoinOrder))
             .getAll().get(0).get(0);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheJoinQueryWithAffinityKeyTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheJoinQueryWithAffinityKeyTest.java
@@ -208,7 +208,7 @@ public class IgniteCacheJoinQueryWithAffinityKeyTest extends GridCommonAbstractT
                 "where p.orgId = o._key and o._key=?");
         }
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
 
         long total = 0;
 
@@ -233,7 +233,7 @@ public class IgniteCacheJoinQueryWithAffinityKeyTest extends GridCommonAbstractT
                 "from Organization o, Person p where p.orgId = o._key");
         }
 
-        qry2.setDistributedJoins(true);
+        qry2.setNonCollocatedJoins(true);
 
         List<List<Object>> res = cache.query(qry2).getAll();
 
@@ -260,7 +260,7 @@ public class IgniteCacheJoinQueryWithAffinityKeyTest extends GridCommonAbstractT
 
         SqlFieldsQuery qry1 = new SqlFieldsQuery(sql1);
 
-        qry1.setDistributedJoins(true);
+        qry1.setNonCollocatedJoins(true);
 
         String sql2;
 
@@ -275,7 +275,7 @@ public class IgniteCacheJoinQueryWithAffinityKeyTest extends GridCommonAbstractT
 
         SqlFieldsQuery qry2 = new SqlFieldsQuery(sql2);
 
-        qry2.setDistributedJoins(true);
+        qry2.setNonCollocatedJoins(true);
 
         Ignite ignite = (Ignite)cache.unwrap(Ignite.class);
 
@@ -324,7 +324,7 @@ public class IgniteCacheJoinQueryWithAffinityKeyTest extends GridCommonAbstractT
         }
 
         for (SqlFieldsQuery qry : qrys) {
-            qry.setDistributedJoins(true);
+            qry.setNonCollocatedJoins(true);
 
             List<List<Object>> res = cache.query(qry).getAll();
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCrossCachesJoinsQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCrossCachesJoinsQueryTest.java
@@ -782,7 +782,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
             "from \"" + ORG_CACHE_NAME + "\".Organization o, \"" + PERSON_CACHE_NAME + "\".Person p " +
             "where p.orgId = o._key and o._key=?");
 
-        qry.setDistributedJoins(distributedJoins());
+        qry.setNonCollocatedJoins(distributedJoins());
 
         SqlQuery qry2 = null;
 
@@ -792,7 +792,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
                     "where Person.orgId = Organization._key and Organization._key=?"
             );
 
-            qry2.setDistributedJoins(distributedJoins());
+            qry2.setNonCollocatedJoins(distributedJoins());
         }
 
         long total = 0;
@@ -819,7 +819,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
         SqlFieldsQuery qry3 = new SqlFieldsQuery("select count(*) " +
             "from \"" + ORG_CACHE_NAME + "\".Organization o, \"" + PERSON_CACHE_NAME + "\".Person p where p.orgId = o._key");
 
-        qry3.setDistributedJoins(distributedJoins());
+        qry3.setNonCollocatedJoins(distributedJoins());
 
         List<List<Object>> res = cache.query(qry3).getAll();
 
@@ -896,12 +896,12 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
 
             for (Query q : qrys) {
                 if (q instanceof SqlFieldsQuery) {
-                    ((SqlFieldsQuery)q).setDistributedJoins(distributedJoins());
+                    ((SqlFieldsQuery)q).setNonCollocatedJoins(distributedJoins());
 
                     ((SqlFieldsQuery)q).setArgs(key);
                 }
                 else {
-                    ((SqlQuery)q).setDistributedJoins(distributedJoins());
+                    ((SqlQuery)q).setNonCollocatedJoins(distributedJoins());
 
                     ((SqlQuery)q).setArgs(key);
                 }
@@ -936,7 +936,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
             total += cnt;
 
         for (Query q : qrys) {
-            ((SqlFieldsQuery)q).setDistributedJoins(distributedJoins());
+            ((SqlFieldsQuery)q).setNonCollocatedJoins(distributedJoins());
 
             List<List<Object>> res = cache.query(q).getAll();
 
@@ -991,7 +991,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
                     "\"" + ACC_CACHE_NAME + "\".Account  " +
                     "where Person.orgId = Organization.id and Person.id = Account.personId and Organization.id = ?");
 
-                q.setDistributedJoins(distributedJoins());
+                q.setNonCollocatedJoins(distributedJoins());
 
                 q.setArgs(orgId);
 
@@ -1098,7 +1098,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
             "group by o.name " +
             "having o.id = ?");
 
-        q.setDistributedJoins(distributedJoins());
+        q.setNonCollocatedJoins(distributedJoins());
 
         for (Map.Entry<Integer, Integer> e : data.maxSalaryPerOrg.entrySet()) {
             Integer orgId = e.getKey();
@@ -1137,7 +1137,7 @@ public class IgniteCrossCachesJoinsQueryTest extends AbstractH2CompareQueryTest 
             "group by p.name " +
             "having p.id = ?");
 
-        q.setDistributedJoins(distributedJoins());
+        q.setNonCollocatedJoins(distributedJoins());
 
         List<Integer> keys = new ArrayList<>(data.accountsPerPerson.keySet());
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/IgniteCacheQueryNodeRestartDistributedJoinSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/IgniteCacheQueryNodeRestartDistributedJoinSelfTest.java
@@ -81,9 +81,9 @@ public class IgniteCacheQueryNodeRestartDistributedJoinSelfTest extends IgniteCa
         SqlFieldsQuery qry0 ;
 
         if (broadcastQry)
-            qry0 = new SqlFieldsQuery(QRY_0_BROADCAST).setDistributedJoins(true).setEnforceJoinOrder(true);
+            qry0 = new SqlFieldsQuery(QRY_0_BROADCAST).setNonCollocatedJoins(true).setEnforceJoinOrder(true);
         else
-            qry0 = new SqlFieldsQuery(QRY_0).setDistributedJoins(true);
+            qry0 = new SqlFieldsQuery(QRY_0).setNonCollocatedJoins(true);
 
         String plan = queryPlan(grid(0).cache("pu"), qry0);
 
@@ -100,9 +100,9 @@ public class IgniteCacheQueryNodeRestartDistributedJoinSelfTest extends IgniteCa
         final SqlFieldsQuery qry1;
 
         if (broadcastQry)
-            qry1 = new SqlFieldsQuery(QRY_1_BROADCAST).setDistributedJoins(true).setEnforceJoinOrder(true);
+            qry1 = new SqlFieldsQuery(QRY_1_BROADCAST).setNonCollocatedJoins(true).setEnforceJoinOrder(true);
         else
-            qry1 = new SqlFieldsQuery(QRY_1).setDistributedJoins(true);
+            qry1 = new SqlFieldsQuery(QRY_1).setNonCollocatedJoins(true);
 
         plan = queryPlan(grid(0).cache("co"), qry1);
 
@@ -142,9 +142,9 @@ public class IgniteCacheQueryNodeRestartDistributedJoinSelfTest extends IgniteCa
                             SqlFieldsQuery qry;
 
                             if (broadcastQry)
-                                qry = new SqlFieldsQuery(QRY_0_BROADCAST).setDistributedJoins(true).setEnforceJoinOrder(true);
+                                qry = new SqlFieldsQuery(QRY_0_BROADCAST).setNonCollocatedJoins(true).setEnforceJoinOrder(true);
                             else
-                                qry = new SqlFieldsQuery(QRY_0).setDistributedJoins(true);
+                                qry = new SqlFieldsQuery(QRY_0).setNonCollocatedJoins(true);
 
                             boolean smallPageSize = rnd.nextBoolean();
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/IgniteCacheQueryStopOnCancelOrTimeoutDistributedJoinSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/IgniteCacheQueryStopOnCancelOrTimeoutDistributedJoinSelfTest.java
@@ -81,7 +81,7 @@ public class IgniteCacheQueryStopOnCancelOrTimeoutDistributedJoinSelfTest extend
     /** */
     private void testQueryCancel(Ignite ignite, String cacheName, String sql, int timeoutUnits, TimeUnit timeUnit,
                            boolean timeout) throws Exception {
-        SqlFieldsQuery qry = new SqlFieldsQuery(sql).setDistributedJoins(true);
+        SqlFieldsQuery qry = new SqlFieldsQuery(sql).setNonCollocatedJoins(true);
 
         IgniteCache<Object, Object> cache = ignite.cache(cacheName);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlDistributedJoinSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlDistributedJoinSelfTest.java
@@ -108,7 +108,7 @@ public class IgniteSqlDistributedJoinSelfTest extends GridCommonAbstractTest {
 
             SqlQuery qry = new SqlQuery<String, Person>(Person.class, joinSql).setArgs("Organization #0");
 
-            qry.setDistributedJoins(true);
+            qry.setNonCollocatedJoins(true);
 
             List<Person> prns = c1.query(qry).getAll();
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSegmentedIndexSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSegmentedIndexSelfTest.java
@@ -217,7 +217,7 @@ public class IgniteSqlSegmentedIndexSelfTest extends GridCommonAbstractTest {
 
             String select0 = "select o.name n1, p.name n2 from \"pers\".Person p, \"org\".Organization o where p.orgId = o._key";
 
-            List<List<?>> result = c1.query(new SqlFieldsQuery(select0).setDistributedJoins(true)).getAll();
+            List<List<?>> result = c1.query(new SqlFieldsQuery(select0).setNonCollocatedJoins(true)).getAll();
 
             assertEquals(expectedPersons, result.size());
         }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSplitterSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlSplitterSelfTest.java
@@ -790,7 +790,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
                 " where p.orgId = o._key and o._key=2";
 
             String plan = c1.query(new SqlFieldsQuery("explain " + select)
-                .setDistributedJoins(true).setEnforceJoinOrder(true))
+                .setNonCollocatedJoins(true).setEnforceJoinOrder(true))
                 .getAll().toString();
 
             X.println("Plan : " + plan);
@@ -798,13 +798,13 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
             assertEquals(2, StringUtils.countOccurrencesOf(plan, "batched"));
             assertEquals(2, StringUtils.countOccurrencesOf(plan, "batched:unicast"));
 
-            assertEquals(2, c1.query(new SqlFieldsQuery(select).setDistributedJoins(true)
+            assertEquals(2, c1.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)
                 .setEnforceJoinOrder(false)).getAll().size());
 
             select = "select * from (" + select + ")";
 
             plan = c1.query(new SqlFieldsQuery("explain " + select)
-                .setDistributedJoins(true).setEnforceJoinOrder(true))
+                .setNonCollocatedJoins(true).setEnforceJoinOrder(true))
                 .getAll().toString();
 
             X.println("Plan : " + plan);
@@ -812,7 +812,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
             assertEquals(2, StringUtils.countOccurrencesOf(plan, "batched"));
             assertEquals(2, StringUtils.countOccurrencesOf(plan, "batched:unicast"));
 
-            assertEquals(2, c1.query(new SqlFieldsQuery(select).setDistributedJoins(true)
+            assertEquals(2, c1.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)
                 .setEnforceJoinOrder(false)).getAll().size());
         }
         finally {
@@ -844,45 +844,45 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
                 " union select o.name n1, p.name n2 from \"org\".Organization o, \"pers\".Person2 p where p.orgId = o._key and o._key=2";
 
             String plan = (String)c1.query(new SqlFieldsQuery("explain " + select0)
-                .setDistributedJoins(true))
+                .setNonCollocatedJoins(true))
                 .getAll().get(0).get(0);
 
             X.println("Plan: " + plan);
 
             assertEquals(0, StringUtils.countOccurrencesOf(plan, "batched"));
-            assertEquals(2, c1.query(new SqlFieldsQuery(select0).setDistributedJoins(true)).getAll().size());
+            assertEquals(2, c1.query(new SqlFieldsQuery(select0).setNonCollocatedJoins(true)).getAll().size());
 
             String select = "select * from (" + select0 + ")";
 
             plan = (String)c1.query(new SqlFieldsQuery("explain " + select)
-                .setDistributedJoins(true))
+                .setNonCollocatedJoins(true))
                 .getAll().get(0).get(0);
 
             X.println("Plan : " + plan);
 
             assertEquals(0, StringUtils.countOccurrencesOf(plan, "batched"));
-            assertEquals(2, c1.query(new SqlFieldsQuery(select).setDistributedJoins(true)).getAll().size());
+            assertEquals(2, c1.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)).getAll().size());
 
             String select1 = "select o.name n1, p.name n2 from \"pers\".Person2 p, \"org\".Organization o where p.orgId = o._key and o._key=1" +
                 " union select * from (select o.name n1, p.name n2 from \"org\".Organization o, \"pers\".Person2 p where p.orgId = o._key and o._key=2)";
 
             plan = (String)c1.query(new SqlFieldsQuery("explain " + select1)
-                .setDistributedJoins(true)).getAll().get(0).get(0);
+                .setNonCollocatedJoins(true)).getAll().get(0).get(0);
 
             X.println("Plan: " + plan);
 
             assertEquals(0, StringUtils.countOccurrencesOf(plan, "batched"));
-            assertEquals(2, c1.query(new SqlFieldsQuery(select).setDistributedJoins(true)).getAll().size());
+            assertEquals(2, c1.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)).getAll().size());
 
             select = "select * from (" + select1 + ")";
 
             plan = (String)c1.query(new SqlFieldsQuery("explain " + select)
-                .setDistributedJoins(true)).getAll().get(0).get(0);
+                .setNonCollocatedJoins(true)).getAll().get(0).get(0);
 
             X.println("Plan : " + plan);
 
             assertEquals(0, StringUtils.countOccurrencesOf(plan, "batched"));
-            assertEquals(2, c1.query(new SqlFieldsQuery(select).setDistributedJoins(true)).getAll().size());
+            assertEquals(2, c1.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)).getAll().size());
         }
         finally {
             c1.destroy();
@@ -1411,7 +1411,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
 
             SqlFieldsQuery qry = new SqlFieldsQuery(select0);
 
-            qry.setDistributedJoins(true);
+            qry.setNonCollocatedJoins(true);
 
             List<List<?>> results = c1.query(qry).getAll();
 
@@ -1421,7 +1421,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
 
             qry = new SqlFieldsQuery(select0);
 
-            qry.setDistributedJoins(true);
+            qry.setNonCollocatedJoins(true);
 
             results = c1.query(qry).getAll();
 
@@ -1437,11 +1437,11 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
                 "where p.orgId = o.orgId";
 
             X.println("Plan: \n" +
-                c1.query(new SqlFieldsQuery("explain " + select0).setDistributedJoins(true)).getAll());
+                c1.query(new SqlFieldsQuery("explain " + select0).setNonCollocatedJoins(true)).getAll());
 
             qry = new SqlFieldsQuery(select0);
 
-            qry.setDistributedJoins(true);
+            qry.setNonCollocatedJoins(true);
 
             results = c1.query(qry).getAll();
 
@@ -1477,7 +1477,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
 
             final SqlFieldsQuery qry = new SqlFieldsQuery(select0);
 
-            qry.setDistributedJoins(true);
+            qry.setNonCollocatedJoins(true);
 
             GridTestUtils.assertThrows(log, new Callable<Void>() {
                 @Override public Void call() throws Exception {
@@ -1503,7 +1503,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
         boolean enforceJoinOrder) {
         final SqlFieldsQuery qry = new SqlFieldsQuery(sql);
 
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
         qry.setEnforceJoinOrder(enforceJoinOrder);
 
         GridTestUtils.assertThrows(log, new Callable<Void>() {
@@ -1605,7 +1605,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
         SqlFieldsQuery qry,
         String... expText) {
         qry.setEnforceJoinOrder(enforceJoinOrder);
-        qry.setDistributedJoins(true);
+        qry.setNonCollocatedJoins(true);
 
         String plan = queryPlan(cache, qry);
 
@@ -1722,7 +1722,7 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
         String select = "select count(*) from \"org\".Organization o, \"pers\".Person2 p where p.orgId = o._key";
 
         String plan = (String)qryCache.query(new SqlFieldsQuery("explain " + select)
-            .setDistributedJoins(true).setEnforceJoinOrder(enforceJoinOrder).setPageSize(pageSize))
+            .setNonCollocatedJoins(true).setEnforceJoinOrder(enforceJoinOrder).setPageSize(pageSize))
             .getAll().get(0).get(0);
 
         X.println("Plan : " + plan);
@@ -1732,14 +1732,14 @@ public class IgniteSqlSplitterSelfTest extends GridCommonAbstractTest {
         else
             assertTrue(plan, plan.contains("batched:unicast"));
 
-        assertEquals((long)persons, qryCache.query(new SqlFieldsQuery(select).setDistributedJoins(true)
+        assertEquals((long)persons, qryCache.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)
             .setEnforceJoinOrder(enforceJoinOrder).setPageSize(pageSize)).getAll().get(0).get(0));
 
         c1.clear();
         c2.clear();
 
         assertEquals(0, c1.size(CachePeekMode.ALL));
-        assertEquals(0L, c1.query(new SqlFieldsQuery(select).setDistributedJoins(true)
+        assertEquals(0L, c1.query(new SqlFieldsQuery(select).setNonCollocatedJoins(true)
             .setEnforceJoinOrder(enforceJoinOrder).setPageSize(pageSize)).getAll().get(0).get(0));
     }
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/IgniteSqlQueryMinMaxTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/IgniteSqlQueryMinMaxTest.java
@@ -307,7 +307,7 @@ public class IgniteSqlQueryMinMaxTest extends GridCommonAbstractTest {
                             "min(b._key), max(b._key), min(b.idxVal), max(b.idxVal), min(b.nonIdxVal), max(b.nonIdxVal) " +
                             "from \"intCache\".Integer a, \"valCache\".ValueObj b where a._key = b.idxVal " +
                             "group by b.groupVal order by b.groupVal")
-                            .setDistributedJoins(true));
+                            .setNonCollocatedJoins(true));
 
             result = cursor.getAll();
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/sql/AbstractH2CompareQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/sql/AbstractH2CompareQueryTest.java
@@ -285,7 +285,7 @@ public abstract class AbstractH2CompareQueryTest extends GridCommonAbstractTest 
 
         List<List<?>> cacheRes = cache.query(new SqlFieldsQuery(sql).
             setArgs(args).
-            setDistributedJoins(distrib).
+            setNonCollocatedJoins(distrib).
             setEnforceJoinOrder(enforceJoinOrder)).getAll();
 
         assertRsEquals(h2Res, cacheRes, ordering);

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/sql/H2CompareBigQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/sql/H2CompareBigQueryTest.java
@@ -288,7 +288,7 @@ public class H2CompareBigQueryTest extends AbstractH2CompareQueryTest {
         X.println();
 
         X.println("   Plan: \n" + cacheCustOrd.query(new SqlFieldsQuery("EXPLAIN " + bigQry)
-            .setDistributedJoins(distributedJoins())).getAll());
+            .setNonCollocatedJoins(distributedJoins())).getAll());
 
         List<List<?>> res = compareQueryRes0(cacheCustOrd, bigQry, distributedJoins(), new Object[0], Ordering.RANDOM);
 


### PR DESCRIPTION
1. SqlQuery, SqlFieldsQuery: old methods deprecated, new ones added.
2. All internal usages of the deprecated methods are replaced with the new ones.