### PR TITLE
IGNITE-7771 Names of Ignite JMX beans should not be quoted unless required

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -312,7 +312,7 @@ public abstract class IgniteUtils {
     private static final String HTTPS_PROTOCOL = "TLS";
 
     /** Correct Mbean cache name pattern. */
-    private static Pattern MBEAN_CACHE_NAME_PATTERN = Pattern.compile("^[a-zA-Z_0-9]+$");
+    private static Pattern MBEAN_SPECIAL_SYMBOLS_PATTERN = Pattern.compile("[\\\\\"?*]");
 
     /** Project home directory. */
     private static volatile GridTuple<String> ggHome;
@@ -4509,7 +4509,7 @@ public abstract class IgniteUtils {
      * @return An escaped string.
      */
     private static String escapeObjectNameValue(String s) {
-        if (MBEAN_CACHE_NAME_PATTERN.matcher(s).matches())
+        if (!MBEAN_SPECIAL_SYMBOLS_PATTERN.matcher(s).find())
             return s;
 
         return '\"' + s.replaceAll("[\\\\\"?*]", "\\\\$0") + '\"';

--- a/modules/core/src/test/java/org/apache/ignite/util/mbeans/GridMBeanExoticNamesSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/util/mbeans/GridMBeanExoticNamesSelfTest.java
@@ -37,6 +37,31 @@ public class GridMBeanExoticNamesSelfTest extends GridCommonAbstractTest {
         checkMBeanRegistration("dummygrp", "dum!@#$^&*()?\\my");
     }
 
+    /** Test checks that asterisk symbol will be escaped */
+    public void testEscapeAsterisk() throws Exception {
+        checkMBeanNamesAfterRegistration("dummy*grp", "dum*my", "\"dummy\\*grp\"", "\"dum\\*my\"");
+    }
+
+    /** Test checks that quote symbol will be escaped */
+    public void testEscapeQuote() throws Exception {
+        checkMBeanNamesAfterRegistration("dummy\"grp", "dum\"my", "\"dummy\\\"grp\"", "\"dum\\\"my\"");
+    }
+
+    /** Test checks that question mark will be escaped */
+    public void testEscapeQuestionMark() throws Exception {
+        checkMBeanNamesAfterRegistration("dummy?grp", "dum?my", "\"dummy\\?grp\"", "\"dum\\?my\"");
+    }
+
+    /** Test checks that backslash symbol will be escaped */
+    public void testEscapeBackslash() throws Exception {
+        checkMBeanNamesAfterRegistration("dummy\\grp", "dum\\my", "\"dummy\\\\grp\"", "\"dum\\\\my\"");
+    }
+
+    /** Test checks that name without special symbols but with whitespaces will bot be escaped */
+    public void testWhitespaceNotEscaped() throws Exception {
+        checkMBeanNamesAfterRegistration("dummy grp", "dum my", "dummy grp", "dum my");
+    }
+
     /** Test MBean registration. */
     private void checkMBeanRegistration(String grp, String name) throws Exception {
         // Node should start and stop with no errors.
@@ -47,6 +72,20 @@ public class GridMBeanExoticNamesSelfTest extends GridCommonAbstractTest {
 
             ObjectName objName = U.makeMBeanName(ignite.name(), grp, name + '2');
             U.registerMBean(srv, objName, new DummyMBeanImpl(), DummyMBean.class);
+        }
+    }
+
+    /** Test MBean names after registration. */
+    private void checkMBeanNamesAfterRegistration(String grp, String name, String expectedGrp,
+        String expectedName) throws Exception {
+        // Node should start and stop with no errors.
+        try (Ignite ignite = startGrid(0)) {
+            MBeanServer srv = ignite.configuration().getMBeanServer();
+
+            ObjectName resultObjName = U.registerMBean(srv, ignite.name(), grp, name, new DummyMBeanImpl(), DummyMBean.class);
+
+            assertTrue(resultObjName.getCanonicalName().contains("name=" + expectedName));
+            assertTrue(resultObjName.getCanonicalName().contains("group=" + expectedGrp));
         }
     }
 


### PR DESCRIPTION
Names of Ignite JMX beans and bean groups are currently quoted if they contain non-alphanumeric characters. This leads to names with spaces, e.g. Thread Pools, appearing as "Thread Pools". Moreover, Thread Pools and "Thread Pools" are recognized by JMX as distinct names, so code accessing that MBean needs to take that into account.

It would be better not to quote the bean and group names unless they contain specific control characters. That way users won't need to quote names in their JMX clients.

Logic of generation of the ObjectName instances was updates. Also new tests were added.