### PR TITLE
IGNITE-8546 Permission denied while copying OPTION_LIBS on Openshift

### DIFF
--- a/docker/apache-ignite/Dockerfile
+++ b/docker/apache-ignite/Dockerfile
@@ -32,6 +32,15 @@ COPY apache-ignite-fabric* apache-ignite-fabric
 # Copy sh files and set permission
 COPY run.sh $IGNITE_HOME/
 
+# Grant permission to copy optional libs
+RUN chmod 777 ${IGNITE_HOME}/libs
+
+# Grant permission to create work directory
+RUN chmod 777 ${IGNITE_HOME}
+
+# Grant permission to execute entry point
+RUN chmod 555 $IGNITE_HOME/run.sh
+
 # Entry point
 CMD $IGNITE_HOME/run.sh
 

--- a/docker/apache-ignite/run.sh
+++ b/docker/apache-ignite/run.sh
@@ -20,7 +20,7 @@ if [ ! -z "$OPTION_LIBS" ]; then
   IFS=, LIBS_LIST=("$OPTION_LIBS")
 
   for lib in ${LIBS_LIST[@]}; do
-    cp -r $IGNITE_HOME/libs/optional/"$lib"/* \
+    cp -r $IGNITE_HOME/libs/optional/"$lib" \
         $IGNITE_HOME/libs/
   done
 fi


### PR DESCRIPTION
* Added permissions to copy optional libs, create work dir and execute entry point.
* Changed run.sh: `cp libs/optional/$lib/*` replaced  by `cp libs/optional/$lib` to avoid overwriting files (licenses, README, etc).