### PR TITLE
Ignite-6669: CacheStoreSessionListener#onSessionStart() #onSessionEnd() methods are called by GridCacheStoreManagerAdapter even if a store operation should not be performed.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/store/GridCacheStoreManagerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/store/GridCacheStoreManagerAdapter.java
@@ -179,10 +179,6 @@ public abstract class GridCacheStoreManagerAdapter extends GridCacheManagerAdapt
         return writeThrough;
     }
 
-    private boolean isReadWriteThroughEnabled() {
-        return writeThrough || readThrough;
-    }
-
     /**
      * Creates a wrapped cache store if write-behind cache is configured.
      *
@@ -881,7 +877,7 @@ public abstract class GridCacheStoreManagerAdapter extends GridCacheManagerAdapt
 
         sesHolder.set(ses);
 
-        notifySessionListeners(ses, op, writeBehindStoreInitiator);
+        notifyCacheStoreSessionListeners(ses, op, writeBehindStoreInitiator);
     }
 
     /**
@@ -890,7 +886,7 @@ public abstract class GridCacheStoreManagerAdapter extends GridCacheManagerAdapt
      * @param writeBehindStoreInitiator {@code true} if method call is initiated by {@link GridCacheWriteBehindStore}.
      * @throws IgniteCheckedException If failed.
      */
-    private void notifySessionListeners(SessionData ses, @Nullable StoreOperation op,
+    private void notifyCacheStoreSessionListeners(SessionData ses, @Nullable StoreOperation op,
         boolean writeBehindStoreInitiator) throws IgniteCheckedException {
         try {
             boolean notifyLsnrs = false;

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreListenerRWThroughDisabledAtomicCache.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreListenerRWThroughDisabledAtomicCache.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store;
+
+import org.apache.ignite.cache.CacheAtomicityMode;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
+
+/**
+ * This class tests that redundant calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+ * and {@link CacheStoreSessionListener#onSessionEnd(CacheStoreSession, boolean)} are not executed.
+ */
+public class CacheStoreListenerRWThroughDisabledAtomicCache extends CacheStoreSessionListenerReadWriteThroughDisabled {
+    /** {@inheritDoc} */
+    @Override protected CacheAtomicityMode atomicityMode() {
+        return ATOMIC;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreListenerRWThroughDisabledTransactionalCache.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreListenerRWThroughDisabledTransactionalCache.java
@@ -41,6 +41,9 @@ public class CacheStoreListenerRWThroughDisabledTransactionalCache extends Cache
         return TRANSACTIONAL;
     }
 
+    /**
+     * Tests {@link IgniteCache#get(Object)} with disabled read-through and write-through modes.
+     */
     public void testTransactionalLookup() {
         testTransactionalLookup(OPTIMISTIC, READ_COMMITTED);
         testTransactionalLookup(OPTIMISTIC, REPEATABLE_READ);
@@ -51,6 +54,10 @@ public class CacheStoreListenerRWThroughDisabledTransactionalCache extends Cache
         testTransactionalLookup(PESSIMISTIC, SERIALIZABLE);
     }
 
+    /**
+     * @param concurrency Transaction concurrency level.
+     * @param isolation Transaction isolation level.
+     */
     private void testTransactionalLookup(TransactionConcurrency concurrency, TransactionIsolation isolation) {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -64,6 +71,9 @@ public class CacheStoreListenerRWThroughDisabledTransactionalCache extends Cache
         }
     }
 
+    /**
+     * Tests {@link IgniteCache#put(Object, Object)} with disabled read-through and write-through modes.
+     */
     public void testTransactionalUpdate() {
         testTransactionalUpdate(OPTIMISTIC, READ_COMMITTED);
         testTransactionalUpdate(OPTIMISTIC, REPEATABLE_READ);
@@ -74,6 +84,10 @@ public class CacheStoreListenerRWThroughDisabledTransactionalCache extends Cache
         testTransactionalUpdate(PESSIMISTIC, SERIALIZABLE);
     }
 
+    /**
+     * @param concurrency Transaction concurrency level.
+     * @param isolation Transaction isolation level.
+     */
     private void testTransactionalUpdate(TransactionConcurrency concurrency, TransactionIsolation isolation) {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -87,6 +101,9 @@ public class CacheStoreListenerRWThroughDisabledTransactionalCache extends Cache
         }
     }
 
+    /**
+     * Tests {@link IgniteCache#remove(Object)} with disabled read-through and write-through modes.
+     */
     public void testTransactionalRemove() {
         testTransactionalRemove(OPTIMISTIC, READ_COMMITTED);
         testTransactionalRemove(OPTIMISTIC, REPEATABLE_READ);
@@ -97,6 +114,10 @@ public class CacheStoreListenerRWThroughDisabledTransactionalCache extends Cache
         testTransactionalRemove(PESSIMISTIC, SERIALIZABLE);
     }
 
+    /**
+     * @param concurrency Transaction concurrency level.
+     * @param isolation Transaction isolation level.
+     */
     private void testTransactionalRemove(TransactionConcurrency concurrency, TransactionIsolation isolation) {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreListenerRWThroughDisabledTransactionalCache.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreListenerRWThroughDisabledTransactionalCache.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store;
+
+import java.util.Random;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.transactions.Transaction;
+import org.apache.ignite.transactions.TransactionConcurrency;
+import org.apache.ignite.transactions.TransactionIsolation;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
+import static org.apache.ignite.transactions.TransactionConcurrency.OPTIMISTIC;
+import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
+import static org.apache.ignite.transactions.TransactionIsolation.READ_COMMITTED;
+import static org.apache.ignite.transactions.TransactionIsolation.REPEATABLE_READ;
+import static org.apache.ignite.transactions.TransactionIsolation.SERIALIZABLE;
+
+/**
+ * This class tests that redundant calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+ * and {@link CacheStoreSessionListener#onSessionEnd(CacheStoreSession, boolean)} are not executed.
+ */
+public class CacheStoreListenerRWThroughDisabledTransactionalCache extends CacheStoreSessionListenerReadWriteThroughDisabled {
+    /** {@inheritDoc} */
+    @Override protected CacheAtomicityMode atomicityMode() {
+        return TRANSACTIONAL;
+    }
+
+    public void testTransactionalLookup() {
+        testTransactionalLookup(OPTIMISTIC, READ_COMMITTED);
+        testTransactionalLookup(OPTIMISTIC, REPEATABLE_READ);
+        testTransactionalLookup(OPTIMISTIC, SERIALIZABLE);
+
+        testTransactionalLookup(PESSIMISTIC, READ_COMMITTED);
+        testTransactionalLookup(PESSIMISTIC, REPEATABLE_READ);
+        testTransactionalLookup(PESSIMISTIC, SERIALIZABLE);
+    }
+
+    private void testTransactionalLookup(TransactionConcurrency concurrency, TransactionIsolation isolation) {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        Random r = new Random();
+
+        try (Transaction tx = grid(0).transactions().txStart(concurrency, isolation)) {
+            for (int i = 0; i < CNT; ++i)
+                cache.get(r.nextInt());
+
+            tx.commit();
+        }
+    }
+
+    public void testTransactionalUpdate() {
+        testTransactionalUpdate(OPTIMISTIC, READ_COMMITTED);
+        testTransactionalUpdate(OPTIMISTIC, REPEATABLE_READ);
+        testTransactionalUpdate(OPTIMISTIC, SERIALIZABLE);
+
+        testTransactionalUpdate(PESSIMISTIC, READ_COMMITTED);
+        testTransactionalUpdate(PESSIMISTIC, REPEATABLE_READ);
+        testTransactionalUpdate(PESSIMISTIC, SERIALIZABLE);
+    }
+
+    private void testTransactionalUpdate(TransactionConcurrency concurrency, TransactionIsolation isolation) {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        Random r = new Random();
+
+        try (Transaction tx = grid(0).transactions().txStart(concurrency, isolation)) {
+            for (int i = 0; i < CNT; ++i)
+                cache.put(r.nextInt(), "test-value");
+
+            tx.commit();
+        }
+    }
+
+    public void testTransactionalRemove() {
+        testTransactionalRemove(OPTIMISTIC, READ_COMMITTED);
+        testTransactionalRemove(OPTIMISTIC, REPEATABLE_READ);
+        testTransactionalRemove(OPTIMISTIC, SERIALIZABLE);
+
+        testTransactionalRemove(PESSIMISTIC, READ_COMMITTED);
+        testTransactionalRemove(PESSIMISTIC, REPEATABLE_READ);
+        testTransactionalRemove(PESSIMISTIC, SERIALIZABLE);
+    }
+
+    private void testTransactionalRemove(TransactionConcurrency concurrency, TransactionIsolation isolation) {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        Random r = new Random();
+
+        try (Transaction tx = grid(0).transactions().txStart(concurrency, isolation)) {
+            for (int i = 0; i < CNT; ++i) {
+                int key = r.nextInt();
+
+                cache.put(key, "test-value");
+
+                cache.remove(key, "test-value");
+            }
+
+            tx.commit();
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerReadWriteThroughDisabled.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerReadWriteThroughDisabled.java
@@ -59,7 +59,7 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
 
         cacheCfg.setCacheStoreFactory(FactoryBuilder.factoryOf(EmptyCacheStore.class));
 
-        cacheCfg.setCacheStoreSessionListenerFactories(new CacheStroreSessionFactory());
+        cacheCfg.setCacheStoreSessionListenerFactories(new CacheStoreSessionFactory());
 
         cacheCfg.setReadThrough(false);
         cacheCfg.setWriteThrough(false);
@@ -74,6 +74,13 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
         return null;
     }
 
+    /**
+     * Tests that there are no calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)} and
+     * {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#get(Object)} performed.
+     *
+     * @throws Exception If failed.
+     */
     public void testLookup() throws Exception {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -83,6 +90,13 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
             cache.get(r.nextInt());
     }
 
+    /**
+     * Tests that there are no calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)} and
+     * {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#getAll(Set)} performed.
+     *
+     * @throws Exception If failed.
+     */
     public void testBatchLookup() throws Exception {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -96,6 +110,13 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
         cache.getAll(values);
     }
 
+    /**
+     * Tests that there are no calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)} and
+     * {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#put(Object, Object)} performed.
+     *
+     * @throws Exception If failed.
+     */
     public void testUpdate() throws Exception {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -105,6 +126,13 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
             cache.put(r.nextInt(), "test-value");
     }
 
+    /**
+     * Tests that there are no calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)} and
+     * {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#putAll(Map)} performed.
+     *
+     * @throws Exception If failed.
+     */
     public void testBatchUpdate() throws Exception {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -118,6 +146,13 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
         cache.putAll(values);
     }
 
+    /**
+     * Tests that there are no calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)} and
+     * {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#remove(Object)} performed.
+     *
+     * @throws Exception If failed.
+     */
     public void testRemove() throws Exception {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -132,6 +167,13 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
         }
     }
 
+    /**
+     * Tests that there are no calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)} and
+     * {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#removeAll(Set)} performed.
+     *
+     * @throws Exception If failed.
+     */
     public void testBatchRemove() throws Exception {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -150,7 +192,10 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
         cache.removeAll(values);
     }
 
-    public static class CacheStroreSessionFactory implements Factory<TestCacheStoreSessionListener> {
+    /**
+     * Cache store session factory.
+     */
+    public static class CacheStoreSessionFactory implements Factory<TestCacheStoreSessionListener> {
         /** {@inheritDoc} */
         @Override public TestCacheStoreSessionListener create() {
             TestCacheStoreSessionListener lsnr = new TestCacheStoreSessionListener();
@@ -159,6 +204,9 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
         }
     }
 
+    /**
+     * Test cache store session listener.
+     */
     public static class TestCacheStoreSessionListener extends CacheJdbcStoreSessionListener {
         /** {@inheritDoc} */
         @Override public void onSessionStart(CacheStoreSession ses) {
@@ -180,48 +228,62 @@ public abstract class CacheStoreSessionListenerReadWriteThroughDisabled extends 
             return null;
         }
 
+        /** {@inheritDoc} */
         @Override public void write(Cache.Entry entry) throws CacheWriterException {
             fail("EmptyCacheStore.write(Cache.Entry) should not be called.");
         }
 
+        /** {@inheritDoc} */
         @Override public void delete(Object key) throws CacheWriterException {
             fail("EmptyCacheStore.delete(Object) should not be called.");
         }
     }
 
+    /**
+     * Data source stub which should not be called.
+     */
     public static class DataSourceStub implements DataSource, Serializable {
+        /** {@inheritDoc} */
         @Override public Connection getConnection() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public Connection getConnection(String username, String password) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public <T> T unwrap(Class<T> iface) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public boolean isWrapperFor(Class<?> iface) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public PrintWriter getLogWriter() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public void setLogWriter(PrintWriter out) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public void setLoginTimeout(int seconds) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public int getLoginTimeout() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public Logger getParentLogger() throws SQLFeatureNotSupportedException {
             throw new UnsupportedOperationException();
         }

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerReadWriteThroughDisabled.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerReadWriteThroughDisabled.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Random;
+import java.util.logging.Logger;
+import javax.cache.Cache;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriterException;
+import javax.sql.DataSource;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.store.jdbc.CacheJdbcStoreSessionListener;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.processors.cache.GridCacheAbstractSelfTest;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
+
+/**
+ * This class tests that redundant calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+ * and {@link CacheStoreSessionListener#onSessionEnd(CacheStoreSession, boolean)} are not executed.
+ */
+public class CacheStoreSessionListenerReadWriteThroughDisabled extends GridCacheAbstractSelfTest {
+    /** */
+    private static final TcpDiscoveryIpFinder IP_FINDER = new TcpDiscoveryVmIpFinder(true);
+
+    /** {@inheritDoc} */
+    protected int gridCount() {
+        return 1;
+    }
+
+    /** {@inheritDoc} */
+    protected CacheConfiguration cacheConfiguration(String igniteInstanceName) throws Exception {
+        CacheConfiguration cacheCfg = super.cacheConfiguration(igniteInstanceName);
+
+        cacheCfg.setAtomicityMode(TRANSACTIONAL);
+
+        cacheCfg.setCacheStoreFactory(FactoryBuilder.factoryOf(EmptyCacheStore.class));
+
+        cacheCfg.setCacheStoreSessionListenerFactories(new CacheStroreSessionFactory());
+
+        cacheCfg.setReadThrough(false);
+        cacheCfg.setWriteThrough(false);
+
+        return cacheCfg;
+    }
+
+    public void testLookup() throws Exception {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        cache.get(new Random().nextInt());
+    }
+
+    public void testUpdate() throws Exception {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        int key = new Random().nextInt();
+
+        cache.put(key, key);
+    }
+
+    public void testRemove() throws Exception {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        int key = new Random().nextInt();
+
+        cache.put(key, key);
+
+        cache.remove(key);
+    }
+
+    public static class CacheStroreSessionFactory implements Factory<TestCacheStoreSessionListener> {
+        /** {@inheritDoc} */
+        @Override public TestCacheStoreSessionListener create() {
+            TestCacheStoreSessionListener lsnr = new TestCacheStoreSessionListener();
+            lsnr.setDataSource(new DataSourceStub());
+            return lsnr;
+        }
+    }
+
+    public static class TestCacheStoreSessionListener extends CacheJdbcStoreSessionListener {
+        /** {@inheritDoc} */
+        @Override public void onSessionStart(CacheStoreSession ses) {
+            fail("TestCacheStoreSessionListener.onSessionStart(CacheStoreSession) should not be called.");
+        }
+
+        /** {@inheritDoc} */
+        @Override public void onSessionEnd(CacheStoreSession ses, boolean commit) {
+            fail("TestCacheStoreSessionListener.onSessionEnd(CacheStoreSession, boolean) should not be called.");
+        }
+    }
+
+    /** Empty cache store implementation. All overridden methods should not be called while the test is running. */
+    public static class EmptyCacheStore extends CacheStoreAdapter {
+        /** {@inheritDoc} */
+        @Override public Object load(Object key) throws CacheLoaderException {
+            fail("EmptyCacheStore.load(Object) should not be called.");
+
+            return null;
+        }
+
+        @Override public void write(Cache.Entry entry) throws CacheWriterException {
+            fail("EmptyCacheStore.write(Cache.Entry) should not be called.");
+        }
+
+        @Override public void delete(Object key) throws CacheWriterException {
+            fail("EmptyCacheStore.delete(Object) should not be called.");
+        }
+    }
+
+    public static class DataSourceStub implements DataSource, Serializable {
+        @Override public Connection getConnection() throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Connection getConnection(String username, String password) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public <T> T unwrap(Class<T> iface) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public PrintWriter getLogWriter() throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void setLogWriter(PrintWriter out) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void setLoginTimeout(int seconds) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public int getLoginTimeout() throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerWriteBehindEnabled.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerWriteBehindEnabled.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import javax.cache.Cache;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriterException;
+import javax.sql.DataSource;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cache.store.jdbc.CacheJdbcStoreSessionListener;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.processors.cache.GridCacheAbstractSelfTest;
+import org.apache.ignite.internal.processors.cache.store.GridCacheWriteBehindStore;
+import org.apache.ignite.resources.CacheStoreSessionResource;
+import org.apache.ignite.resources.IgniteInstanceResource;
+import org.jsr166.ConcurrentHashMap8;
+
+/**
+ * This class tests that calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+ * and {@link CacheStoreSessionListener#onSessionEnd(CacheStoreSession, boolean)} are executed from
+ * {@link GridCacheWriteBehindStore} only.
+ */
+public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstractSelfTest {
+    /** */
+    protected final static int CNT = 100;
+
+    /** */
+    protected final static int WRITE_BEHIND_FLUSH_FREQUENCY = 1000;
+
+    /** */
+    private static final List<OperationType> operations = Collections.synchronizedList(new ArrayList<>());
+
+    /** */
+    private static final AtomicInteger entryCnt = new AtomicInteger();
+
+    /** {@inheritDoc} */
+    @Override protected int gridCount() {
+        return 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected CacheConfiguration cacheConfiguration(String igniteInstanceName) throws Exception {
+        CacheConfiguration cacheCfg = super.cacheConfiguration(igniteInstanceName);
+
+        cacheCfg.setCacheStoreFactory(FactoryBuilder.factoryOf(EmptyCacheStore.class));
+
+        cacheCfg.setCacheStoreSessionListenerFactories(new CacheStroreSessionFactory());
+
+        cacheCfg.setReadThrough(true);
+        cacheCfg.setWriteThrough(true);
+
+        cacheCfg.setWriteBehindEnabled(true);
+        cacheCfg.setWriteBehindBatchSize(CNT*2);
+        cacheCfg.setWriteBehindFlushFrequency(WRITE_BEHIND_FLUSH_FREQUENCY);
+
+        cacheCfg.setBackups(0);
+
+        return cacheCfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        operations.clear();
+
+        entryCnt.set(0);
+    }
+
+    public void testLookup() {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        for (int i = 0; i < CNT; ++i)
+            cache.get(i);
+
+        checkSessionCounters(CNT);
+    }
+
+    public void testUpdate() {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        for (int i = 0; i < CNT; ++i)
+            cache.put(i, i);
+
+        checkSessionCounters(1);
+    }
+
+    public void testRemove() {
+        IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        for (int i = 0; i < CNT; ++i) {
+            cache.remove(i);
+        }
+
+        checkSessionCounters(1);
+    }
+
+    private void checkSessionCounters(int startedSessions) {
+        try {
+            // Wait for GridCacheWriteBehindStore
+            Thread.sleep(WRITE_BEHIND_FLUSH_FREQUENCY * 4);
+
+            assertEquals(CNT, entryCnt.get());
+
+            checkOpCount(operations, OperationType.SESSION_START, startedSessions);
+
+            checkOpCount(operations, OperationType.SESSION_END, startedSessions);
+        }
+        catch (InterruptedException e) {
+            throw new IgniteException("Failed to wait for the GridCacheWriteBehindStore due to interruption.", e);
+        }
+    }
+
+    private void checkOpCount(List<OperationType> operations, OperationType op, int expected) {
+        int n = 0;
+
+        for (OperationType o : operations) {
+            if (op.equals(o))
+                ++n;
+        }
+
+        assertEquals("Operation=" + op.name(), expected, n);
+    }
+
+    public enum OperationType {
+        SESSION_START,
+
+        SESSION_END,
+    }
+
+    public static class CacheStroreSessionFactory implements Factory<TestCacheStoreSessionListener> {
+        /** {@inheritDoc} */
+        @Override public TestCacheStoreSessionListener create() {
+            TestCacheStoreSessionListener lsnr = new TestCacheStoreSessionListener();
+            lsnr.setDataSource(new DataSourceStub());
+            return lsnr;
+        }
+    }
+
+    public static class TestCacheStoreSessionListener extends CacheJdbcStoreSessionListener {
+        @IgniteInstanceResource
+        private Ignite ignite;
+
+        /** {@inheritDoc} */
+        @Override public void onSessionStart(CacheStoreSession ses) {
+            operations.add(OperationType.SESSION_START);
+        }
+
+        /** {@inheritDoc} */
+        @Override public void onSessionEnd(CacheStoreSession ses, boolean commit) {
+            operations.add(OperationType.SESSION_END);
+        }
+    }
+
+    public static class EmptyCacheStore extends CacheStoreAdapter<Object, Object> {
+        @IgniteInstanceResource
+        private Ignite ignite;
+
+        /** {@inheritDoc} */
+        @Override public Object load(Object key) throws CacheLoaderException {
+            entryCnt.getAndIncrement();
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public void writeAll(Collection<Cache.Entry<? extends Object, ? extends Object>> entries) {
+            entryCnt.addAndGet(entries.size());
+        }
+
+        /** {@inheritDoc} */
+        @Override public void write(Cache.Entry entry) throws CacheWriterException {
+        }
+
+        /** {@inheritDoc} */
+        @Override public void deleteAll(Collection<?> keys) {
+            entryCnt.addAndGet(keys.size());
+        }
+
+        /** {@inheritDoc} */
+        @Override public void delete(Object key) throws CacheWriterException {
+        }
+    }
+
+    public static class DataSourceStub implements DataSource, Serializable {
+        @Override public Connection getConnection() throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Connection getConnection(String username, String password) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public <T> T unwrap(Class<T> iface) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public PrintWriter getLogWriter() throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void setLogWriter(PrintWriter out) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public void setLoginTimeout(int seconds) throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public int getLoginTimeout() throws SQLException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerWriteBehindEnabled.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerWriteBehindEnabled.java
@@ -25,11 +25,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import javax.cache.Cache;
@@ -43,12 +39,9 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.cache.store.jdbc.CacheJdbcStoreSessionListener;
 import org.apache.ignite.configuration.CacheConfiguration;
-import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.processors.cache.GridCacheAbstractSelfTest;
 import org.apache.ignite.internal.processors.cache.store.GridCacheWriteBehindStore;
-import org.apache.ignite.resources.CacheStoreSessionResource;
 import org.apache.ignite.resources.IgniteInstanceResource;
-import org.jsr166.ConcurrentHashMap8;
 
 /**
  * This class tests that calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
@@ -63,7 +56,7 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
     protected final static int WRITE_BEHIND_FLUSH_FREQUENCY = 1000;
 
     /** */
-    private static final List<OperationType> operations = Collections.synchronizedList(new ArrayList<>());
+    private static final List<OperationType> operations = Collections.synchronizedList(new ArrayList<OperationType>());
 
     /** */
     private static final AtomicInteger entryCnt = new AtomicInteger();
@@ -85,7 +78,7 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         cacheCfg.setWriteThrough(true);
 
         cacheCfg.setWriteBehindEnabled(true);
-        cacheCfg.setWriteBehindBatchSize(CNT*2);
+        cacheCfg.setWriteBehindBatchSize(CNT * 2);
         cacheCfg.setWriteBehindFlushFrequency(WRITE_BEHIND_FLUSH_FREQUENCY);
 
         cacheCfg.setBackups(0);

--- a/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerWriteBehindEnabled.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/store/CacheStoreSessionListenerWriteBehindEnabled.java
@@ -72,7 +72,7 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
 
         cacheCfg.setCacheStoreFactory(FactoryBuilder.factoryOf(EmptyCacheStore.class));
 
-        cacheCfg.setCacheStoreSessionListenerFactories(new CacheStroreSessionFactory());
+        cacheCfg.setCacheStoreSessionListenerFactories(new CacheStoreSessionFactory());
 
         cacheCfg.setReadThrough(true);
         cacheCfg.setWriteThrough(true);
@@ -95,6 +95,10 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         entryCnt.set(0);
     }
 
+    /**
+     * Tests that there are no redundant calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#get(Object)} performed.
+     */
     public void testLookup() {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -104,6 +108,10 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         checkSessionCounters(CNT);
     }
 
+    /**
+     * Tests that there are no redundant calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#put(Object, Object)} performed.
+     */
     public void testUpdate() {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -113,6 +121,10 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         checkSessionCounters(1);
     }
 
+    /**
+     * Tests that there are no redundant calls of {@link CacheStoreSessionListener#onSessionStart(CacheStoreSession)}
+     * while {@link IgniteCache#remove(Object)} performed.
+     */
     public void testRemove() {
         IgniteCache cache = grid(0).getOrCreateCache(DEFAULT_CACHE_NAME);
 
@@ -123,6 +135,9 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         checkSessionCounters(1);
     }
 
+    /**
+     * @param startedSessions Number of expected sessions.
+     */
     private void checkSessionCounters(int startedSessions) {
         try {
             // Wait for GridCacheWriteBehindStore
@@ -139,6 +154,11 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         }
     }
 
+    /**
+     * @param operations List of {@link OperationType}.
+     * @param op Operation.
+     * @param expected Expected number of operations for the given {@code op}.
+     */
     private void checkOpCount(List<OperationType> operations, OperationType op, int expected) {
         int n = 0;
 
@@ -150,13 +170,25 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         assertEquals("Operation=" + op.name(), expected, n);
     }
 
+    /**
+     * Operation type.
+     */
     public enum OperationType {
+        /**
+         * Cache store session started.
+         */
         SESSION_START,
 
+        /**
+         * Cache store session ended.
+         */
         SESSION_END,
     }
 
-    public static class CacheStroreSessionFactory implements Factory<TestCacheStoreSessionListener> {
+    /**
+     * Cache store session factory.
+     */
+    public static class CacheStoreSessionFactory implements Factory<TestCacheStoreSessionListener> {
         /** {@inheritDoc} */
         @Override public TestCacheStoreSessionListener create() {
             TestCacheStoreSessionListener lsnr = new TestCacheStoreSessionListener();
@@ -165,7 +197,11 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         }
     }
 
+    /**
+     * Test cache store session listener.
+     */
     public static class TestCacheStoreSessionListener extends CacheJdbcStoreSessionListener {
+        /** */
         @IgniteInstanceResource
         private Ignite ignite;
 
@@ -180,7 +216,14 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         }
     }
 
+    /**
+     * Test cache store.
+     *
+     * {@link EmptyCacheStore#writeAll(Collection)} and {@link EmptyCacheStore#deleteAll(Collection)} should be called
+     * by {@link GridCacheWriteBehindStore}.
+     */
     public static class EmptyCacheStore extends CacheStoreAdapter<Object, Object> {
+        /** */
         @IgniteInstanceResource
         private Ignite ignite;
 
@@ -209,39 +252,51 @@ public class CacheStoreSessionListenerWriteBehindEnabled extends GridCacheAbstra
         }
     }
 
+    /**
+     * Data source stub which should not be called.
+     */
     public static class DataSourceStub implements DataSource, Serializable {
+        /** {@inheritDoc} */
         @Override public Connection getConnection() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public Connection getConnection(String username, String password) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public <T> T unwrap(Class<T> iface) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public boolean isWrapperFor(Class<?> iface) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public PrintWriter getLogWriter() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public void setLogWriter(PrintWriter out) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public void setLoginTimeout(int seconds) throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public int getLoginTimeout() throws SQLException {
             throw new UnsupportedOperationException();
         }
 
+        /** {@inheritDoc} */
         @Override public Logger getParentLogger() throws SQLFeatureNotSupportedException {
             throw new UnsupportedOperationException();
         }

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite4.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite4.java
@@ -18,7 +18,9 @@
 package org.apache.ignite.testsuites;
 
 import junit.framework.TestSuite;
-import org.apache.ignite.cache.store.CacheStoreSessionListenerReadWriteThroughDisabled;
+import org.apache.ignite.cache.store.CacheStoreListenerRWThroughDisabledAtomicCache;
+import org.apache.ignite.cache.store.CacheStoreListenerRWThroughDisabledTransactionalCache;
+import org.apache.ignite.cache.store.CacheStoreSessionListenerWriteBehindEnabled;
 import org.apache.ignite.cache.store.jdbc.CacheJdbcStoreSessionListenerSelfTest;
 import org.apache.ignite.internal.processors.GridCacheTxLoadFromStoreOnLockSelfTest;
 import org.apache.ignite.internal.processors.cache.CacheClientStoreSelfTest;
@@ -277,7 +279,9 @@ public class IgniteCacheTestSuite4 extends TestSuite {
         suite.addTestSuite(CacheOffheapMapEntrySelfTest.class);
 
         suite.addTestSuite(CacheJdbcStoreSessionListenerSelfTest.class);
-        suite.addTestSuite(CacheStoreSessionListenerReadWriteThroughDisabled.class);
+        suite.addTestSuite(CacheStoreListenerRWThroughDisabledAtomicCache.class);
+        suite.addTestSuite(CacheStoreListenerRWThroughDisabledTransactionalCache.class);
+        suite.addTestSuite(CacheStoreSessionListenerWriteBehindEnabled.class);
 
         suite.addTestSuite(CacheClientStoreSelfTest.class);
         suite.addTestSuite(CacheStoreUsageMultinodeStaticStartAtomicTest.class);

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite4.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite4.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.testsuites;
 
 import junit.framework.TestSuite;
+import org.apache.ignite.cache.store.CacheStoreSessionListenerReadWriteThroughDisabled;
 import org.apache.ignite.cache.store.jdbc.CacheJdbcStoreSessionListenerSelfTest;
 import org.apache.ignite.internal.processors.GridCacheTxLoadFromStoreOnLockSelfTest;
 import org.apache.ignite.internal.processors.cache.CacheClientStoreSelfTest;
@@ -276,6 +277,7 @@ public class IgniteCacheTestSuite4 extends TestSuite {
         suite.addTestSuite(CacheOffheapMapEntrySelfTest.class);
 
         suite.addTestSuite(CacheJdbcStoreSessionListenerSelfTest.class);
+        suite.addTestSuite(CacheStoreSessionListenerReadWriteThroughDisabled.class);
 
         suite.addTestSuite(CacheClientStoreSelfTest.class);
         suite.addTestSuite(CacheStoreUsageMultinodeStaticStartAtomicTest.class);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Store/CacheStoreSessionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Store/CacheStoreSessionTest.cs
@@ -106,17 +106,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Store
                 tx.Rollback();
             }
 
-            // SessionEnd is called once per store instance.
-            Assert.AreEqual(StoreCount, _dumps.Count);
-
-            foreach (var ops in _dumps)
-            {
-                var op = ops.Single();
-                Assert.AreEqual(OperationType.SesEnd, op.Type);
-                Assert.IsFalse(op.Commit);
-            }
-
-            _dumps = new ConcurrentBag<ICollection<Operation>>();
+            // SessionEnd should not be called.
+            Assert.AreEqual(0, _dumps.Count);
 
             // 2. Test puts.
             using (var tx = ignite.GetTransactions().TxStart())


### PR DESCRIPTION
In the case of transactional cache, which is configured using ```CacheStore``` and ```CacheJdbcStoreSessionListener```, every update triggers ```CacheStoreSessionListener#onSessionStart()```, ```CacheStoreSessionListener#onSessionEnd()``` that results in creating the connection to an underlying database, even if read-through and write-through modes are disabled.