### PR TITLE
IGNITE-6010

### DIFF
--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/zk/ZookeeperIpFinderTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/zk/ZookeeperIpFinderTest.java
@@ -32,8 +32,6 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.events.Event;
 import org.apache.ignite.events.EventType;
-import org.apache.ignite.internal.util.lang.GridAbsPredicate;
-import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteBiPredicate;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.testframework.GridTestUtils;
@@ -359,21 +357,21 @@ public class ZookeeperIpFinderTest extends GridCommonAbstractTest {
         // check that the nodes have registered again
         assertEquals(4, zkCurator.getChildren().forPath(SERVICES_IGNITE_ZK_PATH).size());
 
+        // Block the clients until connected for closing without sessions timeout.
+        for (int i = 0; i < 4; i++) {
+            TcpDiscoverySpi spi = (TcpDiscoverySpi)grid(i).configuration().getDiscoverySpi();
+
+            TcpDiscoveryZookeeperIpFinder zkIpFinder = (TcpDiscoveryZookeeperIpFinder)spi.getIpFinder();
+
+            CuratorFramework curator = GridTestUtils.getFieldValue(zkIpFinder, "curator");
+
+            curator.blockUntilConnected();
+        }
+
         // stop all grids
         stopAllGrids();
 
-        assertTrue(GridTestUtils.waitForCondition(new GridAbsPredicate() {
-            @Override public boolean apply() {
-                try {
-                    return 0 == zkCurator.getChildren().forPath(SERVICES_IGNITE_ZK_PATH).size();
-                }
-                catch (Exception e) {
-                    U.error(log, "Failed to wait for zk condition", e);
-
-                    return false;
-                }
-            }
-        }, 20000));
+        assertEquals(0, zkCurator.getChildren().forPath(SERVICES_IGNITE_ZK_PATH).size());
     }
 
     /**

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/zk/ZookeeperIpFinderTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/zk/ZookeeperIpFinderTest.java
@@ -357,7 +357,7 @@ public class ZookeeperIpFinderTest extends GridCommonAbstractTest {
         // Check that the nodes have registered again with the previous configuration.
         assertEquals(4, zkCurator.getChildren().forPath(SERVICES_IGNITE_ZK_PATH).size());
 
-        // Block the clients until connected for grids stopping without sessions timeout.
+        // Block the clients until connected.
         for (int i = 0; i < 4; i++) {
             TcpDiscoverySpi spi = (TcpDiscoverySpi)grid(i).configuration().getDiscoverySpi();
 

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/zk/ZookeeperIpFinderTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/zk/ZookeeperIpFinderTest.java
@@ -354,10 +354,10 @@ public class ZookeeperIpFinderTest extends GridCommonAbstractTest {
         // block the client until connected
         zkCurator.blockUntilConnected();
 
-        // check that the nodes have registered again
+        // Check that the nodes have registered again with the previous configuration.
         assertEquals(4, zkCurator.getChildren().forPath(SERVICES_IGNITE_ZK_PATH).size());
 
-        // Block the clients until connected for closing without sessions timeout.
+        // Block the clients until connected for grids stopping without sessions timeout.
         for (int i = 0; i < 4; i++) {
             TcpDiscoverySpi spi = (TcpDiscoverySpi)grid(i).configuration().getDiscoverySpi();
 


### PR DESCRIPTION
The test became flaky after commit e05c012f293dcad2cd3a184e6d257a0cb2af509a where the timeout was decreased to 20s. Sometimes curators closed on session timeout (60 sec) and fail the test.

I added the additional block to ensure that clients were connected.

Now session closes expected without timeouts and "wait for condition" block is excess.