### PR TITLE
IGNITE-7697 Update maven-javadoc-plugin version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -311,7 +311,7 @@
                         <version>false</version>
                         <additionalparam>${javadoc.opts}</additionalparam>
                         <links>
-                            <link>http://hadoop.apache.org/docs/current/api/</link>
+                            <link>https://hadoop.apache.org/docs/current/api/</link>
                         </links>
                         <groups>
                             <group>


### PR DESCRIPTION
 * updated maven-javadoc-plugin version
 * added maven-javadoc-plugin version override to ignite-apache-license-gen
 * updated flatten-maven-plugin for tread safety reasons