### PR TITLE
disco update

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
@@ -458,6 +458,9 @@ public final class IgniteSystemProperties {
     /** Maximum size for discovery messages history. */
     public static final String IGNITE_DISCOVERY_HISTORY_SIZE = "IGNITE_DISCOVERY_HISTORY_SIZE";
 
+    /** Maximum size for recently failed nodes history. */
+    public static final String IGNITE_FAILED_NODES_HISTORY_SIZE = "IGNITE_FAILED_NODES_HISTORY_SIZE";
+
     /** Maximum number of discovery message history used to support client reconnect. */
     public static final String IGNITE_DISCOVERY_CLIENT_RECONNECT_HISTORY_SIZE =
         "IGNITE_DISCOVERY_CLIENT_RECONNECT_HISTORY_SIZE";

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtPartitionTopologyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtPartitionTopologyImpl.java
@@ -36,6 +36,7 @@ import org.apache.ignite.cache.PartitionLossPolicy;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.events.DiscoveryEvent;
 import org.apache.ignite.events.EventType;
+import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.managers.discovery.DiscoCache;
 import org.apache.ignite.internal.processors.affinity.AffinityAssignment;
@@ -1819,7 +1820,16 @@ public class GridDhtPartitionTopologyImpl implements GridDhtPartitionTopology {
                             try {
                                 //TODO https://issues.apache.org/jira/browse/IGNITE-6433
                                 locPart.tryEvict();
-                                locPart.rent(false).get();
+
+                                IgniteInternalFuture<?> rentFut = locPart.rent(false);
+
+                                lock.writeLock().unlock();
+                                try {
+                                    rentFut.get();
+                                }
+                                finally {
+                                    lock.writeLock().lock();
+                                }
                             }
                             catch (IgniteCheckedException e) {
                                 U.error(log, "Failed to wait for RENTING partition eviction after partition LOST event",

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ClientImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ClientImpl.java
@@ -57,6 +57,7 @@ import org.apache.ignite.cluster.ClusterMetrics;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.internal.IgniteClientDisconnectedCheckedException;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
+import org.apache.ignite.internal.IgniteNeedReconnectException;
 import org.apache.ignite.internal.IgniteNodeAttributes;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
@@ -635,6 +636,13 @@ class ClientImpl extends TcpDiscoveryImpl {
                 spi.writeToSocket(sock, req, timeoutHelper.nextTimeoutChunk(spi.getSocketTimeout()));
 
                 TcpDiscoveryHandshakeResponse res = spi.readMessage(sock, null, ackTimeout0);
+
+                if (res.failedNodes() != null) {
+                    if (log.isDebugEnabled())
+                        log.debug("Handshake response from failed node: " + res);
+
+                    throw new IgniteNeedReconnectException(locNode, null);
+                }
 
                 UUID rmtNodeId = res.creatorNodeId();
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ClientImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ClientImpl.java
@@ -637,13 +637,6 @@ class ClientImpl extends TcpDiscoveryImpl {
 
                 TcpDiscoveryHandshakeResponse res = spi.readMessage(sock, null, ackTimeout0);
 
-                if (res.failedNodes() != null) {
-                    if (log.isDebugEnabled())
-                        log.debug("Handshake response from failed node: " + res);
-
-                    throw new IgniteNeedReconnectException(locNode, null);
-                }
-
                 UUID rmtNodeId = res.creatorNodeId();
 
                 assert rmtNodeId != null;

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -3011,6 +3011,13 @@ class ServerImpl extends TcpDiscoveryImpl {
 
                                 long nextOrder = res.order();
 
+                                if (nextOrder == 0 && msg instanceof TcpDiscoveryConnectionCheckMessage) {
+                                    if (log.isDebugEnabled())
+                                        log.debug("Skip connection check, next node is still initializing");
+
+                                    return;
+                                }
+
                                 if (!next.id().equals(nextId)) {
                                     // Node with different ID has bounded to the same port.
                                     if (log.isDebugEnabled())

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheLateAffinityAssignmentTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheLateAffinityAssignmentTest.java
@@ -2477,7 +2477,9 @@ public class CacheLateAffinityAssignmentTest extends GridCommonAbstractTest {
 
                         cache.remove(key);
 
-                        assertNull(cache.get(key));
+                        try(Transaction tx = node.transactions().txStart(PESSIMISTIC, REPEATABLE_READ)) {
+                            assertNull(cache.get(key));
+                        }
                     }
                 }
                 catch (Exception e) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheLateAffinityAssignmentTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheLateAffinityAssignmentTest.java
@@ -104,6 +104,8 @@ import static org.apache.ignite.cache.CacheRebalanceMode.ASYNC;
 import static org.apache.ignite.cache.CacheRebalanceMode.SYNC;
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
 import static org.apache.ignite.internal.processors.cache.ExchangeContext.IGNITE_EXCHANGE_COMPATIBILITY_VER_1;
+import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
+import static org.apache.ignite.transactions.TransactionIsolation.REPEATABLE_READ;
 
 /**
  *
@@ -2469,7 +2471,9 @@ public class CacheLateAffinityAssignmentTest extends GridCommonAbstractTest {
 
                         cache.put(key, val);
 
-                        assertEquals(val, cache.get(key));
+                        try(Transaction tx = node.transactions().txStart(PESSIMISTIC, REPEATABLE_READ)) {
+                            assertEquals(val, cache.get(key));
+                        }
 
                         cache.remove(key);
 

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -2264,12 +2264,6 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
                         }
 
                         log.info("Stop sleep on message send: " + msg);
-
-                        if (node.equals(errNext)) {
-                            log.info("Fail write after sleep [node=" + node.id() + ", msg=" + msg + ']');
-
-                            throw new SocketTimeoutException();
-                        }
                     }
                 }
             }
@@ -2605,7 +2599,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
                     throw new RuntimeException("Failing ring message worker explicitly");
                 else {
                     try {
-                        Thread.sleep(5_000);
+                        Thread.sleep(timeout);
                     }
                     catch (InterruptedException ignored) {
                         // No-op.

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySplitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySplitTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.spi.discovery.tcp;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.cache.distributed.dht.IgniteCacheTopologySplitAbstractTest;
+import org.apache.ignite.internal.util.typedef.internal.U;
+
+import static org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi.DFLT_PORT;
+
+/**
+ * {@link TcpDiscoverySpi} test with splitting
+ */
+public class TcpDiscoverySplitTest extends IgniteCacheTopologySplitAbstractTest {
+
+    /** */
+    private static final int SEG_0_SIZE = 4;
+
+    /** */
+    private static final long DISCO_TIMEOUT = 1000L;
+
+    /** */
+    private static final long SPLIT_TIME = 3 * DISCO_TIMEOUT + DISCO_TIMEOUT / 2;
+
+    /** */
+    private static final String NODE_IDX_ATTR = "nodeIdx";
+
+    /** */
+    private static int getDiscoPort(int gridIdx) {
+        return DFLT_PORT + gridIdx;
+    }
+
+    /** */
+    private static boolean isDiscoPort(int port) {
+        return port >= DFLT_PORT && port <= (DFLT_PORT + TcpDiscoverySpi.DFLT_PORT_RANGE);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected long getTestTimeout() {
+        return 120_000L;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(gridName);
+
+        int idx = getTestIgniteInstanceIndex(gridName);
+
+        SplitTcpDiscoverySpi disco = (SplitTcpDiscoverySpi)cfg.getDiscoverySpi();
+
+        disco.setLocalPort(getDiscoPort(idx));
+
+        disco.setSocketTimeout(DISCO_TIMEOUT);
+
+        cfg.setUserAttributes(Collections.singletonMap(NODE_IDX_ATTR, idx));
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected boolean isBlocked(int locPort, int rmtPort) {
+        return isDiscoPort(locPort) && isDiscoPort(rmtPort) && segment(locPort) != segment(rmtPort);
+    }
+
+    /**  */
+    private int segment(int discoPort) {
+        return (discoPort - DFLT_PORT) < SEG_0_SIZE ? 0 : 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected int segment(ClusterNode node) {
+        return ((Integer)node.attribute(NODE_IDX_ATTR)) < SEG_0_SIZE ? 0 : 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+
+        super.afterTest();
+    }
+
+    /** */
+    @SuppressWarnings("unchecked")
+    protected void testSplitRestore(int[] startSeq, long splitTime) throws Exception {
+        if (log.isInfoEnabled())
+            log.info("Start sequence [size=" + startSeq.length + ", indices=" + Arrays.toString(startSeq) +
+                ", splitTime=" + splitTime);
+
+        IgniteEx[] grids = new IgniteEx[startSeq.length];
+
+        try {
+            for (int i = 0; i < startSeq.length; i++) {
+                int idx = startSeq[i];
+
+                grids[i] = startGrid(idx);
+
+                awaitPartitionMapExchange();
+            }
+
+            long beforeSplitTime = U.currentTimeMillis();
+
+            split();
+
+            Thread.sleep(splitTime);
+
+            unsplit(false);
+
+            awaitSegmentation();
+
+            long exchangeEndTime = U.currentTimeMillis();
+
+            if (log.isInfoEnabled())
+                log.info("Split with exchange finished in " + (exchangeEndTime - beforeSplitTime) + " ms");
+
+            Set[] segs = {new HashSet(), new HashSet()};
+
+            for (int i = 0; i < startSeq.length; i++) {
+                int idx = startSeq[i];
+
+                int segIdx = idx < SEG_0_SIZE ? 0 : 1;
+
+                try {
+                    IgniteEx g = grids[i];
+
+                    if (!g.context().isStopping())
+                        segs[segIdx].add(idx);
+                }
+                catch (Exception e) {
+                    U.warn(log, "Error checking grid is live [idx=" + idx + ']', e);
+                }
+            }
+            if (log.isInfoEnabled())
+                for (int i = 0; i < segs.length; ++i) {
+                    Set seg = segs[i];
+
+                    log.info(seg.isEmpty() ? "No live grids [segment=" + i + ']' :
+                        "Live grids [segment=" + i + ", size=" + seg.size() + ", indices=" + seg + ']');
+                }
+            int[] liveExp = startSeq;
+
+            for (int idx : liveExp) {
+                int segIdx = idx < SEG_0_SIZE ? 0 : 1;
+
+                if (!segs[segIdx].contains(idx))
+                    fail("Grid is stopped, but expected to live [idx=" + idx + ']');
+            }
+        }
+        finally {
+//            for (int i = 0; i < startSeq.length; ++i) {
+//                int idx = startSeq[i];
+//                if (grids[i] != null)
+//                    try {
+//                        stopGrid(idx);
+//                    }
+//                    catch (Throwable e) {
+//                        U.warn(log, "Stop grid error", e);
+//                    }
+//            }
+        }
+    }
+
+    /** */
+    public void testFullSplit() throws Exception {
+        int[] startSeq = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+        testSplitRestore(startSeq, startSeq.length * DISCO_TIMEOUT + DISCO_TIMEOUT / 2);
+    }
+
+    /** */
+    public void testConsecutiveCoordSeg0() throws Exception {
+        testSplitRestore(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, SPLIT_TIME);
+    }
+
+    /** */
+    public void testConsecutiveCoordSeg1() throws Exception {
+        testSplitRestore(new int[] {4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3}, SPLIT_TIME);
+    }
+
+    /** */
+    public void testMixedCoordSeg0() throws Exception {
+        testSplitRestore(new int[] {0, 1, 4, 5, 6, 7, 2, 3, 8, 9, 10, 11}, SPLIT_TIME);
+    }
+
+    /** */
+    public void testMixedCoordSeg1() throws Exception {
+        testSplitRestore(new int[] {4, 5, 6, 7, 0, 1, 8, 9, 10, 11, 2, 3}, SPLIT_TIME);
+    }
+
+    /** */
+    public void testShuffledCoordSeg0() throws Exception {
+        testSplitRestore(new int[] {0, 4, 5, 1, 6, 7, 2, 8, 9, 3, 10, 11}, SPLIT_TIME);
+    }
+
+    /** */
+    public void testShuffledCoordSeg1() throws Exception {
+        testSplitRestore(new int[] {4, 5, 0, 6, 7, 1, 8, 9, 2, 10, 11, 3}, SPLIT_TIME);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
@@ -39,6 +39,7 @@ import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpiConfigSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpiFailureTimeoutSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpiSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpiStartStopSelfTest;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySplitTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslSecuredUnsecuredTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslTrustedSelfTest;
@@ -78,6 +79,7 @@ public class IgniteSpiDiscoverySelfTestSuite extends TestSuite {
         suite.addTest(new TestSuite(TcpDiscoverySpiConfigSelfTest.class));
         suite.addTest(new TestSuite(TcpDiscoveryMarshallerCheckSelfTest.class));
         suite.addTest(new TestSuite(TcpDiscoverySnapshotHistoryTest.class));
+        suite.addTest(new TestSuite(TcpDiscoverySplitTest.class));
 
         suite.addTest(new TestSuite(GridTcpSpiForwardingSelfTest.class));
 


### PR DESCRIPTION
Added TcpDiscoverySplitTest, updated IgniteCacheTopologySplitAbstractTest
Early previous node fail with more reliable connection check (keep-alive) algorithm
Fast node failed message transmission, reduced split detection & exchange delay