### PR TITLE
IGNITE-9083 Compute (Affinity Run) TC configuration timeouts because …

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -1590,7 +1590,7 @@ public abstract class GridAbstractTest extends TestCase {
         TcpDiscoverySpi discoSpi = new TestTcpDiscoverySpi();
 
         if (isDebug()) {
-            cfg.setFailureDetectionTimeout(Integer.MAX_VALUE);
+            cfg.setFailureDetectionTimeout(getTestTimeout() <= 0 ? getDefaultTestTimeout() : getTestTimeout());
             cfg.setNetworkTimeout(Long.MAX_VALUE / 3);
         }
         else {


### PR DESCRIPTION
…of infinite socket operation