### PR TITLE
IGNITE-8238: Operation can fails with unexpected RuntimeException when node is stopping.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheTtlManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheTtlManager.java
@@ -216,8 +216,10 @@ public class GridCacheTtlManager extends GridCacheManagerAdapter {
             U.error(log, "Failed to process entry expiration: " + e, e);
         }
         catch (IgniteException e) {
-            if (e.hasCause(NodeStoppingException.class))
-                log.warning("Failed to expire because node is stopped", e);
+            if (e.hasCause(NodeStoppingException.class)) {
+                if (log.isDebugEnabled())
+                    log.debug("Failed to expire because node is stopped: " + e);
+            }
             else
                 throw e;
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheTtlManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheTtlManager.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.LongAdder;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.NodeStoppingException;
 import org.apache.ignite.internal.processors.cache.distributed.near.GridNearCacheAdapter;
 import org.apache.ignite.internal.processors.cache.distributed.near.GridNearCacheEntry;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
@@ -213,6 +214,12 @@ public class GridCacheTtlManager extends GridCacheManagerAdapter {
         }
         catch (IgniteCheckedException e) {
             U.error(log, "Failed to process entry expiration: " + e, e);
+        }
+        catch (IgniteException e) {
+            if (e.hasCause(NodeStoppingException.class))
+                log.warning("Failed to expire because node is stopped", e);
+            else
+                throw e;
         }
 
         return false;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
@@ -1434,6 +1434,7 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
     /**
      * Gets the checkpoint read lock. While this lock is held, checkpoint thread will not acquireSnapshotWorker memory
      * state.
+     * @throws IgniteException If failed.
      */
     @SuppressWarnings("LockAcquiredButNotSafelyReleased")
     @Override public void checkpointReadLock() {
@@ -1446,7 +1447,7 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
             if (stopping) {
                 checkpointLock.readLock().unlock();
 
-                throw new RuntimeException("Failed to perform cache update: node is stopping.");
+                throw new IgniteException(new NodeStoppingException("Failed to perform cache update: node is stopping."));
             }
 
             if (safeToUpdatePageMemories() || checkpointLock.getReadHoldCount() > 1)


### PR DESCRIPTION
For [IGNITE-8238](https://issues.apache.org/jira/browse/IGNITE-8238)