### PR TITLE
IGNITE-5965 fix Flaky failure of GridServiceProcessorMultiNodeConfigS…

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorAbstractSelfTest.java
@@ -795,7 +795,7 @@ public abstract class GridServiceProcessorAbstractSelfTest extends GridCommonAbs
             @Override public boolean applyx() {
                 return actualCount(srvcName, g.services().serviceDescriptors())  == expectedDeps;
             }
-        }, 1500);
+        }, 12_000);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorMultiNodeConfigSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorMultiNodeConfigSelfTest.java
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.lang.GridAbsPredicateX;
 import org.apache.ignite.services.ServiceConfiguration;
+import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
 import org.apache.ignite.testframework.GridTestUtils;
 
 /**
@@ -105,6 +107,15 @@ public class GridServiceProcessorMultiNodeConfigSelfTest extends GridServiceProc
         cfgs.add(cfg);
 
         return cfgs.toArray(new ServiceConfiguration[cfgs.size()]);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(final String igniteInstanceName) throws Exception {
+        final IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        ((TcpCommunicationSpi)cfg.getCommunicationSpi()).setIdleConnectionTimeout(10000);
+
+        return cfg;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Test fixed by decreasing connection timeout. Now GridServiceProcessorMultiNodeConfigSelfTest.testDeployOnEachNodeUpdateTopology that should have failed earlier because of topology not being updated on nodes exit (cause of failures), succeeds but runs > 10 sec. This fix gives 200/200 success rate, but I am not really sure if the approach is right. Needs reviewing