### PR TITLE
IGNITE-7277: override equals() & hashCode() methods for JdbcTableMeta…

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinMetadataSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinMetadataSelfTest.java
@@ -200,11 +200,15 @@ public class JdbcThinMetadataSelfTest extends JdbcThinAbstractSelfTest {
             assertEquals("TABLE", rs.getString("TABLE_TYPE"));
             assertEquals("PERSON", rs.getString("TABLE_NAME"));
 
+            assertFalse(rs.next());
+
             rs = meta.getTables("", "org", "%", new String[]{"TABLE"});
             assertNotNull(rs);
             assertTrue(rs.next());
             assertEquals("TABLE", rs.getString("TABLE_TYPE"));
             assertEquals("ORGANIZATION", rs.getString("TABLE_NAME"));
+
+            assertFalse(rs.next());
 
             rs = meta.getTables("", "pers", "%", null);
             assertNotNull(rs);
@@ -212,11 +216,15 @@ public class JdbcThinMetadataSelfTest extends JdbcThinAbstractSelfTest {
             assertEquals("TABLE", rs.getString("TABLE_TYPE"));
             assertEquals("PERSON", rs.getString("TABLE_NAME"));
 
+            assertFalse(rs.next());
+
             rs = meta.getTables("", "org", "%", null);
             assertNotNull(rs);
             assertTrue(rs.next());
             assertEquals("TABLE", rs.getString("TABLE_TYPE"));
             assertEquals("ORGANIZATION", rs.getString("TABLE_NAME"));
+
+            assertFalse(rs.next());
 
             rs = meta.getTables("", "PUBLIC", "", new String[]{"WRONG"});
             assertFalse(rs.next());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/jdbc/JdbcTableMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/jdbc/JdbcTableMeta.java
@@ -17,9 +17,11 @@
 
 package org.apache.ignite.internal.processors.odbc.jdbc;
 
+import java.util.Objects;
 import org.apache.ignite.binary.BinaryObjectException;
 import org.apache.ignite.internal.binary.BinaryReaderExImpl;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
+import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.S;
 
 /**
@@ -78,5 +80,23 @@ public class JdbcTableMeta implements JdbcRawBinarylizable {
     /** {@inheritDoc} */
     @Override public String toString() {
         return S.toString(JdbcTableMeta.class, this);
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        JdbcTableMeta meta = (JdbcTableMeta)o;
+
+        return F.eq(schemaName, meta.schemaName) && F.eq(tblName, meta.tblName);
+    }
+
+    /** {@inheritDoc} */
+    @Override public int hashCode() {
+        return Objects.hash(schemaName, tblName);
     }
 }


### PR DESCRIPTION
… to prevent tables duplication at the tables metadata result set.