### PR TITLE
IGNITE-6713: Ignite Cache 5 flaky test fix

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheRebalancingSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheRebalancingSelfTest.java
@@ -18,7 +18,8 @@
 
 package org.apache.ignite.internal.processors.cache;
 
-import com.sun.org.apache.regexp.internal.RE;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.CachePeekMode;
@@ -31,11 +32,8 @@ import org.apache.ignite.internal.util.future.IgniteFutureImpl;
 import org.apache.ignite.internal.util.lang.GridAbsPredicate;
 import org.apache.ignite.lang.IgniteFuture;
 import org.apache.ignite.testframework.GridTestUtils;
-import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 
 /**
@@ -113,39 +111,42 @@ public class CacheRebalancingSelfTest extends GridCommonAbstractTest {
 
         Random r = new Random();
 
-        int totalKeysCount = 10240;
+        int totalKeysCnt = 10240;
+
+        final Set<Integer> keys = new HashSet<>();
+        while (keys.size() < totalKeysCnt)
+            keys.add(r.nextInt());
 
         IgniteCache<Integer, Integer> cache = ig0.getOrCreateCache(REBALANCE_TEST_CACHE_NAME);
 
-        for (int i = 0;i < totalKeysCount;i++)
-            cache.put(r.nextInt(), 1);
+        for (Integer next : keys)
+            cache.put(next, 1);
 
-
-        testLocalCacheSize(ig0, 0, totalKeysCount);
-        int before_ig1 = testLocalCacheSize(ig1, 0, totalKeysCount);
+        testLocalCacheSize(ig0, 0, totalKeysCnt);
+        int before_ig1 = testLocalCacheSize(ig1, 0, totalKeysCnt);
 
         stopGrid(2);
 
-        testLocalCacheSize(ig0, totalKeysCount, null);
+        testLocalCacheSize(ig0, totalKeysCnt, null);
         testLocalCacheSize(ig1, before_ig1, null);
 
 
         ig1.rebalanceEnabled(true);
 
-        testLocalCacheSize(ig0, totalKeysCount, null);
-        testLocalCacheSize(ig1, totalKeysCount, null);
+        testLocalCacheSize(ig0, totalKeysCnt, null);
+        testLocalCacheSize(ig1, totalKeysCnt, null);
     }
 
     /**
-     * Test if test cache in specified node have correct local size.
+     * Test if test cache in specified node have correct local size. Waits size to became correct for some time.
      *
-     * @param ignite node to test
-     * @param expFrom left bound
-     * @param expTo right bound (or {@code null})
-     * @return actual local cache size
-     * @throws IgniteInterruptedCheckedException
+     * @param ignite node to test.
+     * @param expFrom left bound, or exact value if {@code expTo} is {@code null}.
+     * @param expTo right bound (or {@code null}).
+     * @return actual local cache size.
+     * @throws IgniteInterruptedCheckedException if interrupted.
      */
-    private int testLocalCacheSize(IgniteEx ignite, final Integer expFrom, final Integer expTo) throws IgniteInterruptedCheckedException {
+    private int testLocalCacheSize(Ignite ignite, final Integer expFrom, final Integer expTo) throws IgniteInterruptedCheckedException {
         final IgniteCache cache = ignite.cache(REBALANCE_TEST_CACHE_NAME);
 
         boolean isOk = GridTestUtils.waitForCondition(new GridAbsPredicate() {


### PR DESCRIPTION
CacheRebalancingSelfTest.testDisableRebalancing()