### PR TITLE
Update release-web-agent.xml

### DIFF
--- a/modules/web-console/web-agent/assembly/release-web-agent.xml
+++ b/modules/web-console/web-agent/assembly/release-web-agent.xml
@@ -51,6 +51,7 @@
             <directory>${basedir}/bin</directory>
             <outputDirectory>/</outputDirectory>
             <fileMode>0755</fileMode>
+            <lineEnding>unix</lineEnding>
             <includes>
                 <include>**/*.sh</include>
             </includes>


### PR DESCRIPTION
I get a error `-bash: ./ignite-web-agent.sh: /bin/bash^M: bad interpreter: No such file or directory` if run the script `ignite-web-agent.sh` on Ubuntu 18.04. The package which i built with Windows. 