### PR TITLE
IGNITE-3935 Test on deserialization from different nodes

### DIFF
--- a/examples/src/test/java/org/apache/ignite/testsuites/IgniteExamplesSelfTestSuite.java
+++ b/examples/src/test/java/org/apache/ignite/testsuites/IgniteExamplesSelfTestSuite.java
@@ -89,6 +89,7 @@ public class IgniteExamplesSelfTestSuite extends TestSuite {
         suite.addTest(new TestSuite(TaskExamplesMultiNodeSelfTest.class));
         suite.addTest(new TestSuite(MemcacheRestExamplesMultiNodeSelfTest.class));
         suite.addTest(new TestSuite(MonteCarloExamplesMultiNodeSelfTest.class));
+        suite.addTest(new TestSuite(ClassLoaderSwitchSelfTest.class));
 
         // Binary.
         suite.addTest(new TestSuite(CacheClientBinaryExampleTest.class));

--- a/examples/src/test/java8/org/apache/ignite/java8/examples/CacheExamplesSelfTest.java
+++ b/examples/src/test/java8/org/apache/ignite/java8/examples/CacheExamplesSelfTest.java
@@ -44,6 +44,10 @@ public class CacheExamplesSelfTest extends GridAbstractExamplesTest {
         CacheEntryProcessorExample.main(EMPTY_ARGS);
     }
 
+    public void testDeserializationLoaderExample() throws Exception {
+        EntryDeserializationExample.main(EMPTY_ARGS);
+    }
+
 //    TODO: IGNITE-711 next example(s) should be implemented for java 8
 //    or testing method(s) should be removed if example(s) does not applicable for java 8.
 //    /**

--- a/modules/core/src/test/java/org/apache/ignite/util/ClassloaderSwitchSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/util/ClassloaderSwitchSelfTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.util;
+
+import org.apache.ignite.*;
+import org.apache.ignite.cache.CacheEntryProcessor;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.stream.StreamTransformer;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.apache.ignite.testframework.junits.common.GridCommonTest;
+import org.junit.Test;
+
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.MutableEntry;
+import java.io.IOException;
+
+/**
+ * Test class loaders related to IGNITE-3935
+ */
+@GridCommonTest(group = "Utils")
+public class ClassloaderSwitchSelfTest extends GridCommonAbstractTest {
+    /** */
+    public static class StreamingCacheEntryProcessor implements CacheEntryProcessor<String, Long, Object> {
+        /** */
+        @Override
+        public Object process(MutableEntry<String, Long> mutableEntry, Object... objects) throws EntryProcessorException {
+            Long val = mutableEntry.getValue();
+            mutableEntry.setValue(val == null ? 1L : val + 1);
+            return null;
+        }
+    }
+
+    /**
+     * Tests two grids from one process.
+     */
+    @Test
+    public static void testClassLoading() throws IgniteException, IOException {
+        IgniteConfiguration cfg = new IgniteConfiguration();
+        Ignition.setClientMode(true);
+        try(Ignite ignite = Ignition.start(cfg)) {
+            IgniteCache<String, Long> stmCache = ignite.getOrCreateCache("mycache");
+            try(IgniteDataStreamer<String, Long> strm = ignite.dataStreamer(stmCache.getName())) {
+                strm.allowOverwrite(true);
+                strm.receiver(StreamTransformer.from(new StreamingCacheEntryProcessor()));
+                strm.addData("smth", 1L);
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
ClassloaderSwitchSelfTest.java implements a test-case where class loaders should be switched to the peer-class-loading loader refering to IGNITE-3935 issue.