### PR TITLE
IGNITE-7083 Reduce memory usage of CachePartitionFullCountersMap

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
@@ -131,7 +131,7 @@ public class CachePartitionFullCountersMap implements Serializable {
     	Map<Integer, T2<Long, Long>> map0 = U.newHashMap(map.partsCnt);
     
     	for (int p = 0; p < map.partsCnt; p++)     		    	
-    		map0.put(p, new T2<>(map.initialUpdCntrs==null?0:map.initialUpdCntrs[p], map.updCntrs==null?0:map.updCntrs[p]));
+             map0.put(p, new T2<>(map.initialUpdCntrs == null ? 0 : map.initialUpdCntrs[p], map.updCntrs == null ? 0 : map.updCntrs[p]));
     		    	
         return map0;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
@@ -20,8 +20,6 @@ package org.apache.ignite.internal.processors.cache.distributed.dht.preloader;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.internal.U;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.processors.cache.distributed.dht.preloader;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
-
 import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.internal.U;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/CachePartitionFullCountersMap.java
@@ -43,10 +43,10 @@ public class CachePartitionFullCountersMap implements Serializable {
      * @param other Map to copy.
      */
     public CachePartitionFullCountersMap(CachePartitionFullCountersMap other) {
-    	if(other.initialUpdCntrs != null)
+    	if (other.initialUpdCntrs != null)
     		initialUpdCntrs = Arrays.copyOf(other.initialUpdCntrs, other.initialUpdCntrs.length);
     	
-    	if(updCntrs != null) 
+    	if (other.updCntrs != null) 
     		updCntrs = Arrays.copyOf(other.updCntrs, other.updCntrs.length);
     }
 
@@ -64,7 +64,7 @@ public class CachePartitionFullCountersMap implements Serializable {
      * @return Initial update counter for the partition with the given ID.
      */
     public long initialUpdateCounter(int p) {
-    	if(initialUpdCntrs == null) 
+    	if (initialUpdCntrs == null) 
     		return 0;
     	else 
     		return initialUpdCntrs[p];
@@ -77,7 +77,7 @@ public class CachePartitionFullCountersMap implements Serializable {
      * @return Update counter for the partition with the given ID.
      */
     public long updateCounter(int p) {
-    	if(updCntrs == null) 
+    	if (updCntrs == null) 
     		return 0;
     	else
     		return updCntrs[p];
@@ -90,8 +90,8 @@ public class CachePartitionFullCountersMap implements Serializable {
      * @param initialUpdCntr Initial update counter to set.
      */
     public void initialUpdateCounter(int p, long initialUpdCntr) {
-    	if(initialUpdCntrs == null) {
-    		if(initialUpdCntr != 0L) 
+    	if (initialUpdCntrs == null) {
+    		if (initialUpdCntr != 0L) 
     			initialUpdCntrs = new long[partsCnt];
     		else 
     			return;    		    		
@@ -106,8 +106,8 @@ public class CachePartitionFullCountersMap implements Serializable {
      * @param updCntr Update counter to set.
      */
     public void updateCounter(int p, long updCntr) {
-    	if(updCntrs == null) {
-    		if(updCntr != 0L) 
+    	if (updCntrs == null) {
+    		if (updCntr != 0L) 
     			updCntrs = new long[partsCnt];
     		else 
     			return;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheExchangeMessageDuplicatedStateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheExchangeMessageDuplicatedStateTest.java
@@ -255,17 +255,14 @@ public class CacheExchangeMessageDuplicatedStateTest extends GridCommonAbstractT
                 long[] updCntrs = getFieldValue(cntrs, "updCntrs");
                 int partCnt = getFieldValue(cntrs, "partsCnt");
                 
-                if(initialUpdCntrs == null && updCntrs == null) {
-                	return;
-                }
+                if (initialUpdCntrs == null && updCntrs == null) 
+                    return;
                 
                 for (int i = 0; i < partCnt; i++) {
-                	if(initialUpdCntrs!=null) {
-                		assertEquals(0, initialUpdCntrs[i]);
-                	}
-                	if(updCntrs != null) {
-                		assertEquals(0, updCntrs[i]);
-                	}
+                    if (initialUpdCntrs != null) 
+                        assertEquals(0, initialUpdCntrs[i]);
+                    if (updCntrs != null) 
+                        assertEquals(0, updCntrs[i]);
                 }
             }
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheExchangeMessageDuplicatedStateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheExchangeMessageDuplicatedStateTest.java
@@ -253,10 +253,19 @@ public class CacheExchangeMessageDuplicatedStateTest extends GridCommonAbstractT
             for (CachePartitionFullCountersMap cntrs : partCntrs.values()) {
                 long[] initialUpdCntrs = getFieldValue(cntrs, "initialUpdCntrs");
                 long[] updCntrs = getFieldValue(cntrs, "updCntrs");
-
-                for (int i = 0; i < initialUpdCntrs.length; i++) {
-                    assertEquals(0, initialUpdCntrs[i]);
-                    assertEquals(0, updCntrs[i]);
+                int partCnt = getFieldValue(cntrs, "partsCnt");
+                
+                if(initialUpdCntrs == null && updCntrs == null) {
+                	return;
+                }
+                
+                for (int i = 0; i < partCnt; i++) {
+                	if(initialUpdCntrs!=null) {
+                		assertEquals(0, initialUpdCntrs[i]);
+                	}
+                	if(updCntrs != null) {
+                		assertEquals(0, updCntrs[i]);
+                	}
                 }
             }
         }


### PR DESCRIPTION
The Cache Partition Exchange Manager kept a copy of the already completed exchange. However, we have found that it uses a significant amount of memory. Upon further investigation using heap dump we have found that a large amount of memory is used by the CachePartitionFullCountersMap. We have also observed in most cases, these maps contains only 0s.

Therefore I propose an optimization for this: Initially the long arrays to store initial update counter and update counter in the CPFCM will be null, and when you get the value and see these tables are null then we will return 0 for the counter. We only allocate the long arrays when there is any non-zero updates to the the map.

In our tests, the amount of heap used by GridCachePartitionExchangeManager was around 70MB (67 copies of these CPFCM), after we apply the optimization it drops to around 9MB.