### PR TITLE
IGNITE-7816: DataFrame examples fixed.

### DIFF
--- a/examples/src/main/scala/org/apache/ignite/scalar/examples/spark/IgniteDataFrameExample.scala
+++ b/examples/src/main/scala/org/apache/ignite/scalar/examples/spark/IgniteDataFrameExample.scala
@@ -15,21 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.examples.spark
+package org.apache.ignite.scalar.examples.spark
 
-import java.lang.{Long ⇒ JLong}
+import java.lang.{Long ⇒ JLong, String ⇒ JString}
 
 import org.apache.ignite.cache.query.SqlFieldsQuery
 import org.apache.ignite.configuration.CacheConfiguration
+import org.apache.ignite.spark.IgniteDataFrameSettings._
 import org.apache.ignite.{Ignite, Ignition}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.sql.ignite.IgniteSparkSession
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
 
 /**
-  * Example application to show use-case for Ignite implementation of Spark SQL {@link org.apache.spark.sql.catalog.Catalog}.
-  * Catalog provides ability to automatically resolve SQL tables created in Ignite.
+  * Example application showing use-cases for Ignite implementation of Spark DataFrame API.
   */
-object IgniteCatalogExample extends App {
+object IgniteDataFrameExample extends App {
     /**
       * Ignite config file.
       */
@@ -44,77 +45,93 @@ object IgniteCatalogExample extends App {
     val ignite = setupServerAndData
 
     closeAfter(ignite) { ignite ⇒
-        //Creating Ignite-specific implementation of Spark session.
-        val igniteSession = IgniteSparkSession.builder()
-            .appName("Spark Ignite catalog example")
+        //Creating spark session.
+        implicit val spark = SparkSession.builder()
+            .appName("Spark Ignite data sources example")
             .master("local")
             .config("spark.executor.instances", "2")
-            .igniteConfig(CONFIG)
             .getOrCreate()
 
-        //Adjust the logger to exclude the logs of no interest.
+        // Adjust the logger to exclude the logs of no interest.
         Logger.getRootLogger.setLevel(Level.ERROR)
         Logger.getLogger("org.apache.ignite").setLevel(Level.INFO)
 
-        println("List of available tables:")
+        // Executing examples.
 
-        //Showing existing tables.
-        igniteSession.catalog.listTables().show()
+        sparkDSLExample
 
-        println("PERSON table description:")
-
-        //Showing `person` schema.
-        igniteSession.catalog.listColumns("person").show()
-
-        println("CITY table description:")
-
-        //Showing `city` schema.
-        igniteSession.catalog.listColumns("city").show()
-
-        println("Querying all persons from city with ID=2.")
-        println
-
-        //Selecting data throw Spark SQL engine.
-        val df = igniteSession.sql("SELECT * FROM person WHERE CITY_ID = 2")
-
-        println("Result schema:")
-
-        df.printSchema()
-
-        println("Result content:")
-
-        df.show()
-
-        println("Querying all persons living in Denver.")
-        println
-
-        //Selecting data throw Spark SQL engine.
-        val df2 = igniteSession.sql("SELECT * FROM person p JOIN city c ON c.ID = p.CITY_ID WHERE c.NAME = 'Denver'")
-
-        println("Result schema:")
-
-        df2.printSchema()
-
-        println("Result content:")
-
-        df2.show()
+        nativeSparkSqlExample
     }
 
     /**
-      * Starting ignite server node and creating.
+      * Examples of usage Ignite DataFrame implementation.
+      * Selecting data throw Spark DSL.
       *
-      * @return Ignite server node.
+      * @param spark SparkSession.
       */
+    def sparkDSLExample(implicit spark: SparkSession): Unit = {
+        println("Querying using Spark DSL.")
+        println
+
+        val igniteDF = spark.read
+            .format(FORMAT_IGNITE) //Data source type.
+            .option(OPTION_TABLE, "person") //Table to read.
+            .option(OPTION_CONFIG_FILE, CONFIG) //Ignite config.
+            .load()
+            .filter(col("id") >= 2) //Filter clause.
+            .filter(col("name") like "%M%") //Another filter clause.
+
+        println("Data frame schema:")
+
+        igniteDF.printSchema() //Printing query schema to console.
+
+        println("Data frame content:")
+
+        igniteDF.show() //Printing query results to console.
+    }
+
+    /**
+      * Examples of usage Ignite DataFrame implementation.
+      * Registration of Ignite DataFrame for following usage.
+      * Selecting data by Spark SQL query.
+      *
+      * @param spark SparkSession.
+      */
+    def nativeSparkSqlExample(implicit spark: SparkSession): Unit = {
+        println("Querying using Spark SQL.")
+        println
+
+        val df = spark.read
+            .format(FORMAT_IGNITE) //Data source type.
+            .option(OPTION_TABLE, "person") //Table to read.
+            .option(OPTION_CONFIG_FILE, CONFIG) //Ignite config.
+            .load()
+
+        //Registering DataFrame as Spark view.
+        df.createOrReplaceTempView("person")
+
+        //Selecting data from Ignite throw Spark SQL Engine.
+        val igniteDF = spark.sql("SELECT * FROM person WHERE id >= 2 AND name = 'Mary Major'")
+
+        println("Result schema:")
+
+        igniteDF.printSchema() //Printing query schema to console.
+
+        println("Result content:")
+
+        igniteDF.show() //Printing query results to console.
+    }
+
     def setupServerAndData: Ignite = {
         //Starting Ignite.
         val ignite = Ignition.start(CONFIG)
 
-        //Creating cache.
-        val ccfg = new CacheConfiguration[Int, Int](CACHE_NAME).setSqlSchema("PUBLIC")
+        //Creating first test cache.
+        val ccfg = new CacheConfiguration[JLong, JString](CACHE_NAME).setSqlSchema("PUBLIC")
 
         val cache = ignite.getOrCreateCache(ccfg)
 
-        //Create tables.
+        //Creating SQL tables.
         cache.query(new SqlFieldsQuery(
             "CREATE TABLE city (id LONG PRIMARY KEY, name VARCHAR) WITH \"template=replicated\"")).getAll
 
@@ -124,7 +141,7 @@ object IgniteCatalogExample extends App {
 
         cache.query(new SqlFieldsQuery("CREATE INDEX on Person (city_id)")).getAll
 
-        //Inserting some data into table.
+        //Inserting some data to tables.
         var qry = new SqlFieldsQuery("INSERT INTO city (id, name) VALUES (?, ?)")
 
         cache.query(qry.setArgs(1L.asInstanceOf[JLong], "Forest Hill")).getAll

--- a/examples/src/main/scala/org/apache/ignite/scalar/examples/spark/IgniteDataFrameWriteExample.scala
+++ b/examples/src/main/scala/org/apache/ignite/scalar/examples/spark/IgniteDataFrameWriteExample.scala
@@ -15,17 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.examples.spark
+package org.apache.ignite.scalar.examples.spark
 
 import java.lang.{Long ⇒ JLong, String ⇒ JString}
 
 import org.apache.ignite.cache.query.SqlFieldsQuery
 import org.apache.ignite.configuration.CacheConfiguration
+import org.apache.ignite.internal.util.IgniteUtils.resolveIgnitePath
+import org.apache.ignite.spark.IgniteDataFrameSettings._
 import org.apache.ignite.{Ignite, Ignition}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.sql.{SaveMode, SparkSession}
-import org.apache.ignite.spark.IgniteDataFrameSettings._
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{SaveMode, SparkSession}
 
 import scala.collection.JavaConversions._
 
@@ -70,7 +71,8 @@ object IgniteDataFrameWriteExample extends App {
 
     def writeJSonToIgnite(implicit spark: SparkSession): Unit = {
         //Load content of json file to data frame.
-        val personsDataFrame = spark.read.json("examples/src/main/resources/person.json")
+        val personsDataFrame = spark.read.json(
+            resolveIgnitePath("examples/src/main/resources/person.json").getAbsolutePath)
 
         println()
         println("Json file content:")

--- a/examples/src/main/scala/org/apache/ignite/scalar/examples/spark/package.scala
+++ b/examples/src/main/scala/org/apache/ignite/scalar/examples/spark/package.scala
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ignite.examples
+
+package org.apache.ignite.scalar.examples
 
 /**
   */

--- a/examples/src/test/spark/org/apache/ignite/spark/examples/IgniteDataFrameSelfTest.java
+++ b/examples/src/test/spark/org/apache/ignite/spark/examples/IgniteDataFrameSelfTest.java
@@ -17,14 +17,15 @@
 
 package org.apache.ignite.spark.examples;
 
-import org.apache.ignite.examples.spark.IgniteCatalogExample;
-import org.apache.ignite.examples.spark.IgniteDataFrameExample;
-import org.apache.ignite.examples.spark.IgniteDataFrameWriteExample;
+import org.apache.ignite.scalar.examples.spark.IgniteCatalogExample;
+import org.apache.ignite.scalar.examples.spark.IgniteDataFrameExample;
+import org.apache.ignite.scalar.examples.spark.IgniteDataFrameWriteExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
 import org.junit.Test;
 
 /**
  */
-public class IgniteDataFrameSelfTest {
+public class IgniteDataFrameSelfTest extends GridAbstractExamplesTest {
     static final String[] EMPTY_ARGS = new String[0];
 
     /**

--- a/examples/src/test/spark/org/apache/ignite/spark/examples/SharedRDDExampleSelfTest.java
+++ b/examples/src/test/spark/org/apache/ignite/spark/examples/SharedRDDExampleSelfTest.java
@@ -18,12 +18,13 @@
 package org.apache.ignite.spark.examples;
 
 import org.apache.ignite.examples.spark.SharedRDDExample;
+import org.apache.ignite.testframework.junits.common.GridAbstractExamplesTest;
 import org.junit.Test;
 
 /**
  * SharedRDD  examples self test.
  */
-public class SharedRDDExampleSelfTest {
+public class SharedRDDExampleSelfTest extends GridAbstractExamplesTest {
     static final String[] EMPTY_ARGS = new String[0];
     /**
      * @throws Exception If failed.


### PR DESCRIPTION
 moved to `org.apache.ignite.scalar.examples.spark` package. Minor examples improvements.