### PR TITLE
IGNITE-8189

### DIFF
--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkDistributedCollectDataFuture.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkDistributedCollectDataFuture.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.spi.discovery.zk.internal;
 
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -145,23 +146,19 @@ class ZkDistributedCollectDataFuture extends GridFutureAdapter<Void> {
         UUID futId,
         IgniteLogger log
     ) throws Exception {
-        // TODO ZK: https://issues.apache.org/jira/browse/IGNITE-8189
+        List<String> batch = new LinkedList<>();
+
         String evtDir = paths.distributedFutureBasePath(futId);
 
-        try {
-            client.deleteAll(evtDir,
-                client.getChildrenIfPathExists(evtDir),
-                -1);
-        }
-        catch (KeeperException.NoNodeException e) {
-            U.log(log, "Node for deletion was not found: " + e.getPath());
+        if (client.exists(evtDir)) {
+            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, client.getChildrenIfPathExists(evtDir)));
 
-            // TODO ZK: https://issues.apache.org/jira/browse/IGNITE-8189
+            batch.add(evtDir);
         }
 
-        client.deleteIfExists(evtDir, -1);
+        batch.add(paths.distributedFutureResultPath(futId));
 
-        client.deleteIfExists(paths.distributedFutureResultPath(futId), -1);
+        client.deleteAll(batch, -1);
     }
 
     /**

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkDistributedCollectDataFuture.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkDistributedCollectDataFuture.java
@@ -151,7 +151,7 @@ class ZkDistributedCollectDataFuture extends GridFutureAdapter<Void> {
         String evtDir = paths.distributedFutureBasePath(futId);
 
         if (client.exists(evtDir)) {
-            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, client.getChildrenIfPathExists(evtDir)));
+            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, client.getChildren(evtDir)));
 
             batch.add(evtDir);
         }

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkDistributedCollectDataFuture.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkDistributedCollectDataFuture.java
@@ -151,7 +151,7 @@ class ZkDistributedCollectDataFuture extends GridFutureAdapter<Void> {
         String evtDir = paths.distributedFutureBasePath(futId);
 
         if (client.exists(evtDir)) {
-            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, client.getChildren(evtDir)));
+            batch.addAll(client.getChildrenPaths(evtDir));
 
             batch.add(evtDir);
         }

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
@@ -17,7 +17,10 @@
 
 package org.apache.ignite.spi.discovery.zk.internal;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.UUID;
+import org.jetbrains.annotations.Nullable;
 
 /**
  *
@@ -303,5 +306,21 @@ class ZkIgnitePaths {
         String flagsStr = path.substring(startIdx, startIdx + 2);
 
         return (byte)(Integer.parseInt(flagsStr, 16) - 128);
+    }
+
+    /**
+     * Add the parent path to each element of a list.
+     *
+     * @param parent Parent path to add.
+     * @param paths List of paths.
+     * @return Flags.
+     */
+    static List<String> addParentPath(@Nullable String parent, List<String> paths) {
+        List<String> data = new LinkedList<>();
+
+        for (String path : paths)
+            data.add(parent != null ? parent + "/" + path : path);
+
+        return data;
     }
 }

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
@@ -313,7 +313,7 @@ class ZkIgnitePaths {
      *
      * @param parent Parent path to add.
      * @param paths List of paths.
-     * @return Flags.
+     * @return List of paths.
      */
     static List<String> addParentPath(@Nullable String parent, List<String> paths) {
         List<String> data = new LinkedList<>();

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
@@ -209,6 +209,22 @@ class ZkIgnitePaths {
     }
 
     /**
+     * Add the parent path to each element of a list.
+     *
+     * @param parent Parent path to add.
+     * @param paths List of paths.
+     * @return List of paths.
+     */
+    static List<String> addParentPath(@Nullable String parent, List<String> paths) {
+        List<String> data = new LinkedList<>();
+
+        for (String path : paths)
+            data.add(parent != null ? parent + "/" + path : path);
+
+        return data;
+    }
+
+    /**
      * @param prefix Prefix.
      * @param nodeId Node ID.
      * @param partCnt Parts count.
@@ -306,21 +322,5 @@ class ZkIgnitePaths {
         String flagsStr = path.substring(startIdx, startIdx + 2);
 
         return (byte)(Integer.parseInt(flagsStr, 16) - 128);
-    }
-
-    /**
-     * Add the parent path to each element of a list.
-     *
-     * @param parent Parent path to add.
-     * @param paths List of paths.
-     * @return List of paths.
-     */
-    static List<String> addParentPath(@Nullable String parent, List<String> paths) {
-        List<String> data = new LinkedList<>();
-
-        for (String path : paths)
-            data.add(parent != null ? parent + "/" + path : path);
-
-        return data;
     }
 }

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZkIgnitePaths.java
@@ -17,10 +17,7 @@
 
 package org.apache.ignite.spi.discovery.zk.internal;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.UUID;
-import org.jetbrains.annotations.Nullable;
 
 /**
  *
@@ -206,22 +203,6 @@ class ZkIgnitePaths {
         assert partCnt >= 1 : partCnt;
 
         return partCnt;
-    }
-
-    /**
-     * Add the parent path to each element of a list.
-     *
-     * @param parent Parent path to add.
-     * @param paths List of paths.
-     * @return List of paths.
-     */
-    static List<String> addParentPath(@Nullable String parent, List<String> paths) {
-        List<String> data = new LinkedList<>();
-
-        for (String path : paths)
-            data.add(parent != null ? parent + "/" + path : path);
-
-        return data;
     }
 
     /**

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClient.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClient.java
@@ -593,7 +593,7 @@ public class ZookeeperClient implements Watcher {
      * @throws ZookeeperClientFailedException If connection to zk was lost.
      * @throws InterruptedException If interrupted.
      */
-    void deleteAll(@Nullable String parent, List<String> paths, int ver)
+    void deleteAll(List<String> paths, int ver)
         throws ZookeeperClientFailedException, InterruptedException {
         if (paths.isEmpty())
             return;
@@ -605,10 +605,8 @@ public class ZookeeperClient implements Watcher {
         List<Op> batch = new LinkedList<>();
 
         for (String path : paths) {
-            String path0 = parent != null ? parent + "/" + path : path;
-
             //TODO ZK: https://issues.apache.org/jira/browse/IGNITE-8187
-            int size = requestOverhead(path0) + 17 /* overhead */;
+            int size = requestOverhead(path) + 17 /* overhead */;
 
             assert size <= MAX_REQ_SIZE;
 
@@ -620,7 +618,7 @@ public class ZookeeperClient implements Watcher {
                 batchSize = 0;
             }
 
-            batch.add(Op.delete(path0, ver));
+            batch.add(Op.delete(path, ver));
 
             batchSize += size;
         }

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClient.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClient.java
@@ -504,9 +504,7 @@ public class ZookeeperClient implements Watcher {
      * @throws ZookeeperClientFailedException If connection to zk was lost.
      * @throws InterruptedException If interrupted.
      */
-    List<String> getChildren(String path)
-        throws ZookeeperClientFailedException, InterruptedException
-    {
+    List<String> getChildren(String path) throws ZookeeperClientFailedException, InterruptedException {
         for (;;) {
             long connStartTime = this.connStartTime;
 
@@ -517,6 +515,25 @@ public class ZookeeperClient implements Watcher {
                 onZookeeperError(connStartTime, e);
             }
         }
+    }
+
+    /**
+     * Get children paths.
+     *
+     * @param path Path.
+     * @return Children paths.
+     * @throws ZookeeperClientFailedException If connection to zk was lost.
+     * @throws InterruptedException If interrupted.
+     */
+    List<String> getChildrenPaths(String path) throws ZookeeperClientFailedException, InterruptedException {
+        List<String> children = getChildren(path);
+
+        ArrayList<String> paths = new ArrayList(children.size());
+
+        for (String child : children)
+            paths.add(path + "/" + child);
+
+        return paths;
     }
 
     /**

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClient.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClient.java
@@ -521,31 +521,6 @@ public class ZookeeperClient implements Watcher {
 
     /**
      * @param path Path.
-     * @return Children nodes.
-     * @throws KeeperException.NoNodeException If provided path does not exist.
-     * @throws ZookeeperClientFailedException If connection to zk was lost.
-     * @throws InterruptedException If interrupted.
-     */
-    List<String> getChildrenIfPathExists(String path) throws
-        KeeperException.NoNodeException, InterruptedException, ZookeeperClientFailedException {
-        for (;;) {
-            long connStartTime = this.connStartTime;
-
-            try {
-                return zk.getChildren(path, false);
-            }
-            catch (KeeperException.NoNodeException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                onZookeeperError(connStartTime, e);
-            }
-        }
-    }
-
-
-    /**
-     * @param path Path.
      * @throws InterruptedException If interrupted.
      * @throws KeeperException In case of error.
      * @return {@code True} if given path exists.

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
@@ -2271,30 +2271,31 @@ public class ZookeeperDiscoveryImpl {
 
         List<String> batch = new LinkedList<>();
 
-        List<String> evtChildren = rtState.zkClient.getChildren(zkPaths.evtsPath);
+        List<String> evtChildren = client.getChildren(zkPaths.evtsPath);
 
         for (String evtPath : evtChildren) {
             String evtDir = zkPaths.evtsPath + "/" + evtPath;
 
-            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, rtState.zkClient.getChildren(evtDir)));
+            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, client.getChildren(evtDir)));
         }
 
         batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.evtsPath, evtChildren));
 
-        batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsDir, client.getChildren(zkPaths.customEvtsDir)));
+        batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsDir,
+            client.getChildren(zkPaths.customEvtsDir)));
 
         batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsPartsDir,
-            rtState.zkClient.getChildren(zkPaths.customEvtsPartsDir)));
+            client.getChildren(zkPaths.customEvtsPartsDir)));
 
         batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsAcksDir,
-            rtState.zkClient.getChildren(zkPaths.customEvtsAcksDir)));
+            client.getChildren(zkPaths.customEvtsAcksDir)));
 
-        rtState.zkClient.deleteAll(batch, -1);
+        client.deleteAll(batch, -1);
 
         if (startInternalOrder > 0) {
-            for (String alive : rtState.zkClient.getChildren(zkPaths.aliveNodesDir)) {
+            for (String alive : client.getChildren(zkPaths.aliveNodesDir)) {
                 if (ZkIgnitePaths.aliveInternalId(alive) < startInternalOrder)
-                    rtState.zkClient.deleteIfExists(zkPaths.aliveNodesDir + "/" + alive, -1);
+                    client.deleteIfExists(zkPaths.aliveNodesDir + "/" + alive, -1);
             }
         }
 

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
@@ -2271,24 +2271,18 @@ public class ZookeeperDiscoveryImpl {
 
         List<String> batch = new LinkedList<>();
 
-        List<String> evtChildren = client.getChildren(zkPaths.evtsPath);
+        List<String> evtChildren = client.getChildrenPaths(zkPaths.evtsPath);
 
-        for (String evtPath : evtChildren) {
-            String evtDir = zkPaths.evtsPath + "/" + evtPath;
+        for (String evtPath : evtChildren)
+            batch.addAll(client.getChildrenPaths(evtPath));
 
-            batch.addAll(ZkIgnitePaths.addParentPath(evtDir, client.getChildren(evtDir)));
-        }
+        batch.addAll(evtChildren);
 
-        batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.evtsPath, evtChildren));
+        batch.addAll(client.getChildrenPaths(zkPaths.customEvtsDir));
 
-        batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsDir,
-            client.getChildren(zkPaths.customEvtsDir)));
+        batch.addAll(client.getChildrenPaths(zkPaths.customEvtsPartsDir));
 
-        batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsPartsDir,
-            client.getChildren(zkPaths.customEvtsPartsDir)));
-
-        batch.addAll(ZkIgnitePaths.addParentPath(zkPaths.customEvtsAcksDir,
-            client.getChildren(zkPaths.customEvtsAcksDir)));
+        batch.addAll(client.getChildrenPaths(zkPaths.customEvtsAcksDir));
 
         client.deleteAll(batch, -1);
 

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClientTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClientTest.java
@@ -201,7 +201,7 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
 
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
-        client.deleteAll(Collections.singletonList("/apacheIgnite1"), -1);
+        client.deleteAll(Collections.singletonList("/apacheIgnite/1"), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClientTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClientTest.java
@@ -196,12 +196,12 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
         client.createIfNeeded("/apacheIgnite/2", null, CreateMode.PERSISTENT);
 
-        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", Arrays.asList("1", "2")), -1);
+        client.deleteAll(Arrays.asList("/apacheIgnite/1", "/apacheIgnite/2"), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
 
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
-        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", Collections.singletonList("1")), -1);
+        client.deleteAll(Collections.singletonList("/apacheIgnite1"), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }
@@ -227,12 +227,7 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
 
         assertEquals(cnt, client.getChildren("/apacheIgnite").size());
 
-        List<String> subPaths = new ArrayList<>(cnt);
-
-        for (int i = 0; i < cnt; i++)
-            subPaths.add(String.valueOf(i));
-
-        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", subPaths), -1);
+        client.deleteAll(paths, -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }
@@ -249,7 +244,7 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
         client.createIfNeeded("/apacheIgnite/2", null, CreateMode.PERSISTENT);
 
-        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", Arrays.asList("1", "2", "3")), -1);
+        client.deleteAll(Arrays.asList("/apacheIgnite/1", "/apacheIgnite/2", "/apacheIgnite/3"), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClientTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClientTest.java
@@ -196,12 +196,12 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
         client.createIfNeeded("/apacheIgnite/2", null, CreateMode.PERSISTENT);
 
-        client.deleteAll("/apacheIgnite", Arrays.asList("1", "2"), -1);
+        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", Arrays.asList("1", "2")), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
 
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
-        client.deleteAll("/apacheIgnite", Collections.singletonList("1"), -1);
+        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", Collections.singletonList("1")), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }
@@ -232,7 +232,7 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
         for (int i = 0; i < cnt; i++)
             subPaths.add(String.valueOf(i));
 
-        client.deleteAll("/apacheIgnite", subPaths, -1);
+        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", subPaths), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }
@@ -249,7 +249,7 @@ public class ZookeeperClientTest extends GridCommonAbstractTest {
         client.createIfNeeded("/apacheIgnite/1", null, CreateMode.PERSISTENT);
         client.createIfNeeded("/apacheIgnite/2", null, CreateMode.PERSISTENT);
 
-        client.deleteAll("/apacheIgnite", Arrays.asList("1", "2", "3"), -1);
+        client.deleteAll(ZkIgnitePaths.addParentPath("/apacheIgnite", Arrays.asList("1", "2", "3")), -1);
 
         assertTrue(client.getChildren("/apacheIgnite").isEmpty());
     }


### PR DESCRIPTION
1. I have added **ZookeeperClient#getChildrenPaths** method that returns path for children.
2. I prepare batches for _deleteAll_ operation in **deleteFutureData** and **cleanupPreviousClusterData** methods. _deleteAll_ operation requires path with parents for better batching.
3. _deleteAll_ method already max-size safe + NoNodeException safe (see IGNITE-8188)
4. I have removed _getChildrenIfPathExists()_ method because it has similar behavior with _getChildren()_. I check to exist the path in _deleteFutureData_ method to avoiding fallback to onebyone processing in _deleteAll_ method.
