### PR TITLE
IGNITE-8242: Remove method GAGridUtils.getGenesForChromosome() as pro…

### DIFF
--- a/examples/src/main/java/org/apache/ignite/examples/ml/genetic/change/OptimizeMakeChangeTerminateCriteria.java
+++ b/examples/src/main/java/org/apache/ignite/examples/ml/genetic/change/OptimizeMakeChangeTerminateCriteria.java
@@ -58,7 +58,7 @@ public class OptimizeMakeChangeTerminateCriteria implements ITerminateCriteria {
         igniteLogger.info("Generation: " + currentGeneration);
         igniteLogger.info("Fittest is Chromosome Key: " + fittestChromosome);
         igniteLogger.info("Chromsome: " + fittestChromosome);
-        printCoins(GAGridUtils.getGenesForChromosome(ignite, fittestChromosome));
+        printCoins(GAGridUtils.getGenesInOrderForChromosome(ignite, fittestChromosome));
         igniteLogger.info("Avg Chromsome Fitness: " + averageFitnessScore);
         igniteLogger.info("##########################################################################################");
 

--- a/examples/src/main/java/org/apache/ignite/examples/ml/genetic/movie/MovieTerminateCriteria.java
+++ b/examples/src/main/java/org/apache/ignite/examples/ml/genetic/movie/MovieTerminateCriteria.java
@@ -61,7 +61,7 @@ public class MovieTerminateCriteria implements ITerminateCriteria {
         igniteLogger.info("Generation: " + currentGeneration);
         igniteLogger.info("Fittest is Chromosome Key: " + fittestChromosome);
         igniteLogger.info("Chromsome: " + fittestChromosome);
-        printMovies(GAGridUtils.getGenesForChromosome(ignite, fittestChromosome));
+        printMovies(GAGridUtils.getGenesInOrderForChromosome(ignite, fittestChromosome));
         igniteLogger.info("##########################################################################################");
 
         if (!(fittestChromosome.getFitnessScore() > 32)) {

--- a/modules/ml/src/main/java/org/apache/ignite/ml/genetic/utils/GAGridUtils.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/genetic/utils/GAGridUtils.java
@@ -60,33 +60,6 @@ public class GAGridUtils {
     }
 
     /**
-     * @param ignite Ignite
-     * @param chromosome Chromosome
-     * @return List of Genes
-     */
-    public static List<Gene> getGenesForChromosome(Ignite ignite, Chromosome chromosome) {
-        List<Gene> genes = new ArrayList<Gene>();
-        IgniteCache<Long, Gene> cache = ignite.cache(GAGridConstants.GENE_CACHE);
-        StringBuffer sbSqlClause = new StringBuffer();
-        sbSqlClause.append("_key IN ");
-        String sqlInClause = Arrays.toString(chromosome.getGenes());
-
-        sqlInClause = sqlInClause.replace("[", "(");
-        sqlInClause = sqlInClause.replace("]", ")");
-
-        sbSqlClause.append(sqlInClause);
-
-        SqlQuery sql = new SqlQuery(Gene.class, sbSqlClause.toString());
-
-        try (QueryCursor<Entry<Long, Gene>> cursor = cache.query(sql)) {
-            for (Entry<Long, Gene> e : cursor)
-                genes.add(e.getValue());
-        }
-
-        return genes;
-    }
-
-    /**
      * Retrieve genes in order
      *
      * @param ignite Ignite


### PR DESCRIPTION
Remove method GAGridUtils.getGenesForChromosome() as problematic when Chromosome contains duplicate genes. GAGridUtils.getGenesInOrderForChromosome() will be used instead.