### PR TITLE
#ignite example - Readme.txt typo fix

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -6,7 +6,7 @@ This folder contains code examples for various Apache Ignite functionality.
 Examples are shipped as a separate Maven project, so to start running you simply need
 to import provided `pom.xml` file into your favourite IDE.
 
-The examples folder contains he following subfolders:
+The examples folder contains the following subfolders:
 
 - `config` - contains Ignite configuration files needed for examples.
 - `memcached` - contains PHP script demonstrating how Ignite Cache can be accessed using Memcached client.


### PR DESCRIPTION
I believe there is typo error (he instead of the)  in  README.txt inside example folder. Please look into this if pull request stand correct take necessary action.