### PR TITLE
WebSessionFilter can handle liberty session ids

### DIFF
--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-spring</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
## Problem:
Websphere Liberty creates session ids in the following form (way the session id is serialized in the cookie):
\<leadingZeros\>\<id\>:\<cloneId\> 
e.g. 00003XeX_c5NHR5fJLYufFzt5ka:a3e94cfd-b391-4d9b-b9e7-6ddfcbf8c334

If a request is received by the same instance where the session was created, the requested session id is only the \<id\> part.
If a request is received by the another instance, the requested session id is the complete 
\<leadingZeros\>\<id\>:\<cloneId\>

Because of this behavior, Ignite searches for \<leadingZeros\>\<id\>:\<cloneId\> in the cache, but only \<id\> was stored. 

## Solution:
Implement a sessionIdTransformer for Websphere Liberty that normalizes \<leadingZeros\>\<id\>:\<cloneId\> to \<id\>
