### PR TITLE
ignite-7396: fixed NullPointerException

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -1246,8 +1246,12 @@ public abstract class IgniteUtils {
         // In bytes.
         double totalOffheap = 0.0;
 
-        for (ClusterNode n : nodesPerJvm(nodes))
-            totalOffheap += n.<Long>attribute(ATTR_DATA_REGIONS_OFFHEAP_SIZE);
+        for (ClusterNode n : nodesPerJvm(nodes)) {
+            Long val = n.<Long>attribute(ATTR_DATA_REGIONS_OFFHEAP_SIZE);
+
+            if (val != null)
+                totalOffheap += val;
+        }
 
         return roundedHeapSize(totalOffheap, precision);
     }


### PR DESCRIPTION
In case of a newly joined node does not specify ATTR_DATA_REGIONS_OFFHEAP_SIZE via node attributes, IgniteUtils.offheapSize() throws NullPointerException