### PR TITLE
Ignite web console docker should listen to all interface for nginx.

### DIFF
--- a/modules/web-console/docker/standalone/nginx/web-console.conf
+++ b/modules/web-console/docker/standalone/nginx/web-console.conf
@@ -16,7 +16,7 @@
 #
 
 upstream backend-api {
-  server localhost:3000;
+  server 0.0.0.0:3000;
 }
 
 server {


### PR DESCRIPTION
When running ignite web console standalone on remote machine, nginx setting set backend api as localhost which cause browser to lookup wrong hostname. Setting to 0.0.0.0 will ensure correct binding.