### PR TITLE
IGNITE-8065 setSwapPath option used with enabled persistence was removed from some tests

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsCacheRebalancingAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsCacheRebalancingAbstractTest.java
@@ -130,7 +130,6 @@ public abstract class IgnitePdsCacheRebalancingAbstractTest extends GridCommonAb
         memPlcCfg.setName("dfltDataRegion");
         memPlcCfg.setMaxSize(150 * 1024 * 1024);
         memPlcCfg.setInitialSize(100 * 1024 * 1024);
-        memPlcCfg.setSwapPath("work/swap");
         memPlcCfg.setPersistenceEnabled(true);
 
         memCfg.setDefaultDataRegionConfiguration(memPlcCfg);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsRemoveDuringRebalancingTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsRemoveDuringRebalancingTest.java
@@ -64,8 +64,7 @@ public class IgnitePdsRemoveDuringRebalancingTest extends GridCommonAbstractTest
             .setDefaultDataRegionConfiguration(
                 new DataRegionConfiguration()
                     .setMaxSize(100 * 1024 * 1024)
-                    .setPersistenceEnabled(true)
-                    .setSwapPath(DFLT_STORE_DIR))
+                    .setPersistenceEnabled(true))
             .setWalMode(WALMode.LOG_ONLY)
             .setPageSize(1024)
             .setConcurrencyLevel(Runtime.getRuntime().availableProcessors() * 4);


### PR DESCRIPTION
Some of PDS indexing tests became red after IGNITE-7902

The reason is that some tests enable both swap and persistence at the same time for a data region.