### PR TITLE
IGNITE-9440 control.sh --wal delete do not delete files

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistory.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistory.java
@@ -98,7 +98,7 @@ public class CheckpointHistory {
      * @return Initialized entry.
      * @throws IgniteCheckedException If failed to initialize entry.
      */
-    private CheckpointEntry entry(Long cpTs) throws IgniteCheckedException {
+    public CheckpointEntry entry(Long cpTs) throws IgniteCheckedException {
         CheckpointEntry entry = histMap.get(cpTs);
 
         if (entry == null)


### PR DESCRIPTION
Do not delete the files by the utility on command "control.sh --wal delete".
Remain both checkpoints and wal in the archive.