### PR TITLE
IGNITE-898: Fixed error when path to Ignite folder contains whitespaces

### DIFF
--- a/bin/ignite.bat
+++ b/bin/ignite.bat
@@ -98,7 +98,6 @@ set PROG_NAME=ignite.bat
 if "%OS%" == "Windows_NT" set PROG_NAME=%~nx0%
 
 :run
-
 ::
 :: Set IGNITE_LIBS
 ::
@@ -119,8 +118,10 @@ if %ERRORLEVEL% neq 0 (
 ::
 :: Process 'restart'.
 ::
-set RANDOM_NUMBER_COMMAND="!JAVA_HOME!\bin\java.exe" -cp %CP% org.apache.ignite.startup.cmdline.CommandLineRandomNumberGenerator
-for /f "usebackq tokens=*" %%i in (`!RANDOM_NUMBER_COMMAND!`) do set RANDOM_NUMBER=%%i
+set RANDOM_NUMBER_COMMAND="!JAVA_HOME!\bin\java.exe" -cp "%CP%" org.apache.ignite.startup.cmdline.CommandLineRandomNumberGenerator
+for /f "usebackq tokens=*" %%i in (`"!RANDOM_NUMBER_COMMAND!"`) do (
+    set RANDOM_NUMBER=%%i
+)
 
 set RESTART_SUCCESS_FILE="%IGNITE_HOME%\work\ignite_success_%RANDOM_NUMBER%"
 set RESTART_SUCCESS_OPT=-DIGNITE_SUCCESS_FILE=%RESTART_SUCCESS_FILE%
@@ -133,7 +134,8 @@ set RESTART_SUCCESS_OPT=-DIGNITE_SUCCESS_FILE=%RESTART_SUCCESS_FILE%
 :: This is executed if -nojmx is not specified
 ::
 if not "%NO_JMX%" == "1" (
-    for /F "usebackq tokens=*" %%A in (`"!JAVA_HOME!\bin\java.exe -cp %CP% org.apache.ignite.internal.util.portscanner.GridJmxPortFinder"`) do (
+    set JMX_PORT="!JAVA_HOME!\bin\java.exe" -cp "%CP%" org.apache.ignite.internal.util.portscanner.GridJmxPortFinder
+    for /f "usebackq tokens=*" %%A in (`"!JMX_PORT!"`) do (
         set JMX_PORT=%%A
     )
 )

--- a/bin/include/build-classpath.bat
+++ b/bin/include/build-classpath.bat
@@ -27,20 +27,19 @@
 
 for /D %%F in (modules\*) do if not %%F == "modules" call :includeToClassPath %%F
 
-for /D %%F in (%IGNITE_HOME%\modules\*) do if not %%F == "%IGNITE_HOME%\modules" call :includeToClassPath %%F
-
+for /F %%F in ('dir /A:D /b "%IGNITE_HOME%\modules\*" /b') do call :includeToClassPath "%IGNITE_HOME%\modules\%%F"
 goto :eof
 
 :includeToClassPath
-if exist "%1\target\" (
-    if exist "%1\target\classes\" call :concat %1\target\classes
+if exist "%~1\target\" (
+    if exist "%~1\target\classes\" call :concat "%~1\target\classes"
 
-    if exist "%1\target\test-classes\" call :concat %1\target\test-classes
+    if exist "%~1\target\test-classes\" call :concat "%~1\target\test-classes"
 
-    if exist "%1\target\libs\" call :concat %1\target\libs\*
+    if exist "%~1\target\libs\" call :concat "%~1\target\libs\*"
 )
 goto :eof
 
 :concat
-set IGNITE_LIBS=%IGNITE_LIBS%;%1
+	set IGNITE_LIBS=%IGNITE_LIBS%;%~1
 goto :eof

--- a/bin/include/build-classpath.sh
+++ b/bin/include/build-classpath.sh
@@ -42,6 +42,9 @@ case "`uname`" in
 esac
 
 includeToClassPath() {
+    SAVEIFS=$IFS
+    IFS=$(echo -en "\n\b")
+
     for file in $1/*
     do
         if [ -d ${file} ] && [ -d "${file}/target" ]; then
@@ -58,6 +61,8 @@ includeToClassPath() {
             fi
         fi
     done
+
+    IFS=$SAVEIFS
 }
 
 #
@@ -68,4 +73,4 @@ includeToClassPath modules
 #
 # Include target libraries for opensourse modules to classpath.
 #
-includeToClassPath ${IGNITE_HOME}/modules
+includeToClassPath "${IGNITE_HOME}"/modules

--- a/bin/include/parseargs.bat
+++ b/bin/include/parseargs.bat
@@ -39,8 +39,9 @@
 :: )
 :: in other scripts to parse common command lines parameters.
 
-set convertArgsCmd=!JAVA_HOME!\bin\java.exe -Dfile.encoding=IBM866 -cp %CP% org.apache.ignite.startup.cmdline.CommandLineTransformer %*
-for /f "usebackq tokens=*" %%i in (`!convertArgsCmd!`) do set reformattedArgs=%%i
+set convertArgsCmd="!JAVA_HOME!\bin\java.exe" -Dfile.encoding=IBM866 -cp "%CP%" org.apache.ignite.startup.cmdline.CommandLineTransformer %*
+
+for /f "usebackq tokens=*" %%i in (`"!convertArgsCmd!"`) do set reformattedArgs=%%i
 
 for %%i in (%reformattedArgs%) do (
     if "%%i" == "CommandLineTransformerError" exit /b 1

--- a/bin/include/setenv.bat
+++ b/bin/include/setenv.bat
@@ -41,12 +41,16 @@ goto :eof
 :: The following libraries are required for Ignite.
 set IGNITE_LIBS=%IGNITE_HOME%\libs\*
 
-for /D %%F in (%IGNITE_HOME%\libs\*) do if not "%%F" == "%IGNITE_HOME%\libs\optional" call :concat %%F\*
+if not exist "%IGNITE_LIBS%" goto :eof
+
+for /F %%F in ('dir /A:D /b "%IGNITE_LIBS%"') do (
+	if not "%%F" == "optional" call :concat "%IGNITE_HOME%\libs\%%F\*"
+)
 
 if defined USER_LIBS set IGNITE_LIBS=%USER_LIBS%;%IGNITE_LIBS%
 
 goto :eof
 
 :concat
-set IGNITE_LIBS=%IGNITE_LIBS%;%1
+set IGNITE_LIBS=%IGNITE_LIBS%;%~1
 goto :eof

--- a/bin/include/setenv.sh
+++ b/bin/include/setenv.sh
@@ -56,12 +56,17 @@ esac
 #
 IGNITE_LIBS="${IGNITE_HOME}/libs/*"
 
+SAVEIFS=$IFS
+IFS=$(echo -en "\n\b")
+
 for file in ${IGNITE_HOME}/libs/*
 do
     if [ -d ${file} ] && [ "${file}" != "${IGNITE_HOME}"/libs/optional ]; then
         IGNITE_LIBS=${IGNITE_LIBS}${SEP}${file}/*
     fi
 done
+
+IFS=$SAVEIFS
 
 if [ "${USER_LIBS}" != "" ]; then
     IGNITE_LIBS=${USER_LIBS}${SEP}${IGNITE_LIBS}


### PR DESCRIPTION
 * Fixed error when path to ignite folder contains whitespaces
 * Fixed error when path to ignite folder contains whitespaces (for Windows batch files)
 * Fixed condition operator for paths with spaces
 * Returned full path to java.exe