### PR TITLE
IGNITE-7144 Java 9: fix build issue with tools.jar not found

### DIFF
--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -57,20 +57,46 @@
     <!-- http://maven.apache.org/general.html#tools-jar-dependency -->
     <profiles>
         <profile>
-            <id>default-tools.jar</id>
+            <id>jigsaw</id>
             <activation>
-                <property>
-                    <name>java.vendor</name>
-                    <value>Oracle Corporation</value>
-                </property>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <!-- No dependencies needed by Jigsaw -->
+            <dependencies/>
+        </profile>
+
+        <profile>
+            <id>default-jdk</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
             </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
-                    <version>${java.version}</version>
                     <scope>system</scope>
+                    <version>${java.version}</version>
                     <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>osx-jdk</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../Classes/classes.jar</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                    <scope>system</scope>
+                    <version>${java.version}</version>
+                    <systemPath>${java.home}/../Classes/classes.jar</systemPath>
                 </dependency>
             </dependencies>
         </profile>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -975,40 +975,56 @@
         </profile>
 
         <profile>
-            <id>tools.jar-default</id>
+            <id>jigsaw</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <!-- No dependencies needed by Jigsaw -->
+            <dependencies/>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <source>9</source>
+                            <target>9</target>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
+        <profile>
+            <id>default-jdk</id>
             <activation>
                 <file>
                     <exists>${java.home}/../lib/tools.jar</exists>
                 </file>
             </activation>
-
             <dependencies>
                 <dependency>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
-                    <version>1.4.2</version>
                     <scope>system</scope>
+                    <version>${java.version}</version>
                     <systemPath>${java.home}/../lib/tools.jar</systemPath>
                 </dependency>
             </dependencies>
         </profile>
 
         <profile>
-            <id>tools.jar-mac</id>
-
+            <id>osx-jdk</id>
             <activation>
                 <file>
                     <exists>${java.home}/../Classes/classes.jar</exists>
                 </file>
             </activation>
-
             <dependencies>
                 <dependency>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
-                    <version>1.4.2</version>
                     <scope>system</scope>
+                    <version>${java.version}</version>
                     <systemPath>${java.home}/../Classes/classes.jar</systemPath>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
 * added profiles to parent and ignite-tools modules to detect java-9 environment and run parametrised build
 * added macOS compatibility for previouse java versions