### PR TITLE
IGNITE-7640: make DiscoveryDataClusterState immutable

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -858,9 +858,6 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
 
         DiscoveryDataClusterState state = cctx.kernalContext().state().clusterState();
 
-        if (state.transitionError() != null)
-            changeGlobalStateE = state.transitionError();
-
         if (req.activeChanged()) {
             if (req.activate()) {
                 if (log.isInfoEnabled()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -136,13 +136,6 @@ public final class DiscoveryDataClusterState implements Serializable {
         @Nullable Set<UUID> transitionNodes,
         @Nullable GridFutureAdapter<Boolean> transitionFut
     ) {
-        assert (transitionReqId == null && transitionTopVer == null &&
-            transitionNodes == null && transitionFut == null)
-            ||
-            (transitionReqId != null && transitionTopVer != null &&
-                transitionNodes != null && transitionFut != null) :
-            "The main invariant has broken.";
-
         this.prevState = prevState;
         this.active = active;
         this.baselineTopology = baselineTopology;
@@ -156,7 +149,8 @@ public final class DiscoveryDataClusterState implements Serializable {
      * @return Local flag for state transition result (global state is updated asynchronously by custom message).
      */
     public boolean transitionResult(boolean waitForTransition) {
-        assert transitionFut != null;
+        if (transitionFut == null)
+            return false;
 
         if (transitionFut.isDone() || waitForTransition) {
             try {
@@ -177,18 +171,16 @@ public final class DiscoveryDataClusterState implements Serializable {
      * @param active New cluster state.
      */
     public void setTransitionResult(boolean active) {
-        assert transitionFut != null;
-
-        transitionFut.onDone(active);
+        if (transitionFut != null)
+            transitionFut.onDone(active);
     }
 
     /**
      * Registers listener closure to be asynchronously notified whenever transition result completes.
      */
     public void listen(IgniteInClosure<IgniteInternalFuture<Boolean>> c) {
-        assert transitionFut != null;
-
-        transitionFut.listen(c);
+        if (transitionFut != null)
+            transitionFut.listen(c);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -152,7 +152,7 @@ public final class DiscoveryDataClusterState implements Serializable {
      * @param reqId Request ID.
      * @param active New cluster state.
      */
-    public DiscoveryDataClusterState setTransitionResult(UUID reqId, boolean active) {
+    public DiscoveryDataClusterState withTransitionResult(UUID reqId, boolean active) {
         if (reqId.equals(transitionReqId))
             return new DiscoveryDataClusterState(this.prevState, this.active, this.baselineTopology,
                 this.transitionReqId, this.transitionTopVer, this.transitionNodes, active);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -174,20 +174,6 @@ public final class DiscoveryDataClusterState implements Serializable {
      * Discovery cluster state is changed asynchronously by discovery message, this methods changes local status
      * for public API calls.
      *
-     * @param reqId Request ID.
-     * @param active New cluster state.
-     */
-    public void setTransitionResult(UUID reqId, boolean active) {
-        assert transitionFut != null;
-
-        if (reqId.equals(transitionReqId))
-            transitionFut.onDone(active);
-    }
-
-    /**
-     * Discovery cluster state is changed asynchronously by discovery message, this methods changes local status
-     * for public API calls.
-     *
      * @param active New cluster state.
      */
     public void setTransitionResult(boolean active) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -72,7 +72,7 @@ public final class DiscoveryDataClusterState implements Serializable {
      * Local flag for state transition active state result (global state is updated asynchronously by custom message),
      * {@code null} means that state change is not completed yet.
      */
-    @Nullable public transient final GridFutureAdapter<Boolean> transitionFut;
+    @Nullable private transient final GridFutureAdapter<Boolean> transitionFut;
 
     /**
      * Previous cluster state if this state is a transition state and it was not received by a joining node.
@@ -145,8 +145,7 @@ public final class DiscoveryDataClusterState implements Serializable {
             ||
             (transitionReqId != null && transitionTopVer != null &&
                 transitionNodes != null && transitionFut != null) :
-            (transitionReqId != null)+ " " +(transitionTopVer != null)+" "+
-                (transitionNodes != null)+ " " + (transitionFut != null);
+            "The main invariant has broken.";
 
         this.prevState = prevState;
         this.active = active;
@@ -202,7 +201,7 @@ public final class DiscoveryDataClusterState implements Serializable {
     }
 
     /**
-     * @return Future for transitin result.
+     * Registers listener closure to be asynchronously notified whenever transition result completes.
      */
     public void listen(IgniteInClosure<IgniteInternalFuture<Boolean>> c) {
         assert transitionFut != null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -79,7 +79,8 @@ public final class DiscoveryDataClusterState implements Serializable {
      * @return State instance.
      */
     static DiscoveryDataClusterState createState(boolean active, @Nullable BaselineTopology baselineTopology) {
-        return new DiscoveryDataClusterState(null, active, baselineTopology, null, null, null, null);
+        return new DiscoveryDataClusterState(null, active, baselineTopology, null,
+            null, null, null);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -253,6 +253,19 @@ public final class DiscoveryDataClusterState implements Serializable {
             prevState;
     }
 
+    /**
+     * Add transition future which disappeared after deserialization.
+     *
+     * @return Cluster state with future.
+     */
+    public DiscoveryDataClusterState withFuture() {
+        if (transitionFut != null || !transition())
+            return this;
+
+        return new DiscoveryDataClusterState(prevState, active, baselineTopology, transitionReqId, transitionTopVer,
+            transitionNodes, new GridFutureAdapter<>());
+    }
+
     /** {@inheritDoc} */
     @Override public String toString() {
         return S.toString(DiscoveryDataClusterState.class, this);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -72,12 +72,12 @@ public final class DiscoveryDataClusterState implements Serializable {
      * Local future for state transition active state result (global state is updated asynchronously by custom message),
      * {@code null} means state is not transition.
      */
-    @Nullable private transient final GridFutureAdapter<Boolean> transitionFut;
+    @Nullable private final transient GridFutureAdapter<Boolean> transitionFut;
 
     /**
      * Previous cluster state if this state is a transition state and it was not received by a joining node.
      */
-    private transient final DiscoveryDataClusterState prevState;
+    private final transient DiscoveryDataClusterState prevState;
 
     /**
      * @param active Current status.
@@ -108,7 +108,7 @@ public final class DiscoveryDataClusterState implements Serializable {
         assert !F.isEmpty(transitionNodes) : transitionNodes;
         assert prevState != null;
 
-        GridFutureAdapter<Boolean> fut = new GridFutureAdapter<Boolean>();
+        GridFutureAdapter<Boolean> fut = new GridFutureAdapter<>();
 
         return new DiscoveryDataClusterState(
             prevState,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -69,8 +69,8 @@ public final class DiscoveryDataClusterState implements Serializable {
     @Nullable private final Set<UUID> transitionNodes;
 
     /**
-     * Local flag for state transition active state result (global state is updated asynchronously by custom message),
-     * {@code null} means that state change is not completed yet.
+     * Local future for state transition active state result (global state is updated asynchronously by custom message),
+     * {@code null} means state is not transition.
      */
     @Nullable private transient final GridFutureAdapter<Boolean> transitionFut;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/DiscoveryDataClusterState.java
@@ -101,8 +101,7 @@ public final class DiscoveryDataClusterState implements Serializable {
         @Nullable BaselineTopology baselineTopology,
         UUID transitionReqId,
         AffinityTopologyVersion transitionTopVer,
-        Set<UUID> transitionNodes,
-        @Nullable Boolean transitionRes
+        Set<UUID> transitionNodes
     ) {
         assert transitionReqId != null;
         assert transitionTopVer != null;
@@ -110,9 +109,6 @@ public final class DiscoveryDataClusterState implements Serializable {
         assert prevState != null;
 
         GridFutureAdapter<Boolean> fut = new GridFutureAdapter<Boolean>();
-
-        if (transitionRes != null)
-            fut.onDone(transitionRes);
 
         return new DiscoveryDataClusterState(
             prevState,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -667,9 +667,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
         BaselineStateAndHistoryData stateDiscoData = (BaselineStateAndHistoryData)data.commonData();
 
         if (stateDiscoData != null) {
-            DiscoveryDataClusterState state = stateDiscoData.globalState;
-
-            globalState = state;
+            globalState = stateDiscoData.globalState;
 
             if (stateDiscoData.recentHistory != null) {
                 for (BaselineTopologyHistoryItem item : stateDiscoData.recentHistory.history())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -374,7 +374,6 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
     /** {@inheritDoc} */
     @Override public void onStateFinishMessage(ChangeGlobalStateFinishMessage msg) {
         UUID transitionRequestId = globalState.transitionRequestId();
-        DiscoveryDataClusterState state = globalState;
 
         if (msg.requestId().equals(transitionRequestId)) {
             log.info("Received state change finish message: " + msg.clusterActive());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -200,7 +200,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
             assert !(transitionRes == null && waitForTransition) : "Forgot to set result in future.";
 
             // Use null as false
-            return transitionRes == true;
+            return transitionRes == null ? false : transitionRes;
         }
         else
             return globalState.active();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -449,14 +449,18 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
                 BaselineTopologyHistoryItem bltHistItem = BaselineTopologyHistoryItem.fromBaseline(
                     state.baselineTopology());
 
-                globalState = DiscoveryDataClusterState.createTransitionState(
+                state = DiscoveryDataClusterState.createTransitionState(
                     state,
                     msg.activate(),
                     msg.activate() ? msg.baselineTopology() : state.baselineTopology(),
                     msg.requestId(),
                     topVer,
-                    nodeIds,
-                    msg.forceChangeBaselineTopology() ? msg.activate() : null);
+                    nodeIds);
+
+                if (msg.forceChangeBaselineTopology())
+                    state.setTransitionResult(msg.activate());
+
+                globalState = state;
 
                 AffinityTopologyVersion stateChangeTopVer = topVer.nextMinorVersion();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -356,7 +356,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
         if (msg.requestId().equals(state.transitionRequestId())) {
             log.info("Received state change finish message: " + msg.clusterActive());
 
-            globalState = globalState.finish(msg.success());
+            globalState = state.finish(msg.success());
 
             afterStateChangeFinished(msg.id(), msg.success());
 
@@ -853,8 +853,10 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
         if (node.isClient() || node.isDaemon())
             return null;
 
+        DiscoveryDataClusterState state = globalState;
+
         if (discoData.joiningNodeData() == null) {
-            if (globalState.baselineTopology() != null) {
+            if (state.baselineTopology() != null) {
                 String msg = "Node not supporting BaselineTopology" +
                     " is not allowed to join the cluster with BaselineTopology";
 
@@ -878,8 +880,6 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
 
         if (joiningNodeState == null || joiningNodeState.baselineTopology() == null)
             return null;
-
-        DiscoveryDataClusterState state = globalState;
 
         if (state == null || state.baselineTopology() == null) {
             if (joiningNodeState != null && joiningNodeState.baselineTopology() != null) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -393,22 +393,24 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
         if (state.transition()) {
             final GridChangeGlobalStateFuture stateFut = changeStateFuture(msg);
 
-            if (stateFut != null && isApplicable(msg, state))
-                stateFut.onDone(concurrentStateChangeError(msg.activate()));
-            else {
-                state.listen(new IgniteInClosure<IgniteInternalFuture<Boolean>>() {
-                    @Override public void apply(IgniteInternalFuture<Boolean> fut) {
-                        try {
-                            fut.get();
+            if (stateFut != null) {
+                if (isApplicable(msg, state))
+                    stateFut.onDone(concurrentStateChangeError(msg.activate()));
+                else {
+                    state.listen(new IgniteInClosure<IgniteInternalFuture<Boolean>>() {
+                        @Override public void apply(IgniteInternalFuture<Boolean> fut) {
+                            try {
+                                fut.get();
 
-                            stateFut.onDone();
-                        }
-                        catch (Exception ex) {
-                            stateFut.onDone(ex);
-                        }
+                                stateFut.onDone();
+                            }
+                            catch (Exception ex) {
+                                stateFut.onDone(ex);
+                            }
 
-                    }
-                });
+                        }
+                    });
+                }
             }
         }
         else {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -449,7 +449,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
                 BaselineTopologyHistoryItem bltHistItem = BaselineTopologyHistoryItem.fromBaseline(
                     state.baselineTopology());
 
-                state = DiscoveryDataClusterState.createTransitionState(
+                DiscoveryDataClusterState newState = DiscoveryDataClusterState.createTransitionState(
                     state,
                     msg.activate(),
                     msg.activate() ? msg.baselineTopology() : state.baselineTopology(),
@@ -458,9 +458,9 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
                     nodeIds);
 
                 if (msg.forceChangeBaselineTopology())
-                    state.setTransitionResult(msg.activate());
+                    newState.setTransitionResult(msg.activate());
 
-                globalState = state;
+                globalState = newState;
 
                 AffinityTopologyVersion stateChangeTopVer = topVer.nextMinorVersion();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -1094,8 +1094,8 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
 
                 DiscoveryDataClusterState state = globalState;
 
-                if (state.transition())
-                    state.setTransitionResult(req.requestId(), req.activate());
+                if (state.transition() && state.transitionRequestId().equals(req.requestId()))
+                    state.setTransitionResult(req.activate());
             }
 
             sendChangeGlobalStateResponse(req.requestId(), req.initiatorNodeId(), null);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -667,7 +667,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
         BaselineStateAndHistoryData stateDiscoData = (BaselineStateAndHistoryData)data.commonData();
 
         if (stateDiscoData != null) {
-            globalState = stateDiscoData.globalState;
+            globalState = stateDiscoData.globalState.withFuture();
 
             if (stateDiscoData.recentHistory != null) {
                 for (BaselineTopologyHistoryItem item : stateDiscoData.recentHistory.history())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -392,7 +392,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
             GridFutureAdapter<Boolean> transitionFut = transitionFuts.remove(transitionRequestId);
 
             if (transitionFut != null)
-                transitionFut.onDone(msg.requestId().equals(transitionRequestId) ? msg.clusterActive() : null);
+                transitionFut.onDone(msg.clusterActive());
         }
         else
             U.warn(log, "Received state finish message with unexpected ID: " + msg);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -484,7 +484,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
 
                 Boolean activate = null;
 
-                if (msg.forceChangeBaselineTopology() && msg.requestId().equals(msg.requestId()))
+                if (msg.forceChangeBaselineTopology())
                     activate = msg.activate();
 
                 globalState = DiscoveryDataClusterState.createTransitionState(


### PR DESCRIPTION
Done. Please review.

**Details:**

1) I removed field `DiscoveryDataClusterState.transitionError` because there is no place in the project where setter was called, so it always was null.

2) Replaced `DiscoveryDataClusterState.transitionRes` with `DiscoveryDataClusterState.transitionFut` to avoid concurrent passing result from `GridClusterStateProcessor#onStateFinishMessage` to `GridClusterStateProcessor#publicApiActiveState` . It also allows me to remove `GridClusterStateProcessor.transitionFuts`. See details in code.

3) Optimized `DiscoveryDataClusterState#setTransitionResult` using because in all cases except one we don't need comparison of request id. See details in code.