### PR TITLE
IGNITE-7135 IgniteCluster.startNodes() returns successful ClusterStartNodeResult even though the remote process fails.

### DIFF
--- a/bin/ignite.bat
+++ b/bin/ignite.bat
@@ -133,7 +133,7 @@ set RESTART_SUCCESS_OPT=-DIGNITE_SUCCESS_FILE=%RESTART_SUCCESS_FILE%
 :: This is executed if -nojmx is not specified
 ::
 if not "%NO_JMX%" == "1" (
-    for /F "tokens=*" %%A in ('""!JAVA_HOME!\bin\java" -cp %CP% org.apache.ignite.internal.util.portscanner.GridJmxPortFinder"') do (
+    for /F "usebackq tokens=*" %%A in (`"!JAVA_HOME!\bin\java.exe -cp %CP% org.apache.ignite.internal.util.portscanner.GridJmxPortFinder"`) do (
         set JMX_PORT=%%A
     )
 )

--- a/bin/include/parseargs.bat
+++ b/bin/include/parseargs.bat
@@ -39,7 +39,7 @@
 :: )
 :: in other scripts to parse common command lines parameters.
 
-set convertArgsCmd="!JAVA_HOME!\bin\java.exe" -cp %CP% org.apache.ignite.startup.cmdline.CommandLineTransformer %*
+set convertArgsCmd=!JAVA_HOME!\bin\java.exe -Dfile.encoding=IBM866 -cp %CP% org.apache.ignite.startup.cmdline.CommandLineTransformer %*
 for /f "usebackq tokens=*" %%i in (`!convertArgsCmd!`) do set reformattedArgs=%%i
 
 for %%i in (%reformattedArgs%) do (

--- a/modules/core/src/main/java/org/apache/ignite/startup/cmdline/CommandLineTransformer.java
+++ b/modules/core/src/main/java/org/apache/ignite/startup/cmdline/CommandLineTransformer.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.startup.cmdline;
 
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -84,8 +85,9 @@ public class CommandLineTransformer {
         PrintStream ps = null;
 
         try {
-            // Intentionality configure output stream with UTF-8 encoding to support  non-ASCII named parameter values.
-            ps = new PrintStream(System.out, true, "UTF-8");
+            String encoding = System.getProperty("file.encoding", Charset.defaultCharset().name());
+
+            ps = new PrintStream(System.out, true, encoding);
 
             ps.println(transform(args));
         }

--- a/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
+++ b/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
@@ -180,15 +180,17 @@ public class StartNodeCallableImpl implements StartNodeCallable {
 
             String scriptOutputDir;
 
-            if (win) {
-                String tmpDir = env(ses, "%TEMP%", "C:\\Windows\\Temp", WINDOWS_ENCODING);
+            String dfltLogDir = igniteHome + "/work/log";
 
-                scriptOutputDir = tmpDir + "\\ignite-startNodes";
+            if (win) {
+                String logDir = env(ses, "%TMPDIR%", dfltLogDir, WINDOWS_ENCODING);
+
+                scriptOutputDir = logDir + "\\ignite-startNodes";
             }
             else { // Assume Unix.
-                String tmpDir = env(ses, "$TMPDIR", "/tmp/");
+                String logDir = env(ses, "$TMPDIR", dfltLogDir);
 
-                scriptOutputDir = tmpDir + "ignite-startNodes";
+                scriptOutputDir = logDir + "/ignite-startNodes";
             }
 
             String scriptOutputPath = scriptOutputDir + separator + scriptOutputFileName;

--- a/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
+++ b/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
@@ -431,20 +431,22 @@ public class StartNodeCallableImpl implements StartNodeCallable {
 
             proc.addTimeoutObject(to);
 
-            SB out = new SB();
+            SB out = null;
 
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(ch.getInputStream(), encoding))) {
                 String line;
 
-                boolean nl = false;
+                boolean first = true;
 
                 while ((line = reader.readLine()) != null) {
-                    if (nl)
+                    if (first)
+                        out = new SB();
+                    else
                         out.a('\n');
 
                     out.a(line);
 
-                    nl = true;
+                    first = false;
                 }
             }
             catch (InterruptedIOException ignore) {
@@ -453,7 +455,7 @@ public class StartNodeCallableImpl implements StartNodeCallable {
                 proc.removeTimeoutObject(to);
             }
 
-            return out.toString();
+            return out == null || out.length() == 0 ? null : out.toString();
         }
         finally {
             if (ch != null && ch.isConnected())

--- a/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
+++ b/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
@@ -180,22 +180,25 @@ public class StartNodeCallableImpl implements StartNodeCallable {
 
             String scriptOutputDir;
 
-            String dfltLogDir = igniteHome + "/work/log";
+            String dfltTmpDir = igniteHome + separator + "work" + separator + "log";
 
             if (win) {
-                String logDir = env(ses, "%TMPDIR%", dfltLogDir, WINDOWS_ENCODING);
+                String tmpDir = env(ses, "%TMPDIR%", dfltTmpDir, WINDOWS_ENCODING);
 
-                scriptOutputDir = logDir + "\\ignite-startNodes";
+                if ("%TMPDIR%".equals(tmpDir))
+                    tmpDir = dfltTmpDir;
+
+                scriptOutputDir = tmpDir + "\\ignite-startNodes";
             }
             else { // Assume Unix.
-                String logDir = env(ses, "$TMPDIR", dfltLogDir);
+                String logDir = env(ses, "$TMPDIR", dfltTmpDir);
 
                 scriptOutputDir = logDir + "/ignite-startNodes";
             }
 
-            String scriptOutputPath = scriptOutputDir + separator + scriptOutputFileName;
-
             shell(ses, "mkdir " + scriptOutputDir);
+
+            String scriptOutputPath = scriptOutputDir + separator + scriptOutputFileName;
 
             String findSuccess;
 

--- a/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
+++ b/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
@@ -364,7 +364,10 @@ public class StartNodeCallableImpl implements StartNodeCallable {
     private String env(Session ses, String name, String dflt, String encoding) throws JSchException {
         try {
             String res = exec(ses, "echo " + name, encoding);
-            return res == null || res.isEmpty() ? dflt : res;
+            if (res == null)
+                return dflt;
+            res = res.trim();
+            return res.isEmpty() ? dflt : res;
         }
         catch (IOException ignored) {
             return dflt;

--- a/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
+++ b/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
@@ -363,7 +363,8 @@ public class StartNodeCallableImpl implements StartNodeCallable {
      */
     private String env(Session ses, String name, String dflt, String encoding) throws JSchException {
         try {
-            return exec(ses, "echo " + name, encoding);
+            String res = exec(ses, "echo " + name, encoding);
+            return res == null || res.isEmpty() ? dflt : res;
         }
         catch (IOException ignored) {
             return dflt;


### PR DESCRIPTION
Fix windows startup scripts. Add startNodes() Windows support through task scheduling.
Check successful node startup by reading the output log.