### PR TITLE
IGNITE-6234 Initialize schemaIds as empty set if schemas field is null

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryMetadata.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryMetadata.java
@@ -304,8 +304,10 @@ public class BinaryMetadata implements Externalizable {
 
         int schemasSize = in.readInt();
 
-        if (schemasSize == -1)
+        if (schemasSize == -1) {
             schemas = null;
+            schemaIds = Collections.emptySet();
+        }
         else {
             schemas = new ArrayList<>();
 


### PR DESCRIPTION
Initialize schemaIds as an empty set if schemas field is null during BinaryMetada deserialization.  
This behavior is concise with BinaryMetadata constructor. 

This should prevent NPE for some situations when BinarryMetadata object is created from deserialization and we call hasSchema(int i) on it. - https://issues.apache.org/jira/browse/IGNITE-6234