### PR TITLE
IGNITE-7169: Missed javadoc for IgniteToDoubleFunction

### DIFF
--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/functions/IgniteToDoubleFunction.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/functions/IgniteToDoubleFunction.java
@@ -20,7 +20,11 @@ package org.apache.ignite.ml.math.functions;
 import java.io.Serializable;
 import java.util.function.ToDoubleFunction;
 
-/** */
+/**
+ * Serializable function that produces a double-valued result.
+ *
+ * @see java.util.function.ToDoubleFunction
+ */
 @FunctionalInterface
 public interface IgniteToDoubleFunction<T> extends ToDoubleFunction<T>, Serializable {
 }


### PR DESCRIPTION
fixed