### PR TITLE
IGNITE-6827 Configurable rollback for long running transactions before partition exchange

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/TransactionConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/TransactionConfiguration.java
@@ -42,6 +42,9 @@ public class TransactionConfiguration implements Serializable {
     /** Default transaction timeout. */
     public static final long DFLT_TRANSACTION_TIMEOUT = 0;
 
+    /** Default rollback on topology change timeout. */
+    public static final long DFLT_ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT = 0;
+
     /** Default size of pessimistic transactions log. */
     public static final int DFLT_PESSIMISTIC_TX_LOG_LINGER = 10_000;
 
@@ -56,6 +59,9 @@ public class TransactionConfiguration implements Serializable {
 
     /** Default transaction timeout. */
     private long dfltTxTimeout = DFLT_TRANSACTION_TIMEOUT;
+
+    /** Rollback on topology change timeout. */
+    private long rollbackOnTopologyChangeTimeout = DFLT_ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT;
 
     /** Pessimistic tx log size. */
     private int pessimisticTxLogSize;
@@ -89,6 +95,7 @@ public class TransactionConfiguration implements Serializable {
         dfltConcurrency = cfg.getDefaultTxConcurrency();
         dfltIsolation = cfg.getDefaultTxIsolation();
         dfltTxTimeout = cfg.getDefaultTxTimeout();
+        rollbackOnTopologyChangeTimeout = cfg.getRollbackOnTopologyChangeTimeout();
         pessimisticTxLogLinger = cfg.getPessimisticTxLogLinger();
         pessimisticTxLogSize = cfg.getPessimisticTxLogSize();
         txSerEnabled = cfg.isTxSerializableEnabled();
@@ -187,6 +194,29 @@ public class TransactionConfiguration implements Serializable {
      */
     public TransactionConfiguration setDefaultTxTimeout(long dfltTxTimeout) {
         this.dfltTxTimeout = dfltTxTimeout;
+
+        return this;
+    }
+
+    /**
+     * Gets rollback on topology change timeout. Default value is defined by {@link #DFLT_ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT}
+     * which is {@code 0} and means that transactions will never time out.
+     *
+     * @return Rollback on topology change timeout.
+     */
+    public long getRollbackOnTopologyChangeTimeout() {
+        return rollbackOnTopologyChangeTimeout;
+    }
+
+    /**
+     * Sets rollback on topology change timeout in milliseconds. By default this value is defined by {@link
+     * #DFLT_ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT}.
+     *
+     * @param rollbackOnTopologyChangeTimeout Rollback on topology change timeout.
+     * @return {@code this} for chaining.
+     */
+    public TransactionConfiguration setRollbackOnTopologyChangeTimeout(long rollbackOnTopologyChangeTimeout) {
+        this.rollbackOnTopologyChangeTimeout = rollbackOnTopologyChangeTimeout;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/configuration/TransactionConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/TransactionConfiguration.java
@@ -43,7 +43,7 @@ public class TransactionConfiguration implements Serializable {
     public static final long DFLT_TRANSACTION_TIMEOUT = 0;
 
     /** Default rollback on topology change timeout. */
-    public static final long DFLT_ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT = 0;
+    public static final long DFLT_ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT = 60_000;
 
     /** Default size of pessimistic transactions log. */
     public static final int DFLT_PESSIMISTIC_TX_LOG_LINGER = 10_000;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
@@ -1943,6 +1943,7 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
                             }
 
                             if (!skipEntry) {
+                                // TODO There is a race between reading an entry and adding the one
                                 boolean isNewLocalEntry = this.map.getEntry(ctx, key) == null;
 
                                 entry = entryEx(key);
@@ -2155,6 +2156,7 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
                         ctx.evicts().touch(peekEx(key0), topVer);
                 }
 
+                // TODO Possible removing of an entry added by another thread
                 if (newLocalEntries != null) {
                     for (GridCacheEntryEx entry : newLocalEntries)
                         removeEntry(entry);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheIoManager.java
@@ -876,13 +876,6 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
             break;
 
-            case 52: {
-                if (log.isDebugEnabled())
-                    log.debug("Ignore unhandled GridNearLockResponse");
-            }
-
-            break;
-
             case 55: {
                 GridNearTxPrepareRequest req = (GridNearTxPrepareRequest)msg;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheIoManager.java
@@ -876,6 +876,13 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
             break;
 
+            case 52: {
+                if (log.isDebugEnabled())
+                    log.debug("Ignore unhandled GridNearLockResponse");
+            }
+
+            break;
+
             case 55: {
                 GridNearTxPrepareRequest req = (GridNearTxPrepareRequest)msg;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMvccManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMvccManager.java
@@ -1065,38 +1065,6 @@ public class GridCacheMvccManager extends GridCacheSharedManagerAdapter {
     }
 
     /**
-     * Complete active futures blocking partition map exchange.
-     *
-     * @param topVer Initial exchange version.
-     */
-    public void cancelOnTopologyChange(AffinityTopologyVersion topVer) {
-        for (GridCacheFuture<?> fut: activeFutures()) {
-            if (fut instanceof GridCacheVersionedFuture) {
-                GridCacheVersionedFuture f = (GridCacheVersionedFuture)fut;
-
-                // TODO how to relate GridCacheVersion to AffinityTopologyVersion?
-                IgniteInternalTx tx = cctx.tm().tx(f.version());
-
-                if (tx != null && tx.near()) {
-                    AffinityTopologyVersion txTopVer = tx.topologyVersionSnapshot();
-
-                    if(txTopVer != null && txTopVer.compareTo(topVer) < 0) {
-                        if (log.isInfoEnabled())
-                            log.info("Forcibly canceling future: " + f);
-
-                        try {
-                            f.cancel();
-                        }
-                        catch (IgniteCheckedException e) {
-                            U.error(log, "Failed to cancel the future: " + f, e);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
      * @param topVer Topology version to finish.
      *
      * @return Finish update future.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCachePartitionExchangeManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCachePartitionExchangeManager.java
@@ -2313,11 +2313,8 @@ public class GridCachePartitionExchangeManager<K, V> extends GridCacheSharedMana
                                         nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, dumpTimeout);
                                     }
 
-                                    if (rollbackEnabled) {
-                                        cctx.mvcc().cancelOnTopologyChange(exchFut.initialVersion());
-
+                                    if (rollbackEnabled)
                                         cctx.tm().rollbackOnTopologyChange(exchFut.initialVersion());
-                                    }
                                 }
                                 catch (Exception e) {
                                     if (exchFut.reconnectOnError(e))

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCachePartitionExchangeManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCachePartitionExchangeManager.java
@@ -46,6 +46,7 @@ import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cache.affinity.AffinityFunction;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.events.DiscoveryEvent;
 import org.apache.ignite.internal.IgniteClientDisconnectedCheckedException;
 import org.apache.ignite.internal.IgniteDiagnosticAware;
@@ -2280,23 +2281,28 @@ public class GridCachePartitionExchangeManager<K, V> extends GridCacheSharedMana
 
                             int dumpCnt = 0;
 
-                            final long futTimeout = 2 * cctx.gridConfig().getNetworkTimeout();
+                            IgniteConfiguration cfg = cctx.gridConfig();
+
+                            boolean rollbackEnabled = cfg.getTransactionConfiguration().getRollbackOnTopologyChangeTimeout() > 0;
+
+                            final long dumpTimeout = 2 * cctx.gridConfig().getNetworkTimeout();
 
                             long nextDumpTime = 0;
 
                             while (true) {
                                 try {
-                                    resVer = exchFut.get(futTimeout, TimeUnit.MILLISECONDS);
+                                    resVer = exchFut.get(rollbackEnabled ? cfg.getTransactionConfiguration().
+                                        getRollbackOnTopologyChangeTimeout() : dumpTimeout, TimeUnit.MILLISECONDS);
 
                                     break;
                                 }
                                 catch (IgniteFutureTimeoutCheckedException ignored) {
-                                    U.warn(diagnosticLog, "Failed to wait for partition map exchange [" +
-                                        "topVer=" + exchFut.initialVersion() +
-                                        ", node=" + cctx.localNodeId() + "]. " +
-                                        "Dumping pending objects that might be the cause: ");
-
                                     if (nextDumpTime <= U.currentTimeMillis()) {
+                                        U.warn(diagnosticLog, "Failed to wait for partition map exchange [" +
+                                            "topVer=" + exchFut.initialVersion() +
+                                            ", node=" + cctx.localNodeId() + "]. " +
+                                            "Dumping pending objects that might be the cause: ");
+
                                         try {
                                             dumpDebugInfo(exchFut);
                                         }
@@ -2304,7 +2310,13 @@ public class GridCachePartitionExchangeManager<K, V> extends GridCacheSharedMana
                                             U.error(diagnosticLog, "Failed to dump debug information: " + e, e);
                                         }
 
-                                        nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, futTimeout);
+                                        nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, dumpTimeout);
+                                    }
+
+                                    if (rollbackEnabled) {
+                                        cctx.mvcc().cancelOnTopologyChange(exchFut.initialVersion());
+
+                                        cctx.tm().rollbackOnTopologyChange(exchFut.initialVersion());
                                     }
                                 }
                                 catch (Exception e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
@@ -820,6 +820,22 @@ public class GridCacheUtils {
     }
 
     /**
+     * @param fut Future.
+     * @return String view of all safe-to-print future properties.
+     */
+    public static String futString(@Nullable GridCacheFuture fut, IgniteInternalTx tx) {
+        if (fut == null)
+            return "null";
+
+        return fut.getClass().getSimpleName() + "[futId=" + fut.futureId() +
+            ", trackable=" + fut.trackable() +
+            ", done=" + fut.isDone() +
+            ", cancelled=" + fut.isCancelled() +
+            ", duration=" + fut.duration() +
+            ", tx=" + txString(tx) +']';
+    }
+
+    /**
      * @param ctx Cache context.
      */
     public static void unwindEvicts(GridCacheContext ctx) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
@@ -828,10 +828,11 @@ public class GridCacheUtils {
             return "null";
 
         return fut.getClass().getSimpleName() + "[futId=" + fut.futureId() +
-            ", trackable=" + fut.trackable() +
             ", done=" + fut.isDone() +
             ", cancelled=" + fut.isCancelled() +
-            ", duration=" + fut.duration() +
+            ", trackable=" + fut.trackable() +
+            ", startTime=" + fut.startTime() +
+            ", duration=" + fut.duration() + "ms" +
             ", tx=" + txString(tx) +']';
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedTxRemoteAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedTxRemoteAdapter.java
@@ -794,7 +794,7 @@ public abstract class GridDistributedTxRemoteAdapter extends IgniteTxAdapter
             if (!isSystemInvalidate())
                 throw new IgniteCheckedException("Invalid transaction state for commit [state=" + state + ", tx=" + this + ']');
 
-            rollbackRemoteTx();
+            rollbackRemoteTx(false);
         }
 
         commitIfLocked();
@@ -851,14 +851,14 @@ public abstract class GridDistributedTxRemoteAdapter extends IgniteTxAdapter
     }
 
     /** {@inheritDoc} */
-    @Override public final void rollbackRemoteTx() {
+    @Override public final void rollbackRemoteTx(boolean onTimeout) {
         try {
             // Note that we don't evict near entries here -
             // they will be deleted by their corresponding transactions.
-            if (state(ROLLING_BACK) || state() == UNKNOWN) {
-                cctx.tm().rollbackTx(this, false);
+            if (state(ROLLING_BACK, onTimeout) || state() == UNKNOWN) {
+                cctx.tm().rollbackTx(this, !onTimeout);
 
-                state(ROLLED_BACK);
+                state(ROLLED_BACK, onTimeout);
             }
         }
         catch (RuntimeException | Error e) {
@@ -870,7 +870,7 @@ public abstract class GridDistributedTxRemoteAdapter extends IgniteTxAdapter
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<IgniteInternalTx> rollbackAsync() {
-        rollbackRemoteTx();
+        rollbackRemoteTx(false);
 
         return new GridFinishedFuture<IgniteInternalTx>(this);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
@@ -771,7 +771,8 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
                     if (tx.isRollbackOnly() && tx.timedOut()) {
                         if (log.isInfoEnabled())
-                            log.info("Forcibly cancelling DHT lock future: " + GridDhtLockFuture.this);
+                            log.info("Forcibly cancelling DHT lock future: " +
+                                CU.futString(GridDhtLockFuture.this, tx));
 
                         onTimeout();
                     }
@@ -1138,7 +1139,7 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
                     return;
 
                 err = new GridDistributedLockCancelledException("Failed to acquire lock, " +
-                    "transaction was rolled back [tx=" + tx + ']');
+                    "transaction was rolled back [tx=" + CU.txString(tx) + ']');
             }
             onComplete(false, false, false);
         }
@@ -1171,7 +1172,7 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(LockTimeoutObject.class, this, "fut", GridDhtLockFuture.this);
+            return S.toString(LockTimeoutObject.class, this);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
@@ -766,10 +766,10 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
 
         readyLocks();
 
-        if (tx != null)
+        if (tx != null) {
             tx.finishFuture().listen(new IgniteInClosure<IgniteInternalFuture<IgniteInternalTx>>() {
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
-                    if(tx.isRollbackOnly()) {
+                    if (tx.isRollbackOnly()) {
                         if (log.isInfoEnabled())
                             log.info("Forcibly cancelling DHT lock future: " + GridDhtLockFuture.this);
 
@@ -777,6 +777,10 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
                     }
                 }
             });
+
+            if (isDone())
+                return;
+        }
 
         if (timeout > 0) {
             timeoutObj = new LockTimeoutObject();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
@@ -1135,7 +1135,7 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(LockTimeoutObject.class, this);
+            return S.toString(LockTimeoutObject.class, this, "fut", GridDhtLockFuture.this);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
@@ -769,7 +769,7 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
         if (tx != null) {
             tx.finishFuture().listen(new IgniteInClosure<IgniteInternalFuture<IgniteInternalTx>>() {
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
-                    if (tx.isRollbackOnly()) {
+                    if (tx.isRollbackOnly() && tx.timedOut()) {
                         if (log.isInfoEnabled())
                             log.info("Forcibly cancelling DHT lock future: " + GridDhtLockFuture.this);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
@@ -1137,7 +1137,7 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
                 if (err != null)
                     return;
 
-                err = new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
+                err = new GridDistributedLockCancelledException("Failed to acquire lock, " +
                     "transaction was rolled back [tx=" + tx + ']');
             }
             onComplete(false, false, false);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTransactionalCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTransactionalCacheAdapter.java
@@ -1119,6 +1119,9 @@ public abstract class GridDhtTransactionalCacheAdapter<K, V> extends GridDhtCach
 
                             assert !t.empty();
 
+                            if(e != null)
+                                return new GridFinishedFuture<>(e);
+
                             // Create response while holding locks.
                             final GridNearLockResponse resp = createLockReply(nearNode,
                                 entries,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTransactionalCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTransactionalCacheAdapter.java
@@ -1119,9 +1119,6 @@ public abstract class GridDhtTransactionalCacheAdapter<K, V> extends GridDhtCach
 
                             assert !t.empty();
 
-                            if(e != null)
-                                return new GridFinishedFuture<>(e);
-
                             // Create response while holding locks.
                             final GridNearLockResponse resp = createLockReply(nearNode,
                                 entries,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTransactionalCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTransactionalCacheAdapter.java
@@ -319,7 +319,7 @@ public abstract class GridDhtTransactionalCacheAdapter<K, V> extends GridDhtCach
                                 if (tx.state() == COMMITTING)
                                     tx.forceCommit();
                                 else
-                                    tx.rollbackRemoteTx();
+                                    tx.rollbackRemoteTx(false);
                             }
 
                             return null;
@@ -374,7 +374,7 @@ public abstract class GridDhtTransactionalCacheAdapter<K, V> extends GridDhtCach
             if (log.isDebugEnabled())
                 log.debug("Rolling back remote DHT transaction because it is empty [req=" + req + ", res=" + res + ']');
 
-            tx.rollbackRemoteTx();
+            tx.rollbackRemoteTx(false);
 
             tx = null;
         }
@@ -573,10 +573,10 @@ public abstract class GridDhtTransactionalCacheAdapter<K, V> extends GridDhtCach
 
         if (fail) {
             if (dhtTx != null)
-                dhtTx.rollbackRemoteTx();
+                dhtTx.rollbackRemoteTx(false);
 
             if (nearTx != null) // Even though this should never happen, we leave this check for consistency.
-                nearTx.rollbackRemoteTx();
+                nearTx.rollbackRemoteTx(false);
 
             List<KeyCacheObject> keys = req.keys();
 
@@ -1416,7 +1416,7 @@ public abstract class GridDhtTransactionalCacheAdapter<K, V> extends GridDhtCach
 
             if (tx != null)
                 try {
-                    tx.rollbackDhtLocalAsync();
+                    tx.rollbackDhtLocalAsync(false);
                 }
                 catch (Throwable e1) {
                     e.addSuppressed(e1);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxFinishFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxFinishFuture.java
@@ -86,6 +86,11 @@ public final class GridDhtTxFinishFuture<K, V> extends GridCacheCompoundIdentity
     /** Commit flag. */
     private boolean commit;
 
+    /**
+     * {@code True} if transaction timed out.
+     */
+    private boolean timedout;
+
     /** Error. */
     @SuppressWarnings("UnusedDeclaration")
     @GridToStringExclude
@@ -101,13 +106,17 @@ public final class GridDhtTxFinishFuture<K, V> extends GridCacheCompoundIdentity
      * @param cctx Context.
      * @param tx Transaction.
      * @param commit Commit flag.
+     * @param timedout {@code true} if transaction timed out.
      */
-    public GridDhtTxFinishFuture(GridCacheSharedContext<K, V> cctx, GridDhtTxLocalAdapter tx, boolean commit) {
+    public GridDhtTxFinishFuture(GridCacheSharedContext<K, V> cctx, GridDhtTxLocalAdapter tx, boolean commit,
+        boolean timedout) {
+
         super(F.<IgniteInternalTx>identityReducer(tx));
 
         this.cctx = cctx;
         this.tx = tx;
         this.commit = commit;
+        this.timedout = timedout;
 
         dhtMap = tx.dhtMap();
         nearMap = tx.nearMap();
@@ -157,6 +166,13 @@ public final class GridDhtTxFinishFuture<K, V> extends GridCacheCompoundIdentity
     /** {@inheritDoc} */
     @Override public void markNotTrackable() {
         assert false;
+    }
+
+    /**
+     * {@code True} if transaction timed out.
+     */
+    public boolean timedOut() {
+        return timedout;
     }
 
     /**
@@ -333,6 +349,7 @@ public final class GridDhtTxFinishFuture<K, V> extends GridCacheCompoundIdentity
                 tx.threadId(),
                 tx.isolation(),
                 false,
+                timedout,
                 tx.isInvalidate(),
                 tx.system(),
                 tx.ioPolicy(),
@@ -435,6 +452,7 @@ public final class GridDhtTxFinishFuture<K, V> extends GridCacheCompoundIdentity
                 tx.threadId(),
                 tx.isolation(),
                 commit,
+                timedout,
                 tx.isInvalidate(),
                 tx.system(),
                 tx.ioPolicy(),
@@ -505,6 +523,7 @@ public final class GridDhtTxFinishFuture<K, V> extends GridCacheCompoundIdentity
                     tx.threadId(),
                     tx.isolation(),
                     commit,
+                    timedout,
                     tx.isInvalidate(),
                     tx.system(),
                     tx.ioPolicy(),

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxFinishRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxFinishRequest.java
@@ -83,6 +83,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
      * @param commitVer Commit version.
      * @param isolation Transaction isolation.
      * @param commit Commit flag.
+     * @param timedout {@code True} if transaction timed out.
      * @param invalidate Invalidate flag.
      * @param sys System flag.
      * @param plc IO policy.
@@ -107,6 +108,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
         long threadId,
         TransactionIsolation isolation,
         boolean commit,
+        boolean timedout,
         boolean invalidate,
         boolean sys,
         byte plc,
@@ -130,6 +132,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
             commitVer,
             threadId,
             commit,
+            timedout,
             invalidate,
             sys,
             plc,
@@ -166,6 +169,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
      * @param commitVer Commit version.
      * @param isolation Transaction isolation.
      * @param commit Commit flag.
+     * @param timedout {@code True} if transaction timed out.
      * @param invalidate Invalidate flag.
      * @param sys System flag.
      * @param plc IO policy.
@@ -191,6 +195,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
         long threadId,
         TransactionIsolation isolation,
         boolean commit,
+        boolean timedout,
         boolean invalidate,
         boolean sys,
         byte plc,
@@ -217,6 +222,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
             threadId,
             isolation,
             commit,
+            timedout,
             invalidate,
             sys,
             plc,
@@ -354,37 +360,37 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
         }
 
         switch (writer.state()) {
-            case 21:
+            case 22:
                 if (!writer.writeByte("isolation", isolation != null ? (byte)isolation.ordinal() : -1))
                     return false;
 
                 writer.incrementState();
 
-            case 22:
+            case 23:
                 if (!writer.writeInt("miniId", miniId))
                     return false;
 
                 writer.incrementState();
 
-            case 23:
+            case 24:
                 if (!writer.writeUuid("nearNodeId", nearNodeId))
                     return false;
 
                 writer.incrementState();
 
-            case 24:
+            case 25:
                 if (!writer.writeMessage("partUpdateCnt", partUpdateCnt))
                     return false;
 
                 writer.incrementState();
 
-            case 25:
+            case 26:
                 if (!writer.writeCollection("pendingVers", pendingVers, MessageCollectionItemType.MSG))
                     return false;
 
                 writer.incrementState();
 
-            case 26:
+            case 27:
                 if (!writer.writeMessage("writeVer", writeVer))
                     return false;
 
@@ -406,7 +412,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
             return false;
 
         switch (reader.state()) {
-            case 21:
+            case 22:
                 byte isolationOrd;
 
                 isolationOrd = reader.readByte("isolation");
@@ -418,7 +424,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
 
                 reader.incrementState();
 
-            case 22:
+            case 23:
                 miniId = reader.readInt("miniId");
 
                 if (!reader.isLastRead())
@@ -426,7 +432,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
 
                 reader.incrementState();
 
-            case 23:
+            case 24:
                 nearNodeId = reader.readUuid("nearNodeId");
 
                 if (!reader.isLastRead())
@@ -434,7 +440,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
 
                 reader.incrementState();
 
-            case 24:
+            case 25:
                 partUpdateCnt = reader.readMessage("partUpdateCnt");
 
                 if (!reader.isLastRead())
@@ -442,7 +448,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
 
                 reader.incrementState();
 
-            case 25:
+            case 26:
                 pendingVers = reader.readCollection("pendingVers", MessageCollectionItemType.MSG);
 
                 if (!reader.isLastRead())
@@ -450,7 +456,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
 
                 reader.incrementState();
 
-            case 26:
+            case 27:
                 writeVer = reader.readMessage("writeVer");
 
                 if (!reader.isLastRead())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxLocalAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxLocalAdapter.java
@@ -734,7 +734,7 @@ public abstract class GridDhtTxLocalAdapter extends IgniteTxLocalAdapter {
 
     /** {@inheritDoc} */
     @SuppressWarnings({"CatchGenericClass", "ThrowableInstanceNeverThrown"})
-    @Override public boolean localFinish(boolean commit, boolean clearThreadMap) throws IgniteCheckedException {
+    @Override public boolean localFinish(boolean commit, boolean onTimeout) throws IgniteCheckedException {
         if (log.isDebugEnabled())
             log.debug("Finishing dht local tx [tx=" + this + ", commit=" + commit + "]");
 
@@ -757,7 +757,7 @@ public abstract class GridDhtTxLocalAdapter extends IgniteTxLocalAdapter {
             }
         }
         else {
-            if (!state(ROLLING_BACK)) {
+            if (!state(ROLLING_BACK, onTimeout)) {
                 if (log.isDebugEnabled())
                     log.debug("Invalid transaction state for rollback [state=" + state() + ", tx=" + this + ']');
 
@@ -773,7 +773,7 @@ public abstract class GridDhtTxLocalAdapter extends IgniteTxLocalAdapter {
             if (commit && !isRollbackOnly())
                 userCommit();
             else
-                userRollback(clearThreadMap);
+                userRollback(!onTimeout);
         }
         catch (IgniteCheckedException e) {
             err = e;
@@ -806,7 +806,7 @@ public abstract class GridDhtTxLocalAdapter extends IgniteTxLocalAdapter {
                 }
             }
             else {
-                if (!state(ROLLED_BACK)) {
+                if (!state(ROLLED_BACK, onTimeout)) {
                     state(UNKNOWN);
 
                     throw new IgniteCheckedException("Invalid transaction state for rollback: " + this);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
@@ -717,7 +717,7 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
                         onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
                             "transaction was rolled back [tx=" + tx + ']'));
 
-                        onComplete(false, false, false);
+                        onComplete(false, true, false);
                     }
                 }
             });

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
@@ -717,7 +717,7 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
                         onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
                             "transaction was rolled back [tx=" + tx + ']'));
 
-                        onComplete(false, true, false);
+                        onComplete(false, false, false);
                     }
                 }
             });

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
@@ -701,7 +701,7 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
                     @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
                         IgniteTxTimeoutCheckedException err = new IgniteTxTimeoutCheckedException("Failed to " +
                             "acquire lock, transaction was rolled back on timeout [timeout=" + tx.timeout() +
-                            ", tx=" + tx + ']');
+                            ", tx=" + CU.txString(tx) + ']');
 
                         onError(err);
 
@@ -715,7 +715,7 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
                     if(tx.isRollbackOnly()) {
                         onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
-                            "transaction was rolled back [tx=" + tx + ']'));
+                            "transaction was rolled back [tx=" + CU.txString(tx) + ']'));
 
                         onComplete(false, false, false);
                     }
@@ -1486,7 +1486,7 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(LockTimeoutObject.class, this, "fut", GridDhtColocatedLockFuture.this);
+            return S.toString(LockTimeoutObject.class, this);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
@@ -721,6 +721,9 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
                     }
                 }
             });
+
+            if (isDone())
+                return;
         }
 
         if (timeout > 0) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/colocated/GridDhtColocatedLockFuture.java
@@ -713,12 +713,12 @@ public final class GridDhtColocatedLockFuture extends GridCacheCompoundIdentityF
             }
             tx.finishFuture().listen(new IgniteInClosure<IgniteInternalFuture<IgniteInternalTx>>() {
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
-                    assert tx.isRollbackOnly() : "Transaction is expected to be rolled back: " + tx;
+                    if(tx.isRollbackOnly()) {
+                        onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
+                            "transaction was rolled back [tx=" + tx + ']'));
 
-                    onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
-                        "transaction was rolled back [tx=" + tx + ']'));
-
-                    onComplete(false, false, false);
+                        onComplete(false, false, false);
+                    }
                 }
             });
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -1109,11 +1109,8 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
                     nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, dumpTimeout);
                 }
 
-                if (rollbackEnabled) {
-                    cctx.mvcc().cancelOnTopologyChange(initialVersion());
-
+                if (rollbackEnabled)
                     cctx.tm().rollbackOnTopologyChange(initialVersion());
-                }
             }
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -41,6 +41,7 @@ import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.NearCacheConfiguration;
 import org.apache.ignite.events.DiscoveryEvent;
 import org.apache.ignite.internal.IgniteClientDisconnectedCheckedException;
@@ -1087,11 +1088,16 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
 
         long nextDumpTime = 0;
 
-        long futTimeout = 2 * cctx.gridConfig().getNetworkTimeout();
+        IgniteConfiguration cfg = cctx.gridConfig();
+
+        boolean rollbackEnabled = cfg.getTransactionConfiguration().getRollbackOnTopologyChangeTimeout() > 0;
+
+        long dumpTimeout = 2 * cfg.getNetworkTimeout();
 
         while (true) {
             try {
-                partReleaseFut.get(futTimeout, TimeUnit.MILLISECONDS);
+                partReleaseFut.get(rollbackEnabled ? cfg.getTransactionConfiguration().
+                    getRollbackOnTopologyChangeTimeout() : dumpTimeout, TimeUnit.MILLISECONDS);
 
                 break;
             }
@@ -1100,7 +1106,13 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
                 if (nextDumpTime <= U.currentTimeMillis()) {
                     dumpPendingObjects(partReleaseFut);
 
-                    nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, futTimeout);
+                    nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, dumpTimeout);
+                }
+
+                if (rollbackEnabled) {
+                    cctx.mvcc().cancelOnTopologyChange(initialVersion());
+
+                    cctx.tm().rollbackOnTopologyChange(initialVersion());
                 }
             }
         }
@@ -1125,7 +1137,7 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
 
         while (true) {
             try {
-                locksFut.get(futTimeout, TimeUnit.MILLISECONDS);
+                locksFut.get(dumpTimeout, TimeUnit.MILLISECONDS);
 
                 break;
             }
@@ -1148,7 +1160,7 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
                     for (Map.Entry<IgniteTxKey, Collection<GridCacheMvccCandidate>> e : locks.entrySet())
                         U.warn(log, "Awaited locked entry [key=" + e.getKey() + ", mvcc=" + e.getValue() + ']');
 
-                    nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, futTimeout);
+                    nextDumpTime = U.currentTimeMillis() + nextDumpTimeout(dumpCnt++, dumpTimeout);
 
                     if (getBoolean(IGNITE_THREAD_DUMP_ON_EXCHANGE_TIMEOUT, false))
                         U.dumpThreads(log);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
@@ -804,9 +804,13 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
             }
             tx.finishFuture().listen(new IgniteInClosure<IgniteInternalFuture<IgniteInternalTx>>() {
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
-                    if(tx.isRollbackOnly()) {
+                    if (tx.isRollbackOnly() && tx.timedOut()) {
+                        if (log.isInfoEnabled())
+                            log.info("Forcibly cancelling near lock future: " + GridNearLockFuture.this);
+
+
                         onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
-                            "transaction was rolled back [tx=" + tx + ']'));
+                            "transaction was rolled back on timeout [tx=" + tx + ']'));
 
                         onComplete(false, true, false);
                     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
@@ -804,12 +804,12 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
             }
             tx.finishFuture().listen(new IgniteInClosure<IgniteInternalFuture<IgniteInternalTx>>() {
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
-                    assert tx.isRollbackOnly() : "Transaction is expected to be rolled back: " + tx;
+                    if(tx.isRollbackOnly()) {
+                        onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
+                            "transaction was rolled back [tx=" + tx + ']'));
 
-                    onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
-                        "transaction was rolled back [tx=" + tx + ']'));
-
-                    onComplete(false, false, false);
+                        onComplete(false, false, false);
+                    }
                 }
             });
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
@@ -792,7 +792,7 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
                     @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
                         IgniteTxTimeoutCheckedException err = new IgniteTxTimeoutCheckedException("Failed to " +
                             "acquire lock, transaction was rolled back on timeout [timeout=" + tx.timeout() +
-                            ", tx=" + tx + ']');
+                            ", tx=" + CU.txString(tx) + ']');
 
                         onError(err);
 
@@ -806,11 +806,12 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
                 @Override public void apply(IgniteInternalFuture<IgniteInternalTx> fut) {
                     if (tx.isRollbackOnly() && tx.timedOut()) {
                         if (log.isInfoEnabled())
-                            log.info("Forcibly cancelling near lock future: " + GridNearLockFuture.this);
+                            log.info("Forcibly cancelling near lock future: " +
+                                CU.futString(GridNearLockFuture.this, tx));
 
 
                         onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
-                            "transaction was rolled back on timeout [tx=" + tx + ']'));
+                            "transaction was rolled back on timeout [tx=" + CU.txString(tx) + ']'));
 
                         onComplete(false, true, false);
                     }
@@ -1537,7 +1538,7 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(LockTimeoutObject.class, this, "fut", GridNearLockFuture.this);
+            return S.toString(LockTimeoutObject.class, this);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
@@ -808,7 +808,7 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
                         onError(new IgniteFutureCancelledCheckedException("Failed to acquire lock, " +
                             "transaction was rolled back [tx=" + tx + ']'));
 
-                        onComplete(false, false, false);
+                        onComplete(false, true, false);
                     }
                 }
             });

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearLockFuture.java
@@ -812,6 +812,9 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
                     }
                 }
             });
+
+            if (isDone())
+                return;
         }
 
         if (timeout > 0) {
@@ -820,6 +823,7 @@ public final class GridNearLockFuture extends GridCacheCompoundIdentityFuture<Bo
             cctx.time().addTimeoutObject(timeoutObj);
         }
 
+        // TODO possible race between mapping the future and LockTimeoutObject.onTimeout()
         boolean added = cctx.mvcc().addFuture(this);
 
         assert added : this;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTransactionalCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTransactionalCache.java
@@ -378,7 +378,7 @@ public class GridNearTransactionalCache<K, V> extends GridNearCacheAdapter<K, V>
                                 log.debug("Node requesting lock left grid (lock request will be ignored): " + req);
 
                             if (tx != null)
-                                tx.rollbackRemoteTx();
+                                tx.rollbackRemoteTx(false);
 
                             return null;
                         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxFinishRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxFinishRequest.java
@@ -54,6 +54,7 @@ public class GridNearTxFinishRequest extends GridDistributedTxFinishRequest {
      * @param xidVer Transaction ID.
      * @param threadId Thread ID.
      * @param commit Commit flag.
+     * @param timedout {@code True} if transaction timed out.
      * @param invalidate Invalidate flag.
      * @param sys System flag.
      * @param plc IO policy.
@@ -74,6 +75,7 @@ public class GridNearTxFinishRequest extends GridDistributedTxFinishRequest {
         GridCacheVersion xidVer,
         long threadId,
         boolean commit,
+        boolean timedout,
         boolean invalidate,
         boolean sys,
         byte plc,
@@ -95,6 +97,7 @@ public class GridNearTxFinishRequest extends GridDistributedTxFinishRequest {
             null,
             threadId,
             commit,
+            timedout,
             invalidate,
             sys,
             plc,
@@ -171,7 +174,7 @@ public class GridNearTxFinishRequest extends GridDistributedTxFinishRequest {
         }
 
         switch (writer.state()) {
-            case 21:
+            case 22:
                 if (!writer.writeInt("miniId", miniId))
                     return false;
 
@@ -193,7 +196,7 @@ public class GridNearTxFinishRequest extends GridDistributedTxFinishRequest {
             return false;
 
         switch (reader.state()) {
-            case 21:
+            case 22:
                 miniId = reader.readInt("miniId");
 
                 if (!reader.isLastRead())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
@@ -3274,7 +3274,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
         if (log.isDebugEnabled())
             log.debug("Rolling back near tx: " + this);
 
-        if (!onTimeout && trackTimeout)
+        if (trackTimeout)
             removeTimeoutHandler();
 
         NearTxFinishFuture fut = finishFut;
@@ -4106,7 +4106,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
     public boolean addTimeoutHandler() {
         assert trackTimeout;
 
-        return cctx.time().addTimeoutObject(this);
+        return isRollbackOnly() || cctx.time().addTimeoutObject(this);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
@@ -4135,7 +4135,8 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
                     // since thread started tx still should be able to see this tx.
                     rollbackNearTxLocalAsync(true);
 
-                    U.warn(log, "Transaction was rolled back because the timeout is reached: " + GridNearTxLocal.this);
+                    U.warn(log, "Transaction was rolled back because the timeout is reached: " +
+                        CU.txString(GridNearTxLocal.this));
                 }
             });
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalLockFuture.java
@@ -517,7 +517,7 @@ public final class GridLocalLockFuture<K, V> extends GridCacheFutureAdapter<Bool
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(LockTimeoutObject.class, this, "fut", GridLocalLockFuture.this);
+            return S.toString(LockTimeoutObject.class, this);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/GridLocalLockFuture.java
@@ -517,7 +517,7 @@ public final class GridLocalLockFuture<K, V> extends GridCacheFutureAdapter<Bool
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(LockTimeoutObject.class, this);
+            return S.toString(LockTimeoutObject.class, this, "fut", GridLocalLockFuture.this);
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxAdapter.java
@@ -1810,6 +1810,7 @@ public abstract class IgniteTxAdapter extends GridMetadataAwareAdapter implement
     /** {@inheritDoc} */
     @Override public String toString() {
         return GridToStringBuilder.toString(IgniteTxAdapter.class, this,
+            "id", xid(),
             "duration", (U.currentTimeMillis() - startTime) + "ms",
             "onePhaseCommit", onePhaseCommit);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxAdapter.java
@@ -690,6 +690,9 @@ public abstract class IgniteTxAdapter extends GridMetadataAwareAdapter implement
      * @return Remaining transaction time. {@code 0} if timeout isn't specified. {@code -1} if time is out.
      */
     @Override public long remainingTime() {
+        if (isRollbackOnly())
+            return -1;
+
         if (timeout() <= 0)
             return 0;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxAdapter.java
@@ -690,7 +690,7 @@ public abstract class IgniteTxAdapter extends GridMetadataAwareAdapter implement
      * @return Remaining transaction time. {@code 0} if timeout isn't specified. {@code -1} if time is out.
      */
     @Override public long remainingTime() {
-        if (isRollbackOnly())
+        if (timedOut)
             return -1;
 
         if (timeout() <= 0)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxHandler.java
@@ -520,7 +520,7 @@ public class IgniteTxHandler {
 
             if (tx.isRollbackOnly() && !tx.commitOnPrepare()) {
                 if (tx.state() != TransactionState.ROLLED_BACK && tx.state() != TransactionState.ROLLING_BACK)
-                    tx.rollbackDhtLocalAsync();
+                    tx.rollbackDhtLocalAsync(false);
             }
 
             final GridDhtTxLocal tx0 = tx;
@@ -948,7 +948,7 @@ public class IgniteTxHandler {
                 return commitFut;
             }
             else {
-                IgniteInternalFuture<IgniteInternalTx> rollbackFut = tx.rollbackDhtLocalAsync();
+                IgniteInternalFuture<IgniteInternalTx> rollbackFut = tx.rollbackDhtLocalAsync(req.timedOut());
 
                 // Only for error logging.
                 rollbackFut.listen(CU.errorLogger(log));
@@ -965,7 +965,7 @@ public class IgniteTxHandler {
                 tx.systemInvalidate(true);
 
                 try {
-                    IgniteInternalFuture<IgniteInternalTx> res = tx.rollbackDhtLocalAsync();
+                    IgniteInternalFuture<IgniteInternalTx> res = tx.rollbackDhtLocalAsync(tx.timedOut());
 
                     // Only for error logging.
                     res.listen(CU.errorLogger(log));
@@ -1002,7 +1002,7 @@ public class IgniteTxHandler {
                 return tx.commitAsyncLocal();
             }
             else
-                return tx.rollbackAsyncLocal();
+                return tx.rollbackAsyncLocal(tx.timedOut());
         }
         catch (Throwable e) {
             U.error(log, "Failed completing transaction [commit=" + commit + ", tx=" + tx + ']', e);
@@ -1111,7 +1111,7 @@ public class IgniteTxHandler {
 
             if (nearTx != null)
                 try {
-                    nearTx.rollbackRemoteTx();
+                    nearTx.rollbackRemoteTx(false);
                 }
                 catch (Throwable e1) {
                     e.addSuppressed(e1);
@@ -1321,7 +1321,7 @@ public class IgniteTxHandler {
             else {
                 tx.doneRemote(req.baseVersion(), null, null, null);
 
-                tx.rollbackRemoteTx();
+                tx.rollbackRemoteTx(req.timedOut());
             }
         }
         catch (Throwable e) {
@@ -1373,7 +1373,7 @@ public class IgniteTxHandler {
             tx.systemInvalidate(true);
 
             try {
-                tx.rollbackRemoteTx();
+                tx.rollbackRemoteTx(false);
             }
             catch (Throwable e1) {
                 e.addSuppressed(e1);
@@ -1425,7 +1425,7 @@ public class IgniteTxHandler {
 
             if (nearTx != null)
                 try {
-                    nearTx.rollbackRemoteTx();
+                    nearTx.rollbackRemoteTx(false);
                 }
                 catch (Throwable e1) {
                     e.addSuppressed(e1);
@@ -1433,7 +1433,7 @@ public class IgniteTxHandler {
 
             if (dhtTx != null)
                 try {
-                    dhtTx.rollbackRemoteTx();
+                    dhtTx.rollbackRemoteTx(false);
                 }
                 catch (Throwable e1) {
                     e.addSuppressed(e1);
@@ -1698,7 +1698,7 @@ public class IgniteTxHandler {
             res.invalidPartitionsByCacheId(tx.invalidPartitions());
 
             if (tx.empty() && req.last()) {
-                tx.rollbackRemoteTx();
+                tx.rollbackRemoteTx(false);
 
                 return null;
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxLocalAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxLocalAdapter.java
@@ -1628,7 +1628,8 @@ public abstract class IgniteTxLocalAdapter extends IgniteTxAdapter implements Ig
 
                 final GridClosureException ex = new GridClosureException(
                     new IgniteTxTimeoutCheckedException("Failed to acquire lock within provided timeout " +
-                        "for transaction [timeout=" + timeout() + ", tx=" + IgniteTxLocalAdapter.this + ']', deadlockErr)
+                        "for transaction [timeout=" + timeout() + ", tx=" + CU.txString(IgniteTxLocalAdapter.this) + ']',
+                        deadlockErr)
                 );
 
                 if (commit && commitAfterLock())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxLocalAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxLocalAdapter.java
@@ -1628,7 +1628,7 @@ public abstract class IgniteTxLocalAdapter extends IgniteTxAdapter implements Ig
 
                 final GridClosureException ex = new GridClosureException(
                     new IgniteTxTimeoutCheckedException("Failed to acquire lock within provided timeout " +
-                        "for transaction [timeout=" + timeout() + ", tx=" + this + ']', deadlockErr)
+                        "for transaction [timeout=" + timeout() + ", tx=" + IgniteTxLocalAdapter.this + ']', deadlockErr)
                 );
 
                 if (commit && commitAfterLock())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxLocalEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxLocalEx.java
@@ -51,9 +51,9 @@ public interface IgniteTxLocalEx extends IgniteInternalTx {
      * Finishes transaction (either commit or rollback).
      *
      * @param commit {@code True} if commit, {@code false} if rollback.
-     * @param clearThreadMap If {@code true} removes {@link GridNearTxLocal} from thread map.
+     * @param onTimeout {@code True} if rolled back asynchronously on timeout.
      * @return {@code True} if state has been changed.
      * @throws IgniteCheckedException If finish failed.
      */
-    public boolean localFinish(boolean commit, boolean clearThreadMap) throws IgniteCheckedException;
+    public boolean localFinish(boolean commit, boolean onTimeout) throws IgniteCheckedException;
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
@@ -303,7 +303,7 @@ public class IgniteTxManager extends GridCacheSharedManagerAdapter {
         for (IgniteInternalTx tx : activeTransactions()) {
             if (tx.near() && needWaitTransaction(tx, topVer)) {
                 if (log.isInfoEnabled())
-                    log.info("Forcibly rolling back near transaction: " + tx);
+                    log.info("Forcibly rolling back near transaction: " + CU.txString(tx));
 
                 ((GridNearTxLocal) tx).onTimeout();
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
@@ -295,6 +295,22 @@ public class IgniteTxManager extends GridCacheSharedManagerAdapter {
     }
 
     /**
+     * Rollback transactions blocking partition map exchange.
+     *
+     * @param topVer Initial exchange version.
+     */
+    public void rollbackOnTopologyChange(AffinityTopologyVersion topVer) {
+        for (IgniteInternalTx tx : activeTransactions()) {
+            if (needWaitTransaction(tx, topVer) && tx.near()) {
+                if (log.isInfoEnabled())
+                    log.info("Forcibly rolling back near transaction: " + tx);
+
+                tx.rollbackAsync();
+            }
+        }
+    }
+
+    /**
      * @param cacheId Cache ID.
      * @param txMap Transactions map.
      */
@@ -1719,6 +1735,7 @@ public class IgniteTxManager extends GridCacheSharedManagerAdapter {
      * @return All transactions.
      */
     public Collection<IgniteInternalTx> txs() {
+        // TODO txs() is the same as activeTransactions()
         return F.concat(false, idMap.values(), nearIdMap.values());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
@@ -301,11 +301,11 @@ public class IgniteTxManager extends GridCacheSharedManagerAdapter {
      */
     public void rollbackOnTopologyChange(AffinityTopologyVersion topVer) {
         for (IgniteInternalTx tx : activeTransactions()) {
-            if (needWaitTransaction(tx, topVer) && tx.near()) {
+            if (tx.near() && needWaitTransaction(tx, topVer)) {
                 if (log.isInfoEnabled())
                     log.info("Forcibly rolling back near transaction: " + tx);
 
-                tx.rollbackAsync();
+                ((GridNearTxLocal) tx).onTimeout();
             }
         }
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxRemoteEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxRemoteEx.java
@@ -31,9 +31,9 @@ public interface IgniteTxRemoteEx extends IgniteInternalTx {
     public void commitRemoteTx() throws IgniteCheckedException;
 
     /**
-     *
+     * @param onTimeout {@code True} if rolled back asynchronously on timeout.
      */
-    public void rollbackRemoteTx();
+    public void rollbackRemoteTx(boolean onTimeout);
 
     /**
      * @param baseVer Base version.

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxRollbackOnTopologyChangeTimeoutTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxRollbackOnTopologyChangeTimeoutTest.java
@@ -69,7 +69,7 @@ public class TxRollbackOnTopologyChangeTimeoutTest extends GridCommonAbstractTes
     private static final int TX_TIMEOUT = 1000;
 
     /**  */
-    private static final int TX_COUNT = 100;
+    private static final int TX_COUNT = 10;
 
     /**  */
     private static final int MAX_BACKUPS = 3;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxRollbackOnTopologyChangeTimeoutTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxRollbackOnTopologyChangeTimeoutTest.java
@@ -1,0 +1,512 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.internal.processors.cache.transactions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCompute;
+import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.binary.BinaryObjectBuilder;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.configuration.TransactionConfiguration;
+import org.apache.ignite.internal.IgniteFutureCancelledCheckedException;
+import org.apache.ignite.internal.NodeStoppingException;
+import org.apache.ignite.internal.cluster.ClusterTopologyCheckedException;
+import org.apache.ignite.internal.processors.cache.CacheInvalidStateException;
+import org.apache.ignite.internal.processors.cache.CacheStoppedException;
+import org.apache.ignite.internal.util.lang.gridfunc.ReadOnlyCollectionView2X;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.G;
+import org.apache.ignite.internal.util.typedef.X;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteCallable;
+import org.apache.ignite.lang.IgniteFuture;
+import org.apache.ignite.lang.IgniteFutureTimeoutException;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.apache.ignite.transactions.Transaction;
+
+import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
+import static org.apache.ignite.transactions.TransactionIsolation.REPEATABLE_READ;
+
+/**
+ * Tests rollback transactions on topology change
+ */
+public class TxRollbackOnTopologyChangeTimeoutTest extends GridCommonAbstractTest {
+
+    /**  */
+    private static final long ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT = 500;
+
+    /**  */
+    private static final long TX_TIMEOUT = 5000;
+
+    /**  */
+    private static final int MAX_BACKUPS = 3;
+
+    /**  */
+    private static final int MAX_SRV_NODES = MAX_BACKUPS + 1;
+
+    /**  */
+    private static final int CLIENT_IDX = MAX_SRV_NODES;
+
+    /**  */
+    private static final int MAX_CLNT_NODES = 3;
+
+    /** IP finder. */
+    private static final TcpDiscoveryIpFinder IP_FINDER = new TcpDiscoveryVmIpFinder(true);
+
+    /**  */
+    private static final String TMP_CACHE = "tmpCache";
+
+    /**  */
+    private List<Callable<Ignite>> shuffleOps;
+
+    /**  */
+    private Collection<Callable<Ignite>> minorOps;
+
+    /**  */
+    private AtomicInteger binaryTypeIdx;
+
+    /**  */
+    private int backups;
+
+    /**  */
+    private CountDownLatch finishTxLatch;
+
+    /**  */
+    private CountDownLatch closeTxLatch;
+
+    /**  */
+    private Collection<Exception> txErrors;
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        super.beforeTestsStarted();
+
+        System.setProperty(IgniteSystemProperties.IGNITE_START_CACHES_ON_JOIN, "true");
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        super.afterTestsStopped();
+
+        System.clearProperty(IgniteSystemProperties.IGNITE_START_CACHES_ON_JOIN);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        int idx = getTestIgniteInstanceIndex(igniteInstanceName);
+
+        if (idx >= CLIENT_IDX)
+            cfg.setClientMode(true);
+
+        TcpDiscoverySpi disco = (TcpDiscoverySpi)cfg.getDiscoverySpi();
+
+        disco.setIpFinder(IP_FINDER);
+
+        TransactionConfiguration tcfg = cfg.getTransactionConfiguration();
+
+        tcfg.setRollbackOnTopologyChangeTimeout(ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT);
+
+        CacheConfiguration txCache = defaultCacheConfiguration();
+
+        txCache.setBackups(backups);
+
+        cfg.setCacheConfiguration(txCache);
+
+        return cfg;
+    }
+
+    /**  */
+    private void startTx() throws Exception {
+        final List<Ignite> grids = G.allGrids();
+
+        final AtomicInteger idx = new AtomicInteger(0);
+
+        final Random rnd = new Random();
+
+        final CountDownLatch startTxLatch = new CountDownLatch(grids.size());
+
+        final Collection<Exception> errors = new LinkedBlockingQueue<>();
+
+        txErrors = errors;
+
+        finishTxLatch = new CountDownLatch(1);
+
+        closeTxLatch = new CountDownLatch(grids.size());
+
+        multithreadedAsync(new Runnable() {
+            @Override public void run() {
+                int i = idx.getAndIncrement();
+
+                Ignite grid = grids.get(i);
+
+                Thread.currentThread().setName("startTx-" + grid.name());
+
+                IgniteCache<Integer, String> cache = grid.cache(DEFAULT_CACHE_NAME);
+
+                Transaction tx = grid.transactions().txStart(PESSIMISTIC, REPEATABLE_READ, 0, 1);
+                try {
+                    if (rnd.nextBoolean())
+                        tx.timeout(TX_TIMEOUT);
+
+                    int key = rnd.nextInt(grids.size());
+
+                    IgniteFuture<Void> fut = cache.putAsync(key, Thread.currentThread().getName());
+
+                    try {
+                        fut.get(ROLLBACK_ON_TOPOLOGY_CHANGE_TIMEOUT / 2);
+                    }
+                    catch (IgniteFutureTimeoutException ignore) {
+                    }
+
+                    startTxLatch.countDown();
+
+                    fut.get();
+
+                    finishTxLatch.await();
+
+                    cache.put(key + 1, Thread.currentThread().getName());
+                }
+                catch (Exception e) {
+                    Exception exp = X.cause(e, CacheStoppedException.class);
+
+                    if (exp == null)
+                        exp = X.cause(e, IgniteFutureCancelledCheckedException.class);
+
+                    if (exp == null)
+                        exp = X.cause(e, NodeStoppingException.class);
+
+                    if (exp == null) {
+                        exp = X.cause(e, ClusterTopologyCheckedException.class);
+
+                        if (exp != null && !(exp.getMessage() != null && exp.getMessage().startsWith(
+                            "Failed to acquire lock for keys (primary node left grid, retry transaction if possible)")))
+                            exp = null;
+                    }
+
+                    if (exp == null) {
+                        exp = X.cause(e, CacheInvalidStateException.class);
+
+                        if (exp != null && !(exp.getMessage() != null && exp.getMessage().startsWith(
+                            "Failed to perform cache operation (cluster is not activated)")))
+                            exp = null;
+                    }
+
+                    if (exp != null) {
+                        if (grid.log().isInfoEnabled())
+                            grid.log().info("Expected transaction error: " + exp);
+                    }
+                    else {
+                        errors.add(e);
+
+                        U.error(grid.log(), "Unexpected transaction error", e);
+                    }
+                }
+                finally {
+                    U.closeQuiet(tx);
+
+                    closeTxLatch.countDown();
+                }
+            }
+        }, grids.size());
+
+        startTxLatch.await();
+    }
+
+    /**  */
+    private void checkTxErrors() throws Exception {
+        finishTxLatch.countDown();
+
+        closeTxLatch.await();
+
+        for (Exception e : txErrors)
+            U.error(log, "Unexpected transaction error", e);
+
+        if (!txErrors.isEmpty())
+            fail("Unexpected transaction error occurs. See log for details");
+    }
+
+    /**  */
+    private void initMinorTopologyChangeOps() {
+        shuffleOps = new ArrayList<>();
+
+        shuffleOps.add(new Callable<Ignite>() {
+            @Override public Ignite call() {
+                Ignite grid = F.rand(G.allGrids());
+
+                if (grid.log().isInfoEnabled())
+                    grid.log().info(">>> Deactivate cluster");
+
+                grid.active(false);
+
+                return grid;
+            }
+        });
+
+        shuffleOps.add(new Callable<Ignite>() {
+            @Override public Ignite call() {
+                Ignite grid = F.rand(G.allGrids());
+
+                if (grid.log().isInfoEnabled())
+                    grid.log().info(">>> Create cache");
+
+                CacheConfiguration ccfg = defaultCacheConfiguration();
+
+                ccfg.setName(TMP_CACHE);
+
+                grid.createCache(ccfg);
+
+                return grid;
+            }
+        });
+
+        shuffleOps.add(new Callable<Ignite>() {
+            @Override public Ignite call() {
+                Ignite grid = F.rand(G.allGrids());
+
+                if (grid.log().isInfoEnabled())
+                    grid.log().info(">>> Register binary type");
+
+                String typeName = TxRollbackOnTopologyChangeTimeoutTest.class.getSimpleName() +
+                    binaryTypeIdx.getAndIncrement();
+
+                BinaryObjectBuilder builder = grid.binary().builder(typeName);
+
+                builder.setField("gridName", grid.name());
+
+                BinaryObject binObj = builder.build();
+
+                IgniteCompute compute = grid.compute(grid.cluster());
+
+                String res = compute.call(new GetBinaryObjectType(binObj));
+
+                assertEquals(res, typeName);
+
+                return grid;
+            }
+        });
+
+        minorOps = new ReadOnlyCollectionView2X<>(shuffleOps, Collections.<Callable<Ignite>>singleton(new Callable<Ignite>() {
+            @Override public Ignite call() {
+                Ignite grid = F.rand(G.allGrids());
+
+                if (grid.log().isInfoEnabled())
+                    grid.log().info(">>> Destroy cache");
+
+                grid.cache(TMP_CACHE).destroy();
+
+                return grid;
+            }
+        }));
+    }
+
+    /**  */
+    private void doMinorTopologyChanges() throws Exception {
+        Collections.shuffle(shuffleOps);
+
+        for (Callable<Ignite> op : minorOps) {
+            startTx();
+
+            Ignite grid = op.call();
+
+            checkTxErrors();
+
+            if (!grid.active()) {
+                if (grid.log().isInfoEnabled())
+                    grid.log().info(">>> Restore active state");
+
+                grid.active(true);
+            }
+        }
+    }
+
+    /**  */
+    private List<Runnable> createMajorTopologyChangeOps() {
+        List<Runnable> ops = new ArrayList<>();
+
+        ops.add(new RX() {
+            @Override public void runX() throws Exception {
+                startGrid(0);
+            }
+        });
+
+        ops.add(new RX() {
+            @Override public void runX() throws Exception {
+                startGrid(CLIENT_IDX);
+            }
+        });
+
+        return ops;
+    }
+
+    /**  */
+    private void startStopServers() throws Exception {
+        startGrid(0);
+
+        doMinorTopologyChanges();
+
+        startStopClients();
+
+        for (int i = 1; i < MAX_SRV_NODES; ++i) {
+            startTx();
+
+            startGrid(i);
+
+            checkTxErrors();
+
+            doMinorTopologyChanges();
+
+            startStopClients();
+        }
+        for (int i = 0; i < MAX_SRV_NODES; ++i) {
+            startTx();
+
+            stopGrid(i);
+
+            checkTxErrors();
+
+            if (i < MAX_CLNT_NODES - 1) {
+                doMinorTopologyChanges();
+
+                startStopClients();
+            }
+        }
+    }
+
+    /**  */
+    private void startStopClients() throws Exception {
+        for (int i = 0; i < MAX_CLNT_NODES; ++i) {
+            startGrid(CLIENT_IDX + i);
+
+            doMinorTopologyChanges();
+        }
+        for (int i = 0; i < MAX_CLNT_NODES; ++i) {
+            startTx();
+
+            stopGrid(CLIENT_IDX + i);
+
+            checkTxErrors();
+
+            doMinorTopologyChanges();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", true);
+
+        U.resolveWorkDirectory(U.defaultWorkDirectory(), "binary_meta", true);
+
+        binaryTypeIdx = new AtomicInteger();
+
+        initMinorTopologyChangeOps();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        shuffleOps = null;
+
+        minorOps = null;
+    }
+
+    /**  */
+    private void testRollbackTxOnTopChange(int backups) throws Exception {
+        assert backups <= MAX_BACKUPS : "Maximum backups is exceeded [cur=" + backups + ", max=" + MAX_BACKUPS + ']';
+
+        this.backups = backups;
+
+        try {
+            startStopServers();
+        }
+        finally {
+            stopAllGrids();
+        }
+    }
+
+    /**  */
+    public void testBackups0() throws Exception {
+        testRollbackTxOnTopChange(0);
+    }
+
+    /**  */
+    public void testBackups1() throws Exception {
+        testRollbackTxOnTopChange(1);
+    }
+
+    /**  */
+    public void testBackups2() throws Exception {
+        testRollbackTxOnTopChange(2);
+    }
+
+    /**  */
+    public void testBackups3() throws Exception {
+        testRollbackTxOnTopChange(3);
+    }
+
+    /**  */
+    private static class GetBinaryObjectType implements IgniteCallable<String> {
+
+        /**  */
+        private BinaryObject binaryObject;
+
+        /**  */
+        public GetBinaryObjectType(BinaryObject binaryObject) {
+            this.binaryObject = binaryObject;
+        }
+
+        /** {@inheritDoc} */
+        @Override public String call() throws Exception {
+            return binaryObject.type().typeName();
+        }
+    }
+
+    private abstract static class RX implements Runnable {
+
+        /** {@inheritDoc} */
+        @Override public void run() {
+            try {
+                runX();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /**  */
+        protected abstract void runX() throws Exception;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite6.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite6.java
@@ -29,6 +29,7 @@ import org.apache.ignite.internal.processors.cache.distributed.IgnitePessimistic
 import org.apache.ignite.internal.processors.cache.transactions.TxRollbackOnTimeoutNearCacheTest;
 import org.apache.ignite.internal.processors.cache.transactions.TxRollbackOnTimeoutNoDeadlockDetectionTest;
 import org.apache.ignite.internal.processors.cache.transactions.TxRollbackOnTimeoutTest;
+import org.apache.ignite.internal.processors.cache.transactions.TxRollbackOnTopologyChangeTimeoutTest;
 
 /**
  * Test suite.
@@ -51,6 +52,7 @@ public class IgniteCacheTestSuite6 extends TestSuite {
         suite.addTestSuite(CacheExchangeMergeTest.class);
 
         suite.addTestSuite(TxRollbackOnTimeoutTest.class);
+        suite.addTestSuite(TxRollbackOnTopologyChangeTimeoutTest.class);
         suite.addTestSuite(TxRollbackOnTimeoutNoDeadlockDetectionTest.class);
         suite.addTestSuite(TxRollbackOnTimeoutNearCacheTest.class);
         suite.addTestSuite(IgniteCacheThreadLocalTxTest.class);


### PR DESCRIPTION
Add property TransactionConfiguration.rollbackOnTopologyChangeTimeout.
Check rollbackOnTopologyChangeTimeout on partition release and partition map exchange waiting.
Perform cancelOnTopologyChange() for near futures and rollbackOnTopologyChange() for near transactions.
Add TxRollbackOnTopologyChangeTimeoutTest to IgniteCacheTestSuite6.