### PR TITLE
Adding experimental support for Intel Optane DC Persistent Memory

### DIFF
--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiClientExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiClientExample.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.examples.model.Organization;
+import org.apache.ignite.examples.model.Person;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+
+import javax.cache.Cache;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * This example demonstrates some of the cache rich API capabilities.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheApiClientExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheApiExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setClientMode(true);
+        Ignition.setAepStore("/mnt/mem/" + CacheApiClientExample.class.getSimpleName(), true);
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            System.out.println(">>> Cache API example started.");
+
+            ignite.active(true);
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, Person> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+
+                if (true) {
+                    cache.put(1, new Person(1L, "Donald", "Knuth"));
+                    cache.put(2, new Person(2L, "John ", "Backus"));
+                    cache.put(3, new Person(3L, "Dennis", "Ritchie"));
+                }
+
+                Iterator<Cache.Entry<Integer, Person>> itr = cache.iterator();
+                while (itr.hasNext())
+                    Ignition.print(itr.next().getValue().toString());
+
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+}
+

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiExample.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.examples.model.Person;
+import javax.cache.Cache;
+import java.util.Iterator;
+
+
+/**
+ * This example demonstrates some of the cache rich API capabilities.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheApiExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheApiExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheApiExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            System.out.println(">>> Cache API example started.");
+
+            CacheConfiguration<Integer, Person> cacheCfg = new CacheConfiguration<>(CACHE_NAME);
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, Person> cache = ignite.getOrCreateCache(cacheCfg)) {
+
+                if (true) {
+                    cache.put(1, new Person(1L, "Alan", "Turing"));
+                    cache.put(2, new Person(2L, "John", "Backus"));
+                    cache.put(3, new Person(3L, "Donald", "Knuth"));
+                }
+
+                Iterator<Cache.Entry<Integer, Person>> itr = cache.iterator();
+                while (itr.hasNext())
+                    Ignition.print(itr.next().getValue().toString());
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+}
+

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiPersistenceExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiPersistenceExample.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import java.util.List;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteDataStreamer;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheWriteSynchronizationMode;
+import org.apache.ignite.cache.query.QueryCursor;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.datagrid.CacheQueryExample;
+import org.apache.ignite.examples.model.Organization;
+
+/**
+ * This example demonstrates the usage of Apache Ignite Persistent Store.
+ * <p>
+ * To execute this example you should start an instance of {@link ServerNode}
+ * class which will start up an Apache Ignite remote server node with a proper configuration.
+ * <p>
+ * When {@code UPDATE} parameter of this example is set to {@code true}, the example will populate
+ * the cache with some data and will then run a sample SQL query to fetch some results.
+ * <p>
+ * When {@code UPDATE} parameter of this example is set to {@code false}, the example will run
+ * the SQL query against the cache without the initial data pre-loading from the store.
+ * <p>
+ * You can populate the cache first with {@code UPDATE} set to {@code true}, then restart the nodes and
+ * run the example with {@code UPDATE} set to {@code false} to verify that Apache Ignite can work with the
+ * data that is in the persistence only.
+ */
+public class CacheApiPersistenceExample {
+    /** Organizations cache name. */
+    private static final String ORG_CACHE = CacheQueryExample.class.getSimpleName() + "Organizations";
+
+    /** */
+    private static final boolean UPDATE = true;
+
+    /**
+     * @param args Program arguments, ignored.
+     * @throws Exception If failed.
+     */
+    public static void main(String[] args) throws Exception {
+        //Ignition.setClientMode(true);
+
+        try (Ignite ignite = Ignition.start("examples/config/persistentstore/example-persistent-store.xml")) {
+            // Activate the cluster. Required to do if the persistent store is enabled because you might need
+            // to wait while all the nodes, that store a subset of data on disk, join the cluster.
+            //ignite.active(true);
+
+            CacheConfiguration<Long, Organization> cacheCfg = new CacheConfiguration<>(ORG_CACHE);
+
+            cacheCfg.setAtomicityMode(CacheAtomicityMode.ATOMIC);
+            cacheCfg.setBackups(1);
+            cacheCfg.setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC);
+            cacheCfg.setIndexedTypes(Long.class, Organization.class);
+
+            IgniteCache<Long, Organization> cache = ignite.getOrCreateCache(cacheCfg);
+
+            if (UPDATE) {
+                System.out.println("Populating the cache...");
+
+
+                for (long i = 0; i < 100_000; i++) {
+                    cache.put(i, new Organization(i, "organization-" + i));
+
+                    if (i > 0 && i % 10_000 == 0)
+                        System.out.println("Done: " + i);
+                }
+            }
+
+            // Run SQL without explicitly calling to loadCache().
+            QueryCursor<List<?>> cur = cache.query(
+                    new SqlFieldsQuery("select id, name from Organization where name like ?")
+                            .setArgs("organization-54321"));
+
+            System.out.println("SQL Result: " + cur.getAll());
+
+            // Run get() without explicitly calling to loadCache().
+            Organization org = cache.get(54321l);
+
+            System.out.println("GET Result: " + org);
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiPrimitiveExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheApiPrimitiveExample.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.examples.model.Organization;
+import org.apache.ignite.examples.model.Person;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+
+import javax.cache.Cache;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * This example demonstrates some of the cache rich API capabilities.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheApiPrimitiveExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheApiPrimitiveExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheApiPrimitiveExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            System.out.println(">>> Cache API Primitives example started.");
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, Integer> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+
+                if (true) {
+                    cache.put(1, 111);
+                    cache.put(2, 222);
+                    cache.put(3, 333);
+                }
+
+                for (int i = 1; i <= 3; i++)
+                    Ignition.print("key = " + i + ", value = " + cache.get(i));
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+}
+

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheAsyncApiExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheAsyncApiExample.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.lang.IgniteFuture;
+import org.apache.ignite.lang.IgniteInClosure;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * This example demonstrates some of the cache rich API capabilities.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheAsyncApiExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheAsyncApiExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheAsyncApiExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            Ignition.print(">>> Cache asynchronous API example started.");
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+                Collection<IgniteFuture<?>> futs = new ArrayList<>();
+
+                // Execute several puts asynchronously.
+                for (int i = 0; i < 10; i++)
+                    futs.add(cache.putAsync(i, String.valueOf(i)));
+
+                // Wait for completion of all futures.
+                for (IgniteFuture<?> fut : futs)
+                    fut.get();
+
+                // Execute get operation asynchronously and wait for result.
+                cache.getAsync(1).listen(new IgniteInClosure<IgniteFuture<String>>() {
+                    @Override public void apply(IgniteFuture<String> fut) {
+                        Ignition.print("Get operation completed [value=" + fut.get() + ']');
+                    }
+                });
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheDataStoreExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheDataStoreExample.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteDataStreamer;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheWriteSynchronizationMode;
+import org.apache.ignite.cache.query.FieldsQueryCursor;
+import org.apache.ignite.cache.query.QueryCursor;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.datagrid.CacheQueryExample;
+import org.apache.ignite.examples.model.Organization;
+import org.apache.ignite.examples.model.Person;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+
+import javax.cache.Cache;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * This example demonstrates the usage of Apache Ignite Persistent Store.
+ * <p>
+ * To execute this example you should start an instance of {@link CacheDataStoreExample}
+ * class which will start up an Apache Ignite remote server node with a proper configuration.
+ * <p>
+ * When {@code UPDATE} parameter of this example is set to {@code true}, the example will populate
+ * the cache with some data and will then run a sample SQL query to fetch some results.
+ * <p>
+ * When {@code UPDATE} parameter of this example is set to {@code false}, the example will run
+ * the SQL query against the cache without the initial data pre-loading from the store.
+ * <p>
+ * You can populate the cache first with {@code UPDATE} set to {@code true}, then restart the nodes and
+ * run the example with {@code UPDATE} set to {@code false} to verify that Apache Ignite can work with the
+ * data that is in the persistence only.
+ */
+public class CacheDataStoreExample {
+    /** Organizations cache name. */
+    private static final String ORG_CACHE = CacheQueryExample.class.getSimpleName() + "Organizations";
+
+    /**
+     * @param args Program arguments, ignored.
+     * @throws Exception If failed.
+     */
+    public static void main(String[] args) throws Exception {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheDataStoreExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+
+            CacheConfiguration<Long, Organization> cacheCfg = new CacheConfiguration<>(ORG_CACHE);
+
+            cacheCfg.setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC);
+            cacheCfg.setIndexedTypes(Long.class, Organization.class);
+
+            IgniteCache<Long, Organization> cache = ignite.getOrCreateCache(cacheCfg);
+
+            if (true) {
+                Ignition.print(">>> Populating the cache...");
+                for (long i = 0; i < 10; i++)
+                    cache.put(i, new Organization(i, "organization-" + i));
+            }
+
+            QueryCursor<List<?>> cur = cache.query(new SqlFieldsQuery("select id,name from Organization"));
+
+            Ignition.print(">>> SQL result:");
+            Iterator<List<?>> itr = cur.iterator();
+            while (itr.hasNext())
+                Ignition.print(itr.next().toString());
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheDataStreamExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheDataStreamExample.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.*;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.examples.model.Organization;
+import org.apache.ignite.examples.model.Person;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+
+import javax.cache.Cache;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * This example demonstrates some of the cache rich API capabilities.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheDataStreamExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheDataStreamExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheDataStreamExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            Ignition.print(">>> Cache data stream example started.");
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, Person> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+
+                if (true) {
+
+                    try (IgniteDataStreamer<Long, Person> stmr = ignite.dataStreamer(CACHE_NAME)) {
+                        stmr.allowOverwrite(true);
+
+                        for (long i = 0; i < 10; i++)
+                            stmr.addData(i, new Person(i, "First Name -" + i, "Last Name - " + i));
+
+                    }
+
+                }
+
+
+                Iterator<Cache.Entry<Integer, Person>> itr = cache.iterator();
+                while (itr.hasNext())
+                    Ignition.print(itr.next().getValue().toString());
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheEntryProcessorExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheEntryProcessorExample.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheEntryProcessor;
+import org.apache.ignite.examples.ExampleNodeStartup;
+
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.MutableEntry;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This example demonstrates the simplest code that populates the distributed cache
+ * and co-locates simple closure execution with each key. The goal of this particular
+ * example is to provide the simplest code example of this logic using EntryProcessor.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheEntryProcessorExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheEntryProcessorExample.class.getSimpleName();
+
+    /** Number of keys. */
+    private static final int KEY_CNT = 20;
+
+    /** Keys predefined set. */
+    private static final Set<Integer> KEYS_SET;
+
+    /**
+     * Initializes keys set that is used in bulked operations in the example.
+     */
+    static {
+        KEYS_SET = new HashSet<>();
+
+        for (int i = 0; i < KEY_CNT; i++)
+            KEYS_SET.add(i);
+    }
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheEntryProcessor.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            Ignition.print(">>> Entry processor example started.");
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, Integer> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+                // Demonstrates usage of EntryProcessor.invoke(...) method.
+                populateEntriesWithInvoke(cache);
+
+                // Demonstrates usage of EntryProcessor.invokeAll(...) method.
+                incrementEntriesWithInvokeAll(cache);
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+
+    /**
+     * Populates cache with values using {@link IgniteCache#invoke(Object, EntryProcessor, Object...)} method.
+     *
+     * @param cache Cache that must be populated.
+     */
+    private static void populateEntriesWithInvoke(IgniteCache<Integer, Integer> cache) {
+        // Must be no entry in the cache at this point.
+        printCacheEntries(cache);
+
+        Ignition.print("");
+        Ignition.print(">> Populating the cache using EntryProcessor.");
+
+        // Invokes EntryProcessor for every key sequentially.
+        for (int i = 0; i < KEY_CNT; i++) {
+            cache.invoke(i, new EntryProcessor<Integer, Integer, Object>() {
+                @Override public Object process(MutableEntry<Integer, Integer> entry,
+                    Object... objects) throws EntryProcessorException {
+                    // Initializes entry's value if it's not set.
+                    if (entry.getValue() == null)
+                        entry.setValue((entry.getKey() + 1) * 10);
+
+                    return null;
+                }
+            });
+        }
+
+        // Print outs entries that are set using the EntryProcessor above.
+        printCacheEntries(cache);
+    }
+
+    /**
+     * Increments values of entries stored in the cache using
+     * {@link IgniteCache#invokeAll(Set, EntryProcessor, Object...)} method.
+     *
+     * @param cache Cache instance.
+     */
+    private static void incrementEntriesWithInvokeAll(IgniteCache<Integer, Integer> cache) {
+        Ignition.print("");
+        Ignition.print(">> Incrementing values in the cache using EntryProcessor.");
+
+        // Using EntryProcessor.invokeAll to increment every value in place.
+        cache.invokeAll(KEYS_SET, new EntryProcessor<Integer, Integer, Object>() {
+            @Override public Object process(MutableEntry<Integer, Integer> entry,
+                Object... arguments) throws EntryProcessorException {
+
+                entry.setValue(entry.getValue() + 5);
+
+                return null;
+            }
+        });
+
+        // Print outs entries that are incremented using the EntryProcessor above.
+        printCacheEntries(cache);
+    }
+
+    /**
+     * Prints out all the entries that are stored in a cache.
+     *
+     * @param cache Cache.
+     */
+    private static void printCacheEntries(IgniteCache<Integer, Integer> cache) {
+        System.out.println();
+        Ignition.print(">>> Entries in the cache.");
+
+        Map<Integer, Integer> entries = cache.getAll(KEYS_SET);
+
+        if (entries.isEmpty())
+            Ignition.print("No entries in the cache.");
+        else {
+            for (Map.Entry<Integer, Integer> entry : entries.entrySet())
+                Ignition.print("Entry [key=" + entry.getKey() + ", value=" + entry.getValue() + ']');
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheEventsExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheEventsExample.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheEntryProcessor;
+import org.apache.ignite.events.CacheEvent;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.lang.IgniteBiPredicate;
+import org.apache.ignite.lang.IgnitePredicate;
+
+import java.util.UUID;
+
+import static org.apache.ignite.events.EventType.*;
+
+/**
+ * This examples demonstrates events API. Note that ignite events are disabled by default and
+ * must be specifically enabled, just like in {@code examples/config/example-ignite.xml} file.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheEventsExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheEventsExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException, InterruptedException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheEventsExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            System.out.println(">>> Cache events example started.");
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+                // This optional local callback is called for each event notification
+                // that passed remote predicate listener.
+                IgniteBiPredicate<UUID, CacheEvent> locLsnr = new IgniteBiPredicate<UUID, CacheEvent>() {
+                    @Override public boolean apply(UUID uuid, CacheEvent evt) {
+                        System.out.println("Received event [evt=" + evt.name() + ", key=" + evt.key() +
+                            ", oldVal=" + evt.oldValue() + ", newVal=" + evt.newValue());
+
+                        return true; // Continue listening.
+                    }
+                };
+
+                // Remote listener which only accepts events for keys that are
+                // greater or equal than 10 and if event node is primary for this key.
+                IgnitePredicate<CacheEvent> rmtLsnr = new IgnitePredicate<CacheEvent>() {
+                    @Override public boolean apply(CacheEvent evt) {
+                        System.out.println("Cache event [name=" + evt.name() + ", key=" + evt.key() + ']');
+
+                        int key = evt.key();
+
+                        return key >= 10 && ignite.affinity(CACHE_NAME).isPrimary(ignite.cluster().localNode(), key);
+                    }
+                };
+
+                // Subscribe to specified cache events on all nodes that have cache running.
+                // Cache events are explicitly enabled in examples/config/example-ignite.xml file.
+                ignite.events(ignite.cluster().forCacheNodes(CACHE_NAME)).remoteListen(locLsnr, rmtLsnr,
+                    EVT_CACHE_OBJECT_PUT, EVT_CACHE_OBJECT_READ, EVT_CACHE_OBJECT_REMOVED);
+
+                // Generate cache events.
+                for (int i = 0; i < 20; i++)
+                    cache.put(i, Integer.toString(i));
+
+                // Wait for a while while callback is notified about remaining puts.
+                Thread.sleep(2000);
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CachePutGetExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CachePutGetExample.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.examples.ExampleNodeStartup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This example demonstrates very basic operations on cache, such as 'put' and 'get'.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CachePutGetExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CachePutGetExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CachePutGetExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            try (IgniteCache<Integer, String> cache = ignite.getOrCreateCache(CACHE_NAME)) {
+                // Individual puts and gets.
+                putGet(cache);
+
+                // Bulk puts and gets.
+                putAllGetAll(cache);
+            }
+        }
+    }
+
+    /**
+     * Execute individual puts and gets.
+     *
+     * @throws IgniteException If failed.
+     */
+    private static void putGet(IgniteCache<Integer, String> cache) throws IgniteException {
+        System.out.println();
+        Ignition.print(">>> Cache put-get example started.");
+
+        final int keyCnt = 4;
+
+        if (true) {
+            // Store keys in cache.
+            for (int i = 0; i < keyCnt; i++)
+                cache.put(i, Integer.toString(i));
+
+            Ignition.print(">>> Stored values in cache.");
+        }
+
+        for (int i = 0; i < keyCnt; i++)
+            Ignition.print("Got [key=" + i + ", val=" + cache.get(i) + ']');
+    }
+
+    /**
+     * Execute bulk {@code putAll(...)} and {@code getAll(...)} operations.
+     *
+     * @throws IgniteException If failed.
+     */
+    private static void putAllGetAll(IgniteCache<Integer, String> cache) throws IgniteException {
+        System.out.println();
+        Ignition.print(">>> Starting putAll-getAll example.");
+
+        final int keyCnt = 4;
+
+        if (true) {
+
+            // Create batch.
+            Map<Integer, String> batch = new HashMap<>();
+
+            for (int i = 0; i < keyCnt; i++)
+                batch.put(i, "bulk-" + Integer.toString(i));
+
+            // Bulk-store entries in cache.
+            cache.putAll(batch);
+
+            Ignition.print(">>> Bulk-stored values in cache.");
+
+            // Bulk-get values from cache.
+            Map<Integer, String> vals = cache.getAll(batch.keySet());
+
+            for (Map.Entry<Integer, String> e : vals.entrySet())
+                Ignition.print("Got entry [key=" + e.getKey() + ", val=" + e.getValue() + ']');
+        }
+
+        for (int i = 0; i < keyCnt; i++)
+            Ignition.print("Got [key=" + i + ", val=" + cache.get(i) + ']');
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheQueryDdlExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheQueryDdlExample.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.ExampleNodeStartup;
+
+import java.util.List;
+
+/**
+ * Example to showcase DDL capabilities of Ignite's SQL engine.
+ * <p>
+ * Remote nodes could be started from command line as follows:
+ * {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in either same or another JVM.
+ */
+public class CacheQueryDdlExample {
+    /** Dummy cache name. */
+    private static final String DUMMY_CACHE_NAME = "dummy_cache";
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws Exception If example execution failed.
+     */
+    @SuppressWarnings({"unused", "ThrowFromFinallyBlock"})
+    public static void main(String[] args) throws Exception {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheQueryDdlExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            print("Cache query DDL example started.");
+
+            // Create dummy cache to act as an entry point for SQL queries (new SQL API which do not require this
+            // will appear in future versions, JDBC and ODBC drivers do not require it already).
+            CacheConfiguration<?, ?> cacheCfg = new CacheConfiguration<>(DUMMY_CACHE_NAME).setSqlSchema("PUBLIC");
+
+            try (
+                IgniteCache<?, ?> cache = ignite.getOrCreateCache(cacheCfg)
+            ) {
+
+
+                    // Create reference City table based on REPLICATED template.
+                cache.query(new SqlFieldsQuery(
+                        "CREATE TABLE city (id LONG PRIMARY KEY, name VARCHAR) WITH \"template=replicated\"")).getAll();
+
+                // Create table based on PARTITIONED template with one backup.
+                cache.query(new SqlFieldsQuery(
+                        "CREATE TABLE person (id LONG, name VARCHAR, city_id LONG, PRIMARY KEY (id, city_id)) " +
+                                "WITH \"backups=1, affinityKey=city_id\"")).getAll();
+
+                if (true) {
+                    // Create an index.
+                    cache.query(new SqlFieldsQuery("CREATE INDEX on Person (city_id)")).getAll();
+
+                    print("Created database objects.");
+
+                    SqlFieldsQuery qry = new SqlFieldsQuery("INSERT INTO city (id, name) VALUES (?, ?)");
+
+                    cache.query(qry.setArgs(1L, "Forest Hill")).getAll();
+                    cache.query(qry.setArgs(2L, "Denver")).getAll();
+                    cache.query(qry.setArgs(3L, "St. Petersburg")).getAll();
+
+                    qry = new SqlFieldsQuery("INSERT INTO person (id, name, city_id) values (?, ?, ?)");
+
+                    cache.query(qry.setArgs(1L, "John Doe", 3L)).getAll();
+                    cache.query(qry.setArgs(2L, "Jane Roe", 2L)).getAll();
+                    cache.query(qry.setArgs(3L, "Mary Major", 1L)).getAll();
+                    cache.query(qry.setArgs(4L, "Richard Miles", 2L)).getAll();
+
+                }
+
+                print("Populated data.");
+
+                List<List<?>> res = cache.query(new SqlFieldsQuery(
+                    "SELECT p.name, c.name FROM Person p INNER JOIN City c on c.id = p.city_id")).getAll();
+
+                print("Query results:");
+
+                for (Object next : res)
+                    Ignition.print(">>>    " + next);
+
+                if (false) {
+
+                    cache.query(new SqlFieldsQuery("drop table Person")).getAll();
+                    cache.query(new SqlFieldsQuery("drop table City")).getAll();
+
+                    print("Dropped database objects.");
+                }
+
+            }
+            finally {
+                // Distributed cache can be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(DUMMY_CACHE_NAME);
+            }
+
+            print("Cache query DDL example finished.");
+        }
+    }
+
+    /**
+     * Prints message.
+     *
+     * @param msg Message to print before all objects are printed.
+     */
+    private static void print(String msg) {
+        System.out.println();
+        Ignition.print(">>> " + msg);
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheQueryDmlExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheQueryDmlExample.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.binary.BinaryObjectBuilder;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.model.Organization;
+import org.apache.ignite.examples.model.Person;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.binary.BinaryWriterExImpl;
+import org.apache.ignite.internal.binary.builder.BinaryBuilderSerializer;
+import org.apache.ignite.internal.binary.builder.BinaryObjectBuilderImpl;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+
+import java.util.List;
+
+/**
+ * Example to showcase DML capabilities of Ignite's SQL engine.
+ */
+public class CacheQueryDmlExample {
+    /** Organizations cache name. */
+    private static final String ORG_CACHE = CacheQueryDmlExample.class.getSimpleName() + "Organizations";
+
+    /** Persons cache name. */
+    private static final String PERSON_CACHE = CacheQueryDmlExample.class.getSimpleName() + "Persons";
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws Exception If example execution failed.
+     */
+    @SuppressWarnings({"unused", "ThrowFromFinallyBlock"})
+    public static void main(String[] args) throws Exception {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheQueryDmlExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            print("Cache query DML example started.");
+
+            CacheConfiguration<Long, Organization> orgCacheCfg = new CacheConfiguration<>(ORG_CACHE);
+            orgCacheCfg.setIndexedTypes(Long.class, Organization.class);
+
+            CacheConfiguration<Long, Person> personCacheCfg = new CacheConfiguration<>(PERSON_CACHE);
+            personCacheCfg.setIndexedTypes(Long.class, Person.class);
+
+            // Auto-close cache at the end of the example.
+            try (
+                IgniteCache<Long, Organization> orgCache = ignite.getOrCreateCache(orgCacheCfg);
+                IgniteCache<Long, Person> personCache = ignite.getOrCreateCache(personCacheCfg)
+            ) {
+
+                if (true) {
+                    insert(orgCache, personCache);
+                }
+
+                select(personCache, "Select data");
+
+                update(personCache);
+
+                select(personCache, "Update salary for Master degrees");
+                delete(personCache);
+                select(personCache, "Delete non-Apache employees");
+
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(PERSON_CACHE);
+                ignite.destroyCache(ORG_CACHE);
+            }
+
+            print("Cache query DML example finished.");
+        }
+    }
+
+    /**
+     * Populate cache with test data.
+     *
+     * @param orgCache Organization cache,
+     * @param personCache Person cache.
+     */
+    private static void insert(IgniteCache<Long, Organization> orgCache, IgniteCache<Long, Person> personCache) {
+        // Insert organizations.
+        SqlFieldsQuery qry = new SqlFieldsQuery("insert into Organization (_key, id, name) values (?, ?, ?)");
+
+        orgCache.query(qry.setArgs(1L, 1L, "ASF"));
+        orgCache.query(qry.setArgs(2L, 2L, "Eclipse"));
+
+        // Insert persons.
+        qry = new SqlFieldsQuery(
+            "insert into Person (_key, id, orgId, firstName, lastName, salary, resume) values (?, ?, ?, ?, ?, ?, ?)");
+
+        personCache.query(qry.setArgs(1L, 1L, 1L, "John", "Doe", 4000, "Master"));
+        personCache.query(qry.setArgs(2L, 2L, 1L, "Jane", "Roe", 2000, "Bachelor"));
+        personCache.query(qry.setArgs(3L, 3L, 2L, "Mary", "Major", 5000, "Master"));
+        personCache.query(qry.setArgs(4L, 4L, 2L, "Richard", "Miles", 3000, "Bachelor"));
+    }
+
+    /**
+     * Example of conditional UPDATE query: raise salary by 10% to everyone who has Master degree.
+     *
+     * @param personCache Person cache.
+     */
+    private static void update(IgniteCache<Long, Person> personCache) {
+        String sql =
+            "update Person set salary = salary * 1.1 " +
+            "where resume = ?";
+
+        personCache.query(new SqlFieldsQuery(sql).setArgs("Master"));
+    }
+
+    /**
+     * Example of conditional DELETE query: delete non-Apache employees.
+     *
+     * @param personCache Person cache.
+     */
+    private static void delete(IgniteCache<Long, Person> personCache) {
+        String sql =
+            "delete from Person " +
+            "where id in (" +
+                "select p.id " +
+                "from Person p, \"" + ORG_CACHE + "\".Organization as o " +
+                "where o.name != ? and p.orgId = o.id" +
+            ")";
+
+        personCache.query(new SqlFieldsQuery(sql).setArgs("ASF")).getAll();
+    }
+
+    /**
+     * Query current data.
+     *
+     * @param personCache Person cache.
+     * @param msg Message.
+     */
+    private static void select(IgniteCache<Long, Person> personCache, String msg) {
+        String sql =
+            "select p.id, concat(p.firstName, ' ', p.lastName), o.name, p.resume, p.salary " +
+            "from Person as p, \"" + ORG_CACHE + "\".Organization as o " +
+            "where p.orgId = o.id";
+
+        List<List<?>> res = personCache.query(new SqlFieldsQuery(sql).setDistributedJoins(true)).getAll();
+
+        print(msg);
+
+        for (Object next : res)
+            Ignition.print(">>>     " + next);
+    }
+
+    /**
+     * Prints message.
+     *
+     * @param msg Message to print before all objects are printed.
+     */
+    private static void print(String msg) {
+        System.out.println();
+        Ignition.print(">>> " + msg);
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheQueryExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheQueryExample.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.cache.affinity.AffinityKey;
+import org.apache.ignite.cache.query.*;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.examples.model.Organization;
+import org.apache.ignite.examples.model.Person;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+import org.apache.ignite.lang.IgniteBiPredicate;
+
+import javax.cache.Cache;
+import java.util.List;
+
+/**
+ * Cache queries example. This example demonstrates SQL, TEXT, and FULL SCAN
+ * queries over cache.
+ * <p>
+ * Example also demonstrates usage of fields queries that return only required
+ * fields instead of whole key-value pairs. When fields queries are distributed
+ * across several nodes, they may not work as expected. Keep in mind following
+ * limitations (not applied if data is queried from one node only):
+ * <ul>
+ *     <li>
+ *         Non-distributed joins will work correctly only if joined objects are stored in
+ *         collocated mode. Refer to {@link AffinityKey} javadoc for more details.
+ *         <p>
+ *         To use distributed joins it is necessary to set query 'distributedJoin' flag using
+ *         {@link SqlFieldsQuery#setDistributedJoins(boolean)} or {@link SqlQuery#setDistributedJoins(boolean)}.
+ *     </li>
+ *     <li>
+ *         Note that if you created query on to replicated cache, all data will
+ *         be queried only on one node, not depending on what caches participate in
+ *         the query (some data from partitioned cache can be lost). And visa versa,
+ *         if you created it on partitioned cache, data from replicated caches
+ *         will be duplicated.
+ *     </li>
+ * </ul>
+ * <p>
+ * Remote nodes should be started using {@link ExampleNodeStartup} which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheQueryExample {
+    /** Organizations cache name. */
+    private static final String ORG_CACHE = CacheQueryExample.class.getSimpleName() + "Organizations";
+
+    /** Persons collocated with Organizations cache name. */
+    private static final String COLLOCATED_PERSON_CACHE = CacheQueryExample.class.getSimpleName() + "CollocatedPersons";
+
+    /** Persons cache name. */
+    private static final String PERSON_CACHE = CacheQueryExample.class.getSimpleName() + "Persons";
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws Exception If example execution failed.
+     */
+    public static void main(String[] args) throws Exception {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheQueryExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            Ignition.print(">>> Cache query example started.");
+
+            CacheConfiguration<Long, Organization> orgCacheCfg = new CacheConfiguration<>(ORG_CACHE);
+
+            orgCacheCfg.setCacheMode(CacheMode.PARTITIONED); // Default.
+            orgCacheCfg.setIndexedTypes(Long.class, Organization.class);
+
+            CacheConfiguration<AffinityKey<Long>, Person> colPersonCacheCfg =
+                new CacheConfiguration<>(COLLOCATED_PERSON_CACHE);
+
+            colPersonCacheCfg.setCacheMode(CacheMode.PARTITIONED); // Default.
+            colPersonCacheCfg.setIndexedTypes(AffinityKey.class, Person.class);
+
+            CacheConfiguration<Long, Person> personCacheCfg = new CacheConfiguration<>(PERSON_CACHE);
+
+            personCacheCfg.setCacheMode(CacheMode.PARTITIONED); // Default.
+            personCacheCfg.setIndexedTypes(Long.class, Person.class);
+
+            try {
+                // Create caches.
+                ignite.getOrCreateCache(orgCacheCfg);
+                ignite.getOrCreateCache(colPersonCacheCfg);
+                ignite.getOrCreateCache(personCacheCfg);
+
+                BinaryContext ctx = ignite.context().cacheObjects().getBinaryCtx();
+                ctx.registerClassDescriptor(Organization.class, false);
+                ctx.registerClassDescriptor(Person.class, false);
+
+                // Populate caches.
+                if (true) {
+                    initialize();
+                }
+
+                // Example for SCAN-based query based on a predicate.
+                scanQuery();
+
+                // Example for SQL-based querying employees based on salary ranges.
+                sqlQuery();
+
+                // Example for SQL-based querying employees for a given organization
+                // (includes SQL join for collocated objects).
+                sqlQueryWithJoin();
+
+                // Example for SQL-based querying employees for a given organization
+                // (includes distributed SQL join).
+                sqlQueryWithDistributedJoin();
+
+                // Example for TEXT-based querying for a given string in peoples resumes.
+                textQuery();
+
+                // Example for SQL-based querying to calculate average salary
+                // among all employees within a company.
+                sqlQueryWithAggregation();
+
+                // Example for SQL-based fields queries that return only required
+                // fields instead of whole key-value pairs.
+                sqlFieldsQuery();
+
+                // Example for SQL-based fields queries that uses joins.
+                sqlFieldsQueryWithJoin();
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by Ignite.destroyCache() call.
+                ignite.destroyCache(COLLOCATED_PERSON_CACHE);
+                ignite.destroyCache(PERSON_CACHE);
+                ignite.destroyCache(ORG_CACHE);
+            }
+
+            print("Cache query example finished.");
+        }
+    }
+
+    /**
+     * Example for scan query based on a predicate using binary objects.
+     */
+    private static void scanQuery() {
+        IgniteCache<BinaryObject, BinaryObject> cache = Ignition.ignite()
+            .cache(COLLOCATED_PERSON_CACHE).withKeepBinary();
+
+        ScanQuery<BinaryObject, BinaryObject> scan = new ScanQuery<>(
+            new IgniteBiPredicate<BinaryObject, BinaryObject>() {
+                @Override public boolean apply(BinaryObject key, BinaryObject person) {
+                    return person.<Double>field("salary") <= 1000;
+                }
+            }
+        );
+
+        // Execute queries for salary ranges.
+        print("People with salaries between 0 and 1000 (queried with SCAN query): ", cache.query(scan).getAll());
+    }
+
+    /**
+     * Example for SQL queries based on salary ranges.
+     */
+    private static void sqlQuery() {
+        IgniteCache<Long, Person> cache = Ignition.ignite().cache(PERSON_CACHE);
+
+        // SQL clause which selects salaries based on range.
+        String sql = "salary > ? and salary <= ?";
+
+        // Execute queries for salary ranges.
+        print("People with salaries between 0 and 1000 (queried with SQL query): ",
+            cache.query(new SqlQuery<AffinityKey<Long>, Person>(Person.class, sql).
+                setArgs(0, 1000)).getAll());
+
+        print("People with salaries between 1000 and 2000 (queried with SQL query): ",
+            cache.query(new SqlQuery<AffinityKey<Long>, Person>(Person.class, sql).
+                setArgs(1000, 2000)).getAll());
+    }
+
+    /**
+     * Example for SQL queries based on all employees working for a specific organization.
+     */
+    private static void sqlQueryWithJoin() {
+        IgniteCache<AffinityKey<Long>, Person> cache = Ignition.ignite().cache(COLLOCATED_PERSON_CACHE);
+
+        // SQL clause query which joins on 2 types to select people for a specific organization.
+        String joinSql =
+            "from Person, \"" + ORG_CACHE + "\".Organization as org " +
+            "where Person.orgId = org.id " +
+            "and lower(org.name) = lower(?)";
+
+        // Execute queries for find employees for different organizations.
+        print("Following people are 'ApacheIgnite' employees: ",
+            cache.query(new SqlQuery<AffinityKey<Long>, Person>(Person.class, joinSql).
+                setArgs("ApacheIgnite")).getAll());
+
+        print("Following people are 'Other' employees: ",
+            cache.query(new SqlQuery<AffinityKey<Long>, Person>(Person.class, joinSql).
+                setArgs("Other")).getAll());
+    }
+
+    /**
+     * Example for SQL queries based on all employees working
+     * for a specific organization (query uses distributed join).
+     */
+    private static void sqlQueryWithDistributedJoin() {
+        IgniteCache<Long, Person> cache = Ignition.ignite().cache(PERSON_CACHE);
+
+        // SQL clause query which joins on 2 types to select people for a specific organization.
+        String joinSql =
+            "from Person, \"" + ORG_CACHE + "\".Organization as org " +
+            "where Person.orgId = org.id " +
+            "and lower(org.name) = lower(?)";
+
+        SqlQuery qry = new SqlQuery<Long, Person>(Person.class, joinSql).
+            setArgs("ApacheIgnite");
+
+        // Enable distributed joins for query.
+        qry.setDistributedJoins(true);
+
+        // Execute queries for find employees for different organizations.
+        print("Following people are 'ApacheIgnite' employees (distributed join): ", cache.query(qry).getAll());
+
+        qry.setArgs("Other");
+
+        print("Following people are 'Other' employees (distributed join): ", cache.query(qry).getAll());
+    }
+
+    /**
+     * Example for TEXT queries using LUCENE-based indexing of people's resumes.
+     */
+    private static void textQuery() {
+        IgniteCache<Long, Person> cache = Ignition.ignite().cache(PERSON_CACHE);
+
+        //  Query for all people with "Master Degree" in their resumes.
+        QueryCursor<Cache.Entry<Long, Person>> masters =
+            cache.query(new TextQuery<Long, Person>(Person.class, "Master"));
+
+        // Query for all people with "Bachelor Degree" in their resumes.
+        QueryCursor<Cache.Entry<Long, Person>> bachelors =
+            cache.query(new TextQuery<Long, Person>(Person.class, "Bachelor"));
+
+        print("Following people have 'Master Degree' in their resumes: ", masters.getAll());
+        print("Following people have 'Bachelor Degree' in their resumes: ", bachelors.getAll());
+    }
+
+    /**
+     * Example for SQL queries to calculate average salary for a specific organization.
+     */
+    private static void sqlQueryWithAggregation() {
+        IgniteCache<AffinityKey<Long>, Person> cache = Ignition.ignite().cache(COLLOCATED_PERSON_CACHE);
+
+        // Calculate average of salary of all persons in ApacheIgnite.
+        // Note that we also join on Organization cache as well.
+        String sql =
+            "select avg(salary) " +
+            "from Person, \"" + ORG_CACHE + "\".Organization as org " +
+            "where Person.orgId = org.id " +
+            "and lower(org.name) = lower(?)";
+
+        QueryCursor<List<?>> cursor = cache.query(new SqlFieldsQuery(sql).setArgs("ApacheIgnite"));
+
+        // Calculate average salary for a specific organization.
+        print("Average salary for 'ApacheIgnite' employees: ", cursor.getAll());
+    }
+
+    /**
+     * Example for SQL-based fields queries that return only required
+     * fields instead of whole key-value pairs.
+     */
+    private static void sqlFieldsQuery() {
+        IgniteCache<Long, Person> cache = Ignition.ignite().cache(PERSON_CACHE);
+
+        // Execute query to get names of all employees.
+        QueryCursor<List<?>> cursor = cache.query(new SqlFieldsQuery(
+            "select concat(firstName, ' ', lastName) from Person"));
+
+        // In this particular case each row will have one element with full name of an employees.
+        List<List<?>> res = cursor.getAll();
+
+        // Print names.
+        print("Names of all employees:", res);
+    }
+
+    /**
+     * Example for SQL-based fields queries that return only required
+     * fields instead of whole key-value pairs.
+     */
+    private static void sqlFieldsQueryWithJoin() {
+        IgniteCache<AffinityKey<Long>, Person> cache = Ignition.ignite().cache(COLLOCATED_PERSON_CACHE);
+
+        // Execute query to get names of all employees.
+        String sql =
+            "select concat(firstName, ' ', lastName), org.name " +
+            "from Person, \"" + ORG_CACHE + "\".Organization as org " +
+            "where Person.orgId = org.id";
+
+        QueryCursor<List<?>> cursor = cache.query(new SqlFieldsQuery(sql));
+
+        // In this particular case each row will have one element with full name of an employees.
+        List<List<?>> res = cursor.getAll();
+
+        // Print persons' names and organizations' names.
+        print("Names of all employees and organizations they belong to: ", res);
+    }
+
+    /**
+     * Populate cache with test data.
+     */
+    private static void initialize() {
+        IgniteCache<Long, Organization> orgCache = Ignition.ignite().cache(ORG_CACHE);
+
+        // Clear cache before running the example.
+        orgCache.clear();
+
+        // Organizations.
+        Organization org1 = new Organization("ApacheIgnite");
+        Organization org2 = new Organization("Other");
+
+        orgCache.put(org1.id(), org1);
+        orgCache.put(org2.id(), org2);
+
+        IgniteCache<AffinityKey<Long>, Person> colPersonCache = Ignition.ignite().cache(COLLOCATED_PERSON_CACHE);
+        IgniteCache<Long, Person> personCache = Ignition.ignite().cache(PERSON_CACHE);
+
+        // Clear caches before running the example.
+        colPersonCache.clear();
+        personCache.clear();
+
+        // People.
+        Person p1 = new Person(org1, "John", "Doe", 2000, "John Doe has Master Degree.");
+        Person p2 = new Person(org1, "Jane", "Doe", 1000, "Jane Doe has Bachelor Degree.");
+        Person p3 = new Person(org2, "John", "Smith", 1000, "John Smith has Bachelor Degree.");
+        Person p4 = new Person(org2, "Jane", "Smith", 2000, "Jane Smith has Master Degree.");
+
+        // Note that in this example we use custom affinity key for Person objects
+        // to ensure that all persons are collocated with their organizations.
+        colPersonCache.put(p1.key(), p1);
+        colPersonCache.put(p2.key(), p2);
+        colPersonCache.put(p3.key(), p3);
+        colPersonCache.put(p4.key(), p4);
+
+        // These Person objects are not collocated with their organizations.
+        personCache.put(p1.id, p1);
+        personCache.put(p2.id, p2);
+        personCache.put(p3.id, p3);
+        personCache.put(p4.id, p4);
+    }
+
+    /**
+     * Prints message and query results.
+     *
+     * @param msg Message to print before all objects are printed.
+     * @param col Query results.
+     */
+    private static void print(String msg, Iterable<?> col) {
+        print(msg);
+        print(col);
+    }
+
+    /**
+     * Prints message.
+     *
+     * @param msg Message to print before all objects are printed.
+     */
+    private static void print(String msg) {
+        System.out.println();
+        Ignition.print(">>> " + msg);
+    }
+
+    /**
+     * Prints query results.
+     *
+     * @param col Query results.
+     */
+    private static void print(Iterable<?> col) {
+        for (Object next : col)
+            Ignition.print(">>>     " + next);
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/CacheTransactionExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/CacheTransactionExample.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.internal.binary.BinaryContext;
+import org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl;
+import org.apache.ignite.transactions.Transaction;
+
+import java.io.Serializable;
+
+import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
+import static org.apache.ignite.transactions.TransactionIsolation.REPEATABLE_READ;
+
+/**
+ * Demonstrates how to use cache transactions.
+ * <p>
+ * Remote nodes should always be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} examples/config/example-ignite.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which will
+ * start node with {@code examples/config/example-ignite.xml} configuration.
+ */
+public class CacheTransactionExample {
+    /** Cache name. */
+    private static final String CACHE_NAME = CacheTransactionExample.class.getSimpleName();
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + CacheTransactionExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-ignite.xml")) {
+            System.out.println();
+            Ignition.print(">>> Cache transaction example started.");
+
+            CacheConfiguration<Integer, Account> cfg = new CacheConfiguration<>(CACHE_NAME);
+
+            cfg.setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL);
+
+            // Auto-close cache at the end of the example.
+            try (IgniteCache<Integer, Account> cache = ignite.getOrCreateCache(cfg)) {
+
+                // Initialize.
+                if (true) {
+
+                    cache.put(1, new Account(1, 100));
+                    cache.put(2, new Account(1, 200));
+
+                    System.out.println();
+                    Ignition.print(">>> Accounts before deposit: ");
+                    Ignition.print(">>> " + cache.get(1));
+                    Ignition.print(">>> " + cache.get(2));
+
+                    // Make transactional deposits.
+                    deposit(cache, 1, 100);
+                    deposit(cache, 2, 200);
+                }
+
+                System.out.println();
+                Ignition.print(">>> Accounts after transfer: ");
+                Ignition.print(">>> " + cache.get(1));
+                Ignition.print(">>> " + cache.get(2));
+
+                Ignition.print(">>> Cache transaction example finished.");
+            }
+            finally {
+                // Distributed cache could be removed from cluster only by #destroyCache() call.
+                ignite.destroyCache(CACHE_NAME);
+            }
+        }
+    }
+
+    /**
+     * Make deposit into specified account.
+     *
+     * @param acctId Account ID.
+     * @param amount Amount to deposit.
+     * @throws IgniteException If failed.
+     */
+    private static void deposit(IgniteCache<Integer, Account> cache, int acctId, double amount) throws IgniteException {
+        try (Transaction tx = Ignition.ignite().transactions().txStart(PESSIMISTIC, REPEATABLE_READ)) {
+            Account acct = cache.get(acctId);
+
+            assert acct != null;
+
+            // Deposit into account.
+            acct.update(amount);
+
+            // Store updated account in cache.
+            cache.put(acctId, acct);
+
+            tx.commit();
+        }
+
+        System.out.println();
+        Ignition.print(">>> Transferred amount: $" + amount);
+    }
+
+    /**
+     * Account.
+     */
+    private static class Account implements Serializable {
+        /** Account ID. */
+        private int id;
+
+        /** Account balance. */
+        private double balance;
+
+        /**
+         * @param id Account ID.
+         * @param balance Balance.
+         */
+        Account(int id, double balance) {
+            this.id = id;
+            this.balance = balance;
+        }
+
+        /**
+         * Change balance by specified amount.
+         *
+         * @param amount Amount to add to balance (may be negative).
+         */
+        void update(double amount) {
+            balance += amount;
+        }
+
+        /** {@inheritDoc} */
+        @Override public String toString() {
+            return "Account [id=" + id + ", balance=$" + balance + ']';
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/DataRegionsExample.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/DataRegionsExample.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.examples.ExampleNodeStartup;
+import org.apache.ignite.internal.processors.cache.GatewayProtectedCacheProxy;
+
+/**
+ * This example demonstrates how to tweak particular settings of Apache Ignite page memory using
+ * {@link DataStorageConfiguration} and set up several data regions for different caches with
+ * {@link DataRegionConfiguration}.
+ * <p>
+ * Additional remote nodes can be started with special configuration file which
+ * enables P2P class loading: {@code 'ignite.{sh|bat} example-data-regions.xml'}.
+ * <p>
+ * Alternatively you can run {@link ExampleNodeStartup} in another JVM which passing
+ * {@code examples/config/example-data-regions.xml} configuration to it.
+ */
+public class DataRegionsExample {
+    /** Name of the default data region defined in 'example-data-regions.xml'. */
+    public static final String REGION_DEFAULT = "Default_Region";
+
+    /** Name of the data region that creates a memory region limited by 40 MB with eviction enabled */
+    public static final String REGION_40MB_EVICTION = "40MB_Region_Eviction";
+
+    /** Name of the data region that creates a memory region mapped to a memory-mapped file. */
+    public static final String REGION_30MB_MEMORY_MAPPED_FILE = "30MB_Region_Swapping";
+
+    /**
+     * Executes example.
+     *
+     * @param args Command line arguments, none required.
+     * @throws IgniteException If example execution failed.
+     */
+    public static void main(String[] args) throws IgniteException {
+
+        Ignition.setAepStore("/mnt/mem/" + DataRegionsExample.class.getSimpleName());
+
+        try (Ignite ignite = Ignition.start("examples/config/example-data-regions.xml")) {
+            System.out.println();
+            Ignition.print(">>> Data regions example started.");
+
+            /*
+             * Preparing configurations for 2 caches that will be bound to the memory region defined by
+             * '10MB_Region_Eviction' data region from 'example-data-regions.xml' configuration.
+             */
+            CacheConfiguration<Integer, Integer> firstCacheCfg = new CacheConfiguration<>("firstCache");
+
+            firstCacheCfg.setDataRegionName(REGION_40MB_EVICTION);
+            firstCacheCfg.setCacheMode(CacheMode.PARTITIONED);
+            firstCacheCfg.setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL);
+
+            CacheConfiguration<Integer, Integer> secondCacheCfg = new CacheConfiguration<>("secondCache");
+            secondCacheCfg.setDataRegionName(REGION_40MB_EVICTION);
+            secondCacheCfg.setCacheMode(CacheMode.REPLICATED);
+            secondCacheCfg.setAtomicityMode(CacheAtomicityMode.ATOMIC);
+
+            IgniteCache<Integer, Integer> firstCache = ignite.createCache(firstCacheCfg);
+            IgniteCache<Integer, Integer> secondCache = ignite.createCache(secondCacheCfg);
+
+            Ignition.print(">>> Started two caches bound to '" + REGION_40MB_EVICTION + "' memory region.");
+
+            /*
+             * Preparing a configuration for a cache that will be bound to the memory region defined by
+             * '5MB_Region_Swapping' data region from 'example-data-regions.xml' configuration.
+             */
+            CacheConfiguration<Integer, Integer> thirdCacheCfg = new CacheConfiguration<>("thirdCache");
+
+            thirdCacheCfg.setDataRegionName(REGION_30MB_MEMORY_MAPPED_FILE);
+
+            IgniteCache<Integer, Integer> thirdCache = ignite.createCache(thirdCacheCfg);
+
+            Ignition.print(">>> Started a cache bound to '" + REGION_30MB_MEMORY_MAPPED_FILE + "' memory region.");
+
+            /*
+             * Preparing a configuration for a cache that will be bound to the default memory region defined by
+             * default 'Default_Region' data region from 'example-data-regions.xml' configuration.
+             */
+            CacheConfiguration<Integer, Integer> fourthCacheCfg = new CacheConfiguration<>("fourthCache");
+
+            IgniteCache<Integer, Integer> fourthCache = ignite.createCache(fourthCacheCfg);
+
+            Ignition.print(">>> Started a cache bound to '" + REGION_DEFAULT + "' memory region.");
+
+            Ignition.print(">>> Destroying caches...");
+
+            firstCache.destroy();
+            secondCache.destroy();
+            thirdCache.destroy();
+            fourthCache.destroy();
+
+        }
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/SampleValue.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/SampleValue.java
@@ -1,0 +1,72 @@
+package org.apache.ignite.examples.aep;
+
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import org.apache.ignite.binary.BinaryObjectException;
+import org.apache.ignite.binary.BinaryReader;
+import org.apache.ignite.binary.BinaryWriter;
+import org.apache.ignite.binary.Binarylizable;
+import org.apache.ignite.cache.query.annotations.QuerySqlField;
+
+/**
+ * Entity class for benchmark.
+ */
+public class SampleValue implements Externalizable, Binarylizable {
+    /** */
+    @QuerySqlField
+    private int id;
+
+    /** */
+    public SampleValue() {
+        // No-op.
+    }
+
+    /**
+     * @param id Id.
+     */
+    public SampleValue(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @param id Id.
+     */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    /**
+     * @return Id.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        id = in.readInt();
+    }
+
+    /** {@inheritDoc} */
+    @Override public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override public void writeBinary(BinaryWriter writer) throws BinaryObjectException {
+        writer.writeInt("id", id);
+    }
+
+    /** {@inheritDoc} */
+    @Override public void readBinary(BinaryReader reader) throws BinaryObjectException {
+        id = reader.readInt("id");
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "SampleValue [id=" + id + ']';
+    }
+}

--- a/examples/src/main/java/org/apache/ignite/examples/aep/ServerNode.java
+++ b/examples/src/main/java/org/apache/ignite/examples/aep/ServerNode.java
@@ -1,0 +1,19 @@
+package org.apache.ignite.examples.aep;
+
+import org.apache.ignite.Ignition;
+
+/**
+ * @see org.apache.ignite.examples.persistentstore.PersistentStoreExampleNodeStartup
+ */
+public class ServerNode {
+    /**
+     * @param args Program arguments, ignored.
+     * @throws Exception If failed.
+     */
+    public static void main(String[] args) throws Exception {
+        Ignition.setAepStore("/mnt/mem/" + CacheApiClientExample.class.getSimpleName());
+        Ignition.start("examples/config/example-ignite.xml");
+        //Ignition.start("examples/config/persistentstore/example-persistent-store.xml");
+
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/Ignite.java
+++ b/modules/core/src/main/java/org/apache/ignite/Ignite.java
@@ -31,6 +31,7 @@ import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.NearCacheConfiguration;
+import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.lang.IgniteProductVersion;
 import org.apache.ignite.plugin.IgnitePlugin;
@@ -722,4 +723,11 @@ public interface Ignite extends AutoCloseable {
      * @return {@link DataStorageMetrics} snapshot.
      */
     public DataStorageMetrics dataStorageMetrics();
+
+    /**
+     *
+     * @return
+     */
+    public GridKernalContext context();
+
 }

--- a/modules/core/src/main/java/org/apache/ignite/configuration/DataRegionConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/DataRegionConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.ignite.configuration;
 
 import java.io.Serializable;
 import org.apache.ignite.DataRegionMetrics;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.mem.IgniteOutOfMemoryException;
 import org.apache.ignite.mxbean.DataRegionMetricsMXBean;
 
@@ -339,7 +340,8 @@ public final class DataRegionConfiguration implements Serializable {
      * @return {@code this} for chaining.
      */
     public DataRegionConfiguration setPersistenceEnabled(boolean persistenceEnabled) {
-        this.persistenceEnabled = persistenceEnabled;
+        if (!Ignition.isAepEnabled())
+            this.persistenceEnabled = persistenceEnabled;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -93,6 +93,7 @@ import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.MemoryConfiguration;
 import org.apache.ignite.configuration.NearCacheConfiguration;
+import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.binary.BinaryEnumCache;
 import org.apache.ignite.internal.binary.BinaryMarshaller;
 import org.apache.ignite.internal.binary.BinaryUtils;
@@ -3170,6 +3171,9 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
     /** {@inheritDoc} */
     @Override public boolean destroyCache0(String cacheName, boolean sql) throws CacheException {
         CU.validateCacheName(cacheName);
+
+        if (Ignition.isAepClientModeEnabled())
+            return true;
 
         IgniteInternalFuture<Boolean> stopFut = destroyCacheAsync(cacheName, sql, true);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryObjectException;
 import org.apache.ignite.binary.BinaryReflectiveSerializer;
 import org.apache.ignite.binary.BinarySerializer;
@@ -389,7 +390,7 @@ public class BinaryClassDescriptor {
      * @param f Field.
      * @return {@code True} if must be serialized.
      */
-    private static boolean serializeField(Field f) {
+    public static boolean serializeField(Field f) {
         int mod = f.getModifiers();
 
         return !Modifier.isStatic(mod) && !Modifier.isTransient(mod);
@@ -921,7 +922,7 @@ public class BinaryClassDescriptor {
      */
     private Object newInstance() throws BinaryObjectException {
         try {
-            return ctor != null ? ctor.newInstance() : GridUnsafe.allocateInstance(cls);
+            return ctor != null ? ctor.newInstance() : Ignition.UNSAFE.allocateInstance(cls);
         }
         catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
             throw new BinaryObjectException("Failed to instantiate instance: " + cls, e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
@@ -721,7 +721,7 @@ public class BinaryContext {
      * @param cls Class.
      * @return Class descriptor.
      */
-    private BinaryClassDescriptor registerClassDescriptor(Class<?> cls, boolean deserialize) {
+    public BinaryClassDescriptor registerClassDescriptor(Class<?> cls, boolean deserialize) {
         BinaryClassDescriptor desc;
 
         String clsName = cls.getName();
@@ -761,7 +761,7 @@ public class BinaryContext {
      * @param cls Class.
      * @return Class descriptor.
      */
-    private BinaryClassDescriptor registerUserClassDescriptor(Class<?> cls, boolean deserialize) {
+    public BinaryClassDescriptor registerUserClassDescriptor(Class<?> cls, boolean deserialize) {
         boolean registered;
 
         final String clsName = cls.getName();
@@ -791,7 +791,7 @@ public class BinaryContext {
         );
 
         if (!deserialize)
-            metaHnd.addMeta(typeId, new BinaryMetadata(typeId, typeName, desc.fieldsMeta(), affFieldName, null,
+            metaHnd.addMeta(typeId, new BinaryMetadata(typeId, typeName, desc.fieldsMeta(), affFieldName, /*Collections.singleton(desc.schema())*/ null,
                 desc.isEnum(), cls.isEnum() ? enumMap(cls) : null).wrap(this));
 
         descByCls.put(cls, desc);

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryFieldAccessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryFieldAccessor.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryObjectException;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.typedef.F;
@@ -197,7 +198,7 @@ public abstract class BinaryFieldAccessor {
         protected AbstractPrimitiveAccessor(Field field, int id, BinaryWriteMode mode) {
             super(field, id, mode);
 
-            offset = GridUnsafe.objectFieldOffset(field);
+            offset = Ignition.UNSAFE.objectFieldOffset(field);
         }
     }
 
@@ -218,7 +219,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            byte val = GridUnsafe.getByteField(obj, offset);
+            byte val = Ignition.UNSAFE.getByteField(obj, offset);
 
             writer.writeByteFieldPrimitive(val);
         }
@@ -227,7 +228,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             byte val = reader.readByte(id);
 
-            GridUnsafe.putByteField(obj, offset, val);
+            Ignition.UNSAFE.putByteField(obj, offset, val);
         }
     }
 
@@ -248,7 +249,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            boolean val = GridUnsafe.getBooleanField(obj, offset);
+            boolean val = Ignition.UNSAFE.getBooleanField(obj, offset);
 
             writer.writeBooleanFieldPrimitive(val);
         }
@@ -257,7 +258,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             boolean val = reader.readBoolean(id);
 
-            GridUnsafe.putBooleanField(obj, offset, val);
+            Ignition.UNSAFE.putBooleanField(obj, offset, val);
         }
     }
 
@@ -278,7 +279,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            short val = GridUnsafe.getShortField(obj, offset);
+            short val = Ignition.UNSAFE.getShortField(obj, offset);
 
             writer.writeShortFieldPrimitive(val);
         }
@@ -287,7 +288,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             short val = reader.readShort(id);
 
-            GridUnsafe.putShortField(obj, offset, val);
+            Ignition.UNSAFE.putShortField(obj, offset, val);
         }
     }
 
@@ -308,7 +309,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            char val = GridUnsafe.getCharField(obj, offset);
+            char val = Ignition.UNSAFE.getCharField(obj, offset);
 
             writer.writeCharFieldPrimitive(val);
         }
@@ -317,7 +318,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             char val = reader.readChar(id);
 
-            GridUnsafe.putCharField(obj, offset, val);
+            Ignition.UNSAFE.putCharField(obj, offset, val);
         }
     }
 
@@ -338,7 +339,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            int val = GridUnsafe.getIntField(obj, offset);
+            int val = Ignition.UNSAFE.getIntField(obj, offset);
 
             writer.writeIntFieldPrimitive(val);
         }
@@ -347,7 +348,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             int val = reader.readInt(id);
 
-            GridUnsafe.putIntField(obj, offset, val);
+            Ignition.UNSAFE.putIntField(obj, offset, val);
         }
     }
 
@@ -368,7 +369,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            long val = GridUnsafe.getLongField(obj, offset);
+            long val = Ignition.UNSAFE.getLongField(obj, offset);
 
             writer.writeLongFieldPrimitive(val);
         }
@@ -377,7 +378,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             long val = reader.readLong(id);
 
-            GridUnsafe.putLongField(obj, offset, val);
+            Ignition.UNSAFE.putLongField(obj, offset, val);
         }
     }
 
@@ -398,7 +399,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            float val = GridUnsafe.getFloatField(obj, offset);
+            float val = Ignition.UNSAFE.getFloatField(obj, offset);
 
             writer.writeFloatFieldPrimitive(val);
         }
@@ -407,7 +408,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             float val = reader.readFloat(id);
 
-            GridUnsafe.putFloatField(obj, offset, val);
+            Ignition.UNSAFE.putFloatField(obj, offset, val);
         }
     }
 
@@ -428,7 +429,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void write(Object obj, BinaryWriterExImpl writer) throws BinaryObjectException {
             writer.writeFieldIdNoSchemaUpdate(id);
 
-            double val = GridUnsafe.getDoubleField(obj, offset);
+            double val = Ignition.UNSAFE.getDoubleField(obj, offset);
 
             writer.writeDoubleFieldPrimitive(val);
         }
@@ -437,7 +438,7 @@ public abstract class BinaryFieldAccessor {
         @Override public void read0(Object obj, BinaryReaderExImpl reader) throws BinaryObjectException {
             double val = reader.readDouble(id);
 
-            GridUnsafe.putDoubleField(obj, offset, val);
+            Ignition.UNSAFE.putDoubleField(obj, offset, val);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryPrimitives.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryPrimitives.java
@@ -17,8 +17,8 @@
 
 package org.apache.ignite.internal.binary;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
-
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
 
 /**
@@ -31,7 +31,7 @@ public abstract class BinaryPrimitives {
      * @param val Value.
      */
     public static void writeByte(byte[] arr, int off, byte val) {
-        GridUnsafe.putByte(arr, GridUnsafe.BYTE_ARR_OFF + off, val);
+        Ignition.UNSAFE.putByte(arr, GridUnsafe.BYTE_ARR_OFF + off, val);
     }
 
     /**
@@ -40,7 +40,7 @@ public abstract class BinaryPrimitives {
      * @return Value.
      */
     public static byte readByte(byte[] arr, int off) {
-        return GridUnsafe.getByte(arr, GridUnsafe.BYTE_ARR_OFF + off);
+        return Ignition.UNSAFE.getByte(arr, GridUnsafe.BYTE_ARR_OFF + off);
     }
 
     /**
@@ -49,7 +49,7 @@ public abstract class BinaryPrimitives {
      * @return Value.
      */
     public static byte readByte(long ptr, int off) {
-        return GridUnsafe.getByte(ptr + off);
+        return Ignition.UNSAFE.getByte(ptr + off);
     }
 
     /**
@@ -73,7 +73,7 @@ public abstract class BinaryPrimitives {
     public static byte[] readByteArray(long ptr, int off, int len) {
         byte[] arr0 = new byte[len];
 
-        GridUnsafe.copyOffheapHeap(ptr + off, arr0, GridUnsafe.BYTE_ARR_OFF, len);
+        Ignition.UNSAFE.copyOffheapHeap(ptr + off, arr0, GridUnsafe.BYTE_ARR_OFF, len);
 
         return arr0;
     }
@@ -111,12 +111,12 @@ public abstract class BinaryPrimitives {
      * @param val Value.
      */
     public static void writeShort(byte[] arr, int off, short val) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(arr, pos, val);
+            Ignition.UNSAFE.putShortLE(arr, pos, val);
         else
-            GridUnsafe.putShort(arr, pos, val);
+            Ignition.UNSAFE.putShort(arr, pos, val);
     }
 
     /**
@@ -126,9 +126,9 @@ public abstract class BinaryPrimitives {
      */
     public static void writeShort(long ptr, int off, short val) {
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(ptr + off, val);
+            Ignition.UNSAFE.putShortLE(ptr + off, val);
         else
-            GridUnsafe.putShort(ptr + off, val);
+            Ignition.UNSAFE.putShort(ptr + off, val);
     }
 
     /**
@@ -137,9 +137,9 @@ public abstract class BinaryPrimitives {
      * @return Value.
      */
     public static short readShort(byte[] arr, int off) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(arr, pos) : GridUnsafe.getShort(arr, pos);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(arr, pos) : Ignition.UNSAFE.getShort(arr, pos);
     }
 
     /**
@@ -150,7 +150,7 @@ public abstract class BinaryPrimitives {
     public static short readShort(long ptr, int off) {
         long addr = ptr + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(addr) : GridUnsafe.getShort(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(addr) : Ignition.UNSAFE.getShort(addr);
     }
 
     /**
@@ -159,12 +159,12 @@ public abstract class BinaryPrimitives {
      * @param val Value.
      */
     public static void writeChar(byte[] arr, int off, char val) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putCharLE(arr, pos, val);
+            Ignition.UNSAFE.putCharLE(arr, pos, val);
         else
-            GridUnsafe.putChar(arr, pos, val);
+            Ignition.UNSAFE.putChar(arr, pos, val);
     }
 
     /**
@@ -173,9 +173,9 @@ public abstract class BinaryPrimitives {
      * @return Value.
      */
     public static char readChar(byte[] arr, int off) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getCharLE(arr, pos): GridUnsafe.getChar(arr, pos);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getCharLE(arr, pos): Ignition.UNSAFE.getChar(arr, pos);
     }
 
     /**
@@ -186,7 +186,7 @@ public abstract class BinaryPrimitives {
     public static char readChar(long ptr, int off) {
         long addr = ptr + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getCharLE(addr) : GridUnsafe.getChar(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getCharLE(addr) : Ignition.UNSAFE.getChar(addr);
     }
 
     /**
@@ -197,7 +197,7 @@ public abstract class BinaryPrimitives {
     public static char[] readCharArray(byte[] arr, int off, int len) {
         char[] arr0 = new char[len];
 
-        GridUnsafe.copyMemory(arr, GridUnsafe.BYTE_ARR_OFF + off, arr0, GridUnsafe.CHAR_ARR_OFF, len << 1);
+        Ignition.UNSAFE.copyMemory(arr, Ignition.UNSAFE.BYTE_ARR_OFF + off, arr0, Ignition.UNSAFE.CHAR_ARR_OFF, len << 1);
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < len; i++)
@@ -215,7 +215,7 @@ public abstract class BinaryPrimitives {
     public static char[] readCharArray(long ptr, int off, int len) {
         char[] arr0 = new char[len];
 
-        GridUnsafe.copyOffheapHeap(ptr + off, arr0, GridUnsafe.CHAR_ARR_OFF, len << 1);
+        Ignition.UNSAFE.copyOffheapHeap(ptr + off, arr0, Ignition.UNSAFE.CHAR_ARR_OFF, len << 1);
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < len; i++)
@@ -231,12 +231,12 @@ public abstract class BinaryPrimitives {
      * @param val Value.
      */
     public static void writeInt(byte[] arr, int off, int val) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(arr, pos, val);
+            Ignition.UNSAFE.putIntLE(arr, pos, val);
         else
-            GridUnsafe.putInt(arr, pos, val);
+            Ignition.UNSAFE.putInt(arr, pos, val);
     }
 
     /**
@@ -246,9 +246,9 @@ public abstract class BinaryPrimitives {
      */
     public static void writeInt(long ptr, int off, int val) {
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(ptr + off, val);
+            Ignition.UNSAFE.putIntLE(ptr + off, val);
         else
-            GridUnsafe.putInt(ptr + off, val);
+            Ignition.UNSAFE.putInt(ptr + off, val);
     }
 
     /**
@@ -257,9 +257,9 @@ public abstract class BinaryPrimitives {
      * @return Value.
      */
     public static int readInt(byte[] arr, int off) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(arr, pos) : GridUnsafe.getInt(arr, pos);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(arr, pos) : Ignition.UNSAFE.getInt(arr, pos);
     }
 
     /**
@@ -270,7 +270,7 @@ public abstract class BinaryPrimitives {
     public static int readInt(long ptr, int off) {
         long addr = ptr + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(addr) : GridUnsafe.getInt(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(addr) : Ignition.UNSAFE.getInt(addr);
     }
 
     /**
@@ -279,12 +279,12 @@ public abstract class BinaryPrimitives {
      * @param val Value.
      */
     public static void writeLong(byte[] arr, int off, long val) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putLongLE(arr, pos, val);
+            Ignition.UNSAFE.putLongLE(arr, pos, val);
         else
-            GridUnsafe.putLong(arr, pos, val);
+            Ignition.UNSAFE.putLong(arr, pos, val);
     }
 
     /**
@@ -293,9 +293,9 @@ public abstract class BinaryPrimitives {
      * @return Value.
      */
     public static long readLong(byte[] arr, int off) {
-        long pos = GridUnsafe.BYTE_ARR_OFF + off;
+        long pos = Ignition.UNSAFE.BYTE_ARR_OFF + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getLongLE(arr, pos) : GridUnsafe.getLong(arr, pos);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getLongLE(arr, pos) : Ignition.UNSAFE.getLong(arr, pos);
     }
 
     /**
@@ -306,7 +306,7 @@ public abstract class BinaryPrimitives {
     public static long readLong(long ptr, int off) {
         long addr = ptr + off;
 
-        return BIG_ENDIAN ? GridUnsafe.getLongLE(addr) : GridUnsafe.getLong(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getLongLE(addr) : Ignition.UNSAFE.getLong(addr);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinarySchema.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinarySchema.java
@@ -25,10 +25,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * Schema describing binary object content. We rely on the following assumptions:

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinarySchemaWithId.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinarySchemaWithId.java
@@ -1,0 +1,24 @@
+package org.apache.ignite.internal.binary;
+
+import java.io.Serializable;
+
+public class BinarySchemaWithId implements Serializable {
+
+    private static final long serialVersionUID = 0L;
+
+    private int schemaId;
+    private BinarySchema schema;
+
+    BinarySchemaWithId(int schemaId, BinarySchema schema) {
+        this.schemaId = schemaId;
+        this.schema = schema;
+    }
+
+    public int getSchemaId() {
+        return schemaId;
+    }
+
+    public BinarySchema getSchema() {
+        return schema;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryBuilderSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryBuilderSerializer.java
@@ -31,7 +31,7 @@ import org.apache.ignite.internal.binary.GridBinaryMarshaller;
 /**
  *
  */
-class BinaryBuilderSerializer {
+public class BinaryBuilderSerializer {
     /** */
     private final Map<BinaryObjectBuilderImpl, Integer> objToPos = new IdentityHashMap<>();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryObjectBuilderImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryObjectBuilderImpl.java
@@ -193,7 +193,7 @@ public class BinaryObjectBuilderImpl implements BinaryObjectBuilder {
      * @param serializer Serializer.
      */
     @SuppressWarnings("ResultOfMethodCallIgnored")
-    void serializeTo(BinaryWriterExImpl writer, BinaryBuilderSerializer serializer) {
+    public void serializeTo(BinaryWriterExImpl writer, BinaryBuilderSerializer serializer) {
         try {
             writer.preWrite(registeredType ? null : clsNameToWrite);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapInputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapInputStream.java
@@ -18,6 +18,8 @@
 package org.apache.ignite.internal.binary.streams;
 
 import java.util.Arrays;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
@@ -122,57 +124,57 @@ public final class BinaryHeapInputStream extends BinaryAbstractInputStream {
 
     /** {@inheritDoc} */
     @Override protected void copyAndShift(Object target, long off, int len) {
-        GridUnsafe.copyMemory(data, GridUnsafe.BYTE_ARR_OFF + pos, target, off, len);
+        Ignition.UNSAFE.copyMemory(data, Ignition.UNSAFE.BYTE_ARR_OFF + pos, target, off, len);
 
         shift(len);
     }
 
     /** {@inheritDoc} */
     @Override protected short readShortFast() {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(data, off) : GridUnsafe.getShort(data, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(data, off) : Ignition.UNSAFE.getShort(data, off);
 
     }
 
     /** {@inheritDoc} */
     @Override protected char readCharFast() {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getCharLE(data, off) : GridUnsafe.getChar(data, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getCharLE(data, off) : Ignition.UNSAFE.getChar(data, off);
     }
 
     /** {@inheritDoc} */
     @Override protected int readIntFast() {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(data, off) : GridUnsafe.getInt(data, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(data, off) : Ignition.UNSAFE.getInt(data, off);
     }
 
     /** {@inheritDoc} */
     @Override protected long readLongFast() {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getLongLE(data, off) : GridUnsafe.getLong(data, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getLongLE(data, off) : Ignition.UNSAFE.getLong(data, off);
     }
 
     /** {@inheritDoc} */
     @Override protected byte readBytePositioned0(int pos) {
-        return GridUnsafe.getByte(data, GridUnsafe.BYTE_ARR_OFF + pos);
+        return Ignition.UNSAFE.getByte(data, Ignition.UNSAFE.BYTE_ARR_OFF + pos);
     }
 
     /** {@inheritDoc} */
     @Override protected short readShortPositioned0(int pos) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(data, off) : GridUnsafe.getShort(data, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(data, off) : Ignition.UNSAFE.getShort(data, off);
 
     }
 
     /** {@inheritDoc} */
     @Override protected int readIntPositioned0(int pos) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(data, off) : GridUnsafe.getInt(data, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(data, off) : Ignition.UNSAFE.getInt(data, off);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary.streams;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
@@ -92,120 +93,120 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
 
     /** {@inheritDoc} */
     @Override protected void copyAndShift(Object src, long off, int len) {
-        GridUnsafe.copyMemory(src, off, data, GridUnsafe.BYTE_ARR_OFF + pos, len);
+        Ignition.UNSAFE.copyMemory(src, off, data, Ignition.UNSAFE.BYTE_ARR_OFF + pos, len);
 
         shift(len);
     }
 
     /** {@inheritDoc} */
     @Override protected void writeShortFast(short val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(data, off, val);
+            Ignition.UNSAFE.putShortLE(data, off, val);
         else
-            GridUnsafe.putShort(data, off, val);
+            Ignition.UNSAFE.putShort(data, off, val);
     }
 
     /** {@inheritDoc} */
     @Override protected void writeCharFast(char val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putCharLE(data, off, val);
+            Ignition.UNSAFE.putCharLE(data, off, val);
         else
-            GridUnsafe.putChar(data, off, val);
+            Ignition.UNSAFE.putChar(data, off, val);
     }
 
     /** {@inheritDoc} */
     @Override protected void writeIntFast(int val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(data, off, val);
+            Ignition.UNSAFE.putIntLE(data, off, val);
         else
-            GridUnsafe.putInt(data, off, val);
+            Ignition.UNSAFE.putInt(data, off, val);
     }
 
     /** {@inheritDoc} */
     @Override protected void writeLongFast(long val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putLongLE(data, off, val);
+            Ignition.UNSAFE.putLongLE(data, off, val);
         else
-            GridUnsafe.putLong(data, off, val);
+            Ignition.UNSAFE.putLong(data, off, val);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteByte(byte val) {
-        GridUnsafe.putByte(data, GridUnsafe.BYTE_ARR_OFF + pos++, val);
+        Ignition.UNSAFE.putByte(data, Ignition.UNSAFE.BYTE_ARR_OFF + pos++, val);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteShort(short val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(data, off, val);
+            Ignition.UNSAFE.putShortLE(data, off, val);
         else
-            GridUnsafe.putShort(data, off, val);
+            Ignition.UNSAFE.putShort(data, off, val);
 
         shift(2);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteShort(int pos, short val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(data, off, val);
+            Ignition.UNSAFE.putShortLE(data, off, val);
         else
-            GridUnsafe.putShort(data, off, val);
+            Ignition.UNSAFE.putShort(data, off, val);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteChar(char val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putCharLE(data, off, val);
+            Ignition.UNSAFE.putCharLE(data, off, val);
         else
-            GridUnsafe.putChar(data, off, val);
+            Ignition.UNSAFE.putChar(data, off, val);
 
         shift(2);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteInt(int val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(data, off, val);
+            Ignition.UNSAFE.putIntLE(data, off, val);
         else
-            GridUnsafe.putInt(data, off, val);
+            Ignition.UNSAFE.putInt(data, off, val);
 
         shift(4);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteInt(int pos, int val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(data, off, val);
+            Ignition.UNSAFE.putIntLE(data, off, val);
         else
-            GridUnsafe.putInt(data, off, val);
+            Ignition.UNSAFE.putInt(data, off, val);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteLong(long val) {
-        long off = GridUnsafe.BYTE_ARR_OFF + pos;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putLongLE(data, off, val);
+            Ignition.UNSAFE.putLongLE(data, off, val);
         else
-            GridUnsafe.putLong(data, off, val);
+            Ignition.UNSAFE.putLong(data, off, val);
 
         shift(8);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryOffheapInputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryOffheapInputStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary.streams;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
@@ -79,7 +80,7 @@ public class BinaryOffheapInputStream extends BinaryAbstractInputStream {
     @Override public byte[] arrayCopy() {
         byte[] res = new byte[len];
 
-        GridUnsafe.copyOffheapHeap(ptr, res, GridUnsafe.BYTE_ARR_OFF, res.length);
+        Ignition.UNSAFE.copyOffheapHeap(ptr, res, Ignition.UNSAFE.BYTE_ARR_OFF, res.length);
 
         return res;
     }
@@ -91,12 +92,12 @@ public class BinaryOffheapInputStream extends BinaryAbstractInputStream {
 
     /** {@inheritDoc} */
     @Override protected byte readByteAndShift() {
-        return GridUnsafe.getByte(ptr + pos++);
+        return Ignition.UNSAFE.getByte(ptr + pos++);
     }
 
     /** {@inheritDoc} */
     @Override protected void copyAndShift(Object target, long off, int len) {
-        GridUnsafe.copyOffheapHeap(ptr + pos, target, off, len);
+        Ignition.UNSAFE.copyOffheapHeap(ptr + pos, target, off, len);
 
         shift(len);
     }
@@ -105,47 +106,47 @@ public class BinaryOffheapInputStream extends BinaryAbstractInputStream {
     @Override protected short readShortFast() {
         long addr = ptr + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(addr) : GridUnsafe.getShort(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(addr) : Ignition.UNSAFE.getShort(addr);
     }
 
     /** {@inheritDoc} */
     @Override protected char readCharFast() {
         long addr = ptr + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getCharLE(addr) : GridUnsafe.getChar(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getCharLE(addr) : Ignition.UNSAFE.getChar(addr);
     }
 
     /** {@inheritDoc} */
     @Override protected int readIntFast() {
         long addr = ptr + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(addr) : GridUnsafe.getInt(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(addr) : Ignition.UNSAFE.getInt(addr);
     }
 
     /** {@inheritDoc} */
     @Override protected long readLongFast() {
         long addr = ptr + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getLongLE(addr) : GridUnsafe.getLong(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getLongLE(addr) : Ignition.UNSAFE.getLong(addr);
     }
 
     /** {@inheritDoc} */
     @Override protected byte readBytePositioned0(int pos) {
-        return GridUnsafe.getByte(ptr + pos);
+        return Ignition.UNSAFE.getByte(ptr + pos);
     }
 
     /** {@inheritDoc} */
     @Override protected short readShortPositioned0(int pos) {
         long addr = ptr + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(addr) : GridUnsafe.getShort(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(addr) : Ignition.UNSAFE.getShort(addr);
     }
 
     /** {@inheritDoc} */
     @Override protected int readIntPositioned0(int pos) {
         long addr = ptr + pos;
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(addr) : GridUnsafe.getInt(addr);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(addr) : Ignition.UNSAFE.getInt(addr);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryOffheapOutputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryOffheapOutputStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary.streams;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
@@ -77,7 +78,7 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
     @Override public byte[] arrayCopy() {
         byte[] res = new byte[pos];
 
-        GridUnsafe.copyOffheapHeap(ptr, res, GridUnsafe.BYTE_ARR_OFF, pos);
+        Ignition.UNSAFE.copyOffheapHeap(ptr, res, Ignition.UNSAFE.BYTE_ARR_OFF, pos);
 
         return res;
     }
@@ -96,12 +97,12 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
 
     /** {@inheritDoc} */
     @Override protected void writeByteAndShift(byte val) {
-        GridUnsafe.putByte(ptr + pos++, val);
+        Ignition.UNSAFE.putByte(ptr + pos++, val);
     }
 
     /** {@inheritDoc} */
     @Override protected void copyAndShift(Object src, long offset, int len) {
-        GridUnsafe.copyHeapOffheap(src, offset, ptr + pos, len);
+        Ignition.UNSAFE.copyHeapOffheap(src, offset, ptr + pos, len);
 
         shift(len);
     }
@@ -111,9 +112,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(addr, val);
+            Ignition.UNSAFE.putShortLE(addr, val);
         else
-            GridUnsafe.putShort(addr, val);
+            Ignition.UNSAFE.putShort(addr, val);
     }
 
     /** {@inheritDoc} */
@@ -121,9 +122,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putCharLE(addr, val);
+            Ignition.UNSAFE.putCharLE(addr, val);
         else
-            GridUnsafe.putChar(addr, val);
+            Ignition.UNSAFE.putChar(addr, val);
     }
 
     /** {@inheritDoc} */
@@ -131,9 +132,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(addr, val);
+            Ignition.UNSAFE.putIntLE(addr, val);
         else
-            GridUnsafe.putInt(addr, val);
+            Ignition.UNSAFE.putInt(addr, val);
     }
 
     /** {@inheritDoc} */
@@ -141,9 +142,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putLongLE(addr, val);
+            Ignition.UNSAFE.putLongLE(addr, val);
         else
-            GridUnsafe.putLong(addr, val);
+            Ignition.UNSAFE.putLong(addr, val);
     }
 
     /** {@inheritDoc} */
@@ -153,7 +154,7 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteByte(byte val) {
-        GridUnsafe.putByte(ptr + pos++, val);
+        Ignition.UNSAFE.putByte(ptr + pos++, val);
     }
 
     /** {@inheritDoc} */
@@ -161,9 +162,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(addr, val);
+            Ignition.UNSAFE.putShortLE(addr, val);
         else
-            GridUnsafe.putShort(addr, val);
+            Ignition.UNSAFE.putShort(addr, val);
 
         shift(2);
     }
@@ -173,9 +174,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(addr, val);
+            Ignition.UNSAFE.putShortLE(addr, val);
         else
-            GridUnsafe.putShort(addr, val);
+            Ignition.UNSAFE.putShort(addr, val);
     }
 
     /** {@inheritDoc} */
@@ -183,9 +184,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putCharLE(addr, val);
+            Ignition.UNSAFE.putCharLE(addr, val);
         else
-            GridUnsafe.putChar(addr, val);
+            Ignition.UNSAFE.putChar(addr, val);
 
         shift(2);
     }
@@ -195,9 +196,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(addr, val);
+            Ignition.UNSAFE.putIntLE(addr, val);
         else
-            GridUnsafe.putInt(addr, val);
+            Ignition.UNSAFE.putInt(addr, val);
 
         shift(4);
     }
@@ -207,9 +208,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(addr, val);
+            Ignition.UNSAFE.putIntLE(addr, val);
         else
-            GridUnsafe.putInt(addr, val);
+            Ignition.UNSAFE.putInt(addr, val);
     }
 
     /** {@inheritDoc} */
@@ -217,9 +218,9 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
         long addr = ptr + pos;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putLongLE(addr, val);
+            Ignition.UNSAFE.putLongLE(addr, val);
         else
-            GridUnsafe.putLong(addr, val);
+            Ignition.UNSAFE.putLong(addr, val);
 
         shift(8);
     }
@@ -231,7 +232,7 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
      * @return Pointer.
      */
     protected long allocate(int cap) {
-        return GridUnsafe.allocateMemory(cap);
+        return Ignition.UNSAFE.allocateMemory(cap);
     }
 
     /**
@@ -242,7 +243,7 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
      * @return New pointer.
      */
     protected long reallocate(long ptr, int cap) {
-        return GridUnsafe.reallocateMemory(ptr, cap);
+        return Ignition.UNSAFE.reallocateMemory(ptr, cap);
     }
 
     /**
@@ -251,6 +252,6 @@ public class BinaryOffheapOutputStream extends BinaryAbstractOutputStream {
      * @param ptr Pointer.
      */
     protected void release(long ptr) {
-        GridUnsafe.freeMemory(ptr);
+        Ignition.UNSAFE.freeMemory(ptr);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/direct/stream/v1/DirectByteBufferStreamImplV1.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/direct/stream/v1/DirectByteBufferStreamImplV1.java
@@ -26,6 +26,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.direct.stream.DirectByteBufferStream;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
@@ -275,7 +277,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
             this.buf = buf;
 
             heapArr = buf.isDirect() ? null : buf.array();
-            baseOff = buf.isDirect() ? ((DirectBuffer)buf).address() : GridUnsafe.BYTE_ARR_OFF;
+            baseOff = buf.isDirect() ? ((DirectBuffer)buf).address() : Ignition.UNSAFE.BYTE_ARR_OFF;
         }
     }
 
@@ -296,7 +298,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putByte(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putByte(heapArr, baseOff + pos, val);
 
             buf.position(pos + 1);
         }
@@ -309,7 +311,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putShort(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putShort(heapArr, baseOff + pos, val);
 
             buf.position(pos + 2);
         }
@@ -322,7 +324,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putInt(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putInt(heapArr, baseOff + pos, val);
 
             buf.position(pos + 4);
         }
@@ -335,7 +337,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putLong(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putLong(heapArr, baseOff + pos, val);
 
             buf.position(pos + 8);
         }
@@ -350,7 +352,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putFloat(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putFloat(heapArr, baseOff + pos, val);
 
             buf.position(pos + 4);
         }
@@ -363,7 +365,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putDouble(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putDouble(heapArr, baseOff + pos, val);
 
             buf.position(pos + 8);
         }
@@ -376,7 +378,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putChar(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putChar(heapArr, baseOff + pos, val);
 
             buf.position(pos + 2);
         }
@@ -389,7 +391,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putBoolean(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putBoolean(heapArr, baseOff + pos, val);
 
             buf.position(pos + 1);
         }
@@ -398,7 +400,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeByteArray(byte[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.BYTE_ARR_OFF, val.length, val.length);
+            lastFinished = writeArray(val, Ignition.UNSAFE.BYTE_ARR_OFF, val.length, val.length);
         else
             writeInt(-1);
     }
@@ -406,7 +408,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeByteArray(byte[] val, long off, int len) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.BYTE_ARR_OFF + off, len, len);
+            lastFinished = writeArray(val, Ignition.UNSAFE.BYTE_ARR_OFF + off, len, len);
         else
             writeInt(-1);
     }
@@ -414,7 +416,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeShortArray(short[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.SHORT_ARR_OFF, val.length, val.length << 1);
+            lastFinished = writeArray(val, Ignition.UNSAFE.SHORT_ARR_OFF, val.length, val.length << 1);
         else
             writeInt(-1);
     }
@@ -422,7 +424,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeIntArray(int[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.INT_ARR_OFF, val.length, val.length << 2);
+            lastFinished = writeArray(val, Ignition.UNSAFE.INT_ARR_OFF, val.length, val.length << 2);
         else
             writeInt(-1);
     }
@@ -430,7 +432,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeLongArray(long[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.LONG_ARR_OFF, val.length, val.length << 3);
+            lastFinished = writeArray(val, Ignition.UNSAFE.LONG_ARR_OFF, val.length, val.length << 3);
         else
             writeInt(-1);
     }
@@ -438,7 +440,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeFloatArray(float[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.FLOAT_ARR_OFF, val.length, val.length << 2);
+            lastFinished = writeArray(val, Ignition.UNSAFE.FLOAT_ARR_OFF, val.length, val.length << 2);
         else
             writeInt(-1);
     }
@@ -446,7 +448,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeDoubleArray(double[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.DOUBLE_ARR_OFF, val.length, val.length << 3);
+            lastFinished = writeArray(val, Ignition.UNSAFE.DOUBLE_ARR_OFF, val.length, val.length << 3);
         else
             writeInt(-1);
     }
@@ -454,7 +456,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeCharArray(char[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.CHAR_ARR_OFF, val.length, val.length << 1);
+            lastFinished = writeArray(val, Ignition.UNSAFE.CHAR_ARR_OFF, val.length, val.length << 1);
         else
             writeInt(-1);
     }
@@ -462,7 +464,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeBooleanArray(boolean[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.BOOLEAN_ARR_OFF, val.length, val.length);
+            lastFinished = writeArray(val, Ignition.UNSAFE.BOOLEAN_ARR_OFF, val.length, val.length);
         else
             writeInt(-1);
     }
@@ -625,7 +627,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 1);
 
-            return GridUnsafe.getByte(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getByte(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -640,7 +642,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 2);
 
-            return GridUnsafe.getShort(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getShort(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -655,7 +657,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 4);
 
-            return GridUnsafe.getInt(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getInt(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -670,7 +672,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 8);
 
-            return GridUnsafe.getLong(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getLong(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -685,7 +687,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 4);
 
-            return GridUnsafe.getFloat(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getFloat(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -700,7 +702,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 8);
 
-            return GridUnsafe.getDouble(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getDouble(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -715,7 +717,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 2);
 
-            return GridUnsafe.getChar(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getChar(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -730,7 +732,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
             buf.position(pos + 1);
 
-            return GridUnsafe.getBoolean(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getBoolean(heapArr, baseOff + pos);
         }
         else
             return false;
@@ -738,42 +740,42 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
 
     /** {@inheritDoc} */
     @Override public byte[] readByteArray() {
-        return readArray(BYTE_ARR_CREATOR, 0, GridUnsafe.BYTE_ARR_OFF);
+        return readArray(BYTE_ARR_CREATOR, 0, Ignition.UNSAFE.BYTE_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public short[] readShortArray() {
-        return readArray(SHORT_ARR_CREATOR, 1, GridUnsafe.SHORT_ARR_OFF);
+        return readArray(SHORT_ARR_CREATOR, 1, Ignition.UNSAFE.SHORT_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public int[] readIntArray() {
-        return readArray(INT_ARR_CREATOR, 2, GridUnsafe.INT_ARR_OFF);
+        return readArray(INT_ARR_CREATOR, 2, Ignition.UNSAFE.INT_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public long[] readLongArray() {
-        return readArray(LONG_ARR_CREATOR, 3, GridUnsafe.LONG_ARR_OFF);
+        return readArray(LONG_ARR_CREATOR, 3, Ignition.UNSAFE.LONG_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public float[] readFloatArray() {
-        return readArray(FLOAT_ARR_CREATOR, 2, GridUnsafe.FLOAT_ARR_OFF);
+        return readArray(FLOAT_ARR_CREATOR, 2, Ignition.UNSAFE.FLOAT_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public double[] readDoubleArray() {
-        return readArray(DOUBLE_ARR_CREATOR, 3, GridUnsafe.DOUBLE_ARR_OFF);
+        return readArray(DOUBLE_ARR_CREATOR, 3, Ignition.UNSAFE.DOUBLE_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public char[] readCharArray() {
-        return readArray(CHAR_ARR_CREATOR, 1, GridUnsafe.CHAR_ARR_OFF);
+        return readArray(CHAR_ARR_CREATOR, 1, Ignition.UNSAFE.CHAR_ARR_OFF);
     }
 
     /** {@inheritDoc} */
     @Override public boolean[] readBooleanArray() {
-        return readArray(BOOLEAN_ARR_CREATOR, 0, GridUnsafe.BOOLEAN_ARR_OFF);
+        return readArray(BOOLEAN_ARR_CREATOR, 0, Ignition.UNSAFE.BOOLEAN_ARR_OFF);
     }
 
     /** {@inheritDoc} */
@@ -1009,7 +1011,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         int remaining = buf.remaining();
 
         if (toWrite <= remaining) {
-            GridUnsafe.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, toWrite);
+            Ignition.UNSAFE.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, toWrite);
 
             pos += toWrite;
 
@@ -1020,7 +1022,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
             return true;
         }
         else {
-            GridUnsafe.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, remaining);
+            Ignition.UNSAFE.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, remaining);
 
             pos += remaining;
 
@@ -1075,7 +1077,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
         lastFinished = toRead <= remaining;
 
         if (lastFinished) {
-            GridUnsafe.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, toRead);
+            Ignition.UNSAFE.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, toRead);
 
             buf.position(pos + toRead);
 
@@ -1088,7 +1090,7 @@ public class DirectByteBufferStreamImplV1 implements DirectByteBufferStream {
             return arr;
         }
         else {
-            GridUnsafe.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, remaining);
+            Ignition.UNSAFE.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, remaining);
 
             buf.position(pos + remaining);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/direct/stream/v2/DirectByteBufferStreamImplV2.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/direct/stream/v2/DirectByteBufferStreamImplV2.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.RandomAccess;
 import java.util.UUID;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.direct.stream.DirectByteBufferStream;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
@@ -334,7 +335,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putByte(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putByte(heapArr, baseOff + pos, val);
 
             buf.position(pos + 1);
         }
@@ -350,9 +351,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             long off = baseOff + pos;
 
             if (BIG_ENDIAN)
-                GridUnsafe.putShortLE(heapArr, off, val);
+                Ignition.UNSAFE.putShortLE(heapArr, off, val);
             else
-                GridUnsafe.putShort(heapArr, off, val);
+                Ignition.UNSAFE.putShort(heapArr, off, val);
 
             buf.position(pos + 2);
         }
@@ -373,12 +374,12 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             while ((val & 0xFFFF_FF80) != 0) {
                 byte b = (byte)(val | 0x80);
 
-                GridUnsafe.putByte(heapArr, baseOff + pos++, b);
+                Ignition.UNSAFE.putByte(heapArr, baseOff + pos++, b);
 
                 val >>>= 7;
             }
 
-            GridUnsafe.putByte(heapArr, baseOff + pos++, (byte)val);
+            Ignition.UNSAFE.putByte(heapArr, baseOff + pos++, (byte)val);
 
             buf.position(pos);
         }
@@ -399,12 +400,12 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             while ((val & 0xFFFF_FFFF_FFFF_FF80L) != 0) {
                 byte b = (byte)(val | 0x80);
 
-                GridUnsafe.putByte(heapArr, baseOff + pos++, b);
+                Ignition.UNSAFE.putByte(heapArr, baseOff + pos++, b);
 
                 val >>>= 7;
             }
 
-            GridUnsafe.putByte(heapArr, baseOff + pos++, (byte)val);
+            Ignition.UNSAFE.putByte(heapArr, baseOff + pos++, (byte)val);
 
             buf.position(pos);
         }
@@ -420,9 +421,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             long off = baseOff + pos;
 
             if (BIG_ENDIAN)
-                GridUnsafe.putFloatLE(heapArr, off, val);
+                Ignition.UNSAFE.putFloatLE(heapArr, off, val);
             else
-                GridUnsafe.putFloat(heapArr, off, val);
+                Ignition.UNSAFE.putFloat(heapArr, off, val);
 
             buf.position(pos + 4);
         }
@@ -438,9 +439,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             long off = baseOff + pos;
 
             if (BIG_ENDIAN)
-                GridUnsafe.putDoubleLE(heapArr, off, val);
+                Ignition.UNSAFE.putDoubleLE(heapArr, off, val);
             else
-                GridUnsafe.putDouble(heapArr, off, val);
+                Ignition.UNSAFE.putDouble(heapArr, off, val);
 
             buf.position(pos + 8);
         }
@@ -456,9 +457,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             long off = baseOff + pos;
 
             if (BIG_ENDIAN)
-                GridUnsafe.putCharLE(heapArr, off, val);
+                Ignition.UNSAFE.putCharLE(heapArr, off, val);
             else
-                GridUnsafe.putChar(heapArr, off, val);
+                Ignition.UNSAFE.putChar(heapArr, off, val);
 
             buf.position(pos + 2);
         }
@@ -471,7 +472,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
         if (lastFinished) {
             int pos = buf.position();
 
-            GridUnsafe.putBoolean(heapArr, baseOff + pos, val);
+            Ignition.UNSAFE.putBoolean(heapArr, baseOff + pos, val);
 
             buf.position(pos + 1);
         }
@@ -563,7 +564,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
     /** {@inheritDoc} */
     @Override public void writeBooleanArray(boolean[] val) {
         if (val != null)
-            lastFinished = writeArray(val, GridUnsafe.BOOLEAN_ARR_OFF, val.length, val.length);
+            lastFinished = writeArray(val, Ignition.UNSAFE.BOOLEAN_ARR_OFF, val.length, val.length);
         else
             writeInt(-1);
     }
@@ -823,7 +824,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
             buf.position(pos + 1);
 
-            return GridUnsafe.getByte(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getByte(heapArr, baseOff + pos);
         }
         else
             return 0;
@@ -840,7 +841,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
             long off = baseOff + pos;
 
-            return BIG_ENDIAN ? GridUnsafe.getShortLE(heapArr, off) : GridUnsafe.getShort(heapArr, off);
+            return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(heapArr, off) : Ignition.UNSAFE.getShort(heapArr, off);
         }
         else
             return 0;
@@ -855,7 +856,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
         while (buf.hasRemaining()) {
             int pos = buf.position();
 
-            byte b = GridUnsafe.getByte(heapArr, baseOff + pos);
+            byte b = Ignition.UNSAFE.getByte(heapArr, baseOff + pos);
 
             buf.position(pos + 1);
 
@@ -892,7 +893,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
         while (buf.hasRemaining()) {
             int pos = buf.position();
 
-            byte b = GridUnsafe.getByte(heapArr, baseOff + pos);
+            byte b = Ignition.UNSAFE.getByte(heapArr, baseOff + pos);
 
             buf.position(pos + 1);
 
@@ -931,7 +932,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
             long off = baseOff + pos;
 
-            return BIG_ENDIAN ? GridUnsafe.getFloatLE(heapArr, off) : GridUnsafe.getFloat(heapArr, off);
+            return BIG_ENDIAN ? Ignition.UNSAFE.getFloatLE(heapArr, off) : Ignition.UNSAFE.getFloat(heapArr, off);
         }
         else
             return 0;
@@ -948,7 +949,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
             long off = baseOff + pos;
 
-            return BIG_ENDIAN ? GridUnsafe.getDoubleLE(heapArr, off) : GridUnsafe.getDouble(heapArr, off);
+            return BIG_ENDIAN ? Ignition.UNSAFE.getDoubleLE(heapArr, off) : Ignition.UNSAFE.getDouble(heapArr, off);
         }
         else
             return 0;
@@ -965,7 +966,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
             long off = baseOff + pos;
 
-            return BIG_ENDIAN ? GridUnsafe.getCharLE(heapArr, off) : GridUnsafe.getChar(heapArr, off);
+            return BIG_ENDIAN ? Ignition.UNSAFE.getCharLE(heapArr, off) : Ignition.UNSAFE.getChar(heapArr, off);
         }
         else
             return 0;
@@ -980,7 +981,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
             buf.position(pos + 1);
 
-            return GridUnsafe.getBoolean(heapArr, baseOff + pos);
+            return Ignition.UNSAFE.getBoolean(heapArr, baseOff + pos);
         }
         else
             return false;
@@ -1041,7 +1042,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
     /** {@inheritDoc} */
     @Override public boolean[] readBooleanArray() {
-        return readArray(BOOLEAN_ARR_CREATOR, 0, GridUnsafe.BOOLEAN_ARR_OFF);
+        return readArray(BOOLEAN_ARR_CREATOR, 0, Ignition.UNSAFE.BOOLEAN_ARR_OFF);
     }
 
     /** {@inheritDoc} */
@@ -1339,7 +1340,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
         if (toWrite <= remaining) {
             if (toWrite > 0) {
-                GridUnsafe.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, toWrite);
+                Ignition.UNSAFE.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, toWrite);
 
                 buf.position(pos + toWrite);
             }
@@ -1350,7 +1351,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
         }
         else {
             if (remaining > 0) {
-                GridUnsafe.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, remaining);
+                Ignition.UNSAFE.copyMemory(arr, off + arrOff, heapArr, baseOff + pos, remaining);
 
                 buf.position(pos + remaining);
 
@@ -1411,9 +1412,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
 
         for (int i = 0; i < len; i++) {
             for (int j = 0; j < typeSize; j++) {
-                byte b = GridUnsafe.getByteField(arr, off + arrOff + (typeSize - j - 1));
+                byte b = Ignition.UNSAFE.getByteField(arr, off + arrOff + (typeSize - j - 1));
 
-                GridUnsafe.putByte(heapArr, baseOff + pos++, b);
+                Ignition.UNSAFE.putByte(heapArr, baseOff + pos++, b);
             }
 
             buf.position(pos);
@@ -1476,7 +1477,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
         lastFinished = toRead <= remaining;
 
         if (lastFinished) {
-            GridUnsafe.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, toRead);
+            Ignition.UNSAFE.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, toRead);
 
             buf.position(pos + toRead);
 
@@ -1489,7 +1490,7 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             return arr;
         }
         else {
-            GridUnsafe.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, remaining);
+            Ignition.UNSAFE.copyMemory(heapArr, baseOff + pos, tmpArr, off + tmpArrOff, remaining);
 
             buf.position(pos + remaining);
 
@@ -1554,9 +1555,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
                 int pos = buf.position();
 
                 for (int j = 0; j < typeSize; j++) {
-                    byte b = GridUnsafe.getByte(heapArr, baseOff + pos + (typeSize - j - 1));
+                    byte b = Ignition.UNSAFE.getByte(heapArr, baseOff + pos + (typeSize - j - 1));
 
-                    GridUnsafe.putByteField(tmpArr, off + tmpArrOff + j, b);
+                    Ignition.UNSAFE.putByteField(tmpArr, off + tmpArrOff + j, b);
                 }
 
                 buf.position(pos + typeSize);
@@ -1579,9 +1580,9 @@ public class DirectByteBufferStreamImplV2 implements DirectByteBufferStream {
             int pos = buf.position();
 
             for (int j = 0; j < typeSize; j++) {
-                byte b = GridUnsafe.getByte(heapArr, baseOff + pos + (typeSize - j - 1));
+                byte b = Ignition.UNSAFE.getByte(heapArr, baseOff + pos + (typeSize - j - 1));
 
-                GridUnsafe.putByteField(tmpArr, off + tmpArrOff++, b);
+                Ignition.UNSAFE.putByteField(tmpArr, off + tmpArrOff++, b);
             }
 
             buf.position(pos + typeSize);

--- a/modules/core/src/main/java/org/apache/ignite/internal/marshaller/optimized/OptimizedClassDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/marshaller/optimized/OptimizedClassDescriptor.java
@@ -46,8 +46,9 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 
-import org.apache.ignite.internal.util.GridUnsafe;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.SerializableTransient;
+import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteProductVersion;
 import org.apache.ignite.marshaller.MarshallerContext;
@@ -281,7 +282,7 @@ class OptimizedClassDescriptor {
                 type = PROPS;
 
                 try {
-                    dfltsFieldOff = GridUnsafe.objectFieldOffset(Properties.class.getDeclaredField("defaults"));
+                    dfltsFieldOff = Ignition.UNSAFE.objectFieldOffset(Properties.class.getDeclaredField("defaults"));
                 }
                 catch (NoSuchFieldException e) {
                     throw new IOException(e);
@@ -293,7 +294,7 @@ class OptimizedClassDescriptor {
                 type = HASH_MAP;
 
                 try {
-                    loadFactorFieldOff = GridUnsafe.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
+                    loadFactorFieldOff = Ignition.UNSAFE.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
                 }
                 catch (NoSuchFieldException e) {
                     throw new IOException(e);
@@ -303,7 +304,7 @@ class OptimizedClassDescriptor {
                 type = HASH_SET;
 
                 try {
-                    loadFactorFieldOff = GridUnsafe.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
+                    loadFactorFieldOff = Ignition.UNSAFE.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
                 }
                 catch (NoSuchFieldException e) {
                     throw new IOException(e);
@@ -316,9 +317,9 @@ class OptimizedClassDescriptor {
 
                 try {
                     loadFactorFieldOff =
-                        GridUnsafe.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
+                        Ignition.UNSAFE.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
                     accessOrderFieldOff =
-                        GridUnsafe.objectFieldOffset(LinkedHashMap.class.getDeclaredField("accessOrder"));
+                        Ignition.UNSAFE.objectFieldOffset(LinkedHashMap.class.getDeclaredField("accessOrder"));
                 }
                 catch (NoSuchFieldException e) {
                     throw new IOException(e);
@@ -328,7 +329,7 @@ class OptimizedClassDescriptor {
                 type = LINKED_HASH_SET;
 
                 try {
-                    loadFactorFieldOff = GridUnsafe.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
+                    loadFactorFieldOff = Ignition.UNSAFE.objectFieldOffset(HashMap.class.getDeclaredField("loadFactor"));
                 }
                 catch (NoSuchFieldException e) {
                     throw new IOException(e);
@@ -508,7 +509,7 @@ class OptimizedClassDescriptor {
 
                                         fieldInfo = new FieldInfo(f,
                                             serField.getName(),
-                                            GridUnsafe.objectFieldOffset(f),
+                                            Ignition.UNSAFE.objectFieldOffset(f),
                                             fieldType(serField.getType()));
                                     }
 
@@ -532,7 +533,7 @@ class OptimizedClassDescriptor {
 
                                 if (!isStatic(mod) && !isTransient(mod)) {
                                     FieldInfo fieldInfo = new FieldInfo(f, f.getName(),
-                                        GridUnsafe.objectFieldOffset(f), fieldType(f.getType()));
+                                        Ignition.UNSAFE.objectFieldOffset(f), fieldType(f.getType()));
 
                                     clsFields.add(fieldInfo);
                                 }
@@ -865,7 +866,7 @@ class OptimizedClassDescriptor {
                 final Field f = cls.getDeclaredField(fieldName);
 
                 FieldInfo fieldInfo = new FieldInfo(f, f.getName(),
-                    GridUnsafe.objectFieldOffset(f), fieldType(f.getType()));
+                    Ignition.UNSAFE.objectFieldOffset(f), fieldType(f.getType()));
 
                 clsFields.add(fieldInfo);
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/marshaller/optimized/OptimizedMarshallerUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/marshaller/optimized/OptimizedMarshallerUtils.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.marshaller.MarshallerContext;
@@ -159,12 +160,12 @@ class OptimizedMarshallerUtils {
         long mapOff;
 
         try {
-            mapOff = GridUnsafe.objectFieldOffset(HashSet.class.getDeclaredField("map"));
+            mapOff = Ignition.UNSAFE.objectFieldOffset(HashSet.class.getDeclaredField("map"));
         }
         catch (NoSuchFieldException ignored) {
             try {
                 // Workaround for legacy IBM JRE.
-                mapOff = GridUnsafe.objectFieldOffset(HashSet.class.getDeclaredField("backingMap"));
+                mapOff = Ignition.UNSAFE.objectFieldOffset(HashSet.class.getDeclaredField("backingMap"));
             }
             catch (NoSuchFieldException e2) {
                 throw new IgniteException("Initialization failure.", e2);
@@ -359,7 +360,7 @@ class OptimizedMarshallerUtils {
      * @return Byte value.
      */
     static byte getByte(Object obj, long off) {
-        return GridUnsafe.getByteField(obj, off);
+        return Ignition.UNSAFE.getByteField(obj, off);
     }
 
     /**
@@ -370,7 +371,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setByte(Object obj, long off, byte val) {
-        GridUnsafe.putByteField(obj, off, val);
+        Ignition.UNSAFE.putByteField(obj, off, val);
     }
 
     /**
@@ -381,7 +382,7 @@ class OptimizedMarshallerUtils {
      * @return Short value.
      */
     static short getShort(Object obj, long off) {
-        return GridUnsafe.getShortField(obj, off);
+        return Ignition.UNSAFE.getShortField(obj, off);
     }
 
     /**
@@ -392,7 +393,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setShort(Object obj, long off, short val) {
-        GridUnsafe.putShortField(obj, off, val);
+        Ignition.UNSAFE.putShortField(obj, off, val);
     }
 
     /**
@@ -403,7 +404,7 @@ class OptimizedMarshallerUtils {
      * @return Integer value.
      */
     static int getInt(Object obj, long off) {
-        return GridUnsafe.getIntField(obj, off);
+        return Ignition.UNSAFE.getIntField(obj, off);
     }
 
     /**
@@ -414,7 +415,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setInt(Object obj, long off, int val) {
-        GridUnsafe.putIntField(obj, off, val);
+        Ignition.UNSAFE.putIntField(obj, off, val);
     }
 
     /**
@@ -425,7 +426,7 @@ class OptimizedMarshallerUtils {
      * @return Long value.
      */
     static long getLong(Object obj, long off) {
-        return GridUnsafe.getLongField(obj, off);
+        return Ignition.UNSAFE.getLongField(obj, off);
     }
 
     /**
@@ -436,7 +437,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setLong(Object obj, long off, long val) {
-        GridUnsafe.putLongField(obj, off, val);
+        Ignition.UNSAFE.putLongField(obj, off, val);
     }
 
     /**
@@ -447,7 +448,7 @@ class OptimizedMarshallerUtils {
      * @return Float value.
      */
     static float getFloat(Object obj, long off) {
-        return GridUnsafe.getFloatField(obj, off);
+        return Ignition.UNSAFE.getFloatField(obj, off);
     }
 
     /**
@@ -458,7 +459,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setFloat(Object obj, long off, float val) {
-        GridUnsafe.putFloatField(obj, off, val);
+        Ignition.UNSAFE.putFloatField(obj, off, val);
     }
 
     /**
@@ -469,7 +470,7 @@ class OptimizedMarshallerUtils {
      * @return Double value.
      */
     static double getDouble(Object obj, long off) {
-        return GridUnsafe.getDoubleField(obj, off);
+        return Ignition.UNSAFE.getDoubleField(obj, off);
     }
 
     /**
@@ -480,7 +481,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setDouble(Object obj, long off, double val) {
-        GridUnsafe.putDoubleField(obj, off, val);
+        Ignition.UNSAFE.putDoubleField(obj, off, val);
     }
 
     /**
@@ -491,7 +492,7 @@ class OptimizedMarshallerUtils {
      * @return Char value.
      */
     static char getChar(Object obj, long off) {
-        return GridUnsafe.getCharField(obj, off);
+        return Ignition.UNSAFE.getCharField(obj, off);
     }
 
     /**
@@ -502,7 +503,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setChar(Object obj, long off, char val) {
-        GridUnsafe.putCharField(obj, off, val);
+        Ignition.UNSAFE.putCharField(obj, off, val);
     }
 
     /**
@@ -513,7 +514,7 @@ class OptimizedMarshallerUtils {
      * @return Boolean value.
      */
     static boolean getBoolean(Object obj, long off) {
-        return GridUnsafe.getBooleanField(obj, off);
+        return Ignition.UNSAFE.getBooleanField(obj, off);
     }
 
     /**
@@ -524,7 +525,7 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setBoolean(Object obj, long off, boolean val) {
-        GridUnsafe.putBooleanField(obj, off, val);
+        Ignition.UNSAFE.putBooleanField(obj, off, val);
     }
 
     /**
@@ -535,7 +536,7 @@ class OptimizedMarshallerUtils {
      * @return Value.
      */
     static Object getObject(Object obj, long off) {
-        return GridUnsafe.getObjectField(obj, off);
+        return Ignition.UNSAFE.getObjectField(obj, off);
     }
 
     /**
@@ -546,6 +547,6 @@ class OptimizedMarshallerUtils {
      * @param val Value.
      */
     static void setObject(Object obj, long off, Object val) {
-        GridUnsafe.putObjectField(obj, off, val);
+        Ignition.UNSAFE.putObjectField(obj, off, val);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/marshaller/optimized/OptimizedObjectInputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/marshaller/optimized/OptimizedObjectInputStream.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.io.GridDataInput;
 import org.apache.ignite.internal.util.typedef.internal.SB;
@@ -575,7 +576,7 @@ class OptimizedObjectInputStream extends ObjectInputStream {
         Object obj;
 
         try {
-            obj = GridUnsafe.allocateInstance(cls);
+            obj = Ignition.UNSAFE.allocateInstance(cls);
         }
         catch (InstantiationException e) {
             throw new IOException(e);
@@ -673,7 +674,7 @@ class OptimizedObjectInputStream extends ObjectInputStream {
     @SuppressWarnings("unchecked")
     HashSet<?> readHashSet(long mapFieldOff) throws ClassNotFoundException, IOException {
         try {
-            HashSet<Object> set = (HashSet<Object>)GridUnsafe.allocateInstance(HashSet.class);
+            HashSet<Object> set = (HashSet<Object>) Ignition.UNSAFE.allocateInstance(HashSet.class);
 
             handles.assign(set);
 
@@ -745,7 +746,7 @@ class OptimizedObjectInputStream extends ObjectInputStream {
     @SuppressWarnings("unchecked")
     LinkedHashSet<?> readLinkedHashSet(long mapFieldOff) throws ClassNotFoundException, IOException {
         try {
-            LinkedHashSet<Object> set = (LinkedHashSet<Object>)GridUnsafe.allocateInstance(LinkedHashSet.class);
+            LinkedHashSet<Object> set = (LinkedHashSet<Object>)Ignition.UNSAFE.allocateInstance(LinkedHashSet.class);
 
             handles.assign(set);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/mem/DirectMemoryProvider.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/mem/DirectMemoryProvider.java
@@ -37,4 +37,7 @@ public interface DirectMemoryProvider {
      * @return Next memory region.
      */
     public DirectMemoryRegion nextRegion();
+
+    public DirectMemoryRegion nextRegion(String regionName);
+
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/mem/DirectMemoryRegion.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/mem/DirectMemoryRegion.java
@@ -38,4 +38,10 @@ public interface DirectMemoryRegion {
      * @return Sub-region.
      */
     public DirectMemoryRegion slice(long offset);
+
+    /**
+     * Added for AEP support.
+     * @return
+     */
+    public String getName();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/mem/UnsafeChunk.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/mem/UnsafeChunk.java
@@ -31,13 +31,21 @@ public class UnsafeChunk implements DirectMemoryRegion {
     /** */
     private long len;
 
+
+    private String name;
+
+    public UnsafeChunk(String name, long ptr, long len) {
+        this.name = name;
+        this.ptr = ptr;
+        this.len = len;
+    }
+
     /**
      * @param ptr Pointer to the memory start.
      * @param len Memory length.
      */
     public UnsafeChunk(long ptr, long len) {
-        this.ptr = ptr;
-        this.len = len;
+        this("", ptr, len);
     }
 
     /** {@inheritDoc} */
@@ -62,5 +70,10 @@ public class UnsafeChunk implements DirectMemoryRegion {
     /** {@inheritDoc} */
     @Override public String toString() {
         return S.toString(UnsafeChunk.class, this);
+    }
+
+    @Override
+    public String getName() {
+        return name;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/mem/file/MappedFile.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/mem/file/MappedFile.java
@@ -149,4 +149,14 @@ public class MappedFile implements Closeable, DirectMemoryRegion {
             throw new IllegalStateException(e.getTargetException());
         }
     }
+
+    /**
+     * Added to support AEP.
+     * @return
+     */
+    @Override
+    public String getName() {
+        /* no-op */
+        return "";
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/mem/file/MappedFileMemoryProvider.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/mem/file/MappedFileMemoryProvider.java
@@ -105,8 +105,12 @@ public class MappedFileMemoryProvider implements DirectMemoryProvider {
         }
     }
 
-    /** {@inheritDoc} */
     @Override public DirectMemoryRegion nextRegion() {
+        return nextRegion("");
+    }
+
+    /** {@inheritDoc} */
+    @Override public DirectMemoryRegion nextRegion(String regionName) {
         try {
             if (mappedFiles.size() == sizes.length)
                 return null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/PageMemory.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/PageMemory.java
@@ -43,4 +43,6 @@ public interface PageMemory extends LifecycleAware, PageIdAllocator, PageSupport
      * @return Total number of loaded pages in memory.
      */
     public long loadedPages();
+
+    public String getDataRegionName();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/PageUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/PageUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.pagemem;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
@@ -24,6 +25,7 @@ import org.apache.ignite.internal.util.GridUnsafe;
  */
 @SuppressWarnings("deprecation")
 public class PageUtils {
+
     /**
      * @param addr Start address. 
      * @param off Offset.
@@ -33,7 +35,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        return GridUnsafe.getByte(addr + off);
+        return Ignition.UNSAFE.getByte(addr + off);
     }
 
     /**
@@ -46,7 +48,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        return GridUnsafe.getByte(addr + off) & 0xFF;
+        return Ignition.UNSAFE.getByte(addr + off) & 0xFF;
     }
 
     /**
@@ -62,7 +64,7 @@ public class PageUtils {
 
         byte[] bytes = new byte[len];
 
-        GridUnsafe.copyMemory(null, addr + off, bytes, GridUnsafe.BYTE_ARR_OFF, len);
+        Ignition.UNSAFE.copyMemory(null, addr + off, bytes, GridUnsafe.BYTE_ARR_OFF, len);
 
         return bytes;
     }
@@ -81,7 +83,7 @@ public class PageUtils {
         assert dstOff >= 0;
         assert len >= 0;
 
-        GridUnsafe.copyMemory(null, srcAddr + srcOff, dst, GridUnsafe.BYTE_ARR_OFF + dstOff, len);
+        Ignition.UNSAFE.copyMemory(null, srcAddr + srcOff, dst, GridUnsafe.BYTE_ARR_OFF + dstOff, len);
     }
 
     /**
@@ -93,7 +95,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        return GridUnsafe.getShort(addr + off);
+        return Ignition.UNSAFE.getShort(addr + off);
     }
 
     /**
@@ -105,7 +107,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        return GridUnsafe.getInt(addr + off);
+        return Ignition.UNSAFE.getInt(addr + off);
     }
 
     /**
@@ -117,7 +119,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        return GridUnsafe.getLong(addr + off);
+        return Ignition.UNSAFE.getLong(addr + off);
     }
 
     /**
@@ -130,7 +132,7 @@ public class PageUtils {
         assert off >= 0;
         assert bytes != null;
 
-        GridUnsafe.copyMemory(bytes, GridUnsafe.BYTE_ARR_OFF, null, addr + off, bytes.length);
+        Ignition.UNSAFE.copyMemory(bytes, GridUnsafe.BYTE_ARR_OFF, null, addr + off, bytes.length);
     }
 
     /**
@@ -145,7 +147,7 @@ public class PageUtils {
         assert bytes != null;
         assert bytesOff >= 0 && (bytesOff < bytes.length || bytes.length == 0) : bytesOff;
 
-        GridUnsafe.copyMemory(bytes, GridUnsafe.BYTE_ARR_OFF + bytesOff, null, addr + off, bytes.length - bytesOff);
+        Ignition.UNSAFE.copyMemory(bytes, GridUnsafe.BYTE_ARR_OFF + bytesOff, null, addr + off, bytes.length - bytesOff);
     }
 
     /**
@@ -161,7 +163,7 @@ public class PageUtils {
         assert bytes != null;
         assert bytesOff >= 0 && (bytesOff < bytes.length || bytes.length == 0) : bytesOff;
 
-        GridUnsafe.copyMemory(bytes, GridUnsafe.BYTE_ARR_OFF + bytesOff, null, addr + off, len);
+        Ignition.UNSAFE.copyMemory(bytes, GridUnsafe.BYTE_ARR_OFF + bytesOff, null, addr + off, len);
     }
 
     /**
@@ -173,7 +175,8 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        GridUnsafe.putByte(addr + off, v);
+
+        Ignition.UNSAFE.putByte(addr + off, v);
     }
 
     /**
@@ -186,7 +189,7 @@ public class PageUtils {
         assert off >= 0;
         assert v >= 0 && v <= 255;
 
-        GridUnsafe.putByte(addr + off, (byte) v);
+        Ignition.UNSAFE.putByte(addr + off, (byte) v);
     }
 
     /**
@@ -198,7 +201,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        GridUnsafe.putShort(addr + off, v);
+        Ignition.UNSAFE.putShort(addr + off, v);
     }
 
     /**
@@ -210,7 +213,7 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        GridUnsafe.putInt(addr + off, v);
+        Ignition.UNSAFE.putInt(addr + off, v);
     }
 
     /**
@@ -222,6 +225,6 @@ public class PageUtils {
         assert addr > 0 : addr;
         assert off >= 0;
 
-        GridUnsafe.putLong(addr + off, v);
+        Ignition.UNSAFE.putLong(addr + off, v);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/PageSnapshot.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/PageSnapshot.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.FullPageId;
 import org.apache.ignite.internal.processors.cache.persistence.tree.io.PageIO;
 import org.apache.ignite.internal.util.GridUnsafe;
@@ -56,7 +57,7 @@ public class PageSnapshot extends WALRecord {
 
         pageData = new byte[pageSize];
 
-        GridUnsafe.copyMemory(null, ptr, pageData, GridUnsafe.BYTE_ARR_OFF, pageSize);
+        Ignition.UNSAFE.copyMemory(null, ptr, pageData, GridUnsafe.BYTE_ARR_OFF, pageSize);
     }
 
     /** {@inheritDoc} */
@@ -84,7 +85,7 @@ public class PageSnapshot extends WALRecord {
         buf.order(ByteOrder.nativeOrder());
         buf.put(pageData);
 
-        long addr = GridUnsafe.bufferAddress(buf);
+        long addr = Ignition.UNSAFE.bufferAddress(buf);
 
         try {
             return "PageSnapshot [fullPageId = " + fullPageId() + ", page = [\n"

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupContext.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.cache.affinity.AffinityFunction;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.CacheConfiguration;
@@ -701,7 +702,8 @@ public class CacheGroupContext {
 
         preldr.onKernalStop();
 
-        offheapMgr.stop();
+        if (!Ignition.isAepEnabled() && !Ignition.isAepClientModeEnabled())
+            offheapMgr.stop();
 
         ctx.io().removeCacheGroupHandlers(grpId);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupData.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupData.java
@@ -20,6 +20,8 @@ package org.apache.ignite.internal.processors.cache;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.UUID;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
@@ -94,7 +96,7 @@ public class CacheGroupData implements Serializable {
         this.deploymentId = deploymentId;
         this.caches = caches;
         this.flags = flags;
-        this.persistenceEnabled = persistenceEnabled;
+        this.persistenceEnabled = !Ignition.isAepEnabled() ? persistenceEnabled : false;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheClearAllRunnable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheClearAllRunnable.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.processors.cache;
 
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.processors.query.QueryUtils;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -81,7 +82,7 @@ public class GridCacheClearAllRunnable<K, V> implements Runnable {
             clearEntry(gridCacheEntryEx);
 
         if (!ctx.isNear()) {
-            if (id == 0)
+            if (id == 0 && ((!Ignition.isAepEnabled() && !Ignition.isClientMode()) || !Ignition.isAepClientModeEnabled()))
                 ctx.offheap().clearCache(ctx, readers);
         }
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/CacheObjectBinaryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/CacheObjectBinaryProcessor.java
@@ -24,6 +24,7 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.binary.BinaryObjectBuilder;
 import org.apache.ignite.binary.BinaryType;
+import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.binary.BinaryFieldMetadata;
 import org.apache.ignite.internal.processors.cacheobject.IgniteCacheObjectProcessor;
 import org.jetbrains.annotations.Nullable;
@@ -144,4 +145,10 @@ public interface CacheObjectBinaryProcessor extends IgniteCacheObjectProcessor {
      * @throws IgniteException If failed.
      */
     public Object marshalToBinary(Object obj) throws IgniteException;
+
+    /**
+     *
+     * @return The binary context.
+     */
+    public BinaryContext getBinaryCtx();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/CacheObjectBinaryProcessorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/CacheObjectBinaryProcessorImpl.java
@@ -29,6 +29,7 @@ import javax.cache.CacheException;
 import org.apache.ignite.IgniteBinary;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryField;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.binary.BinaryObjectBuilder;
@@ -64,9 +65,9 @@ import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.GridCacheUtils;
 import org.apache.ignite.internal.processors.cache.KeyCacheObject;
 import org.apache.ignite.internal.processors.cacheobject.IgniteCacheObjectProcessorImpl;
-import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.MutableSingletonList;
+import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.internal.util.lang.GridMapEntry;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
@@ -305,11 +306,11 @@ public class CacheObjectBinaryProcessorImpl extends IgniteCacheObjectProcessorIm
     public Object unmarshal(long ptr, boolean forceHeap) throws BinaryObjectException {
         assert ptr > 0 : ptr;
 
-        int size = GridUnsafe.getInt(ptr);
+        int size = Ignition.UNSAFE.getInt(ptr);
 
         ptr += 4;
 
-        byte type = GridUnsafe.getByte(ptr++);
+        byte type = Ignition.UNSAFE.getByte(ptr++);
 
         if (type != CacheObject.TYPE_BYTE_ARR) {
             assert size > 0 : size;
@@ -938,5 +939,13 @@ public class CacheObjectBinaryProcessorImpl extends IgniteCacheObjectProcessorIm
      */
     public void setBinaryMetadataFileStoreDir(@Nullable File binaryMetadataFileStoreDir) {
         this.binaryMetadataFileStoreDir = binaryMetadataFileStoreDir;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public BinaryContext getBinaryCtx() {
+        return binaryCtx;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/atomic/GridLocalAtomicCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/local/atomic/GridLocalAtomicCache.java
@@ -34,6 +34,7 @@ import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.processors.cache.CacheEntryPredicate;
@@ -1429,12 +1430,12 @@ public class GridLocalAtomicCache<K, V> extends GridLocalCache<K, V> {
             for (int i = 0; i < locked.size(); i++) {
                 GridCacheEntryEx entry = locked.get(i);
 
-                GridUnsafe.monitorEnter(entry);
+                Ignition.UNSAFE.monitorEnter(entry);
 
                 if (entry.obsolete()) {
                     // Unlock all locked.
                     for (int j = 0; j <= i; j++)
-                        GridUnsafe.monitorExit(locked.get(j));
+                        Ignition.UNSAFE.monitorExit(locked.get(j));
 
                     // Clear entries.
                     locked.clear();
@@ -1465,7 +1466,7 @@ public class GridLocalAtomicCache<K, V> extends GridLocalCache<K, V> {
      */
     private void unlockEntries(Iterable<GridCacheEntryEx> locked) {
         for (GridCacheEntryEx entry : locked)
-            GridUnsafe.monitorExit(entry);
+            Ignition.UNSAFE.monitorExit(entry);
 
         AffinityTopologyVersion topVer = ctx.affinity().affinityTopologyVersion();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataRegionMetricsImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataRegionMetricsImpl.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.internal.processors.cache.persistence;
 
 import org.apache.ignite.DataRegionMetrics;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.internal.pagemem.PageMemory;
 import org.apache.ignite.internal.processors.cache.ratemetrics.HitRateMetrics;
@@ -265,7 +266,8 @@ public class DataRegionMetricsImpl implements DataRegionMetrics {
      * @param persistenceEnabled Persistence enabled.
      */
     public void persistenceEnabled(boolean persistenceEnabled) {
-        this.persistenceEnabled = persistenceEnabled;
+        if (!Ignition.isAepEnabled())
+            this.persistenceEnabled = persistenceEnabled;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
@@ -57,11 +57,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.management.ObjectName;
-import org.apache.ignite.DataStorageMetrics;
-import org.apache.ignite.IgniteCheckedException;
-import org.apache.ignite.IgniteException;
-import org.apache.ignite.IgniteLogger;
-import org.apache.ignite.IgniteSystemProperties;
+
+import org.apache.ignite.*;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.CheckpointWriteOrder;
@@ -119,10 +116,7 @@ import org.apache.ignite.internal.processors.cache.persistence.tree.io.PageParti
 import org.apache.ignite.internal.processors.cache.persistence.wal.FileWALPointer;
 import org.apache.ignite.internal.processors.cache.persistence.wal.crc.PureJavaCrc32;
 import org.apache.ignite.internal.processors.port.GridPortRecord;
-import org.apache.ignite.internal.util.GridConcurrentHashSet;
-import org.apache.ignite.internal.util.GridMultiCollectionWrapper;
-import org.apache.ignite.internal.util.GridUnsafe;
-import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.internal.util.*;
 import org.apache.ignite.internal.util.future.CountDownFuture;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.internal.util.lang.GridInClosure3X;
@@ -2616,7 +2610,7 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
         @Override public void run() {
             ByteBuffer tmpWriteBuf = threadBuf.get();
 
-            long writeAddr = GridUnsafe.bufferAddress(tmpWriteBuf);
+            long writeAddr = Ignition.UNSAFE.bufferAddress(tmpWriteBuf);
 
             snapshotMgr.beforeCheckpointPageWritten();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheOffheapManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheOffheapManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.FullPageId;
 import org.apache.ignite.internal.pagemem.PageIdAllocator;
 import org.apache.ignite.internal.pagemem.PageIdUtils;
@@ -391,11 +392,11 @@ public class GridCacheOffheapManager extends IgniteCacheOffheapManagerImpl imple
     private byte[] serializeCacheSizes(Map<Integer, Long> cacheSizes) {
         // Item size = 4 bytes (cache ID) + 8 bytes (cache size) = 12 bytes
         byte[] data = new byte[cacheSizes.size() * 12];
-        long off = GridUnsafe.BYTE_ARR_OFF;
+        long off = Ignition.UNSAFE.BYTE_ARR_OFF;
 
         for (Map.Entry<Integer, Long> entry : cacheSizes.entrySet()) {
-            GridUnsafe.putInt(data, off, entry.getKey()); off += 4;
-            GridUnsafe.putLong(data, off, entry.getValue()); off += 8;
+            Ignition.UNSAFE.putInt(data, off, entry.getKey()); off += 4;
+            Ignition.UNSAFE.putLong(data, off, entry.getValue()); off += 8;
         }
 
         return data;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/RowStore.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/RowStore.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.processors.cache.persistence;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageMemory;
 import org.apache.ignite.internal.processors.cache.CacheGroupContext;
 import org.apache.ignite.internal.processors.cache.CacheObjectContext;
@@ -57,7 +58,7 @@ public class RowStore {
         coctx = grp.cacheObjectContext();
         pageMem = grp.dataRegion().pageMemory();
 
-        persistenceEnabled = grp.dataRegion().config().isPersistenceEnabled();
+        persistenceEnabled = !Ignition.isAepEnabled() ? grp.dataRegion().config().isPersistenceEnabled() : false;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/PagesList.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/PagesList.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.cache.persistence.freelist;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -1480,7 +1481,10 @@ public abstract class PagesList extends DataStructure {
     /**
      *
      */
-    public static final class Stripe {
+    public static final class Stripe implements Serializable {
+
+        private static final long serialVersionUID = 0L;
+
         /** */
         public volatile long tailId;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListMetaIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListMetaIO.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.processors.cache.persistence.freelist.io;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageUtils;
 import org.apache.ignite.internal.processors.cache.persistence.freelist.PagesList;
 import org.apache.ignite.internal.processors.cache.persistence.tree.io.IOVersions;
@@ -59,8 +60,11 @@ public class PagesListMetaIO extends PageIO {
     @Override public void initNewPage(long pageAddr, long pageId, int pageSize) {
         super.initNewPage(pageAddr, pageId, pageSize);
 
-        setCount(pageAddr, 0);
-        setNextMetaPageId(pageAddr, 0L);
+        if (!Ignition.isAepEnabled()) {
+            setCount(pageAddr, 0);
+
+            setNextMetaPageId(pageAddr, 0L);
+        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListNodeIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListNodeIO.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.processors.cache.persistence.freelist.io;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageIdUtils;
 import org.apache.ignite.internal.pagemem.PageUtils;
 import org.apache.ignite.internal.processors.cache.persistence.tree.io.IOVersions;
@@ -58,7 +59,8 @@ public class PagesListNodeIO extends PageIO {
     @Override public void initNewPage(long pageAddr, long pageId, int pageSize) {
         super.initNewPage(pageAddr, pageId, pageSize);
 
-        setEmpty(pageAddr);
+        if (!Ignition.isAepEnabled())
+            setEmpty(pageAddr);
 
         setPreviousId(pageAddr, 0L);
         setNextId(pageAddr, 0L);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/FullPageIdTable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/FullPageIdTable.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.cache.persistence.pagemem;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.mem.IgniteOutOfMemoryException;
 import org.apache.ignite.internal.pagemem.FullPageId;
 import org.apache.ignite.internal.pagemem.PageIdUtils;
@@ -106,7 +107,7 @@ public class FullPageIdTable {
      * @return Current number of entries in the map.
      */
     public final int size() {
-        return GridUnsafe.getInt(valPtr);
+        return Ignition.UNSAFE.getInt(valPtr);
     }
 
     /**
@@ -204,10 +205,10 @@ public class FullPageIdTable {
             if (isValuePresentAt(idx2)) {
                 long base = entryBase(idx2);
 
-                int cacheId = GridUnsafe.getInt(base);
-                int tag = GridUnsafe.getInt(base + 4);
-                long pageId = GridUnsafe.getLong(base + 8);
-                long val = GridUnsafe.getLong(base + 16);
+                int cacheId = Ignition.UNSAFE.getInt(base);
+                int tag = Ignition.UNSAFE.getInt(base + 4);
+                long pageId = Ignition.UNSAFE.getLong(base + 8);
+                long val = Ignition.UNSAFE.getLong(base + 16);
 
                 return new EvictCandidate(tag, val, new FullPageId(pageId, cacheId));
             }
@@ -225,9 +226,9 @@ public class FullPageIdTable {
     public long clearAt(int idx, GridPredicate3<Integer, Long, Integer> pred, long absent) {
         long base = entryBase(idx);
 
-        int grpId = GridUnsafe.getInt(base);
-        int tag = GridUnsafe.getInt(base + 4);
-        long pageId = GridUnsafe.getLong(base + 8);
+        int grpId = Ignition.UNSAFE.getInt(base);
+        int tag = Ignition.UNSAFE.getInt(base + 4);
+        long pageId = Ignition.UNSAFE.getLong(base + 8);
 
         if ((pageId == REMOVED_PAGE_ID && grpId == REMOVED_CACHE_GRP_ID)
             || (pageId == EMPTY_PAGE_ID && grpId == EMPTY_CACHE_GRP_ID))
@@ -382,9 +383,9 @@ public class FullPageIdTable {
     private int testKeyAt(int index, int testCacheId, long testPageId, int testTag) {
         long base = entryBase(index);
 
-        int grpId = GridUnsafe.getInt(base);
-        int tag = GridUnsafe.getInt(base + 4);
-        long pageId = GridUnsafe.getLong(base + 8);
+        int grpId = Ignition.UNSAFE.getInt(base);
+        int tag = Ignition.UNSAFE.getInt(base + 4);
+        long pageId = Ignition.UNSAFE.getLong(base + 8);
 
         if (pageId == REMOVED_PAGE_ID && grpId == REMOVED_CACHE_GRP_ID)
             return REMOVED;
@@ -405,8 +406,8 @@ public class FullPageIdTable {
     private boolean isValuePresentAt(final int idx) {
         long base = entryBase(idx);
 
-        int grpId = GridUnsafe.getInt(base);
-        long pageId = GridUnsafe.getLong(base + 8);
+        int grpId = Ignition.UNSAFE.getInt(base);
+        long pageId = Ignition.UNSAFE.getLong(base + 8);
 
         return !((pageId == REMOVED_PAGE_ID && grpId == REMOVED_CACHE_GRP_ID)
             || (pageId == EMPTY_PAGE_ID && grpId == EMPTY_CACHE_GRP_ID));
@@ -432,8 +433,8 @@ public class FullPageIdTable {
     private void setKeyAt(int index, int grpId, long pageId) {
         long base = entryBase(index);
 
-        GridUnsafe.putInt(base, grpId);
-        GridUnsafe.putLong(base + 8, pageId);
+        Ignition.UNSAFE.putInt(base, grpId);
+        Ignition.UNSAFE.putLong(base + 8, pageId);
     }
 
     /**
@@ -488,9 +489,9 @@ public class FullPageIdTable {
             if (isValuePresentAt(i)) {
                 long base = entryBase(i);
 
-                int cacheId = GridUnsafe.getInt(base);
-                long pageId = GridUnsafe.getLong(base + 8);
-                long val = GridUnsafe.getLong(base + 16);
+                int cacheId = Ignition.UNSAFE.getInt(base);
+                long pageId = Ignition.UNSAFE.getLong(base + 8);
+                long val = Ignition.UNSAFE.getLong(base + 16);
 
                 visitor.apply(new FullPageId(pageId, cacheId), val);
             }
@@ -502,7 +503,7 @@ public class FullPageIdTable {
      * @return Value.
      */
     private long valueAt(int index) {
-        return GridUnsafe.getLong(entryBase(index) + 16);
+        return Ignition.UNSAFE.getLong(entryBase(index) + 16);
     }
 
     /**
@@ -510,7 +511,7 @@ public class FullPageIdTable {
      * @param value Value.
      */
     private void setValueAt(int index, long value) {
-        GridUnsafe.putLong(entryBase(index) + 16, value);
+        Ignition.UNSAFE.putLong(entryBase(index) + 16, value);
     }
 
     private long entryBase(int index) {
@@ -522,7 +523,7 @@ public class FullPageIdTable {
      * @return Tag at the given index.
      */
     private int tagAt(int index) {
-        return GridUnsafe.getInt(entryBase(index) + 4);
+        return Ignition.UNSAFE.getInt(entryBase(index) + 4);
     }
 
     /**
@@ -530,27 +531,27 @@ public class FullPageIdTable {
      * @param tag Tag to set at the given index.
      */
     private void setTagAt(int index, int tag) {
-        GridUnsafe.putInt(entryBase(index) + 4, tag);
+        Ignition.UNSAFE.putInt(entryBase(index) + 4, tag);
     }
 
     /**
      *
      */
     public void clear() {
-        GridUnsafe.setMemory(valPtr, (long)capacity * BYTES_PER_ENTRY + 8, (byte)0);
+        Ignition.UNSAFE.setMemory(valPtr, (long)capacity * BYTES_PER_ENTRY + 8, (byte)0);
     }
 
     /**
      *
      */
     private void incrementSize() {
-        GridUnsafe.putInt(valPtr, GridUnsafe.getInt(valPtr) + 1);
+        Ignition.UNSAFE.putInt(valPtr, Ignition.UNSAFE.getInt(valPtr) + 1);
     }
 
     /**
      *
      */
     private void decrementSize() {
-        GridUnsafe.putInt(valPtr, GridUnsafe.getInt(valPtr) - 1);
+        Ignition.UNSAFE.putInt(valPtr, Ignition.UNSAFE.getInt(valPtr) - 1);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImpl.java
@@ -38,6 +38,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.mem.DirectMemoryProvider;
 import org.apache.ignite.internal.mem.DirectMemoryRegion;
@@ -62,11 +63,7 @@ import org.apache.ignite.internal.processors.cache.persistence.DataRegionMetrics
 import org.apache.ignite.internal.processors.cache.persistence.tree.io.PageIO;
 import org.apache.ignite.internal.processors.cache.persistence.tree.io.TrackingPageIO;
 import org.apache.ignite.internal.processors.cache.persistence.wal.crc.IgniteDataIntegrityViolationException;
-import org.apache.ignite.internal.util.GridConcurrentHashSet;
-import org.apache.ignite.internal.util.GridLongList;
-import org.apache.ignite.internal.util.GridMultiCollectionWrapper;
-import org.apache.ignite.internal.util.GridUnsafe;
-import org.apache.ignite.internal.util.OffheapReadWriteLock;
+import org.apache.ignite.internal.util.*;
 import org.apache.ignite.internal.util.future.CountDownFuture;
 import org.apache.ignite.internal.util.lang.GridInClosure3X;
 import org.apache.ignite.internal.util.lang.GridPredicate3;
@@ -417,6 +414,7 @@ public class PageMemoryImpl implements PageMemoryEx {
         return isDirty(page);
     }
 
+
     /** {@inheritDoc} */
     @Override public long allocatePage(int cacheId, int partId, byte flags) throws IgniteCheckedException {
         assert flags == PageIdAllocator.FLAG_DATA && partId <= PageIdAllocator.MAX_PARTITION_ID ||
@@ -462,13 +460,13 @@ public class PageMemoryImpl implements PageMemoryEx {
 
             long absPtr = seg.absolute(relPtr);
 
-            GridUnsafe.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
+            Ignition.UNSAFE.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
 
             PageHeader.fullPageId(absPtr, fullId);
             PageHeader.writeTimestamp(absPtr, U.currentTimeMillis());
             rwLock.init(absPtr + PAGE_LOCK_OFFSET, PageIdUtils.tag(pageId));
 
-            assert GridUnsafe.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+            assert Ignition.UNSAFE.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
 
             assert !PageHeader.isAcquired(absPtr) :
                 "Pin counter must be 0 for a new page [relPtr=" + U.hexLong(relPtr) +
@@ -626,7 +624,7 @@ public class PageMemoryImpl implements PageMemoryEx {
                     }
                 }
                 else {
-                    GridUnsafe.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
+                    Ignition.UNSAFE.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
 
                     // Must init page ID in order to ensure RWLock tag consistency.
                     PageIO.setPageId(pageAddr, pageId);
@@ -643,7 +641,7 @@ public class PageMemoryImpl implements PageMemoryEx {
 
                 long pageAddr = absPtr + PAGE_OVERHEAD;
 
-                GridUnsafe.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
+                Ignition.UNSAFE.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
 
                 PageHeader.fullPageId(absPtr, fullId);
                 PageHeader.writeTimestamp(absPtr, U.currentTimeMillis());
@@ -683,14 +681,14 @@ public class PageMemoryImpl implements PageMemoryEx {
 
         long absPtr = seg.absolute(relPtr);
 
-        GridUnsafe.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
+        Ignition.UNSAFE.setMemory(absPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
 
         PageHeader.dirty(absPtr, false);
 
         long tmpBufPtr = PageHeader.tempBufferPointer(absPtr);
 
         if (tmpBufPtr != INVALID_REL_PTR) {
-            GridUnsafe.setMemory(checkpointPool.absolute(tmpBufPtr) + PAGE_OVERHEAD, pageSize(), (byte)0);
+            Ignition.UNSAFE.setMemory(checkpointPool.absolute(tmpBufPtr) + PAGE_OVERHEAD, pageSize(), (byte)0);
 
             PageHeader.tempBufferPointer(absPtr, INVALID_REL_PTR);
 
@@ -733,7 +731,7 @@ public class PageMemoryImpl implements PageMemoryEx {
                                 if (tmpAddr == null) {
                                     assert snapshot.pageData().length <= pageSize() : snapshot.pageData().length;
 
-                                    tmpAddr = GridUnsafe.allocateMemory(pageSize());
+                                    tmpAddr = Ignition.UNSAFE.allocateMemory(pageSize());
                                 }
 
                                 if (curPage == null)
@@ -796,7 +794,7 @@ public class PageMemoryImpl implements PageMemoryEx {
         }
         finally {
             if (tmpAddr != null)
-                GridUnsafe.freeMemory(tmpAddr);
+                Ignition.UNSAFE.freeMemory(tmpAddr);
         }
     }
 
@@ -980,7 +978,7 @@ public class PageMemoryImpl implements PageMemoryEx {
 
                 copyInBuffer(tmpAbsPtr, tmpBuf);
 
-                GridUnsafe.setMemory(tmpAbsPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
+                Ignition.UNSAFE.setMemory(tmpAbsPtr + PAGE_OVERHEAD, pageSize(), (byte)0);
 
                 if (tracker != null)
                     tracker.onCowPageWritten();
@@ -1023,10 +1021,10 @@ public class PageMemoryImpl implements PageMemoryEx {
         if (tmpBuf.isDirect()) {
             long tmpPtr = ((DirectBuffer)tmpBuf).address();
 
-            GridUnsafe.copyMemory(absPtr + PAGE_OVERHEAD, tmpPtr, pageSize());
+            Ignition.UNSAFE.copyMemory(absPtr + PAGE_OVERHEAD, tmpPtr, pageSize());
 
-            assert GridUnsafe.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
-            assert GridUnsafe.getInt(tmpPtr + 4) == 0; //TODO GG-11480
+            assert Ignition.UNSAFE.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+            assert Ignition.UNSAFE.getInt(tmpPtr + 4) == 0; //TODO GG-11480
         }
         else {
             byte[] arr = tmpBuf.array();
@@ -1034,7 +1032,7 @@ public class PageMemoryImpl implements PageMemoryEx {
             assert arr != null;
             assert arr.length == pageSize();
 
-            GridUnsafe.copyMemory(null, absPtr + PAGE_OVERHEAD, arr, GridUnsafe.BYTE_ARR_OFF, pageSize());
+            Ignition.UNSAFE.copyMemory(null, absPtr + PAGE_OVERHEAD, arr, Ignition.UNSAFE.BYTE_ARR_OFF, pageSize());
         }
     }
 
@@ -1162,7 +1160,7 @@ public class PageMemoryImpl implements PageMemoryEx {
 
         PageHeader.writeTimestamp(absPtr, U.currentTimeMillis());
 
-        assert GridUnsafe.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+        assert Ignition.UNSAFE.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
 
         return absPtr + PAGE_OVERHEAD;
     }
@@ -1238,7 +1236,7 @@ public class PageMemoryImpl implements PageMemoryEx {
 
             long tmpAbsPtr = checkpointPool.absolute(tmpRelPtr);
 
-            GridUnsafe.copyMemory(
+            Ignition.UNSAFE.copyMemory(
                 null,
                 absPtr + PAGE_OVERHEAD,
                 null,
@@ -1252,11 +1250,11 @@ public class PageMemoryImpl implements PageMemoryEx {
             PageHeader.dirty(absPtr, false);
             PageHeader.tempBufferPointer(absPtr, tmpRelPtr);
 
-            assert GridUnsafe.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
-            assert GridUnsafe.getInt(tmpAbsPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+            assert Ignition.UNSAFE.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+            assert Ignition.UNSAFE.getInt(tmpAbsPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
         }
 
-        assert GridUnsafe.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+        assert Ignition.UNSAFE.getInt(absPtr + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
 
         return absPtr + PAGE_OVERHEAD;
     }
@@ -1280,7 +1278,7 @@ public class PageMemoryImpl implements PageMemoryEx {
 
         boolean pageWalRec = markDirty && walPlc != FALSE && (walPlc == TRUE || !dirty);
 
-        assert GridUnsafe.getInt(page + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
+        assert Ignition.UNSAFE.getInt(page + PAGE_OVERHEAD + 4) == 0; //TODO GG-11480
 
         if (markDirty)
             setDirty(fullId, page, markDirty, false);
@@ -1303,7 +1301,7 @@ public class PageMemoryImpl implements PageMemoryEx {
             StringBuilder sb = new StringBuilder(sysPageSize * 2);
 
             for (int i = 0; i < systemPageSize(); i += 8)
-                sb.append(U.hexLong(GridUnsafe.getLong(page + i)));
+                sb.append(U.hexLong(Ignition.UNSAFE.getLong(page + i)));
 
             U.error(log, "Failed to unlock page [fullPageId=" + fullId + ", binPage=" + sb + ']');
 
@@ -1457,6 +1455,10 @@ public class PageMemoryImpl implements PageMemoryEx {
         return segments[idx];
     }
 
+    public String getDataRegionName() {
+        /* no-op */
+        return null;
+    }
     /**
      * @param pageId Page ID.
      * @return Segment index.
@@ -1515,8 +1517,8 @@ public class PageMemoryImpl implements PageMemoryEx {
             // Align page start by
             pagesBase = base;
 
-            GridUnsafe.putLong(freePageListPtr, INVALID_REL_PTR);
-            GridUnsafe.putLong(lastAllocatedIdxPtr, 1L);
+            Ignition.UNSAFE.putLong(freePageListPtr, INVALID_REL_PTR);
+            Ignition.UNSAFE.putLong(lastAllocatedIdxPtr, 1L);
         }
 
         /**
@@ -1540,19 +1542,19 @@ public class PageMemoryImpl implements PageMemoryEx {
          */
         private long borrowFreePage() {
             while (true) {
-                long freePageRelPtrMasked = GridUnsafe.getLong(freePageListPtr);
+                long freePageRelPtrMasked = Ignition.UNSAFE.getLong(freePageListPtr);
 
                 long freePageRelPtr = freePageRelPtrMasked & ADDRESS_MASK;
 
                 if (freePageRelPtr != INVALID_REL_PTR) {
                     long freePageAbsPtr = absolute(freePageRelPtr);
 
-                    long nextFreePageRelPtr = GridUnsafe.getLong(freePageAbsPtr) & ADDRESS_MASK;
+                    long nextFreePageRelPtr = Ignition.UNSAFE.getLong(freePageAbsPtr) & ADDRESS_MASK;
 
                     long cnt = ((freePageRelPtrMasked & COUNTER_MASK) + COUNTER_INC) & COUNTER_MASK;
 
-                    if (GridUnsafe.compareAndSwapLong(null, freePageListPtr, freePageRelPtrMasked, nextFreePageRelPtr | cnt)) {
-                        GridUnsafe.putLong(freePageAbsPtr, PAGE_MARKER);
+                    if (Ignition.UNSAFE.compareAndSwapLong(null, freePageListPtr, freePageRelPtrMasked, nextFreePageRelPtr | cnt)) {
+                        Ignition.UNSAFE.putLong(freePageAbsPtr, PAGE_MARKER);
 
                         return freePageRelPtr;
                     }
@@ -1571,13 +1573,13 @@ public class PageMemoryImpl implements PageMemoryEx {
             long limit = region.address() + region.size();
 
             while (true) {
-                long lastIdx = GridUnsafe.getLong(lastAllocatedIdxPtr);
+                long lastIdx = Ignition.UNSAFE.getLong(lastAllocatedIdxPtr);
 
                 // Check if we have enough space to allocate a page.
                 if (pagesBase + (lastIdx + 1) * sysPageSize > limit)
                     return INVALID_REL_PTR;
 
-                if (GridUnsafe.compareAndSwapLong(null, lastAllocatedIdxPtr, lastIdx, lastIdx + 1)) {
+                if (Ignition.UNSAFE.compareAndSwapLong(null, lastAllocatedIdxPtr, lastIdx, lastIdx + 1)) {
                     long absPtr = pagesBase + lastIdx * sysPageSize;
 
                     assert (lastIdx & SEGMENT_INDEX_MASK) == 0L;
@@ -1607,13 +1609,13 @@ public class PageMemoryImpl implements PageMemoryEx {
                 pagesCntr.getAndDecrement();
 
             while (true) {
-                long freePageRelPtrMasked = GridUnsafe.getLong(freePageListPtr);
+                long freePageRelPtrMasked = Ignition.UNSAFE.getLong(freePageListPtr);
 
                 long freePageRelPtr = freePageRelPtrMasked & RELATIVE_PTR_MASK;
 
-                GridUnsafe.putLong(absPtr, freePageRelPtr);
+                Ignition.UNSAFE.putLong(absPtr, freePageRelPtr);
 
-                if (GridUnsafe.compareAndSwapLong(null, freePageListPtr, freePageRelPtrMasked, relPtr))
+                if (Ignition.UNSAFE.compareAndSwapLong(null, freePageListPtr, freePageRelPtrMasked, relPtr))
                     return;
             }
         }
@@ -1700,7 +1702,7 @@ public class PageMemoryImpl implements PageMemoryEx {
 
             acquiredPagesPtr = region.address();
 
-            GridUnsafe.putIntVolatile(null, acquiredPagesPtr, 0);
+            Ignition.UNSAFE.putIntVolatile(null, acquiredPagesPtr, 0);
 
             loadedPages = new FullPageIdTable(region.address() + 8, memPerTbl, true);
 
@@ -1775,7 +1777,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return Total number of acquired pages.
          */
         private int acquiredPages() {
-            return GridUnsafe.getInt(acquiredPagesPtr);
+            return Ignition.UNSAFE.getInt(acquiredPagesPtr);
         }
 
         /**
@@ -2127,11 +2129,11 @@ public class PageMemoryImpl implements PageMemoryEx {
      */
     private static int updateAtomicInt(long ptr, int delta) {
         while (true) {
-            int old = GridUnsafe.getInt(ptr);
+            int old = Ignition.UNSAFE.getInt(ptr);
 
             int updated = old + delta;
 
-            if (GridUnsafe.compareAndSwapInt(null, ptr, old, updated))
+            if (Ignition.UNSAFE.compareAndSwapInt(null, ptr, old, updated))
                 return updated;
         }
     }
@@ -2142,11 +2144,11 @@ public class PageMemoryImpl implements PageMemoryEx {
      */
     private static long updateAtomicLong(long ptr, long delta) {
         while (true) {
-            long old = GridUnsafe.getLong(ptr);
+            long old = Ignition.UNSAFE.getLong(ptr);
 
             long updated = old + delta;
 
-            if (GridUnsafe.compareAndSwapLong(null, ptr, old, updated))
+            if (Ignition.UNSAFE.compareAndSwapLong(null, ptr, old, updated))
                 return updated;
         }
     }
@@ -2164,8 +2166,8 @@ public class PageMemoryImpl implements PageMemoryEx {
 
             tempBufferPointer(absPtr, INVALID_REL_PTR);
 
-            GridUnsafe.putLong(absPtr, PAGE_MARKER);
-            GridUnsafe.putInt(absPtr + PAGE_PIN_CNT_OFFSET, 0);
+            Ignition.UNSAFE.putLong(absPtr, PAGE_MARKER);
+            Ignition.UNSAFE.putInt(absPtr + PAGE_PIN_CNT_OFFSET, 0);
         }
 
         /**
@@ -2194,7 +2196,7 @@ public class PageMemoryImpl implements PageMemoryEx {
             assert (flag & 0xFFFFFFFFFFFFFFL) == 0;
             assert Long.bitCount(flag) == 1;
 
-            long relPtrWithFlags = GridUnsafe.getLong(absPtr + RELATIVE_PTR_OFFSET);
+            long relPtrWithFlags = Ignition.UNSAFE.getLong(absPtr + RELATIVE_PTR_OFFSET);
 
             return (relPtrWithFlags & flag) != 0;
         }
@@ -2211,7 +2213,7 @@ public class PageMemoryImpl implements PageMemoryEx {
             assert (flag & 0xFFFFFFFFFFFFFFL) == 0;
             assert Long.bitCount(flag) == 1;
 
-            long relPtrWithFlags = GridUnsafe.getLong(absPtr + RELATIVE_PTR_OFFSET);
+            long relPtrWithFlags = Ignition.UNSAFE.getLong(absPtr + RELATIVE_PTR_OFFSET);
 
             boolean was = (relPtrWithFlags & flag) != 0;
 
@@ -2220,7 +2222,7 @@ public class PageMemoryImpl implements PageMemoryEx {
             else
                 relPtrWithFlags &= ~flag;
 
-            GridUnsafe.putLong(absPtr + RELATIVE_PTR_OFFSET, relPtrWithFlags);
+            Ignition.UNSAFE.putLong(absPtr + RELATIVE_PTR_OFFSET, relPtrWithFlags);
 
             return was;
         }
@@ -2230,7 +2232,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return If page is pinned.
          */
         private static boolean isAcquired(long absPtr) {
-            return GridUnsafe.getInt(absPtr + PAGE_PIN_CNT_OFFSET) > 0;
+            return Ignition.UNSAFE.getInt(absPtr + PAGE_PIN_CNT_OFFSET) > 0;
         }
 
         /**
@@ -2254,7 +2256,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return Relative pointer written to the page.
          */
         private static long readRelative(long absPtr) {
-            return GridUnsafe.getLong(absPtr + RELATIVE_PTR_OFFSET) & RELATIVE_PTR_MASK;
+            return Ignition.UNSAFE.getLong(absPtr + RELATIVE_PTR_OFFSET) & RELATIVE_PTR_MASK;
         }
 
         /**
@@ -2264,7 +2266,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @param relPtr Relative pointer to write.
          */
         private static void relative(long absPtr, long relPtr) {
-            GridUnsafe.putLong(absPtr + RELATIVE_PTR_OFFSET, relPtr & RELATIVE_PTR_MASK);
+            Ignition.UNSAFE.putLong(absPtr + RELATIVE_PTR_OFFSET, relPtr & RELATIVE_PTR_MASK);
         }
 
         /**
@@ -2275,7 +2277,7 @@ public class PageMemoryImpl implements PageMemoryEx {
         private static void writeTimestamp(final long absPtr, long tstamp) {
             tstamp >>= 8;
 
-            GridUnsafe.putLongVolatile(null, absPtr, (tstamp << 8) | 0x01);
+            Ignition.UNSAFE.putLongVolatile(null, absPtr, (tstamp << 8) | 0x01);
         }
 
         /**
@@ -2285,7 +2287,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return Timestamp.
          */
         private static long readTimestamp(final long absPtr) {
-            long markerAndTs = GridUnsafe.getLong(absPtr);
+            long markerAndTs = Ignition.UNSAFE.getLong(absPtr);
 
             // Clear last byte as it is occupied by page marker.
             return markerAndTs & ~0xFF;
@@ -2296,7 +2298,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @param tmpRelPtr Temp buffer relative pointer.
          */
         private static void tempBufferPointer(long absPtr, long tmpRelPtr) {
-            GridUnsafe.putLong(absPtr + PAGE_TMP_BUF_OFFSET, tmpRelPtr);
+            Ignition.UNSAFE.putLong(absPtr + PAGE_TMP_BUF_OFFSET, tmpRelPtr);
         }
 
         /**
@@ -2304,7 +2306,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return Temp buffer relative pointer.
          */
         private static long tempBufferPointer(long absPtr) {
-            return GridUnsafe.getLong(absPtr + PAGE_TMP_BUF_OFFSET);
+            return Ignition.UNSAFE.getLong(absPtr + PAGE_TMP_BUF_OFFSET);
         }
 
         /**
@@ -2314,7 +2316,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return Page ID written to the page.
          */
         private static long readPageId(long absPtr) {
-            return GridUnsafe.getLong(absPtr + PAGE_ID_OFFSET);
+            return Ignition.UNSAFE.getLong(absPtr + PAGE_ID_OFFSET);
         }
 
         /**
@@ -2324,7 +2326,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @param pageId Page ID to write.
          */
         private static void pageId(long absPtr, long pageId) {
-            GridUnsafe.putLong(absPtr + PAGE_ID_OFFSET, pageId);
+            Ignition.UNSAFE.putLong(absPtr + PAGE_ID_OFFSET, pageId);
         }
 
         /**
@@ -2334,7 +2336,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @return Cache ID written to the page.
          */
         private static int readPageCacheId(final long absPtr) {
-            return GridUnsafe.getInt(absPtr + PAGE_CACHE_ID_OFFSET);
+            return Ignition.UNSAFE.getInt(absPtr + PAGE_CACHE_ID_OFFSET);
         }
 
         /**
@@ -2344,7 +2346,7 @@ public class PageMemoryImpl implements PageMemoryEx {
          * @param cacheId Cache ID to write.
          */
         private static void pageCacheId(final long absPtr, final int cacheId) {
-            GridUnsafe.putInt(absPtr + PAGE_CACHE_ID_OFFSET, cacheId);
+            Ignition.UNSAFE.putInt(absPtr + PAGE_CACHE_ID_OFFSET, cacheId);
         }
 
         /**
@@ -2446,7 +2448,7 @@ public class PageMemoryImpl implements PageMemoryEx {
                             seg.dirtyPages.remove(fullId);
                         }
 
-                        GridUnsafe.setMemory(absPtr + PAGE_OVERHEAD, pageSize, (byte)0);
+                        Ignition.UNSAFE.setMemory(absPtr + PAGE_OVERHEAD, pageSize, (byte)0);
 
                         seg.pool.releaseFreePage(relPtr);
                     }
@@ -2461,4 +2463,5 @@ public class PageMemoryImpl implements PageMemoryEx {
             }
         }
     }
+
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/BPlusTree.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/BPlusTree.java
@@ -25,8 +25,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+
+import lib.llpl.Transaction;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.pagemem.PageIdUtils;
 import org.apache.ignite.internal.pagemem.PageMemory;
@@ -792,7 +795,16 @@ public abstract class BPlusTree<L, T extends L> extends DataStructure implements
      * @throws IgniteCheckedException If failed.
      */
     protected final void initTree(boolean initNew) throws IgniteCheckedException {
-        initTree(initNew, 0);
+        if (!Ignition.isAepEnabled())
+            initTree(initNew, 0);
+        else
+            Transaction.run(Ignition.getAepHeap(), () -> {
+                try {
+                    initTree(initNew, 0);
+                } catch (IgniteCheckedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
     }
 
     /**
@@ -2460,7 +2472,7 @@ public abstract class BPlusTree<L, T extends L> extends DataStructure implements
         }
 
         /**
-         * @param rootId Root page ID.
+         * @param rootId Root pageinit ID.
          * @param rootLvl Root level.
          * @param rmvId Remove ID to be afraid of.
          */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusIO.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.processors.cache.persistence.tree.io;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageUtils;
 import org.apache.ignite.internal.processors.cache.persistence.tree.BPlusTree;
 import org.apache.ignite.internal.util.GridStringBuilder;
@@ -76,7 +77,9 @@ public abstract class BPlusIO<L> extends PageIO {
     @Override public void initNewPage(long pageAddr, long pageId, int pageSize) {
         super.initNewPage(pageAddr, pageId, pageSize);
 
-        setCount(pageAddr, 0);
+        if (!Ignition.isAepEnabled())
+            setCount(pageAddr, 0);
+
         setForward(pageAddr, 0);
         setRemoveId(pageAddr, 0);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionCountersIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionCountersIO.java
@@ -21,6 +21,7 @@ package org.apache.ignite.internal.processors.cache.persistence.tree.io;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageUtils;
 import org.apache.ignite.internal.util.GridStringBuilder;
 
@@ -62,7 +63,9 @@ public class PagePartitionCountersIO extends PageIO {
     @Override public void initNewPage(long pageAddr, long pageId, int pageSize) {
         super.initNewPage(pageAddr, pageId, pageSize);
 
-        setCount(pageAddr, 0);
+        if (!Ignition.isAepEnabled())
+            setCount(pageAddr, 0);
+
         setNextCountersPageId(pageAddr, 0);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIO.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.processors.cache.persistence.tree.io;
 
 import java.nio.ByteBuffer;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageIdUtils;
 import org.apache.ignite.internal.processors.cache.persistence.tree.util.PageHandler;
 import org.apache.ignite.internal.util.GridStringBuilder;
@@ -184,7 +185,7 @@ public class TrackingPageIO extends PageIO {
      * @param addr Address.
      */
     long getLastSnapshotTag(long addr) {
-        return GridUnsafe.getLong(addr + LAST_SNAPSHOT_TAG_OFFSET);
+        return Ignition.UNSAFE.getLong(addr + LAST_SNAPSHOT_TAG_OFFSET);
     }
 
     /**
@@ -350,18 +351,18 @@ public class TrackingPageIO extends PageIO {
     @Override protected void printPage(long addr, int pageSize, GridStringBuilder sb) throws IgniteCheckedException {
         sb.a("TrackingPage [\n\tlastSnapshotTag=").a(getLastSnapshotTag(addr))
             .a(",\n\tleftHalf={")
-            .a("\n\t\tsize=").a(GridUnsafe.getShort(addr + SIZE_FIELD_OFFSET))
+            .a("\n\t\tsize=").a(Ignition.UNSAFE.getShort(addr + SIZE_FIELD_OFFSET))
             .a("\n\t\tdata={");
 
         for (int i = 0; i < (countOfPageToTrack(pageSize) >> 3); i += 2)
-            sb.appendHex(GridUnsafe.getShort(addr + BITMAP_OFFSET + i));
+            sb.appendHex(Ignition.UNSAFE.getShort(addr + BITMAP_OFFSET + i));
 
         sb.a("}\n\t},\n\trightHalf={")
-            .a("\n\t\tsize=").a(GridUnsafe.getShort(addr + BITMAP_OFFSET + (countOfPageToTrack(pageSize) >> 3)))
+            .a("\n\t\tsize=").a(Ignition.UNSAFE.getShort(addr + BITMAP_OFFSET + (countOfPageToTrack(pageSize) >> 3)))
             .a("\n\t\tdata={");
 
         for (int i = 0; i < (countOfPageToTrack(pageSize) >> 3); i += 2)
-            sb.appendHex(GridUnsafe.getShort(addr + BITMAP_OFFSET + (countOfPageToTrack(pageSize) >> 3)
+            sb.appendHex(Ignition.UNSAFE.getShort(addr + BITMAP_OFFSET + (countOfPageToTrack(pageSize) >> 3)
                  + SIZE_FIELD_SIZE + i));
 
         sb.a("}\n\t}\n]");

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/ByteBufferExpander.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/ByteBufferExpander.java
@@ -19,6 +19,8 @@ package org.apache.ignite.internal.processors.cache.persistence.wal;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
@@ -33,7 +35,7 @@ public class ByteBufferExpander implements AutoCloseable {
      * @param order Byte order.
      */
     public ByteBufferExpander(int initSize, ByteOrder order) {
-        ByteBuffer buffer = GridUnsafe.allocateBuffer(initSize);
+        ByteBuffer buffer = Ignition.UNSAFE.allocateBuffer(initSize);
         buffer.order(order);
 
         buf = buffer;
@@ -54,16 +56,13 @@ public class ByteBufferExpander implements AutoCloseable {
      * @return ByteBuffer with requested size.
      */
     public ByteBuffer expand(int size) {
-        assert buf.capacity() < size;
-
-        int pos = buf.position();
-        int lim = buf.limit();
-
-        ByteBuffer newBuf = GridUnsafe.reallocateBuffer(buf, size);
+        ByteBuffer newBuf = ByteBuffer.allocate(size);
 
         newBuf.order(buf.order());
-        newBuf.position(pos);
-        newBuf.limit(lim);
+
+        newBuf.put(buf);
+
+        newBuf.flip();
 
         buf = newBuf;
 
@@ -72,6 +71,6 @@ public class ByteBufferExpander implements AutoCloseable {
 
     /** {@inheritDoc} */
     @Override public void close() {
-        GridUnsafe.freeBuffer(buf);
+        Ignition.UNSAFE.freeBuffer(buf);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/FileWriteAheadLogManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/FileWriteAheadLogManager.java
@@ -52,6 +52,7 @@ import java.util.zip.ZipOutputStream;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.WALMode;
@@ -230,7 +231,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
         @Override protected ByteBuffer initialValue() {
             ByteBuffer buf = ByteBuffer.allocateDirect(tlbSize);
 
-            buf.order(GridUnsafe.NATIVE_BYTE_ORDER);
+            buf.order(Ignition.UNSAFE.NATIVE_BYTE_ORDER);
 
             return buf;
         }
@@ -2429,7 +2430,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
                 boolean tmpBuf = false;
 
                 if (expHead.chainSize() > tlbSize) {
-                    buf = GridUnsafe.allocateBuffer(expHead.chainSize());
+                    buf = Ignition.UNSAFE.allocateBuffer(expHead.chainSize());
 
                     tmpBuf = true; // We need to manually release this temporary direct buffer.
                 }
@@ -2443,7 +2444,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
                 }
                 finally {
                     if (tmpBuf)
-                        GridUnsafe.freeBuffer(buf);
+                        Ignition.UNSAFE.freeBuffer(buf);
                 }
 
                 return true;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cacheobject/IgniteCacheObjectProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cacheobject/IgniteCacheObjectProcessor.java
@@ -24,6 +24,7 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.internal.GridComponent;
 import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.processors.GridProcessor;
 import org.apache.ignite.internal.processors.cache.CacheObject;
 import org.apache.ignite.internal.processors.cache.CacheObjectContext;
@@ -205,4 +206,6 @@ public interface IgniteCacheObjectProcessor extends GridProcessor {
      * @return Ignite binary interface.
      */
     public IgniteBinary binary();
+
+    public BinaryContext getBinaryCtx();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cacheobject/IgniteCacheObjectProcessorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cacheobject/IgniteCacheObjectProcessorImpl.java
@@ -27,6 +27,7 @@ import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.processors.GridProcessorAdapter;
 import org.apache.ignite.internal.processors.cache.CacheObject;
 import org.apache.ignite.internal.processors.cache.CacheObjectByteArrayImpl;
@@ -339,4 +340,8 @@ public class IgniteCacheObjectProcessorImpl extends GridProcessorAdapter impleme
         return false;
     }
 
+    /** {@inheritDoc}*/
+    public BinaryContext getBinaryCtx() {
+        return null;
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/HadoopShuffleMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/HadoopShuffleMessage.java
@@ -23,6 +23,7 @@ import java.io.ObjectOutput;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.processors.hadoop.HadoopJobId;
 import org.apache.ignite.internal.processors.hadoop.message.HadoopMessage;
 import org.apache.ignite.internal.util.GridUnsafe;
@@ -169,11 +170,11 @@ public class HadoopShuffleMessage implements Message, HadoopMessage {
     private void add(byte marker, long ptr, int size) {
         buf[off++] = marker;
 
-        GridUnsafe.putInt(buf, GridUnsafe.BYTE_ARR_OFF + off, size);
+        Ignition.UNSAFE.putInt(buf, GridUnsafe.BYTE_ARR_OFF + off, size);
 
         off += 4;
 
-        GridUnsafe.copyOffheapHeap(ptr, buf, GridUnsafe.BYTE_ARR_OFF + off, size);
+        Ignition.UNSAFE.copyOffheapHeap(ptr, buf, GridUnsafe.BYTE_ARR_OFF + off, size);
 
         off += size;
     }
@@ -185,7 +186,7 @@ public class HadoopShuffleMessage implements Message, HadoopMessage {
         for (int i = 0; i < off;) {
             byte marker = buf[i++];
 
-            int size = GridUnsafe.getInt(buf, GridUnsafe.BYTE_ARR_OFF + i);
+            int size = Ignition.UNSAFE.getInt(buf, GridUnsafe.BYTE_ARR_OFF + i);
 
             i += 4;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/memory/PlatformBigEndianOutputStreamImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/memory/PlatformBigEndianOutputStreamImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.platform.memory;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
@@ -46,7 +47,7 @@ public class PlatformBigEndianOutputStreamImpl extends PlatformOutputStreamImpl 
         long startPos = data + pos;
 
         for (short item : val) {
-            GridUnsafe.putShort(startPos, Short.reverseBytes(item));
+            Ignition.UNSAFE.putShort(startPos, Short.reverseBytes(item));
 
             startPos += 2;
         }
@@ -68,7 +69,7 @@ public class PlatformBigEndianOutputStreamImpl extends PlatformOutputStreamImpl 
         long startPos = data + pos;
 
         for (char item : val) {
-            GridUnsafe.putChar(startPos, Character.reverseBytes(item));
+            Ignition.UNSAFE.putChar(startPos, Character.reverseBytes(item));
 
             startPos += 2;
         }
@@ -90,7 +91,7 @@ public class PlatformBigEndianOutputStreamImpl extends PlatformOutputStreamImpl 
         long startPos = data + pos;
 
         for (int item : val) {
-            GridUnsafe.putInt(startPos, Integer.reverseBytes(item));
+            Ignition.UNSAFE.putInt(startPos, Integer.reverseBytes(item));
 
             startPos += 4;
         }
@@ -117,7 +118,7 @@ public class PlatformBigEndianOutputStreamImpl extends PlatformOutputStreamImpl 
         long startPos = data + pos;
 
         for (float item : val) {
-            GridUnsafe.putInt(startPos, Integer.reverseBytes(Float.floatToIntBits(item)));
+            Ignition.UNSAFE.putInt(startPos, Integer.reverseBytes(Float.floatToIntBits(item)));
 
             startPos += 4;
         }
@@ -139,7 +140,7 @@ public class PlatformBigEndianOutputStreamImpl extends PlatformOutputStreamImpl 
         long startPos = data + pos;
 
         for (long item : val) {
-            GridUnsafe.putLong(startPos, Long.reverseBytes(item));
+            Ignition.UNSAFE.putLong(startPos, Long.reverseBytes(item));
 
             startPos += 8;
         }
@@ -156,7 +157,7 @@ public class PlatformBigEndianOutputStreamImpl extends PlatformOutputStreamImpl 
         long startPos = data + pos;
 
         for (double item : val) {
-            GridUnsafe.putLong(startPos, Long.reverseBytes(Double.doubleToLongBits(item)));
+            Ignition.UNSAFE.putLong(startPos, Long.reverseBytes(Double.doubleToLongBits(item)));
 
             startPos += 8;
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/memory/PlatformInputStreamImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/memory/PlatformInputStreamImpl.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.processors.platform.memory;
 
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
@@ -55,14 +56,14 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public byte readByte() {
         ensureEnoughData(1);
 
-        return GridUnsafe.getByte(data + pos++);
+        return Ignition.UNSAFE.getByte(data + pos++);
     }
 
     /** {@inheritDoc} */
     @Override public byte[] readByteArray(int cnt) {
         byte[] res = new byte[cnt];
 
-        copyAndShift(res, GridUnsafe.BYTE_ARR_OFF, cnt);
+        copyAndShift(res, Ignition.UNSAFE.BYTE_ARR_OFF, cnt);
 
         return res;
     }
@@ -76,7 +77,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public boolean[] readBooleanArray(int cnt) {
         boolean[] res = new boolean[cnt];
 
-        copyAndShift(res, GridUnsafe.BOOLEAN_ARR_OFF, cnt);
+        copyAndShift(res, Ignition.UNSAFE.BOOLEAN_ARR_OFF, cnt);
 
         return res;
     }
@@ -85,7 +86,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public short readShort() {
         ensureEnoughData(2);
 
-        short res = GridUnsafe.getShort(data + pos);
+        short res = Ignition.UNSAFE.getShort(data + pos);
 
         shift(2);
 
@@ -98,7 +99,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
 
         short[] res = new short[cnt];
 
-        copyAndShift(res, GridUnsafe.SHORT_ARR_OFF, len);
+        copyAndShift(res, Ignition.UNSAFE.SHORT_ARR_OFF, len);
 
         return res;
     }
@@ -107,7 +108,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public char readChar() {
         ensureEnoughData(2);
 
-        char res = GridUnsafe.getChar(data + pos);
+        char res = Ignition.UNSAFE.getChar(data + pos);
 
         shift(2);
 
@@ -120,7 +121,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
 
         char[] res = new char[cnt];
 
-        copyAndShift(res, GridUnsafe.CHAR_ARR_OFF, len);
+        copyAndShift(res, Ignition.UNSAFE.CHAR_ARR_OFF, len);
 
         return res;
     }
@@ -129,7 +130,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public int readInt() {
         ensureEnoughData(4);
 
-        int res = GridUnsafe.getInt(data + pos);
+        int res = Ignition.UNSAFE.getInt(data + pos);
 
         shift(4);
 
@@ -143,7 +144,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
         if (delta > 0)
             ensureEnoughData(delta);
 
-        return GridUnsafe.getByte(data + pos);
+        return Ignition.UNSAFE.getByte(data + pos);
     }
 
     /** {@inheritDoc} */
@@ -153,7 +154,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
         if (delta > 0)
             ensureEnoughData(delta);
 
-        return GridUnsafe.getShort(data + pos);
+        return Ignition.UNSAFE.getShort(data + pos);
     }
 
     /** {@inheritDoc} */
@@ -163,7 +164,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
         if (delta > 0)
             ensureEnoughData(delta);
 
-        return GridUnsafe.getInt(data + pos);
+        return Ignition.UNSAFE.getInt(data + pos);
     }
 
     /** {@inheritDoc} */
@@ -172,7 +173,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
 
         int[] res = new int[cnt];
 
-        copyAndShift(res, GridUnsafe.INT_ARR_OFF, len);
+        copyAndShift(res, Ignition.UNSAFE.INT_ARR_OFF, len);
 
         return res;
     }
@@ -181,7 +182,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public float readFloat() {
         ensureEnoughData(4);
 
-        float res = GridUnsafe.getFloat(data + pos);
+        float res = Ignition.UNSAFE.getFloat(data + pos);
 
         shift(4);
 
@@ -194,7 +195,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
 
         float[] res = new float[cnt];
 
-        copyAndShift(res, GridUnsafe.FLOAT_ARR_OFF, len);
+        copyAndShift(res, Ignition.UNSAFE.FLOAT_ARR_OFF, len);
 
         return res;
     }
@@ -203,7 +204,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public long readLong() {
         ensureEnoughData(8);
 
-        long res = GridUnsafe.getLong(data + pos);
+        long res = Ignition.UNSAFE.getLong(data + pos);
 
         shift(8);
 
@@ -216,7 +217,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
 
         long[] res = new long[cnt];
 
-        copyAndShift(res, GridUnsafe.LONG_ARR_OFF, len);
+        copyAndShift(res, Ignition.UNSAFE.LONG_ARR_OFF, len);
 
         return res;
     }
@@ -225,7 +226,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     @Override public double readDouble() {
         ensureEnoughData(8);
 
-        double res = GridUnsafe.getDouble(data + pos);
+        double res = Ignition.UNSAFE.getDouble(data + pos);
 
         shift(8);
 
@@ -238,7 +239,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
 
         double[] res = new double[cnt];
 
-        copyAndShift(res, GridUnsafe.DOUBLE_ARR_OFF, len);
+        copyAndShift(res, Ignition.UNSAFE.DOUBLE_ARR_OFF, len);
 
         return res;
     }
@@ -248,7 +249,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
         if (len > remaining())
             len = remaining();
 
-        copyAndShift(arr, GridUnsafe.BYTE_ARR_OFF + off, len);
+        copyAndShift(arr, Ignition.UNSAFE.BYTE_ARR_OFF + off, len);
 
         return len;
     }
@@ -286,7 +287,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
         if (dataCopy == null) {
             dataCopy = new byte[len];
 
-            GridUnsafe.copyOffheapHeap(data, dataCopy, GridUnsafe.BYTE_ARR_OFF, dataCopy.length);
+            Ignition.UNSAFE.copyOffheapHeap(data, dataCopy, Ignition.UNSAFE.BYTE_ARR_OFF, dataCopy.length);
         }
 
         return dataCopy;
@@ -334,7 +335,7 @@ public class PlatformInputStreamImpl implements PlatformInputStream {
     private void copyAndShift(Object target, long off, int cnt) {
         ensureEnoughData(cnt);
 
-        GridUnsafe.copyOffheapHeap(data + pos, target, off, cnt);
+        Ignition.UNSAFE.copyOffheapHeap(data + pos, target, off, cnt);
 
         shift(cnt);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/memory/PlatformOutputStreamImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/memory/PlatformOutputStreamImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.platform.memory;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
@@ -51,12 +52,12 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
     @Override public void writeByte(byte val) {
         ensureCapacity(pos + 1);
 
-        GridUnsafe.putByte(data + pos++, val);
+        Ignition.UNSAFE.putByte(data + pos++, val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeByteArray(byte[] val) {
-        copyAndShift(val, GridUnsafe.BYTE_ARR_OFF, val.length);
+        copyAndShift(val, Ignition.UNSAFE.BYTE_ARR_OFF, val.length);
     }
 
     /** {@inheritDoc} */
@@ -66,63 +67,63 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
 
     /** {@inheritDoc} */
     @Override public void writeBooleanArray(boolean[] val) {
-        copyAndShift(val, GridUnsafe.BOOLEAN_ARR_OFF, val.length);
+        copyAndShift(val, Ignition.UNSAFE.BOOLEAN_ARR_OFF, val.length);
     }
 
     /** {@inheritDoc} */
     @Override public void writeShort(short val) {
         ensureCapacity(pos + 2);
 
-        GridUnsafe.putShort(data + pos, val);
+        Ignition.UNSAFE.putShort(data + pos, val);
 
         shift(2);
     }
 
     /** {@inheritDoc} */
     @Override public void writeShortArray(short[] val) {
-        copyAndShift(val, GridUnsafe.SHORT_ARR_OFF, val.length << 1);
+        copyAndShift(val, Ignition.UNSAFE.SHORT_ARR_OFF, val.length << 1);
     }
 
     /** {@inheritDoc} */
     @Override public void writeChar(char val) {
         ensureCapacity(pos + 2);
 
-        GridUnsafe.putChar(data + pos, val);
+        Ignition.UNSAFE.putChar(data + pos, val);
 
         shift(2);
     }
 
     /** {@inheritDoc} */
     @Override public void writeCharArray(char[] val) {
-        copyAndShift(val, GridUnsafe.CHAR_ARR_OFF, val.length << 1);
+        copyAndShift(val, Ignition.UNSAFE.CHAR_ARR_OFF, val.length << 1);
     }
 
     /** {@inheritDoc} */
     @Override public void writeInt(int val) {
         ensureCapacity(pos + 4);
 
-        GridUnsafe.putInt(data + pos, val);
+        Ignition.UNSAFE.putInt(data + pos, val);
 
         shift(4);
     }
 
     /** {@inheritDoc} */
     @Override public void writeIntArray(int[] val) {
-        copyAndShift(val, GridUnsafe.INT_ARR_OFF, val.length << 2);
+        copyAndShift(val, Ignition.UNSAFE.INT_ARR_OFF, val.length << 2);
     }
 
     /** {@inheritDoc} */
     @Override public void writeShort(int pos, short val) {
         ensureCapacity(pos + 2);
 
-        GridUnsafe.putShort(data + pos, val);
+        Ignition.UNSAFE.putShort(data + pos, val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeInt(int pos, int val) {
         ensureCapacity(pos + 4);
 
-        GridUnsafe.putInt(data + pos, val);
+        Ignition.UNSAFE.putInt(data + pos, val);
     }
 
     /** {@inheritDoc} */
@@ -132,21 +133,21 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
 
     /** {@inheritDoc} */
     @Override public void writeFloatArray(float[] val) {
-        copyAndShift(val, GridUnsafe.FLOAT_ARR_OFF, val.length << 2);
+        copyAndShift(val, Ignition.UNSAFE.FLOAT_ARR_OFF, val.length << 2);
     }
 
     /** {@inheritDoc} */
     @Override public void writeLong(long val) {
         ensureCapacity(pos + 8);
 
-        GridUnsafe.putLong(data + pos, val);
+        Ignition.UNSAFE.putLong(data + pos, val);
 
         shift(8);
     }
 
     /** {@inheritDoc} */
     @Override public void writeLongArray(long[] val) {
-        copyAndShift(val, GridUnsafe.LONG_ARR_OFF, val.length << 3);
+        copyAndShift(val, Ignition.UNSAFE.LONG_ARR_OFF, val.length << 3);
     }
 
     /** {@inheritDoc} */
@@ -156,12 +157,12 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
 
     /** {@inheritDoc} */
     @Override public void writeDoubleArray(double[] val) {
-        copyAndShift(val, GridUnsafe.DOUBLE_ARR_OFF, val.length << 3);
+        copyAndShift(val, Ignition.UNSAFE.DOUBLE_ARR_OFF, val.length << 3);
     }
 
     /** {@inheritDoc} */
     @Override public void write(byte[] arr, int off, int len) {
-        copyAndShift(arr, GridUnsafe.BYTE_ARR_OFF + off, len);
+        copyAndShift(arr, Ignition.UNSAFE.BYTE_ARR_OFF + off, len);
     }
 
     /** {@inheritDoc} */
@@ -229,7 +230,7 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteByte(byte val) {
-        GridUnsafe.putByte(data + pos++, val);
+        Ignition.UNSAFE.putByte(data + pos++, val);
     }
 
     /** {@inheritDoc} */
@@ -239,38 +240,38 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteShort(short val) {
-        GridUnsafe.putShort(data + pos, val);
+        Ignition.UNSAFE.putShort(data + pos, val);
 
         shift(2);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteShort(int pos, short val) {
-        GridUnsafe.putShort(data + pos, val);
+        Ignition.UNSAFE.putShort(data + pos, val);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteChar(char val) {
-        GridUnsafe.putChar(data + pos, val);
+        Ignition.UNSAFE.putChar(data + pos, val);
 
         shift(2);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteInt(int val) {
-        GridUnsafe.putInt(data + pos, val);
+        Ignition.UNSAFE.putInt(data + pos, val);
 
         shift(4);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteInt(int pos, int val) {
-        GridUnsafe.putInt(data + pos, val);
+        Ignition.UNSAFE.putInt(data + pos, val);
     }
 
     /** {@inheritDoc} */
     @Override public void unsafeWriteLong(long val) {
-        GridUnsafe.putLong(data + pos, val);
+        Ignition.UNSAFE.putLong(data + pos, val);
 
         shift(8);
     }
@@ -330,7 +331,7 @@ public class PlatformOutputStreamImpl implements PlatformOutputStream {
     private void copyAndShift(Object src, long off, int len) {
         ensureCapacity(pos + len);
 
-        GridUnsafe.copyHeapOffheap(src, off, data + pos, len);
+        Ignition.UNSAFE.copyHeapOffheap(src, off, data + pos, len);
 
         shift(len);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/AepUnsafe.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/AepUnsafe.java
@@ -1,0 +1,649 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.util;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.ignite.Ignition;
+import lib.llpl.*;
+import org.apache.ignite.internal.binary.BinarySchemaRegistry;
+import org.apache.ignite.internal.processors.cache.persistence.freelist.FreeListImpl;
+import org.apache.ignite.internal.processors.cache.persistence.freelist.PagesList;
+import sun.nio.ch.DirectBuffer;
+
+/**
+ *
+ *
+ */
+public class AepUnsafe extends GridUnsafe {
+
+    /** A handle for AEP heap. */
+    private Heap heap;
+
+    /** The type of the AEP memory region. */
+    private Class kind = Transactional.class;
+
+    /** A persistent singly linked list. */
+    private PersistentLinkedListOfLong<Transactional> persistentList;
+
+    /** Holds the base address and size of segments. Key: base address, Value: size. */
+    private ConcurrentSkipListMap<Long, Long> segmentsMap;
+
+    public enum BlockType { SEGMENT, BUCKET }
+
+    private Lock casLock = new ReentrantLock();
+
+    @SuppressWarnings("unchecked")
+    public AepUnsafe() {
+        heap = Ignition.getAepHeap();
+        persistentList = new PersistentLinkedListOfLong<>(kind, heap);
+        segmentsMap = new ConcurrentSkipListMap<>();
+        if (heap.getRoot() != 0)
+            loadPersistentStore();
+        else
+            createBinarySchemaRegion();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void loadPersistentStore() {
+        persistentList.setRoot(heap.getRoot());
+        MemoryBlock<MemoryBlock.Kind> block;
+
+        // We skip index 0 (the schema registry region).
+        int size = persistentList.size();
+        for (int i = 1; i < size; i++) {
+            Long base = persistentList.get(i);
+
+            assert base != null;
+
+            block = heap.memoryBlockFromAddress(kind, base);
+
+            assert block != null;
+
+            if (block.getInt(block.size() - 2 * Integer.BYTES) == BlockType.SEGMENT.ordinal())
+                segmentsMap.put(base, block.size() - 2 * Integer.BYTES);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void createBinarySchemaRegion() {
+        MemoryBlock<?> block = heap.allocateMemoryBlock(kind, BinarySchemaRegistry.SCHEMA_REGISTRY_SIZE);
+        persistentList.add(block.address());
+        heap.setRoot(persistentList.getRoot());
+    }
+
+    /**
+     * Allocates a persistent memory block for a segment. If we already have one allocated, we return it.
+     *
+     * @param size Size.
+     * @return address.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public long allocateUnsafeMemory(String regionName, int index, long size) {
+
+        int id = regionName.hashCode() + index;
+
+        // We skip index 0 (the schema registry region).
+        for (int i = 1; i < persistentList.size(); i++) {
+            Long base = persistentList.get(i);
+
+            assert base != null;
+
+            MemoryBlock<MemoryBlock.Kind> block = heap.memoryBlockFromAddress(kind, base);
+
+            if (id == block.getInt(block.size() - Integer.BYTES))
+                return base;
+        }
+
+        MemoryBlock<MemoryBlock.Kind> block = heap.allocateMemoryBlock(kind, size + 2 * Integer.BYTES);
+        block.setInt(size, BlockType.SEGMENT.ordinal());
+        block.setInt(size + Integer.BYTES, id);
+
+        // add chunk to persistent list
+        long address = block.address();
+        persistentList.add(address);
+
+        // add list to skipListMap
+        segmentsMap.put(address, size);
+
+        return address;
+    }
+
+    /**
+     * Get the AEP memory region that holds the given address.
+     * @param address the address whose memory region we want to determine.
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    private MemoryBlock<MemoryBlock.Kind> getMemoryBlock(long address) {
+        Map.Entry<Long, Long> entry = segmentsMap.floorEntry(address);
+        if (entry == null)
+            return null;
+
+        Long baseAddress = entry.getKey();
+        Long size = entry.getValue();
+        if (address <= baseAddress + size)
+            return heap.memoryBlockFromAddress(kind, baseAddress);
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public MemoryBlock<MemoryBlock.Kind> getSchemaRegistryBlock() {
+        Long base = persistentList.get(0);
+
+        assert base != null;
+
+        return heap.memoryBlockFromAddress(kind, base);
+    }
+
+    @Override
+    public PersistentLinkedList<Transactional, Long> getPersistentList() {
+        return persistentList;
+    }
+    /**
+     * Sets all bytes in a given block of memory to a copy of another block.
+     *
+     * @param srcObj Source object.
+     * @param srcOff Source offset.
+     * @param dstObj Dst object.
+     * @param dstOff Dst offset.
+     * @param len Length.
+     */
+    @Override
+    public void copyMemory(Object srcObj, long srcOff, Object dstObj, long dstOff, long len) {
+
+        if (len <= PER_BYTE_THRESHOLD && srcObj != null && dstObj != null) {
+            for (int i = 0; i < len; i++)
+                UNSAFE.putByte(dstObj, dstOff + i, UNSAFE.getByte(srcObj, srcOff + i));
+            return;
+        }
+
+        MemoryBlock<MemoryBlock.Kind> src = getMemoryBlock(srcOff);
+        MemoryBlock<MemoryBlock.Kind> dst = getMemoryBlock(dstOff);
+
+        int mask = ((src == null ? 0 : 1) << 1) | (dst == null ? 0 : 1);
+
+        switch (mask) {
+            case 0:
+                UNSAFE.copyMemory(srcObj, srcOff, dstObj, dstOff, len);
+                break;
+            case 1:
+                for (int i = 0; i < len; i++)
+                    dst.setByte(dstOff + i - dst.address(), UNSAFE.getByte(srcObj, srcOff + i));
+                break;
+            case 2:
+                for (int i = 0; i < len; i++)
+                    UNSAFE.putByte(dstObj, dstOff + i, src.getByte(srcOff + i - src.address()));
+                break;
+            default:
+                copyMemory(srcOff, dstOff, len);
+        }
+
+    }
+
+    /**
+     * Copies len bytes from from src to dst.
+     *
+     * @param srcOff Source.
+     * @param dstOff Dst.
+     * @param len Length.
+     */
+    @Override
+    public void copyMemory(long srcOff, long dstOff, long len) {
+        MemoryBlock<MemoryBlock.Kind> src = getMemoryBlock(srcOff);
+        MemoryBlock<MemoryBlock.Kind> dst = getMemoryBlock(dstOff);
+
+        assert src != null && dst != null;
+
+        dst.copyFromMemory(src, srcOff - src.address(), dstOff - dst.address(), len);
+    }
+
+    /**
+     * Fills memory with the given value.
+     *
+     * @param address Address.
+     * @param len Length.
+     * @param val Value.
+     */
+    @Override
+    public void setMemory(long address, long len, byte val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        if (r != null)
+            r.setMemory(val, address - r.address(), len);
+        else
+            UNSAFE.setMemory(address, len, val);
+    }
+
+
+    /**
+     * De-allocate the memory region whose base address is address.
+     *
+     * @param address the base address of the memory region.
+     */
+    @Override
+    public void freeMemoryBlock(long address) {
+        segmentsMap.remove(address);
+        persistentList.remove(address);
+    }
+
+    /**
+     * De-allocates all allocated memory regions.
+     */
+    @Override
+    public void freeMemoryBlocks() {
+        persistentList.removeAll();
+        segmentsMap.clear();
+    }
+
+    /**
+     * We do not de-allocate on shutdown. Instead, we use it to persist FreelistImpl buckets.
+     *
+     * @param address
+     */
+    @Override
+    public void freeUnsafeMemory(long address) {
+        ConcurrentHashMap<Integer, AtomicReferenceArray<PagesList.Stripe[]>> bucketsMap = FreeListImpl.bucketsMap;
+        for (Map.Entry<Integer, AtomicReferenceArray<PagesList.Stripe[]>> e : bucketsMap.entrySet()) {
+            AtomicReferenceArray<PagesList.Stripe[]> ara = e.getValue();
+            for (int i = 0; i < ara.length(); i++)
+                FreeListImpl.persistStripes(e.getKey().hashCode(), i, ara.get(i));
+
+            bucketsMap.remove(e.getKey());
+        }
+    }
+
+    /**
+     * We currently do not support a ByteBuffer over a persistent memory region.
+     *
+     * @param ptr Pointer to wrap.
+     * @param len Memory location length.
+     * @return Byte buffer wrapping the given memory.
+     */
+    @Override
+    public ByteBuffer wrapPointer(long ptr, int len) {
+
+        MemoryBlock<MemoryBlock.Kind> block = getMemoryBlock(ptr);
+
+        assert block == null;
+
+        ByteBuffer buf = nioAccess.newDirectByteBuffer(ptr, len, null);
+
+        assert buf instanceof DirectBuffer;
+
+        buf.order(NATIVE_BYTE_ORDER);
+
+        return buf;
+    }
+
+    /**
+     * Gets byte value from given address.
+     *
+     * @param address Address.
+     * @return Byte value from given address.
+     */
+    @Override
+    public byte getByte(long address) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        return r != null ? r.getByte(address - r.address()) : UNSAFE.getByte(address);
+    }
+
+    /**
+     * Stores given byte value.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putByte(long address, byte val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        if (r != null)
+            r.setByte(address - r.address(), val);
+        else
+            UNSAFE.putByte(address, val);
+    }
+
+    /**
+     * Gets char value from given address. Alignment aware.
+     *
+     * @param address Address.
+     * @return Char value from given address.
+     */
+    @Override
+    public char getChar(long address) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        return r != null ? (char) r.getShort(address - r.address()) : (char) UNSAFE.getShort(address);
+    }
+
+    /**
+     * Stores given char value. Alignment aware.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putChar(long address, char val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        if (r != null)
+            r.setShort(address - r.address(), (short) val);
+        else
+            UNSAFE.putChar(address, val);
+    }
+
+    /**
+     * Gets short value from given address. Alignment aware.
+     *
+     * @param address Address.
+     * @return Short value from given address.
+     */
+    @Override
+    public short getShort(long address) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        return r != null ? r.getShort(address - r.address()) : UNSAFE.getShort(address);
+    }
+
+    /**
+     * Stores given short value. Alignment aware.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putShort(long address, short val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        if (r != null)
+            r.setShort(address - r.address(), val);
+        else
+            UNSAFE.putShort(address, val);
+    }
+
+    /**
+     * Gets integer value from given address. Alignment aware.
+     *
+     * @param address Address.
+     * @return Integer value from given address.
+     */
+    @Override
+    public int getInt(long address) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        return r != null ? r.getInt(address - r.address()) : UNSAFE.getInt(address);
+    }
+
+    /**
+     * Stores given integer value. Alignment aware.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putInt(long address, int val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        if (r != null)
+            r.setInt(address - r.address(), val);
+        else
+            UNSAFE.putInt(address, val);
+    }
+
+    /**
+     * Gets long value from given address. Alignment aware.
+     *
+     * @param address Address.
+     * @return Long value from given address.
+     */
+    @Override
+    public long getLong(long address) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        return r != null ? r.getLong(address - r.address()) : UNSAFE.getLong(address);
+    }
+
+    /**
+     * Stores given integer value. Alignment aware.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putLong(long address, long val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(address);
+        if (r != null)
+            r.setLong(address - r.address(), val);
+        else
+            UNSAFE.putLong(address, val);
+    }
+
+    /**
+     * Gets float value from given address. Alignment aware.
+     *
+     * @param address Address.
+     * @return Float value from given address.
+     */
+    @Override
+    public float getFloat(long address) {
+        return Float.intBitsToFloat(getInt(address));
+    }
+
+    /**
+     * Stores given float value. Alignment aware.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putFloat(long address, float val) {
+        putInt(address, Float.floatToRawIntBits(val));
+    }
+
+    /**
+     * Gets double value from given address. Alignment aware.
+     *
+     * @param address Address.
+     * @return Double value from given address.
+     */
+    @Override
+    public double getDouble(long address) {
+        return Double.longBitsToDouble(getLong(address));
+    }
+
+    /**
+     * Stores given double value. Alignment aware.
+     *
+     * @param address Address.
+     * @param val Value.
+     */
+    @Override
+    public void putDouble(long address, double val) {
+        putLong(address, Double.doubleToRawLongBits(val));
+    }
+
+    /**
+     * Integer CAS.
+     *
+     * @param obj Object.
+     * @param address Address.
+     * @param exp Expected.
+     * @param upd Upd.
+     * @return {@code True} if operation completed successfully, {@code false} - otherwise.
+     */
+    @Override
+    public boolean compareAndSwapInt(Object obj, long address, int exp, int upd) {
+        return obj != null ? UNSAFE.compareAndSwapInt(obj, address, exp, upd) : compareAndSwapInt(address, exp, upd);
+    }
+
+    /**
+     * Long CAS.
+     *
+     * @param obj Object.
+     * @param address Address.
+     * @param exp Expected.
+     * @param upd Upd.
+     * @return {@code True} if operation completed successfully, {@code false} - otherwise.
+     */
+    @Override
+    public boolean compareAndSwapLong(Object obj, long address, long exp, long upd) {
+        return obj != null ? UNSAFE.compareAndSwapLong(obj, address, exp, upd) : compareAndSwapLong(address, exp, upd);
+    }
+
+    /**
+     * Integer CAS.
+     *
+     * @param address
+     * @param exp
+     * @param upd
+     * @return
+     */
+    public boolean compareAndSwapInt(long address, int exp, int upd) {
+        casLock.lock();
+        try {
+            if (getInt(address) == exp) {
+                putInt(address, upd);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            casLock.unlock();
+        }
+    }
+
+    /**
+     * Long CAS.
+     *
+     * @param address
+     * @param exp
+     * @param upd
+     * @return
+     */
+    public boolean compareAndSwapLong(long address, long exp, long upd) {
+        casLock.lock();
+        try {
+            if (getLong(address) == exp) {
+                putLong(address, upd);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            casLock.unlock();
+        }
+    }
+
+    /**
+     * Gets byte value with volatile semantic.
+     *
+     * @param obj Object.
+     * @param offset Offset.
+     * @return Int value.
+     */
+    @Override
+    public byte getByteVolatile(Object obj, long offset) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(offset);
+        if (obj != null || r == null)
+            return UNSAFE.getByteVolatile(obj, offset);
+
+        return r.getByte(offset - r.address());
+    }
+
+    /**
+     * Stores int value with volatile semantic.
+     *
+     * @param obj Object.
+     * @param offset Offset.
+     * @param val Value.
+     */
+    @Override
+    public void putByteVolatile(Object obj, long offset, byte val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(offset);
+        if (obj != null || r == null)
+            UNSAFE.putByteVolatile(obj, offset, val);
+        else
+            r.setByte(offset - r.address(), val);
+    }
+
+    /**
+     * Gets int value with volatile semantic.
+     *
+     * @param obj Object.
+     * @param offset Offset.
+     * @return Int value.
+     */
+    @Override
+    public int getIntVolatile(Object obj, long offset) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(offset);
+        if (obj != null || r == null)
+            return UNSAFE.getIntVolatile(obj, offset);
+
+        return r.getInt(offset - r.address());
+    }
+
+    /**
+     * Stores int value with volatile semantic.
+     *
+     * @param obj Object.
+     * @param offset Offset.
+     * @param val Value.
+     */
+    @Override
+    public void putIntVolatile(Object obj, long offset, int val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(offset);
+        if (obj != null || r == null)
+            UNSAFE.putIntVolatile(obj, offset, val);
+        else
+            r.setInt(offset - r.address(), val);
+    }
+
+    /**
+     * Gets long value with volatile semantic.
+     *
+     * @param obj Object.
+     * @param offset Offset.
+     * @return Long value.
+     */
+    @Override
+    public long getLongVolatile(Object obj, long offset) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(offset);
+        if (obj != null || r == null)
+            return UNSAFE.getLongVolatile(obj, offset);
+
+        return r.getLong(offset - r.address());
+    }
+
+    /**
+     * Stores long value with volatile semantic.
+     *
+     * @param obj Object.
+     * @param offset Offset.
+     * @param val Value.
+     */
+    @Override
+    public void putLongVolatile(Object obj, long offset, long val) {
+        MemoryBlock<MemoryBlock.Kind> r = getMemoryBlock(offset);
+        if (obj != null || r == null)
+            UNSAFE.putLongVolatile(obj, offset, val);
+        else
+            r.setLong(offset - r.address(), val);
+    }
+
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridSpinReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridSpinReadWriteLock.java
@@ -18,6 +18,8 @@
 package org.apache.ignite.internal.util;
 
 import java.util.concurrent.TimeUnit;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -38,10 +40,10 @@ public class GridSpinReadWriteLock {
      */
     static {
         try {
-            STATE_OFFS = GridUnsafe.objectFieldOffset(GridSpinReadWriteLock.class.getDeclaredField("state"));
+            STATE_OFFS = Ignition.UNSAFE.objectFieldOffset(GridSpinReadWriteLock.class.getDeclaredField("state"));
 
             PENDING_WLOCKS_OFFS =
-                GridUnsafe.objectFieldOffset(GridSpinReadWriteLock.class.getDeclaredField("pendingWLocks"));
+                Ignition.UNSAFE.objectFieldOffset(GridSpinReadWriteLock.class.getDeclaredField("pendingWLocks"));
         }
         catch (NoSuchFieldException e) {
             throw new Error(e);
@@ -399,7 +401,7 @@ public class GridSpinReadWriteLock {
      * @return {@code True} on success.
      */
     private boolean compareAndSet(long offs, int expect, int update) {
-        return GridUnsafe.compareAndSwapInt(this, offs, expect, update);
+        return Ignition.UNSAFE.compareAndSwapInt(this, offs, expect, update);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -155,15 +155,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import org.apache.ignite.Ignite;
-import org.apache.ignite.IgniteCheckedException;
-import org.apache.ignite.IgniteClientDisconnectedException;
-import org.apache.ignite.IgniteDeploymentException;
-import org.apache.ignite.IgniteException;
-import org.apache.ignite.IgniteIllegalStateException;
-import org.apache.ignite.IgniteInterruptedException;
-import org.apache.ignite.IgniteLogger;
-import org.apache.ignite.IgniteSystemProperties;
+
+import org.apache.ignite.*;
 import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.binary.BinaryRawWriter;
 import org.apache.ignite.cluster.ClusterGroupEmptyException;
@@ -261,10 +254,6 @@ import static org.apache.ignite.internal.IgniteNodeAttributes.ATTR_BUILD_VER;
 import static org.apache.ignite.internal.IgniteNodeAttributes.ATTR_CACHE;
 import static org.apache.ignite.internal.IgniteNodeAttributes.ATTR_JVM_PID;
 import static org.apache.ignite.internal.IgniteNodeAttributes.ATTR_MACS;
-import static org.apache.ignite.internal.util.GridUnsafe.objectFieldOffset;
-import static org.apache.ignite.internal.util.GridUnsafe.putObjectVolatile;
-import static org.apache.ignite.internal.util.GridUnsafe.staticFieldBase;
-import static org.apache.ignite.internal.util.GridUnsafe.staticFieldOffset;
 
 /**
  * Collection of utility methods used throughout the system.
@@ -742,8 +731,8 @@ public abstract class IgniteUtils {
 
                 // We use unsafe operations to update static fields on interface because
                 // they are treated as static final and cannot be updated via standard reflection.
-                putObjectVolatile(staticFieldBase(f1), staticFieldOffset(f1), gridEvents());
-                putObjectVolatile(staticFieldBase(f2), staticFieldOffset(f2), gridEvents(EVT_NODE_METRICS_UPDATED));
+                Ignition.UNSAFE.putObjectVolatile(Ignition.UNSAFE.staticFieldBase(f1), Ignition.UNSAFE.staticFieldOffset(f1), gridEvents());
+                Ignition.UNSAFE.putObjectVolatile(Ignition.UNSAFE.staticFieldBase(f2), Ignition.UNSAFE.staticFieldOffset(f2), gridEvents(EVT_NODE_METRICS_UPDATED));
 
                 assert EVTS_ALL != null;
                 assert EVTS_ALL.length == GRID_EVTS.length;
@@ -7976,7 +7965,7 @@ public abstract class IgniteUtils {
      */
     public static long fieldOffset(Class<?> cls, String fieldName) {
         try {
-            return objectFieldOffset(cls.getDeclaredField(fieldName));
+            return Ignition.UNSAFE.objectFieldOffset(cls.getDeclaredField(fieldName));
         }
         catch (NoSuchFieldException e) {
             throw new IllegalStateException(e);
@@ -8639,7 +8628,7 @@ public abstract class IgniteUtils {
         assert resBuf.length >= resOff + len;
 
         if (UNSAFE_BYTE_ARR_CP)
-            GridUnsafe.copyMemory(src, GridUnsafe.BYTE_ARR_OFF + off, resBuf, GridUnsafe.BYTE_ARR_OFF + resOff, len);
+            Ignition.UNSAFE.copyMemory(src, Ignition.UNSAFE.BYTE_ARR_OFF + off, resBuf, Ignition.UNSAFE.BYTE_ARR_OFF + resOff, len);
         else
             System.arraycopy(src, off, resBuf, resOff, len);
 
@@ -9279,7 +9268,7 @@ public abstract class IgniteUtils {
     public static byte[] copyMemory(long ptr, int size) {
         byte[] res = new byte[size];
 
-        GridUnsafe.copyMemory(null, ptr, res, GridUnsafe.BYTE_ARR_OFF, size);
+        Ignition.UNSAFE.copyMemory(null, ptr, res, Ignition.UNSAFE.BYTE_ARR_OFF, size);
 
         return res;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/OffheapReadWriteLock.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/OffheapReadWriteLock.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.typedef.internal.U;
 
 /**
@@ -99,14 +100,14 @@ public class OffheapReadWriteLock {
 
         assert tag != 0;
 
-        GridUnsafe.putLong(lock, (long)tag << 16);
+        Ignition.UNSAFE.putLong(lock, (long)tag << 16);
     }
 
     /**
      * @param lock Lock address.
      */
     public boolean readLock(long lock, int tag) {
-        long state = GridUnsafe.getLongVolatile(null, lock);
+        long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
         assert state != 0;
 
@@ -119,14 +120,14 @@ public class OffheapReadWriteLock {
                     return false;
 
                 if (canReadLock(state)) {
-                    if (GridUnsafe.compareAndSwapLong(null, lock, state, updateState(state, 1, 0, 0)))
+                    if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updateState(state, 1, 0, 0)))
                         return true;
                     else
                         // Retry CAS, do not count as spin cycle.
                         i--;
                 }
 
-                state = GridUnsafe.getLongVolatile(null, lock);
+                state = Ignition.UNSAFE.getLongVolatile(null, lock);
             }
         }
 
@@ -151,7 +152,7 @@ public class OffheapReadWriteLock {
      */
     public void readUnlock(long lock) {
         while (true) {
-            long state = GridUnsafe.getLongVolatile(null, lock);
+            long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
             if (lockCount(state) <= 0)
                 throw new IllegalMonitorStateException("Attempted to release a read lock while not holding it " +
@@ -161,7 +162,7 @@ public class OffheapReadWriteLock {
 
             assert updated != 0;
 
-            if (GridUnsafe.compareAndSwapLong(null, lock, state, updated)) {
+            if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated)) {
                 // Notify monitor if we were CASed to zero and there is a write waiter.
                 if (lockCount(updated) == 0 && writersWaitCount(updated) > 0) {
                     int idx = lockIndex(lock);
@@ -189,10 +190,10 @@ public class OffheapReadWriteLock {
      * @param lock Lock address.
      */
     public boolean tryWriteLock(long lock, int tag) {
-        long state = GridUnsafe.getLongVolatile(null, lock);
+        long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
         return checkTag(state, tag) && canWriteLock(state) &&
-            GridUnsafe.compareAndSwapLong(null, lock, state, updateState(state, -1, 0, 0));
+            Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updateState(state, -1, 0, 0));
     }
 
     /**
@@ -202,7 +203,7 @@ public class OffheapReadWriteLock {
         assert tag != 0;
 
         for (int i = 0; i < SPIN_CNT; i++) {
-            long state = GridUnsafe.getLongVolatile(null, lock);
+            long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
             assert state != 0;
 
@@ -210,7 +211,7 @@ public class OffheapReadWriteLock {
                 return false;
 
             if (canWriteLock(state)) {
-                if (GridUnsafe.compareAndSwapLong(null, lock, state, updateState(state, -1, 0, 0)))
+                if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updateState(state, -1, 0, 0)))
                     return true;
                 else
                     // Retry CAS, do not count as spin cycle.
@@ -239,7 +240,7 @@ public class OffheapReadWriteLock {
      * @return {@code True} if write lock is held by any thread for the given offheap RW lock.
      */
     public boolean isWriteLocked(long lock) {
-        return lockCount(GridUnsafe.getLongVolatile(null, lock)) == -1;
+        return lockCount(Ignition.UNSAFE.getLongVolatile(null, lock)) == -1;
     }
 
     /**
@@ -247,7 +248,7 @@ public class OffheapReadWriteLock {
      * @return {@code True} if at least one read lock is held by any thread for the given offheap RW lock.
      */
     public boolean isReadLocked(long lock) {
-        return lockCount(GridUnsafe.getLongVolatile(null, lock)) > 0;
+        return lockCount(Ignition.UNSAFE.getLongVolatile(null, lock)) > 0;
     }
 
     /**
@@ -259,7 +260,7 @@ public class OffheapReadWriteLock {
         assert tag != 0;
 
         while (true) {
-            long state = GridUnsafe.getLongVolatile(null, lock);
+            long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
             if (lockCount(state) != -1)
                 throw new IllegalMonitorStateException("Attempted to release write lock while not holding it " +
@@ -269,7 +270,7 @@ public class OffheapReadWriteLock {
 
             assert updated != 0;
 
-            if (GridUnsafe.compareAndSwapLong(null, lock, state, updated))
+            if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated))
                 break;
         }
 
@@ -344,13 +345,13 @@ public class OffheapReadWriteLock {
      */
     public Boolean upgradeToWriteLock(long lock, int tag) {
         for (int i = 0; i < SPIN_CNT; i++) {
-            long state = GridUnsafe.getLongVolatile(null, lock);
+            long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
             if (!checkTag(state, tag))
                 return null;
 
             if (lockCount(state) == 1) {
-                if (GridUnsafe.compareAndSwapLong(null, lock, state, updateState(state, -2, 0, 0)))
+                if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updateState(state, -2, 0, 0)))
                     return true;
                 else
                     // Retry CAS, do not count as spin cycle.
@@ -367,20 +368,20 @@ public class OffheapReadWriteLock {
         try {
             // First, add write waiter.
             while (true) {
-                long state = GridUnsafe.getLongVolatile(null, lock);
+                long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
                 if (!checkTag(state, tag))
                     return null;
 
                 if (lockCount(state) == 1) {
-                    if (GridUnsafe.compareAndSwapLong(null, lock, state, updateState(state, -2, 0, 0)))
+                    if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updateState(state, -2, 0, 0)))
                         return true;
                     else
                         continue;
                 }
 
                 // Remove read lock and add write waiter simultaneously.
-                if (GridUnsafe.compareAndSwapLong(null, lock, state, updateState(state, -1, 0, 1)))
+                if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updateState(state, -1, 0, 1)))
                     break;
             }
 
@@ -410,13 +411,13 @@ public class OffheapReadWriteLock {
         try {
             while (true) {
                 try {
-                    long state = GridUnsafe.getLongVolatile(null, lock);
+                    long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
                     if (!checkTag(state, tag)) {
                         // We cannot lock with this tag, release waiter.
                         long updated = updateState(state, 0, -1, 0);
 
-                        if (GridUnsafe.compareAndSwapLong(null, lock, state, updated)) {
+                        if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated)) {
                             int writeWaitCnt = writersWaitCount(updated);
                             int readWaitCnt = readersWaitCount(updated);
 
@@ -428,7 +429,7 @@ public class OffheapReadWriteLock {
                     else if (canReadLock(state)) {
                         long updated = updateState(state, 1, -1, 0);
 
-                        if (GridUnsafe.compareAndSwapLong(null, lock, state, updated))
+                        if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated))
                             return true;
                     }
                     else
@@ -464,13 +465,13 @@ public class OffheapReadWriteLock {
         try {
             while (true) {
                 try {
-                    long state = GridUnsafe.getLongVolatile(null, lock);
+                    long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
                     if (!checkTag(state, tag)) {
                         // We cannot lock with this tag, release waiter.
                         long updated = updateState(state, 0, 0, -1);
 
-                        if (GridUnsafe.compareAndSwapLong(null, lock, state, updated)) {
+                        if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated)) {
                             int writeWaitCnt = writersWaitCount(updated);
                             int readWaitCnt = readersWaitCount(updated);
 
@@ -482,7 +483,7 @@ public class OffheapReadWriteLock {
                     else if (canWriteLock(state)) {
                         long updated = updateState(state, -1, 0, -1);
 
-                        if (GridUnsafe.compareAndSwapLong(null, lock, state, updated))
+                        if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated))
                             return true;
                     }
                     else
@@ -641,11 +642,11 @@ public class OffheapReadWriteLock {
 
         while (true) {
             // Safe to do non-volatile read because of CAS below.
-            long state = GridUnsafe.getLongVolatile(null, lock);
+            long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
             long updated = updateState(state, 0, delta, 0);
 
-            if (GridUnsafe.compareAndSwapLong(null, lock, state, updated))
+            if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated))
                 return;
         }
     }
@@ -660,11 +661,11 @@ public class OffheapReadWriteLock {
         assert lockObj.isHeldByCurrentThread();
 
         while (true) {
-            long state = GridUnsafe.getLongVolatile(null, lock);
+            long state = Ignition.UNSAFE.getLongVolatile(null, lock);
 
             long updated = updateState(state, 0, 0, delta);
 
-            if (GridUnsafe.compareAndSwapLong(null, lock, state, updated))
+            if (Ignition.UNSAFE.compareAndSwapLong(null, lock, state, updated))
                 return;
         }
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/PersistentLinkedList.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/PersistentLinkedList.java
@@ -1,0 +1,331 @@
+package org.apache.ignite.internal.util;
+
+import lib.llpl.Heap;
+import lib.llpl.MemoryBlock;
+import lib.llpl.Transaction;
+import org.apache.ignite.Ignition;
+
+import java.io.*;
+import java.util.Iterator;
+
+public class PersistentLinkedList<T extends MemoryBlock.Kind, E extends Serializable> implements Iterator<E> {
+
+    /** The head of the list. */
+    protected long head;
+
+    /** The tail of the list. */
+    protected long tail;
+
+    /** The class type of the memory region */
+    protected Class<T> kind;
+
+    /** The AEP heap the list is on */
+    protected Heap heap;
+
+    /** The current iterator index. */
+    protected int index = 0;
+
+    /**
+     * Constructs a persistent singly linked list. Construction does not allocate memory; adding nodes does.
+     *
+     * @param heap the AEP heap this list is stored on.
+     */
+    public PersistentLinkedList(Class<T> kind, Heap heap) {
+        this.heap = heap;
+        this.kind = kind;
+    }
+
+    /**
+     * Appends item to list.
+     *
+     * @param item is the item to store.
+     */
+    public synchronized void add(E item) {
+        Transaction.run(Ignition.getAepHeap(), () -> {
+            PersistentNode node = new PersistentNode(item);
+            long address = node.getBaseAddress();
+            if (head == 0) {
+                head = address;
+                tail = address;
+            } else {
+                setNextLink(tail, address);
+                tail = address;
+            }
+        });
+    }
+
+    /**
+     * Adds item at index.
+     *
+     * @param index the index after which the item is stored.
+     * @param item the entry to store.
+     */
+    public synchronized void add(final int index, E item) {
+        if (index < 0 || index >= size()) throw new IndexOutOfBoundsException();
+
+        Transaction.run(Ignition.getAepHeap(), () -> {
+            int idx = index;
+            PersistentNode node = new PersistentNode(item);
+            long address = node.getBaseAddress();
+
+            if (idx == 0) {
+                setNextLink(address, head);
+                head = address;
+            } else {
+                long curr = head;
+                while (--idx > 0)
+                    curr = getNextLink(curr);
+
+                setNextLink(address, getNextLink(curr));
+                setNextLink(curr, address);
+            }
+        });
+    }
+
+    /**
+     * Gets the entry stored at index.
+     *
+     * @param index the index.
+     * @return the entry at the index.
+     */
+    public E get(int index) {
+        if (index < 0 || index >= size()) throw new IndexOutOfBoundsException();
+
+        long address = head;
+        while (index-- > 0)
+            address = getNextLink(address);
+
+        return getItem(address);
+    }
+
+    /**
+     * Gets the stored entry of a node whose base address is baseAddress.
+     *
+     * @param baseAddress of a node.
+     * @return the stored entry of the node.
+     */
+    public E getItem(long baseAddress) {
+        if (baseAddress == 0)
+            return null;
+
+        MemoryBlock<T> mr = getMemoryBlock(baseAddress);
+
+        int size = (int) mr.size();
+        byte[] ba = new byte[size];
+        for (int i = 0; i < size; i++)
+            ba[i] = mr.getByte(i);
+
+        return (E) SerializationUtils.deserialize(ba);
+    }
+
+    /**
+     * Checks to see if the item exists in the list.
+     *
+     * @param item
+     * @return true if the item is in the list, false otherwise.
+     */
+    public boolean contains(Object item) {
+        long curr = head;
+
+        while (curr != 0 && getItem(curr).hashCode() != item.hashCode())
+            curr = getNextLink(curr);
+
+        if (curr == 0)
+            return false;
+
+        return true;
+    }
+
+    /**
+     * Removes the entry at index.
+     *
+     * @param index is the index of the entry to remove.
+     */
+    public synchronized void removeAtIndex(int index) {
+        if (index < 0 || index >= size()) throw new IndexOutOfBoundsException();
+
+        Transaction.run(Ignition.getAepHeap(), () -> {
+            int c = index;
+            long curr = head;
+            while (--c > 0)
+                curr = getNextLink(curr);
+
+            long r = getNextLink(curr);
+            if (index == 0) {
+                r = curr;
+                head = getNextLink(r);
+            }
+
+            setNextLink(curr, getNextLink(r));
+            setNextLink(r, 0);
+            heap.freeMemoryBlock(getMemoryBlock(r));
+
+            if (getNextLink(curr) == 0)
+                tail = curr;
+        });
+    }
+
+    /**
+     * Removes entry from the list. Comparision is based on object's hashcode.
+     *
+     * @param item is the entry to remove.
+     * @return true if the item has been successfully removed, false otherwise.
+     */
+    public boolean remove(Object item) {
+        long curr = head;
+
+        int i = 0;
+        while (curr != 0 && getItem(curr).hashCode() != item.hashCode()) {
+            curr = getNextLink(curr);
+            i++;
+        }
+
+        if (i == size())
+            return false;
+
+        removeAtIndex(i);
+
+        return true;
+    }
+
+    /**
+     * Removes and frees all entries from this list.
+     */
+    public void removeAll() {
+        int s = size();
+        while (s-- > 0)
+            removeAtIndex(0);
+    }
+
+    /**
+     * Calculates the number of entries.
+     *
+     * @return the number of entries in the list.
+     */
+    public int size() {
+        int i = 0;
+        long curr = head;
+        if (curr == 0)
+            return 0;
+
+        while (getNextLink(curr) != 0) {
+            curr = getNextLink(curr);
+            i++;
+        }
+
+        return i + 1;
+    }
+
+    /** */
+    @Override
+    public boolean hasNext() {
+        if (index < size())
+            return true;
+        return false;
+    }
+
+    /** */
+    @Override
+    public E next() {
+        if (this.hasNext())
+            return get(index++);
+        return null;
+    }
+
+    /**
+     * Gets the root of the memory region of this list.
+     *
+     * @return the base address of the memory region of the persistent list.
+     */
+    public long getRoot() {
+        return head;
+    }
+
+    /**
+     * Sets the root of this persistent list.
+     *
+     * @param head a base address.
+     */
+    public synchronized void setRoot(long head) {
+        // Reset iterator's index
+        index = 0;
+
+        this.head = head;
+        this.tail = head;
+
+        // Update tail
+        long curr = head;
+        while (getNextLink(curr) != 0) {
+            curr = getNextLink(curr);
+            tail = curr;
+        }
+    }
+
+    /**
+     * Sets the next pointer.
+     *
+     * @param baseAddress the base address of a node.
+     * @param next the next address of the node.
+     */
+    protected void setNextLink(long baseAddress, long next) {
+        MemoryBlock<T> mr = getMemoryBlock(baseAddress);
+        mr.setLong(mr.size(), next);
+    }
+
+    /**
+     * Returns the address of the next node.
+     *
+     * @param baseAddress of a node.
+     * @return the next pointer.
+     */
+    protected long getNextLink(long baseAddress) {
+        MemoryBlock<T> mr = getMemoryBlock(baseAddress);
+        return mr.getLong(mr.size());
+    }
+
+
+    /**
+     * Gets the memory region whose base address equals baseAddress.
+     *
+     * @param baseAddress is a base address.
+     * @return the memory region.
+     */
+    protected MemoryBlock<T> getMemoryBlock(long baseAddress) {
+        return heap.memoryBlockFromAddress(kind, baseAddress);
+    }
+
+    /**
+     * Prints the content of this list.
+     *
+     */
+    public void print() {
+        long curr = head;
+        if (curr == 0) {
+            System.out.println(size());
+            return;
+        }
+
+        while (getNextLink(curr) != 0) {
+            System.out.print(getItem(curr) + " --> ");
+            curr = getNextLink(curr);
+        }
+
+        System.out.println(getItem(curr));
+    }
+
+    private class PersistentNode {
+
+        private MemoryBlock<T> memoryBlock;
+
+        public PersistentNode(E obj) {
+            byte[] objData = SerializationUtils.serialize(obj);
+            memoryBlock = heap.allocateMemoryBlock(kind, objData.length + Long.BYTES);
+            memoryBlock.copyFromArray(objData, 0, 0, objData.length);
+            memoryBlock.setLong(objData.length, 0);
+        }
+
+        long getBaseAddress() {
+            return this.memoryBlock.address();
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/PersistentLinkedListOfLong.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/PersistentLinkedListOfLong.java
@@ -1,0 +1,95 @@
+package org.apache.ignite.internal.util;
+
+import lib.llpl.Heap;
+import lib.llpl.MemoryBlock;
+import lib.llpl.Transaction;
+import org.apache.ignite.Ignition;
+
+public class PersistentLinkedListOfLong<T extends MemoryBlock.Kind> extends PersistentLinkedList<T, Long> {
+
+    /**
+     * Constructs a persistent singly linked list. Construction does not allocate memory; adding nodes does.
+     *
+     * @param heap the AEP heap this list is stored on.
+     */
+    public PersistentLinkedListOfLong(Class<T> kind, Heap heap) {
+        super(kind, heap);
+    }
+    /**
+     * Appends item to list.
+     *
+     * @param item is the item to store.
+     */
+    @Override
+    public synchronized void add(Long item) {
+        Transaction.run(Ignition.getAepHeap(), () -> {
+            PersistentNodeOfLong node = new PersistentNodeOfLong(item);
+            long address = node.getBaseAddress();
+            if (head == 0) {
+                head = address;
+                tail = address;
+            } else {
+                setNextLink(tail, address);
+                tail = address;
+            }
+        });
+    }
+
+    /**
+     * Adds item at index.
+     *
+     * @param index the index after which the item is stored.
+     * @param item the entry to store.
+     */
+    @Override
+    public synchronized void add(final int index, Long item) {
+        if (index < 0 || index >= size()) throw new IndexOutOfBoundsException();
+
+        Transaction.run(Ignition.getAepHeap(), () -> {
+            int idx = index;
+            PersistentNodeOfLong node = new PersistentNodeOfLong(item);
+            long address = node.getBaseAddress();
+
+            if (idx == 0) {
+                setNextLink(address, head);
+                head = address;
+            } else {
+                long curr = head;
+                while (--idx > 0)
+                    curr = getNextLink(curr);
+
+                setNextLink(address, getNextLink(curr));
+                setNextLink(curr, address);
+            }
+        });
+    }
+
+    /**
+     * Gets the stored entry of a node whose base address is baseAddress.
+     *
+     * @param baseAddress of a node.
+     * @return the stored entry of the node.
+     */
+    @Override
+    public Long getItem(long baseAddress) {
+        if (baseAddress == 0)
+            return null;
+
+        return getMemoryBlock(baseAddress).getLong(0);
+    }
+
+    private class PersistentNodeOfLong {
+
+        private MemoryBlock<T> memoryBlock;
+
+        public PersistentNodeOfLong(Long obj) {
+            memoryBlock = heap.allocateMemoryBlock(kind, Long.BYTES + Long.BYTES);
+            memoryBlock.setLong(0, obj);
+            memoryBlock.setLong(Long.BYTES, 0);
+        }
+
+        long getBaseAddress() {
+            return this.memoryBlock.address();
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/SerializationUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/SerializationUtils.java
@@ -1,0 +1,85 @@
+package org.apache.ignite.internal.util;
+
+import java.io.*;
+
+public class SerializationUtils {
+
+    /**
+     * Serializes object obj.
+     *
+     * @param obj the object to serialize.
+     * @return the serialized array.
+     */
+    public static byte[] serialize(Object obj) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+        ObjectOutputStream oos = null;
+        try {
+            oos = new ObjectOutputStream(baos);
+            oos.writeObject(obj);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            try {
+                if (oos != null) {
+                    oos.close();
+                }
+            } catch (IOException ex) {}
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Deserializes object array.
+     *
+     * @param objectArray the byte array of an object.
+     * @return the deserialized object.
+     */
+    public static Object deserialize(byte[] objectArray) {
+
+        if (objectArray == null) {
+            throw new IllegalArgumentException("The object array must not be null.");
+        }
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(objectArray);
+
+        if (bais == null) {
+            throw new IllegalArgumentException("The InputStream must not be null.");
+        }
+
+        ObjectInputStream ois = null;
+        try {
+            ois = new ObjectInputStream(bais);
+            return ois.readObject();
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            try {
+                if (ois != null) {
+                    ois.close();
+                }
+            } catch (IOException ex) {}
+        }
+
+    }
+
+    public static byte[] longToBytes(long l) {
+        byte[] r = new byte[8];
+        for (int i = 7; i >= 0; i--) {
+            r[i] = (byte)(l & 0xFF);
+            l >>= 8;
+        }
+        return r;
+    }
+
+    public static long bytesToLong(byte[] b) {
+        long r = 0;
+        for (int i = 0; i < 8; i++) {
+            r <<= 8;
+            r |= (b[i] & 0xFF);
+        }
+        return r;
+    }
+
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/io/GridUnsafeDataInput.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/io/GridUnsafeDataInput.java
@@ -21,6 +21,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UTFDataFormatException;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -210,13 +212,13 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = GridUnsafe.getShortLE(buf, off);
+                arr[i] = Ignition.UNSAFE.getShortLE(buf, off);
 
                 off += 2;
             }
         }
         else
-            GridUnsafe.copyMemory(buf, off, arr, SHORT_ARR_OFF, bytesToCp);
+            Ignition.UNSAFE.copyMemory(buf, off, arr, SHORT_ARR_OFF, bytesToCp);
 
         return arr;
     }
@@ -235,13 +237,13 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = GridUnsafe.getIntLE(buf, off);
+                arr[i] = Ignition.UNSAFE.getIntLE(buf, off);
 
                 off += 4;
             }
         }
         else
-            GridUnsafe.copyMemory(buf, off, arr, INT_ARR_OFF, bytesToCp);
+            Ignition.UNSAFE.copyMemory(buf, off, arr, INT_ARR_OFF, bytesToCp);
 
         return arr;
     }
@@ -260,13 +262,13 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = GridUnsafe.getDoubleLE(buf, off);
+                arr[i] = Ignition.UNSAFE.getDoubleLE(buf, off);
 
                 off += 8;
             }
         }
         else
-            GridUnsafe.copyMemory(buf, off, arr, DOUBLE_ARR_OFF, bytesToCp);
+            Ignition.UNSAFE.copyMemory(buf, off, arr, DOUBLE_ARR_OFF, bytesToCp);
 
         return arr;
     }
@@ -297,13 +299,13 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = GridUnsafe.getCharLE(buf, off);
+                arr[i] = Ignition.UNSAFE.getCharLE(buf, off);
 
                 off += 2;
             }
         }
         else
-            GridUnsafe.copyMemory(buf, off, arr, CHAR_ARR_OFF, bytesToCp);
+            Ignition.UNSAFE.copyMemory(buf, off, arr, CHAR_ARR_OFF, bytesToCp);
 
         return arr;
     }
@@ -322,13 +324,13 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = GridUnsafe.getLongLE(buf, off);
+                arr[i] = Ignition.UNSAFE.getLongLE(buf, off);
 
                 off += 8;
             }
         }
         else
-            GridUnsafe.copyMemory(buf, off, arr, LONG_ARR_OFF, bytesToCp);
+            Ignition.UNSAFE.copyMemory(buf, off, arr, LONG_ARR_OFF, bytesToCp);
 
         return arr;
     }
@@ -347,13 +349,13 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         if (BIG_ENDIAN) {
             for (int i = 0; i < arr.length; i++) {
-                arr[i] = GridUnsafe.getFloatLE(buf, off);
+                arr[i] = Ignition.UNSAFE.getFloatLE(buf, off);
 
                 off += 4;
             }
         }
         else
-            GridUnsafe.copyMemory(buf, off, arr, FLOAT_ARR_OFF, bytesToCp);
+            Ignition.UNSAFE.copyMemory(buf, off, arr, FLOAT_ARR_OFF, bytesToCp);
 
         return arr;
     }
@@ -388,14 +390,14 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
     @Override public boolean readBoolean() throws IOException {
         fromStream(1);
 
-        return GridUnsafe.getBoolean(buf, BYTE_ARR_OFF + offset(1));
+        return Ignition.UNSAFE.getBoolean(buf, BYTE_ARR_OFF + offset(1));
     }
 
     /** {@inheritDoc} */
     @Override public byte readByte() throws IOException {
         fromStream(1);
 
-        return GridUnsafe.getByte(buf, BYTE_ARR_OFF + offset(1));
+        return Ignition.UNSAFE.getByte(buf, BYTE_ARR_OFF + offset(1));
     }
 
     /** {@inheritDoc} */
@@ -409,7 +411,7 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         long off = BYTE_ARR_OFF + offset(2);
 
-        return BIG_ENDIAN ? GridUnsafe.getShortLE(buf, off) : GridUnsafe.getShort(buf, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getShortLE(buf, off) : Ignition.UNSAFE.getShort(buf, off);
     }
 
     /** {@inheritDoc} */
@@ -423,7 +425,7 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         long off = BYTE_ARR_OFF + this.off;
 
-        char v = BIG_ENDIAN ? GridUnsafe.getCharLE(buf, off) : GridUnsafe.getChar(buf, off);
+        char v = BIG_ENDIAN ? Ignition.UNSAFE.getCharLE(buf, off) : Ignition.UNSAFE.getChar(buf, off);
 
         offset(2);
 
@@ -436,7 +438,7 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         long off = BYTE_ARR_OFF + offset(4);
 
-        return BIG_ENDIAN ? GridUnsafe.getIntLE(buf, off) : GridUnsafe.getInt(buf, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getIntLE(buf, off) : Ignition.UNSAFE.getInt(buf, off);
     }
 
     /** {@inheritDoc} */
@@ -445,7 +447,7 @@ public class GridUnsafeDataInput extends InputStream implements GridDataInput {
 
         long off = BYTE_ARR_OFF + offset(8);
 
-        return BIG_ENDIAN ? GridUnsafe.getLongLE(buf, off) : GridUnsafe.getLong(buf, off);
+        return BIG_ENDIAN ? Ignition.UNSAFE.getLongLE(buf, off) : Ignition.UNSAFE.getLong(buf, off);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/io/GridUnsafeDataOutput.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/io/GridUnsafeDataOutput.java
@@ -19,6 +19,8 @@ package org.apache.ignite.internal.util.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -191,13 +193,13 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
             long off = BYTE_ARR_OFF + this.off;
 
             for (double val : arr) {
-                GridUnsafe.putDoubleLE(bytes, off, val);
+                Ignition.UNSAFE.putDoubleLE(bytes, off, val);
 
                 off += 8;
             }
         }
         else
-            GridUnsafe.copyMemory(arr, DOUBLE_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
+            Ignition.UNSAFE.copyMemory(arr, DOUBLE_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
 
         onWrite(bytesToCp);
     }
@@ -223,13 +225,13 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
             long off = BYTE_ARR_OFF + this.off;
 
             for (char val : arr) {
-                GridUnsafe.putCharLE(bytes, off, val);
+                Ignition.UNSAFE.putCharLE(bytes, off, val);
 
                 off += 2;
             }
         }
         else
-            GridUnsafe.copyMemory(arr, CHAR_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
+            Ignition.UNSAFE.copyMemory(arr, CHAR_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
 
         onWrite(bytesToCp);
     }
@@ -246,13 +248,13 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
             long off = BYTE_ARR_OFF + this.off;
 
             for (long val : arr) {
-                GridUnsafe.putLongLE(bytes, off, val);
+                Ignition.UNSAFE.putLongLE(bytes, off, val);
 
                 off += 8;
             }
         }
         else
-            GridUnsafe.copyMemory(arr, LONG_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
+            Ignition.UNSAFE.copyMemory(arr, LONG_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
 
         onWrite(bytesToCp);
     }
@@ -269,13 +271,13 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
             long off = BYTE_ARR_OFF + this.off;
 
             for (float val : arr) {
-                GridUnsafe.putFloatLE(bytes, off, val);
+                Ignition.UNSAFE.putFloatLE(bytes, off, val);
 
                 off += 4;
             }
         }
         else
-            GridUnsafe.copyMemory(arr, FLOAT_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
+            Ignition.UNSAFE.copyMemory(arr, FLOAT_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
 
         onWrite(bytesToCp);
     }
@@ -310,13 +312,13 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
             long off = BYTE_ARR_OFF + this.off;
 
             for (short val : arr) {
-                GridUnsafe.putShortLE(bytes, off, val);
+                Ignition.UNSAFE.putShortLE(bytes, off, val);
 
                 off += 2;
             }
         }
         else
-            GridUnsafe.copyMemory(arr, SHORT_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
+            Ignition.UNSAFE.copyMemory(arr, SHORT_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
 
         onWrite(bytesToCp);
     }
@@ -333,13 +335,13 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
             long off = BYTE_ARR_OFF + this.off;
 
             for (int val : arr) {
-                GridUnsafe.putIntLE(bytes, off, val);
+                Ignition.UNSAFE.putIntLE(bytes, off, val);
 
                 off += 4;
             }
         }
         else
-            GridUnsafe.copyMemory(arr, INT_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
+            Ignition.UNSAFE.copyMemory(arr, INT_ARR_OFF, bytes, BYTE_ARR_OFF + off, bytesToCp);
 
         onWrite(bytesToCp);
     }
@@ -353,7 +355,7 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
     @Override public void writeBoolean(boolean v) throws IOException {
         requestFreeSize(1);
 
-        GridUnsafe.putBoolean(bytes, BYTE_ARR_OFF + off, v);
+        Ignition.UNSAFE.putBoolean(bytes, BYTE_ARR_OFF + off, v);
 
         onWrite(1);
     }
@@ -362,7 +364,7 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
     @Override public void writeByte(int v) throws IOException {
         requestFreeSize(1);
 
-        GridUnsafe.putByte(bytes, BYTE_ARR_OFF + off, (byte)v);
+        Ignition.UNSAFE.putByte(bytes, BYTE_ARR_OFF + off, (byte)v);
 
         onWrite(1);
     }
@@ -376,9 +378,9 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
         long off = BYTE_ARR_OFF + this.off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putShortLE(bytes, off, val);
+            Ignition.UNSAFE.putShortLE(bytes, off, val);
         else
-            GridUnsafe.putShort(bytes, off, val);
+            Ignition.UNSAFE.putShort(bytes, off, val);
 
         onWrite(2);
     }
@@ -392,9 +394,9 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
         long off = BYTE_ARR_OFF + this.off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putCharLE(bytes, off, val);
+            Ignition.UNSAFE.putCharLE(bytes, off, val);
         else
-            GridUnsafe.putChar(bytes, off, val);
+            Ignition.UNSAFE.putChar(bytes, off, val);
 
         onWrite(2);
     }
@@ -406,9 +408,9 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
         long off = BYTE_ARR_OFF + this.off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putIntLE(bytes, off, v);
+            Ignition.UNSAFE.putIntLE(bytes, off, v);
         else
-            GridUnsafe.putInt(bytes, off, v);
+            Ignition.UNSAFE.putInt(bytes, off, v);
 
         onWrite(4);
     }
@@ -420,9 +422,9 @@ public class GridUnsafeDataOutput extends OutputStream implements GridDataOutput
         long off = BYTE_ARR_OFF + this.off;
 
         if (BIG_ENDIAN)
-            GridUnsafe.putLongLE(bytes, off, v);
+            Ignition.UNSAFE.putLongLE(bytes, off, v);
         else
-            GridUnsafe.putLong(bytes, off, v);
+            Ignition.UNSAFE.putLong(bytes, off, v);
 
         onWrite(8);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/offheap/unsafe/GridUnsafeMemory.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/offheap/unsafe/GridUnsafeMemory.java
@@ -19,12 +19,14 @@ package org.apache.ignite.internal.util.offheap.unsafe;
 
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.offheap.GridOffHeapEventListener;
 import org.apache.ignite.internal.util.offheap.GridOffHeapOutOfMemoryException;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.lang.IgniteBiTuple;
+import sun.misc.Unsafe;
 
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_OFFHEAP_SAFE_RELEASE;
 import static org.apache.ignite.internal.util.offheap.GridOffHeapEvent.ALLOCATE;
@@ -34,6 +36,7 @@ import static org.apache.ignite.internal.util.offheap.GridOffHeapEvent.RELEASE;
  * Unsafe memory.
  */
 public class GridUnsafeMemory {
+
     /** Free byte. */
     private static final byte FREE = (byte)0;
 
@@ -165,7 +168,7 @@ public class GridUnsafeMemory {
             cnt.addAndGet(size);
 
         try {
-            long ptr = GridUnsafe.allocateMemory(size);
+            long ptr = Ignition.UNSAFE.allocateMemory(size);
 
             if (init)
                 fill(ptr, size, FREE);
@@ -189,7 +192,7 @@ public class GridUnsafeMemory {
      * @param b Value.
      */
     public void fill(long ptr, long size, byte b) {
-        GridUnsafe.setMemory(ptr, size, b);
+        Ignition.UNSAFE.setMemory(ptr, size, b);
     }
 
     /**
@@ -224,7 +227,7 @@ public class GridUnsafeMemory {
             if (SAFE_RELEASE)
                 fill(ptr, size, (byte)0xAB);
 
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
 
             cnt.addAndGet(-size);
 
@@ -238,7 +241,7 @@ public class GridUnsafeMemory {
      * @return Long value.
      */
     public long readLong(long ptr) {
-        return GridUnsafe.getLong(ptr);
+        return Ignition.UNSAFE.getLong(ptr);
     }
 
     /**
@@ -246,7 +249,7 @@ public class GridUnsafeMemory {
      * @param v Long value.
      */
     public void writeLong(long ptr, long v) {
-        GridUnsafe.putLong(ptr, v);
+        Ignition.UNSAFE.putLong(ptr, v);
     }
 
     /**
@@ -254,7 +257,7 @@ public class GridUnsafeMemory {
      * @return Long value.
      */
     public long readLongVolatile(long ptr) {
-        return GridUnsafe.getLongVolatile(null, ptr);
+        return Ignition.UNSAFE.getLongVolatile(null, ptr);
     }
 
     /**
@@ -262,7 +265,7 @@ public class GridUnsafeMemory {
      * @param v Long value.
      */
     public void writeLongVolatile(long ptr, long v) {
-        GridUnsafe.putLongVolatile(null, ptr, v);
+        Ignition.UNSAFE.putLongVolatile(null, ptr, v);
     }
 
     /**
@@ -272,7 +275,7 @@ public class GridUnsafeMemory {
      * @return {@code true} If operation succeeded.
      */
     public boolean casLong(long ptr, long exp, long v) {
-        return GridUnsafe.compareAndSwapLong(null, ptr, exp, v);
+        return Ignition.UNSAFE.compareAndSwapLong(null, ptr, exp, v);
     }
 
     /**
@@ -280,7 +283,7 @@ public class GridUnsafeMemory {
      * @return Integer value.
      */
     public int readInt(long ptr) {
-        return GridUnsafe.getInt(ptr);
+        return Ignition.UNSAFE.getInt(ptr);
     }
 
     /**
@@ -288,7 +291,7 @@ public class GridUnsafeMemory {
      * @param v Integer value.
      */
     public void writeInt(long ptr, int v) {
-        GridUnsafe.putInt(ptr, v);
+        Ignition.UNSAFE.putInt(ptr, v);
     }
 
     /**
@@ -296,7 +299,7 @@ public class GridUnsafeMemory {
      * @return Integer value.
      */
     public int readIntVolatile(long ptr) {
-        return GridUnsafe.getIntVolatile(null, ptr);
+        return Ignition.UNSAFE.getIntVolatile(null, ptr);
     }
 
     /**
@@ -304,7 +307,7 @@ public class GridUnsafeMemory {
      * @param v Integer value.
      */
     public void writeIntVolatile(long ptr, int v) {
-        GridUnsafe.putIntVolatile(null, ptr, v);
+        Ignition.UNSAFE.putIntVolatile(null, ptr, v);
     }
 
     /**
@@ -314,7 +317,7 @@ public class GridUnsafeMemory {
      * @return {@code true} If operation succeeded.
      */
     public boolean casInt(long ptr, int exp, int v) {
-        return GridUnsafe.compareAndSwapInt(null, ptr, exp, v);
+        return Ignition.UNSAFE.compareAndSwapInt(null, ptr, exp, v);
     }
 
     /**
@@ -322,7 +325,7 @@ public class GridUnsafeMemory {
      * @return Float value.
      */
     public float readFloat(long ptr) {
-        return GridUnsafe.getFloat(ptr);
+        return Ignition.UNSAFE.getFloat(ptr);
     }
 
     /**
@@ -330,7 +333,7 @@ public class GridUnsafeMemory {
      * @param v Value.
      */
     public void writeFloat(long ptr, float v) {
-        GridUnsafe.putFloat(ptr, v);
+        Ignition.UNSAFE.putFloat(ptr, v);
     }
 
     /**
@@ -338,7 +341,7 @@ public class GridUnsafeMemory {
      * @return Double value.
      */
     public double readDouble(long ptr) {
-        return GridUnsafe.getDouble(ptr);
+        return Ignition.UNSAFE.getDouble(ptr);
     }
 
     /**
@@ -346,7 +349,7 @@ public class GridUnsafeMemory {
      * @param v Value.
      */
     public void writeDouble(long ptr, double v) {
-        GridUnsafe.putDouble(ptr, v);
+        Ignition.UNSAFE.putDouble(ptr, v);
     }
 
     /**
@@ -354,7 +357,7 @@ public class GridUnsafeMemory {
      * @return Short value.
      */
     public short readShort(long ptr) {
-        return GridUnsafe.getShort(ptr);
+        return Ignition.UNSAFE.getShort(ptr);
     }
 
     /**
@@ -362,7 +365,7 @@ public class GridUnsafeMemory {
      * @param v Short value.
      */
     public void writeShort(long ptr, short v) {
-        GridUnsafe.putShort(ptr, v);
+        Ignition.UNSAFE.putShort(ptr, v);
     }
 
     /**
@@ -370,7 +373,7 @@ public class GridUnsafeMemory {
      * @return Integer value.
      */
     public byte readByte(long ptr) {
-        return GridUnsafe.getByte(ptr);
+        return Ignition.UNSAFE.getByte(ptr);
     }
 
     /**
@@ -378,7 +381,7 @@ public class GridUnsafeMemory {
      * @return Integer value.
      */
     public byte readByteVolatile(long ptr) {
-        return GridUnsafe.getByteVolatile(null, ptr);
+        return Ignition.UNSAFE.getByteVolatile(null, ptr);
     }
 
     /**
@@ -386,7 +389,7 @@ public class GridUnsafeMemory {
      * @param v Integer value.
      */
     public void writeByte(long ptr, byte v) {
-        GridUnsafe.putByte(ptr, v);
+        Ignition.UNSAFE.putByte(null, ptr, v);
     }
 
     /**
@@ -394,7 +397,7 @@ public class GridUnsafeMemory {
      * @param v Integer value.
      */
     public void writeByteVolatile(long ptr, byte v) {
-        GridUnsafe.putByteVolatile(null, ptr, v);
+        Ignition.UNSAFE.putByteVolatile(null, ptr, v);
     }
 
     /**
@@ -474,8 +477,8 @@ public class GridUnsafeMemory {
         int words = size / 8;
 
         for (int i = 0; i < words; i++) {
-            long w1 = GridUnsafe.getLong(ptr1);
-            long w2 = GridUnsafe.getLong(ptr2);
+            long w1 = Ignition.UNSAFE.getLong(ptr1);
+            long w2 = Ignition.UNSAFE.getLong(ptr2);
 
             if (w1 != w2)
                 return false;
@@ -487,8 +490,8 @@ public class GridUnsafeMemory {
         int left = size % 8;
 
         for (int i = 0; i < left; i++) {
-            byte b1 = GridUnsafe.getByte(ptr1);
-            byte b2 = GridUnsafe.getByte(ptr2);
+            byte b1 = Ignition.UNSAFE.getByte(ptr1);
+            byte b2 = Ignition.UNSAFE.getByte(ptr2);
 
             if (b1 != b2)
                 return false;
@@ -532,7 +535,7 @@ public class GridUnsafeMemory {
 
         if (align != addrSize) {
             for (int i = 0, tmpOff = bytesOff; i < align && i < len; i++, tmpOff++, ptr++) {
-                if (GridUnsafe.getByte(ptr) != bytes[tmpOff])
+                if (Ignition.UNSAFE.getByte(ptr) != bytes[tmpOff])
                     return false;
             }
         }
@@ -553,9 +556,9 @@ public class GridUnsafeMemory {
                 for (int i = 0; i < words; i++) {
                     int step = i * addrSize + align;
 
-                    int word = GridUnsafe.getInt(ptr);
+                    int word = Ignition.UNSAFE.getInt(ptr);
 
-                    int comp = GridUnsafe.getInt(bytes, GridUnsafe.BYTE_ARR_OFF + step + bytesOff);
+                    int comp = Ignition.UNSAFE.getInt(bytes, GridUnsafe.BYTE_ARR_OFF + step + bytesOff);
 
                     if (word != comp)
                         return false;
@@ -569,9 +572,9 @@ public class GridUnsafeMemory {
                 for (int i = 0; i < words; i++) {
                     int step = i * addrSize + align;
 
-                    long word = GridUnsafe.getLong(ptr);
+                    long word = Ignition.UNSAFE.getLong(ptr);
 
-                    long comp = GridUnsafe.getLong(bytes, GridUnsafe.BYTE_ARR_OFF + step + bytesOff);
+                    long comp = Ignition.UNSAFE.getLong(bytes, GridUnsafe.BYTE_ARR_OFF + step + bytesOff);
 
                     if (word != comp)
                         return false;
@@ -585,7 +588,7 @@ public class GridUnsafeMemory {
         if (left != 0) {
             // Compare left overs byte by byte.
             for (int i = 0; i < left; i++)
-                if (GridUnsafe.getByte(ptr + i) != bytes[bytesOff + i + align + words * GridUnsafe.ADDR_SIZE])
+                if (Ignition.UNSAFE.getByte(ptr + i) != bytes[bytesOff + i + align + words * GridUnsafe.ADDR_SIZE])
                     return false;
         }
 
@@ -607,7 +610,7 @@ public class GridUnsafeMemory {
      * @return The same array as passed in one.
      */
     public byte[] readBytes(long ptr, byte[] arr) {
-        GridUnsafe.copyOffheapHeap(ptr, arr, GridUnsafe.BYTE_ARR_OFF, arr.length);
+        Ignition.UNSAFE.copyOffheapHeap(ptr, arr, GridUnsafe.BYTE_ARR_OFF, arr.length);
 
         return arr;
     }
@@ -620,7 +623,7 @@ public class GridUnsafeMemory {
      * @return The same array as passed in one.
      */
     public byte[] readBytes(long ptr, byte[] arr, int off, int len) {
-        GridUnsafe.copyOffheapHeap(ptr, arr, GridUnsafe.BYTE_ARR_OFF + off, len);
+        Ignition.UNSAFE.copyOffheapHeap(ptr, arr, GridUnsafe.BYTE_ARR_OFF + off, len);
 
         return arr;
     }
@@ -632,7 +635,7 @@ public class GridUnsafeMemory {
      * @param arr Array.
      */
     public void writeBytes(long ptr, byte[] arr) {
-        GridUnsafe.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF, ptr, arr.length);
+        Ignition.UNSAFE.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF, ptr, arr.length);
     }
 
     /**
@@ -644,7 +647,7 @@ public class GridUnsafeMemory {
      * @param len Length.
      */
     public void writeBytes(long ptr, byte[] arr, int off, int len) {
-        GridUnsafe.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF + off, ptr, len);
+        Ignition.UNSAFE.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF + off, ptr, len);
     }
 
     /**
@@ -655,7 +658,7 @@ public class GridUnsafeMemory {
      * @param len Length in bytes.
      */
     public void copyMemory(long srcPtr, long destPtr, long len) {
-        GridUnsafe.copyOffheapOffheap(srcPtr, destPtr, len);
+        Ignition.UNSAFE.copyOffheapOffheap(srcPtr, destPtr, len);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryArrayIdentityResolverSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryArrayIdentityResolverSelfTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.binary.BinaryObjectBuilder;
 import org.apache.ignite.binary.BinaryObjectException;
@@ -61,7 +62,7 @@ public class BinaryArrayIdentityResolverSelfTest extends GridCommonAbstractTest 
     /** {@inheritDoc} */
     @Override protected void afterTest() throws Exception {
         for (Long ptr : ptrs)
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
 
         super.afterTest();
     }
@@ -252,11 +253,11 @@ public class BinaryArrayIdentityResolverSelfTest extends GridCommonAbstractTest 
         if (offheap) {
             byte[] arr = obj0.array();
 
-            long ptr = GridUnsafe.allocateMemory(arr.length);
+            long ptr = Ignition.UNSAFE.allocateMemory(arr.length);
 
             ptrs.add(ptr);
 
-            GridUnsafe.copyMemory(arr, GridUnsafe.BYTE_ARR_OFF, null, ptr, arr.length);
+            Ignition.UNSAFE.copyMemory(arr, Ignition.UNSAFE.BYTE_ARR_OFF, null, ptr, arr.length);
 
             obj0 = new BinaryObjectOffheapImpl(obj0.context(), ptr, 0, obj0.array().length);
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryFieldsOffheapSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryFieldsOffheapSelfTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.eclipse.jetty.util.ConcurrentHashSet;
 
@@ -33,7 +34,7 @@ public class BinaryFieldsOffheapSelfTest extends BinaryFieldsAbstractSelfTest {
 
         // Cleanup allocated objects.
         for (Long ptr : ptrs)
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
 
         ptrs.clear();
     }
@@ -42,11 +43,11 @@ public class BinaryFieldsOffheapSelfTest extends BinaryFieldsAbstractSelfTest {
     @Override protected BinaryObjectExImpl toBinary(BinaryMarshaller marsh, Object obj) throws Exception {
         byte[] arr = marsh.marshal(obj);
 
-        long ptr = GridUnsafe.allocateMemory(arr.length);
+        long ptr = Ignition.UNSAFE.allocateMemory(arr.length);
 
         ptrs.add(ptr);
 
-        GridUnsafe.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF, ptr, arr.length);
+        Ignition.UNSAFE.copyHeapOffheap(arr, Ignition.UNSAFE.BYTE_ARR_OFF, ptr, arr.length);
 
         return new BinaryObjectOffheapImpl(binaryContext(marsh), ptr, 0, arr.length);
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryFooterOffsetsOffheapSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryFooterOffsetsOffheapSelfTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.eclipse.jetty.util.ConcurrentHashSet;
 
@@ -33,7 +34,7 @@ public class BinaryFooterOffsetsOffheapSelfTest extends BinaryFooterOffsetsAbstr
 
         // Cleanup allocated objects.
         for (Long ptr : ptrs)
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
 
         ptrs.clear();
     }
@@ -42,11 +43,11 @@ public class BinaryFooterOffsetsOffheapSelfTest extends BinaryFooterOffsetsAbstr
     @Override protected BinaryObjectExImpl toBinary(BinaryMarshaller marsh, Object obj) throws Exception {
         byte[] arr = marsh.marshal(obj);
 
-        long ptr = GridUnsafe.allocateMemory(arr.length);
+        long ptr = Ignition.UNSAFE.allocateMemory(arr.length);
 
         ptrs.add(ptr);
 
-        GridUnsafe.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF, ptr, arr.length);
+        Ignition.UNSAFE.copyHeapOffheap(arr, Ignition.UNSAFE.BYTE_ARR_OFF, ptr, arr.length);
 
         return new BinaryObjectOffheapImpl(ctx, ptr, 0, arr.length);
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -58,6 +58,7 @@ import junit.framework.Assert;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryBasicIdMapper;
 import org.apache.ignite.binary.BinaryBasicNameMapper;
 import org.apache.ignite.binary.BinaryCollectionFactory;
@@ -81,8 +82,8 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.binary.builder.BinaryObjectBuilderImpl;
 import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
 import org.apache.ignite.internal.processors.cache.CacheObjectContext;
-import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.lang.GridMapEntry;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -2619,13 +2620,13 @@ public class BinaryMarshallerSelfTest extends GridCommonAbstractTest {
             assertFalse(offheapObj2.equals(offheapObj));
         }
         finally {
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
 
             if (ptr1 > 0)
-                GridUnsafe.freeMemory(ptr1);
+                Ignition.UNSAFE.freeMemory(ptr1);
 
             if (ptr2 > 0)
-                GridUnsafe.freeMemory(ptr2);
+                Ignition.UNSAFE.freeMemory(ptr2);
         }
     }
 
@@ -3155,32 +3156,32 @@ public class BinaryMarshallerSelfTest extends GridCommonAbstractTest {
         }
         finally {
             if (binObjOffheap0 != null) {
-                GridUnsafe.freeMemory(binObjOffheap0.offheapAddress());
+                Ignition.UNSAFE.freeMemory(binObjOffheap0.offheapAddress());
                 binObjOffheap0 = null;
             }
 
             if (binObjOffheap1 != null) {
-                GridUnsafe.freeMemory(binObjOffheap1.offheapAddress());
+                Ignition.UNSAFE.freeMemory(binObjOffheap1.offheapAddress());
                 binObjOffheap1 = null;
             }
 
             if (binObjWithRawOffheap0 != null) {
-                GridUnsafe.freeMemory(binObjWithRawOffheap0.offheapAddress());
+                Ignition.UNSAFE.freeMemory(binObjWithRawOffheap0.offheapAddress());
                 binObjOffheap1 = null;
             }
 
             if (binObjWithRawOffheap1 != null) {
-                GridUnsafe.freeMemory(binObjWithRawOffheap1.offheapAddress());
+                Ignition.UNSAFE.freeMemory(binObjWithRawOffheap1.offheapAddress());
                 binObjOffheap1 = null;
             }
 
             if (binObjRawOffheap0 != null) {
-                GridUnsafe.freeMemory(binObjRawOffheap0.offheapAddress());
+                Ignition.UNSAFE.freeMemory(binObjRawOffheap0.offheapAddress());
                 binObjOffheap1 = null;
             }
 
             if (binObjRawOffheap1 != null) {
-                GridUnsafe.freeMemory(binObjRawOffheap1.offheapAddress());
+                Ignition.UNSAFE.freeMemory(binObjRawOffheap1.offheapAddress());
                 binObjOffheap1 = null;
             }
         }
@@ -3552,9 +3553,9 @@ public class BinaryMarshallerSelfTest extends GridCommonAbstractTest {
     private long copyOffheap(BinaryObjectImpl obj) {
         byte[] arr = obj.array();
 
-        long ptr = GridUnsafe.allocateMemory(arr.length);
+        long ptr = Ignition.UNSAFE.allocateMemory(arr.length);
 
-        GridUnsafe.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF, ptr, arr.length);
+        Ignition.UNSAFE.copyHeapOffheap(arr, Ignition.UNSAFE.BYTE_ARR_OFF, ptr, arr.length);
 
         return ptr;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryObjectBuilderDefaultMappersSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryObjectBuilderDefaultMappersSelfTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import junit.framework.TestCase;
 import org.apache.ignite.IgniteBinary;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryIdMapper;
 import org.apache.ignite.binary.BinaryNameMapper;
 import org.apache.ignite.binary.BinaryObject;
@@ -719,21 +720,21 @@ public class BinaryObjectBuilderDefaultMappersSelfTest extends GridCommonAbstrac
 
         byte[] arr = ((CacheObjectBinaryProcessorImpl)(grid(0)).context().cacheObjects()).marshal(po);
 
-        long ptr = GridUnsafe.allocateMemory(arr.length + 5);
+        long ptr = Ignition.UNSAFE.allocateMemory(arr.length + 5);
 
         try {
             long ptr0 = ptr;
 
-            GridUnsafe.putBoolean(null, ptr0++, false);
+            Ignition.UNSAFE.putBoolean(null, ptr0++, false);
 
             int len = arr.length;
 
             if (BIG_ENDIAN)
-                GridUnsafe.putIntLE(ptr0, len);
+                Ignition.UNSAFE.putIntLE(ptr0, len);
             else
-                GridUnsafe.putInt(ptr0, len);
+                Ignition.UNSAFE.putInt(ptr0, len);
 
-            GridUnsafe.copyHeapOffheap(arr, GridUnsafe.BYTE_ARR_OFF, ptr0 + 4, arr.length);
+            Ignition.UNSAFE.copyHeapOffheap(arr, Ignition.UNSAFE.BYTE_ARR_OFF, ptr0 + 4, arr.length);
 
             BinaryObject offheapObj = (BinaryObject)
                 ((CacheObjectBinaryProcessorImpl)(grid(0)).context().cacheObjects()).unmarshal(ptr, false);
@@ -759,7 +760,7 @@ public class BinaryObjectBuilderDefaultMappersSelfTest extends GridCommonAbstrac
             assertEquals(offheapObj, po);
         }
         finally {
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinarySerialiedFieldComparatorSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinarySerialiedFieldComparatorSelfTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.binary;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryObjectBuilder;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.GridUnsafe;
@@ -68,7 +69,7 @@ public class BinarySerialiedFieldComparatorSelfTest extends GridCommonAbstractTe
     /** {@inheritDoc} */
     @Override protected void afterTest() throws Exception {
         for (Long ptr : ptrs)
-            GridUnsafe.freeMemory(ptr);
+            Ignition.UNSAFE.freeMemory(ptr);
 
         super.afterTest();
     }
@@ -498,11 +499,11 @@ public class BinarySerialiedFieldComparatorSelfTest extends GridCommonAbstractTe
         if (offheap) {
             byte[] arr = obj.array();
 
-            long ptr = GridUnsafe.allocateMemory(arr.length);
+            long ptr = Ignition.UNSAFE.allocateMemory(arr.length);
 
             ptrs.add(ptr);
 
-            GridUnsafe.copyMemory(arr, GridUnsafe.BYTE_ARR_OFF, null, ptr, arr.length);
+            Ignition.UNSAFE.copyMemory(arr, GridUnsafe.BYTE_ARR_OFF, null, ptr, arr.length);
 
             obj = new BinaryObjectOffheapImpl(obj.context(), ptr, 0, obj.array().length);
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIOTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIOTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ThreadLocalRandom;
 import junit.framework.TestCase;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 /**
@@ -93,7 +94,7 @@ public class TrackingPageIOTest extends TestCase {
 
         assert basePageId >= 0;
 
-        PageIO.setPageId(GridUnsafe.bufferAddress(buf), basePageId);
+        PageIO.setPageId(Ignition.UNSAFE.bufferAddress(buf), basePageId);
 
         Map<Long, Boolean> map = new HashMap<>();
 
@@ -154,7 +155,7 @@ public class TrackingPageIOTest extends TestCase {
 
         assert basePageId >= 0;
 
-        PageIO.setPageId(GridUnsafe.bufferAddress(buf), basePageId);
+        PageIO.setPageId(Ignition.UNSAFE.bufferAddress(buf), basePageId);
 
         try {
             TreeSet<Long> setIdx = new TreeSet<>();
@@ -199,7 +200,7 @@ public class TrackingPageIOTest extends TestCase {
 
         assert basePageId >= 0;
 
-        PageIO.setPageId(GridUnsafe.bufferAddress(buf), basePageId);
+        PageIO.setPageId(Ignition.UNSAFE.bufferAddress(buf), basePageId);
 
         TreeSet<Long> setIdx = new TreeSet<>();
 
@@ -238,7 +239,7 @@ public class TrackingPageIOTest extends TestCase {
 
         assert basePageId >= 0;
 
-        PageIO.setPageId(GridUnsafe.bufferAddress(buf), basePageId);
+        PageIO.setPageId(Ignition.UNSAFE.bufferAddress(buf), basePageId);
 
         TreeSet<Long> setIdx = new TreeSet<>();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/offheap/unsafe/GridUnsafeMemorySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/offheap/unsafe/GridUnsafeMemorySelfTest.java
@@ -21,6 +21,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 
@@ -30,16 +32,16 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 public class GridUnsafeMemorySelfTest extends GridCommonAbstractTest {
     /** */
     public void testBuffers() {
-        ByteBuffer b1 = GridUnsafe.allocateBuffer(10);
-        ByteBuffer b2 = GridUnsafe.allocateBuffer(20);
+        ByteBuffer b1 = Ignition.UNSAFE.allocateBuffer(10);
+        ByteBuffer b2 = Ignition.UNSAFE.allocateBuffer(20);
 
-        assertEquals(GridUnsafe.NATIVE_BYTE_ORDER, b2.order());
+        assertEquals(Ignition.UNSAFE.NATIVE_BYTE_ORDER, b2.order());
         assertTrue(b2.isDirect());
         assertEquals(20, b2.capacity());
         assertEquals(20, b2.limit());
         assertEquals(0, b2.position());
 
-        assertEquals(GridUnsafe.NATIVE_BYTE_ORDER, b1.order());
+        assertEquals(Ignition.UNSAFE.NATIVE_BYTE_ORDER, b1.order());
         assertTrue(b1.isDirect());
         assertEquals(10, b1.capacity());
         assertEquals(10, b1.limit());
@@ -50,7 +52,7 @@ public class GridUnsafeMemorySelfTest extends GridCommonAbstractTest {
 
         b2.putLong(2L);
 
-        GridUnsafe.freeBuffer(b1);
+        Ignition.UNSAFE.freeBuffer(b1);
 
         b2.putLong(3L);
         b2.putInt(9);
@@ -58,7 +60,7 @@ public class GridUnsafeMemorySelfTest extends GridCommonAbstractTest {
         for (int i = 0; i <= 16; i++)
             b2.putInt(i, 100500);
 
-        GridUnsafe.freeBuffer(b2);
+        Ignition.UNSAFE.freeBuffer(b2);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/lang/GridBasicPerformanceTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/lang/GridBasicPerformanceTest.java
@@ -38,6 +38,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.util.GridLeanMap;
 import org.apache.ignite.internal.util.GridTimer;
@@ -950,11 +952,11 @@ public class GridBasicPerformanceTest {
         int mem = 1024;
 
         for (int i = 0; i < MAX; i++) {
-            addrs[i] = GridUnsafe.allocateMemory(mem);
+            addrs[i] = Ignition.UNSAFE.allocateMemory(mem);
 
-            GridUnsafe.putByte(addrs[i] + RAND.nextInt(mem), (byte)RAND.nextInt(mem));
+            Ignition.UNSAFE.putByte(addrs[i] + RAND.nextInt(mem), (byte)RAND.nextInt(mem));
 
-            v = GridUnsafe.getByte(addrs[i] + RAND.nextInt(mem));
+            v = Ignition.UNSAFE.getByte(addrs[i] + RAND.nextInt(mem));
         }
 
         X.println("Unsafe [time=" + t.stop() + "ms, v=" + v + ']');
@@ -962,7 +964,7 @@ public class GridBasicPerformanceTest {
         Thread.sleep(5000L);
 
         for (long l : addrs)
-            GridUnsafe.freeMemory(l);
+            Ignition.UNSAFE.freeMemory(l);
     }
 
 

--- a/modules/core/src/test/java/org/apache/ignite/lang/utils/IgniteOffheapReadWriteLockSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/lang/utils/IgniteOffheapReadWriteLockSelfTest.java
@@ -17,9 +17,10 @@
 
 package org.apache.ignite.lang.utils;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.IgniteInternalFuture;
-import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.OffheapReadWriteLock;
+import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 
@@ -50,7 +51,7 @@ public class IgniteOffheapReadWriteLockSelfTest extends GridCommonAbstractTest {
 
         final OffheapReadWriteLock lock = new OffheapReadWriteLock(16);
 
-        final long ptr = GridUnsafe.allocateMemory(OffheapReadWriteLock.LOCK_SIZE);
+        final long ptr = Ignition.UNSAFE.allocateMemory(OffheapReadWriteLock.LOCK_SIZE);
 
         lock.init(ptr, TAG_0);
 
@@ -142,7 +143,7 @@ public class IgniteOffheapReadWriteLockSelfTest extends GridCommonAbstractTest {
 
         final OffheapReadWriteLock lock = new OffheapReadWriteLock(16);
 
-        final long ptr = GridUnsafe.allocateMemory(OffheapReadWriteLock.LOCK_SIZE * numPairs);
+        final long ptr = Ignition.UNSAFE.allocateMemory(OffheapReadWriteLock.LOCK_SIZE * numPairs);
 
         for (int i = 0; i < numPairs; i++) {
             data[i] = new Pair();
@@ -228,7 +229,7 @@ public class IgniteOffheapReadWriteLockSelfTest extends GridCommonAbstractTest {
 
         final OffheapReadWriteLock lock = new OffheapReadWriteLock(16);
 
-        final long ptr = GridUnsafe.allocateMemory(OffheapReadWriteLock.LOCK_SIZE * numPairs);
+        final long ptr = Ignition.UNSAFE.allocateMemory(OffheapReadWriteLock.LOCK_SIZE * numPairs);
 
         for (int i = 0; i < numPairs; i++) {
             data[i] = new Pair();
@@ -332,7 +333,7 @@ public class IgniteOffheapReadWriteLockSelfTest extends GridCommonAbstractTest {
 
         final OffheapReadWriteLock lock = new OffheapReadWriteLock(16);
 
-        final long ptr = GridUnsafe.allocateMemory(OffheapReadWriteLock.LOCK_SIZE);
+        final long ptr = Ignition.UNSAFE.allocateMemory(OffheapReadWriteLock.LOCK_SIZE);
 
         lock.init(ptr, TAG_0);
 

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -70,10 +70,7 @@ import org.apache.ignite.internal.binary.BinaryMarshaller;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.processors.cache.CacheGroupContext;
 import org.apache.ignite.internal.processors.resource.GridSpringResourceContext;
-import org.apache.ignite.internal.util.GridClassLoaderCache;
-import org.apache.ignite.internal.util.GridTestClockTimer;
-import org.apache.ignite.internal.util.GridUnsafe;
-import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.internal.util.*;
 import org.apache.ignite.internal.util.lang.GridAbsPredicate;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.G;
@@ -240,7 +237,7 @@ public abstract class GridAbstractTest extends TestCase {
      * @throws Exception If failed.
      */
     protected <T> T allocateInstance(Class<T> cls) throws Exception {
-        return (T)GridUnsafe.allocateInstance(cls);
+        return (T)Ignition.UNSAFE.allocateInstance(cls);
     }
 
     /**
@@ -249,7 +246,7 @@ public abstract class GridAbstractTest extends TestCase {
      */
     @Nullable protected <T> T allocateInstance0(Class<T> cls) {
         try {
-            return (T)GridUnsafe.allocateInstance(cls);
+            return (T) Ignition.UNSAFE.allocateInstance(cls);
         }
         catch (InstantiationException e) {
             e.printStackTrace();

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/IgniteMock.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/IgniteMock.java
@@ -60,6 +60,7 @@ import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.CollectionConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.NearCacheConfiguration;
+import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.binary.BinaryCachingMetadataHandler;
 import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.binary.BinaryMarshaller;
@@ -508,4 +509,13 @@ public class IgniteMock implements Ignite {
     public void setStaticCfg(IgniteConfiguration staticCfg) {
         this.staticCfg = staticCfg;
     }
+
+    /**
+     *
+     * @return
+     */
+    @Override public GridKernalContext context() {
+        throw new UnsupportedOperationException("Operation isn't supported yet.");
+    }
+
 }

--- a/modules/hadoop/src/main/java/org/apache/ignite/hadoop/io/TextPartiallyRawComparator.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/hadoop/io/TextPartiallyRawComparator.java
@@ -19,6 +19,7 @@ package org.apache.ignite.hadoop.io;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.processors.hadoop.impl.HadoopUtils;
 import org.apache.ignite.internal.processors.hadoop.io.OffheapRawMemory;
 import org.apache.ignite.internal.processors.hadoop.io.PartiallyOffheapRawComparatorEx;
@@ -44,7 +45,7 @@ public class TextPartiallyRawComparator implements PartiallyRawComparator<Text>,
 
     /** {@inheritDoc} */
     @Override public int compare(Text val1, long val2Ptr, int val2Len) {
-        int len2 = WritableUtils.decodeVIntSize(GridUnsafe.getByte(val2Ptr));
+        int len2 = WritableUtils.decodeVIntSize(Ignition.UNSAFE.getByte(val2Ptr));
 
         return HadoopUtils.compareBytes(val1.getBytes(), val1.getLength(), val2Ptr + len2, val2Len - len2);
     }

--- a/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/impl/HadoopUtils.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/impl/HadoopUtils.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.processors.hadoop.HadoopCommonUtils;
 import org.apache.ignite.internal.processors.hadoop.HadoopDefaultJobInfo;
 import org.apache.ignite.internal.processors.hadoop.HadoopJobId;
@@ -354,13 +355,13 @@ public class HadoopUtils {
         int minWords = minLength / Longs.BYTES;
 
         for (int i = 0; i < minWords * Longs.BYTES; i += Longs.BYTES) {
-            long lw = GridUnsafe.getLong(buf1, GridUnsafe.BYTE_ARR_OFF + i);
-            long rw = GridUnsafe.getLong(ptr2 + i);
+            long lw = Ignition.UNSAFE.getLong(buf1, GridUnsafe.BYTE_ARR_OFF + i);
+            long rw = Ignition.UNSAFE.getLong(ptr2 + i);
 
             long diff = lw ^ rw;
 
             if (diff != 0) {
-                if (GridUnsafe.BIG_ENDIAN)
+                if (Ignition.UNSAFE.BIG_ENDIAN)
                     return (lw + Long.MIN_VALUE) < (rw + Long.MIN_VALUE) ? -1 : 1;
 
                 // Use binary search
@@ -392,7 +393,7 @@ public class HadoopUtils {
 
         // The epilogue to cover the last (minLength % 8) elements.
         for (int i = minWords * Longs.BYTES; i < minLength; i++) {
-            int res = UnsignedBytes.compare(buf1[i], GridUnsafe.getByte(ptr2 + i));
+            int res = UnsignedBytes.compare(buf1[i], Ignition.UNSAFE.getByte(ptr2 + i));
 
             if (res != 0)
                 return res;

--- a/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/io/OffheapRawMemory.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/io/OffheapRawMemory.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.hadoop.io;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.hadoop.io.RawMemory;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -45,49 +46,49 @@ public class OffheapRawMemory implements RawMemory {
     @Override public byte get(int idx) {
         ensure(idx, 1);
 
-        return GridUnsafe.getByte(ptr + idx);
+        return Ignition.UNSAFE.getByte(ptr + idx);
     }
 
     /** {@inheritDoc} */
     @Override public short getShort(int idx) {
         ensure(idx, 2);
 
-        return GridUnsafe.getShort(ptr + idx);
+        return Ignition.UNSAFE.getShort(ptr + idx);
     }
 
     /** {@inheritDoc} */
     @Override public char getChar(int idx) {
         ensure(idx, 2);
 
-        return GridUnsafe.getChar(ptr + idx);
+        return Ignition.UNSAFE.getChar(ptr + idx);
     }
 
     /** {@inheritDoc} */
     @Override public int getInt(int idx) {
         ensure(idx, 4);
 
-        return GridUnsafe.getInt(ptr + idx);
+        return Ignition.UNSAFE.getInt(ptr + idx);
     }
 
     /** {@inheritDoc} */
     @Override public long getLong(int idx) {
         ensure(idx, 8);
 
-        return GridUnsafe.getLong(ptr + idx);
+        return Ignition.UNSAFE.getLong(ptr + idx);
     }
 
     /** {@inheritDoc} */
     @Override public float getFloat(int idx) {
         ensure(idx, 4);
 
-        return GridUnsafe.getFloat(ptr + idx);
+        return Ignition.UNSAFE.getFloat(ptr + idx);
     }
 
     /** {@inheritDoc} */
     @Override public double getDouble(int idx) {
         ensure(idx, 8);
 
-        return GridUnsafe.getDouble(ptr + idx);
+        return Ignition.UNSAFE.getDouble(ptr + idx);
     }
 
     /** {@inheritDoc} */

--- a/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/HadoopShuffleJob.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/HadoopShuffleJob.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.processors.hadoop.shuffle;
 
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.processors.hadoop.HadoopJobEx;
@@ -583,7 +584,7 @@ public class HadoopShuffleJob<T> implements AutoCloseable {
 
         /** */
         @Override public void copyTo(long ptr) {
-            GridUnsafe.copyHeapOffheap(buf, GridUnsafe.BYTE_ARR_OFF + off, ptr, size);
+            Ignition.UNSAFE.copyHeapOffheap(buf, GridUnsafe.BYTE_ARR_OFF + off, ptr, size);
         }
     }
 

--- a/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/direct/HadoopDirectDataInput.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/direct/HadoopDirectDataInput.java
@@ -18,6 +18,8 @@
 package org.apache.ignite.internal.processors.hadoop.shuffle.direct;
 
 import java.io.EOFException;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.typedef.internal.SB;
 import org.jetbrains.annotations.NotNull;
@@ -90,7 +92,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public byte readByte() throws IOException {
         checkRange(1);
 
-        byte res = GridUnsafe.getByte(buf, BYTE_ARR_OFF + pos);
+        byte res = Ignition.UNSAFE.getByte(buf, BYTE_ARR_OFF + pos);
 
         pos += 1;
 
@@ -106,7 +108,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public short readShort() throws IOException {
         checkRange(2);
 
-        short res = GridUnsafe.getShort(buf, BYTE_ARR_OFF + pos);
+        short res = Ignition.UNSAFE.getShort(buf, BYTE_ARR_OFF + pos);
 
         pos += 2;
 
@@ -122,7 +124,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public char readChar() throws IOException {
         checkRange(2);
 
-        char res = GridUnsafe.getChar(buf, BYTE_ARR_OFF + pos);
+        char res = Ignition.UNSAFE.getChar(buf, BYTE_ARR_OFF + pos);
 
         pos += 2;
 
@@ -133,7 +135,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public int readInt() throws IOException {
         checkRange(4);
 
-        int res = GridUnsafe.getInt(buf, BYTE_ARR_OFF + pos);
+        int res = Ignition.UNSAFE.getInt(buf, BYTE_ARR_OFF + pos);
 
         pos += 4;
 
@@ -144,7 +146,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public long readLong() throws IOException {
         checkRange(8);
 
-        long res = GridUnsafe.getLong(buf, BYTE_ARR_OFF + pos);
+        long res = Ignition.UNSAFE.getLong(buf, BYTE_ARR_OFF + pos);
 
         pos += 8;
 
@@ -155,7 +157,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public float readFloat() throws IOException {
         checkRange(4);
 
-        float res = GridUnsafe.getFloat(buf, BYTE_ARR_OFF + pos);
+        float res = Ignition.UNSAFE.getFloat(buf, BYTE_ARR_OFF + pos);
 
         pos += 4;
 
@@ -166,7 +168,7 @@ public class HadoopDirectDataInput extends InputStream implements DataInput {
     @Override public double readDouble() throws IOException {
         checkRange(8);
 
-        double res = GridUnsafe.getDouble(buf, BYTE_ARR_OFF + pos);
+        double res = Ignition.UNSAFE.getDouble(buf, BYTE_ARR_OFF + pos);
 
         pos += 8;
 

--- a/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/direct/HadoopDirectDataOutput.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/direct/HadoopDirectDataOutput.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.hadoop.shuffle.direct;
 
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.jetbrains.annotations.NotNull;
 
@@ -99,42 +100,42 @@ public class HadoopDirectDataOutput extends OutputStream implements DataOutput {
     @Override public void writeShort(int val) throws IOException {
         int writePos = ensure(2);
 
-        GridUnsafe.putShort(buf, BYTE_ARR_OFF + writePos, (short)val);
+        Ignition.UNSAFE.putShort(buf, BYTE_ARR_OFF + writePos, (short)val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeChar(int val) throws IOException {
         int writePos = ensure(2);
 
-        GridUnsafe.putChar(buf, BYTE_ARR_OFF + writePos, (char)val);
+        Ignition.UNSAFE.putChar(buf, BYTE_ARR_OFF + writePos, (char)val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeInt(int val) throws IOException {
         int writePos = ensure(4);
 
-        GridUnsafe.putInt(buf, BYTE_ARR_OFF + writePos, val);
+        Ignition.UNSAFE.putInt(buf, BYTE_ARR_OFF + writePos, val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeLong(long val) throws IOException {
         int writePos = ensure(8);
 
-        GridUnsafe.putLong(buf, BYTE_ARR_OFF + writePos, val);
+        Ignition.UNSAFE.putLong(buf, BYTE_ARR_OFF + writePos, val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeFloat(float val) throws IOException {
         int writePos = ensure(4);
 
-        GridUnsafe.putFloat(buf, BYTE_ARR_OFF + writePos, val);
+        Ignition.UNSAFE.putFloat(buf, BYTE_ARR_OFF + writePos, val);
     }
 
     /** {@inheritDoc} */
     @Override public void writeDouble(double val) throws IOException {
         int writePos = ensure(8);
 
-        GridUnsafe.putDouble(buf, BYTE_ARR_OFF + writePos, val);
+        Ignition.UNSAFE.putDouble(buf, BYTE_ARR_OFF + writePos, val);
     }
 
     /** {@inheritDoc} */

--- a/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/streams/HadoopDataOutStream.java
+++ b/modules/hadoop/src/main/java/org/apache/ignite/internal/processors/hadoop/shuffle/streams/HadoopDataOutStream.java
@@ -20,6 +20,8 @@ package org.apache.ignite.internal.processors.hadoop.shuffle.streams;
 import java.io.DataOutput;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.offheap.unsafe.GridUnsafeMemory;
 
@@ -67,7 +69,7 @@ public class HadoopDataOutStream extends OutputStream implements DataOutput {
 
     /** {@inheritDoc} */
     @Override public void write(byte[] b, int off, int len) {
-        GridUnsafe.copyHeapOffheap(b, GridUnsafe.BYTE_ARR_OFF + off, move(len), len);
+        Ignition.UNSAFE.copyHeapOffheap(b, GridUnsafe.BYTE_ARR_OFF + off, move(len), len);
     }
 
     /** {@inheritDoc} */

--- a/modules/hadoop/src/test/java/org/apache/ignite/internal/processors/hadoop/impl/shuffle/collections/HadoopConcurrentHashMultimapSelftest.java
+++ b/modules/hadoop/src/test/java/org/apache/ignite/internal/processors/hadoop/impl/shuffle/collections/HadoopConcurrentHashMultimapSelftest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Writable;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.processors.hadoop.HadoopJobInfo;
 import org.apache.ignite.internal.processors.hadoop.HadoopTaskContext;
 import org.apache.ignite.internal.processors.hadoop.HadoopTaskInput;
@@ -162,7 +163,7 @@ public class HadoopConcurrentHashMultimapSelftest extends HadoopAbstractMapTest 
             private void read(long ptr, int size, Writable w) {
                 assert size == 4 : size;
 
-                GridUnsafe.copyOffheapHeap(ptr, buf, GridUnsafe.BYTE_ARR_OFF, size);
+                Ignition.UNSAFE.copyOffheapHeap(ptr, buf, GridUnsafe.BYTE_ARR_OFF, size);
 
                 dataInput.bytes(buf, size);
 

--- a/modules/hadoop/src/test/java/org/apache/ignite/internal/processors/hadoop/impl/shuffle/collections/HadoopSkipListSelfTest.java
+++ b/modules/hadoop/src/test/java/org/apache/ignite/internal/processors/hadoop/impl/shuffle/collections/HadoopSkipListSelfTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Writable;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.processors.hadoop.HadoopJobInfo;
 import org.apache.ignite.internal.processors.hadoop.HadoopTaskContext;
 import org.apache.ignite.internal.processors.hadoop.HadoopTaskInput;
@@ -177,7 +178,7 @@ public class HadoopSkipListSelfTest extends HadoopAbstractMapTest {
             private void read(long ptr, int size, Writable w) {
                 assert size == 4 : size;
 
-                GridUnsafe.copyOffheapHeap(ptr, buf, GridUnsafe.BYTE_ARR_OFF, size);
+                Ignition.UNSAFE.copyOffheapHeap(ptr, buf, GridUnsafe.BYTE_ARR_OFF, size);
 
                 dataInput.bytes(buf, size);
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/InlineIndexHelper.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/InlineIndexHelper.java
@@ -22,6 +22,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.pagemem.PageUtils;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.h2.result.SortOrder;
@@ -552,7 +554,7 @@ public class InlineIndexHelper {
 
         if (compareBinaryUnsigned) {
             for (int i = 0; i < len; i++) {
-                int b1 = GridUnsafe.getByte(addr + i) & 0xff;
+                int b1 = Ignition.UNSAFE.getByte(addr + i) & 0xff;
                 int b2 = bytes[i] & 0xff;
 
                 if (b1 != b2)
@@ -561,7 +563,7 @@ public class InlineIndexHelper {
         }
         else {
             for (int i = 0; i < len; i++) {
-                byte b1 = GridUnsafe.getByte(addr + i);
+                byte b1 = Ignition.UNSAFE.getByte(addr + i);
                 byte b2 = bytes[i];
 
                 if (b1 != b2)
@@ -603,7 +605,7 @@ public class InlineIndexHelper {
 
         // Try reading ASCII.
         while (cntr1 < len1 && cntr2 < len2) {
-            c = (int) GridUnsafe.getByte(addr) & 0xFF;
+            c = (int) Ignition.UNSAFE.getByte(addr) & 0xFF;
 
             if (c > 127)
                 break;
@@ -624,7 +626,7 @@ public class InlineIndexHelper {
 
         // read other
         while (cntr1 < len1 && cntr2 < len2) {
-            c = (int) GridUnsafe.getByte(addr++) & 0xFF;
+            c = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
             switch (c >> 4) {
                 case 0:
@@ -650,7 +652,7 @@ public class InlineIndexHelper {
                     if (cntr1 > len1)
                         throw new IllegalStateException("Malformed input (partial character at the end).");
 
-                    c2 = (int) GridUnsafe.getByte(addr++) & 0xFF;
+                    c2 = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
                     if ((c2 & 0xC0) != 0x80)
                         throw new IllegalStateException("Malformed input around byte: " + (cntr1 - 2));
@@ -669,9 +671,9 @@ public class InlineIndexHelper {
                     if (cntr1 > len1)
                         throw new IllegalStateException("Malformed input (partial character at the end).");
 
-                    c2 = (int) GridUnsafe.getByte(addr++) & 0xFF;
+                    c2 = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
-                    c3 = (int) GridUnsafe.getByte(addr++) & 0xFF;
+                    c3 = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
                     if (((c2 & 0xC0) != 0x80) || ((c3 & 0xC0) != 0x80))
                         throw new IllegalStateException("Malformed input around byte: " + (cntr1 - 3));
@@ -691,11 +693,11 @@ public class InlineIndexHelper {
                     if (cntr1 > len1)
                         throw new IllegalStateException("Malformed input (partial character at the end).");
 
-                    c2 = (int) GridUnsafe.getByte(addr++) & 0xFF;
+                    c2 = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
-                    c3 = (int) GridUnsafe.getByte(addr++) & 0xFF;
+                    c3 = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
-                    c4 = (int) GridUnsafe.getByte(addr++) & 0xFF;
+                    c4 = (int) Ignition.UNSAFE.getByte(addr++) & 0xFF;
 
                     if (((c & 0xF8) != 0xf0) || ((c2 & 0xC0) != 0x80) || ((c3 & 0xC0) != 0x80) || ((c4 & 0xC0) != 0x80))
                     throw new IllegalStateException("Malformed input around byte: " + (cntr1 - 4));

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/dml/UpdatePlanBuilder.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/dml/UpdatePlanBuilder.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.binary.BinaryObjectBuilder;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
@@ -531,7 +532,7 @@ public final class UpdatePlanBuilder {
                     /** {@inheritDoc} */
                     @Override public Object apply(List<?> arg) throws IgniteCheckedException {
                         try {
-                            return GridUnsafe.allocateInstance(cls);
+                            return Ignition.UNSAFE.allocateInstance(cls);
                         }
                         catch (InstantiationException e) {
                             if (S.INCLUDE_SENSITIVE)

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/DenseOffHeapMatrixStorage.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/matrix/DenseOffHeapMatrixStorage.java
@@ -20,6 +20,8 @@ package org.apache.ignite.ml.math.impls.storage.matrix;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.ml.math.MatrixStorage;
 import org.apache.ignite.ml.math.StorageConstants;
@@ -79,12 +81,12 @@ public class DenseOffHeapMatrixStorage implements MatrixStorage {
 
     /** {@inheritDoc} */
     @Override public double get(int x, int y) {
-        return GridUnsafe.getDouble(pointerOffset(x, y));
+        return Ignition.UNSAFE.getDouble(pointerOffset(x, y));
     }
 
     /** {@inheritDoc} */
     @Override public void set(int x, int y, double v) {
-        GridUnsafe.putDouble(pointerOffset(x, y), v);
+        Ignition.UNSAFE.putDouble(pointerOffset(x, y), v);
     }
 
     /** {@inheritDoc} */
@@ -164,7 +166,7 @@ public class DenseOffHeapMatrixStorage implements MatrixStorage {
 
     /** {@inheritDoc} */
     @Override public void destroy() {
-        GridUnsafe.freeMemory(ptr);
+        Ignition.UNSAFE.freeMemory(ptr);
     }
 
     /** */
@@ -210,7 +212,7 @@ public class DenseOffHeapMatrixStorage implements MatrixStorage {
 
     /** */
     private void allocateMemory(int rows, int cols) {
-        ptr = GridUnsafe.allocateMemory((long)rows * cols * Double.BYTES);
+        ptr = Ignition.UNSAFE.allocateMemory((long)rows * cols * Double.BYTES);
 
         ptrInitHash = Long.hashCode(ptr);
     }

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/vector/DenseLocalOffHeapVectorStorage.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/impls/storage/vector/DenseLocalOffHeapVectorStorage.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.stream.IntStream;
+
+import org.apache.ignite.Ignition;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.ml.math.VectorStorage;
 
@@ -62,12 +64,12 @@ public class DenseLocalOffHeapVectorStorage implements VectorStorage {
 
     /** {@inheritDoc} */
     @Override public double get(int i) {
-        return GridUnsafe.getDouble(pointerOffset(i));
+        return Ignition.UNSAFE.getDouble(pointerOffset(i));
     }
 
     /** {@inheritDoc} */
     @Override public void set(int i, double v) {
-        GridUnsafe.putDouble(pointerOffset(i), v);
+        Ignition.UNSAFE.putDouble(pointerOffset(i), v);
     }
 
     /** {@inheritDoc} */
@@ -123,7 +125,7 @@ public class DenseLocalOffHeapVectorStorage implements VectorStorage {
 
     /** {@inheritDoc} */
     @Override public void destroy() {
-        GridUnsafe.freeMemory(ptr);
+        Ignition.UNSAFE.freeMemory(ptr);
     }
 
     /** {@inheritDoc} */
@@ -165,7 +167,7 @@ public class DenseLocalOffHeapVectorStorage implements VectorStorage {
 
     /** */
     private void allocateMemory(int size) {
-        ptr = GridUnsafe.allocateMemory(size * Double.BYTES);
+        ptr = Ignition.UNSAFE.allocateMemory(size * Double.BYTES);
 
         ptrInitHash = Long.hashCode(ptr);
     }

--- a/modules/spring/src/main/java/org/apache/ignite/IgniteSpringBean.java
+++ b/modules/spring/src/main/java/org/apache/ignite/IgniteSpringBean.java
@@ -30,6 +30,7 @@ import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.CollectionConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.NearCacheConfiguration;
+import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.lang.IgniteProductVersion;
@@ -647,4 +648,13 @@ public class IgniteSpringBean implements Ignite, DisposableBean, SmartInitializi
     @Override public String toString() {
         return S.toString(IgniteSpringBean.class, this);
     }
+
+    /**
+     *
+     * @return
+     */
+    @Override public GridKernalContext context() {
+        throw new UnsupportedOperationException("Operation isn't supported yet.");
+    }
+
 }

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/IgniteAbstractBenchmark.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/IgniteAbstractBenchmark.java
@@ -19,6 +19,8 @@ package org.apache.ignite.yardstick;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.commons.codec.binary.StringUtils;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.IgniteState;
@@ -53,13 +55,12 @@ public abstract class IgniteAbstractBenchmark extends BenchmarkDriverAdapter {
         jcommander(cfg.commandLineArguments(), args, "<ignite-driver>");
 
         if (Ignition.state() != IgniteState.STARTED) {
-            node = new IgniteNode(args.isClientOnly() && !args.isNearCache());
-
+            node = new IgniteNode(args.isClientOnly() && !args.isNearCache(), true);
             node.start(cfg);
         }
         else
             // Support for mixed benchmarks mode.
-            node = new IgniteNode(args.isClientOnly() && !args.isNearCache(), Ignition.ignite());
+            node = new IgniteNode(args.isClientOnly() && !args.isNearCache(), Ignition.ignite(), true);
 
         waitForNodes();
 

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/IgniteBenchmarkArguments.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/IgniteBenchmarkArguments.java
@@ -237,6 +237,14 @@ public class IgniteBenchmarkArguments {
     private boolean persistentStoreEnabled;
 
     /** */
+    @Parameter(names = {"-aepPath", "--aepPath"}, description = "AEP path URL")
+    private String aepPath;
+
+    /** */
+    @Parameter(names = {"-aepHeapSize", "--aepHeapSize"}, description = "AEP Heap Size")
+    private long aepHeapSize;
+
+    /** */
     @Parameter(names = {"-stcp", "--streamerCachesPrefix"}, description = "Cache name prefix for streamer benchmark")
     private String streamerCachesPrefix = "streamer";
 
@@ -259,6 +267,13 @@ public class IgniteBenchmarkArguments {
         return persistentStoreEnabled;
     }
 
+    public String getAepPath() {
+        return aepPath;
+    }
+
+    public long getAepHeapSize() {
+        return aepHeapSize;
+    }
     /**
      * @return List of enabled load test operations.
      */

--- a/modules/yardstick/src/main/java/org/apache/ignite/yardstick/IgniteNode.java
+++ b/modules/yardstick/src/main/java/org/apache/ignite/yardstick/IgniteNode.java
@@ -57,6 +57,7 @@ public class IgniteNode implements BenchmarkServer {
 
     /** Client mode. */
     private boolean clientMode;
+    private boolean driver;
 
     /** */
     public IgniteNode() {
@@ -74,11 +75,26 @@ public class IgniteNode implements BenchmarkServer {
         this.ignite = ignite;
     }
 
+    public IgniteNode(boolean clientMode, Ignite ignite, boolean driver) {
+        this.clientMode = clientMode;
+        this.ignite = ignite;
+        this.driver = driver;
+    }
+
+    public IgniteNode(boolean clientMode, boolean driver) {
+        this.clientMode = clientMode;
+        this.driver = driver;
+    }
+
     /** {@inheritDoc} */
     @Override public void start(BenchmarkConfiguration cfg) throws Exception {
         IgniteBenchmarkArguments args = new IgniteBenchmarkArguments();
 
         BenchmarkUtils.jcommander(cfg.commandLineArguments(), args, "<ignite-node>");
+
+        if (args.getAepPath() != null && args.getAepHeapSize() != 0) {
+            Ignition.setAepStore(args.getAepPath(), driver, args.getAepHeapSize());
+        }
 
         IgniteBiTuple<IgniteConfiguration, ? extends ApplicationContext> tup = loadConfiguration(args.configuration());
 


### PR DESCRIPTION
Ignite, when persistence mode is enabled, stores data and indexes on disk. To minimize the latency of disks, several tuning options can be applied. Setting the page size of a memory region to match the page size of the underlying storage, using a separate disk for the WAL, and using production-level SSDs are just a few of them [https://apacheignite.readme.io/docs/durable-memory-tuning#section-native-persistence-related-tuning].

A persistent memory store with low latency and high capacity offers a viable alternative to disks. In light of this, this patch introduces an experimental support for Intel Optane DC Persistent Memory (aka 3DXPoint, AEP) based on our Low Level Persistent Library (LLPL).

The patch eliminates the checkpoint process and the WAL to propagate changes to disk and maintain durability. Instead, we rely on a transactional memory region/block defined by LLPL to store both data and indexes into a persistent heap that is restored back upon application reboots.

LLPL: https://github.com/pmem/LLPL/
Examples: examples/src/main/java/org/apache/ignite/examples/aep/
