### PR TITLE
IGNITE-8167: Fix inconsistent last record pointer in case of recovery from corrupted WAL

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
@@ -1958,7 +1958,7 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
 
         long start = U.currentTimeMillis();
         int applied = 0;
-        WALPointer lastRead = null;
+        WALPointer lastRead = status.endPtr == CheckpointStatus.NULL_PTR ? null : status.endPtr;
 
         Collection<Integer> ignoreGrps = storeOnly ? Collections.emptySet() : initiallyWalDisabledGrps;
 


### PR DESCRIPTION
Let's look at this peace of code from GridCacheDatabaseSharedManager.readCheckpointAndRestoreMemory

            WALPointer restore = restoreMemory(status);

            // First, bring memory to the last consistent checkpoint state if needed.
            // This method should return a pointer to the last valid record in the WAL.

            cctx.wal().resumeLogging(restore);

In case of restore == null. Logging will be resuming from 0 absolute WAL index. But as we can see in restoreMemory method.

        WALPointer lastRead = null;

        Collection<Integer> ignoreGrps = storeOnly ? Collections.emptySet() : initiallyWalDisabledGrps;

        try (WALIterator it = cctx.wal().replay(status.endPtr)) {
            while (it.hasNextX()) {...}
        ....
        return lastRead == null ? null : lastRead.next();

It can return null in case of we have not null wal/cp history, but we haven't non-corrupted valid records after last checkpoint.