### PR TITLE
IGNITE-7118 performance measurement for distributed k-means clustering

### DIFF
--- a/modules/yardstick/src/main/ml/org/apache/ignite/yardstick/ml/clustering/IgniteKMeansDistributedClustererBenchmark.java
+++ b/modules/yardstick/src/main/ml/org/apache/ignite/yardstick/ml/clustering/IgniteKMeansDistributedClustererBenchmark.java
@@ -30,13 +30,12 @@ import org.apache.ignite.yardstick.ml.DataChanger;
 
 /**
  * Ignite benchmark that performs ML Grid operations.
- * Todo: IGNITE-7118, enable this benchmark.
  */
 @SuppressWarnings("unused")
 public class IgniteKMeansDistributedClustererBenchmark extends IgniteAbstractBenchmark {
     /** */
     @IgniteInstanceResource
-    Ignite ignite;
+    private Ignite ignite;
 
     /** {@inheritDoc} */
     @Override public boolean test(Map<Object, Object> ctx) throws Exception {


### PR DESCRIPTION
- enabled benchmark after integration of necessary fix from master
-- verified with diffs overview, clean rebuild, trial execution of the benchmarks and studying results