### PR TITLE
IGNITE-9197 Java thin client querying empty table results in NoSuchElementException

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/GenericQueryPager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/GenericQueryPager.java
@@ -83,8 +83,8 @@ abstract class GenericQueryPager<T> implements QueryPager<T> {
         return hasNext;
     }
 
-    /** Indicates if initial query response was received. */
-    boolean hasFirstPage() {
+    /** {@inheritDoc} */
+    @Override public boolean hasFirstPage() {
         return hasFirstPage;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/QueryPager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/QueryPager.java
@@ -33,4 +33,7 @@ interface QueryPager<T> extends AutoCloseable {
      * @return {@code true} if there are more pages to read; {@code false} otherwise.
      */
     public boolean hasNext();
+
+    /** Indicates if initial query response was received. */
+    public boolean hasFirstPage();
 }


### PR DESCRIPTION
PROBLEM
See https://issues.apache.org/jira/browse/IGNITE-9197

ANALYSIS
ClientQueryCursor#hasNext() returns "true" if the first page has not yet been queried. This is wrong since we return "true" even if the first page is empty.

SOLUTION
ClientQueryCursor#hasNext() must force getting first page to check if the first page is empty.
That requires QueryPager interface to expose information on whether the first page has been extracted.