### PR TITLE
IGNITE-9330

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheMetricsManageTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheMetricsManageTest.java
@@ -36,6 +36,7 @@ import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheMetrics;
 import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.cache.CacheWriteSynchronizationMode;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
@@ -489,7 +490,8 @@ public class CacheMetricsManageTest extends GridCommonAbstractTest {
             .setName(CACHE1)
             .setGroupName(GROUP)
             .setCacheMode(CacheMode.PARTITIONED)
-            .setAtomicityMode(CacheAtomicityMode.ATOMIC);
+            .setAtomicityMode(CacheAtomicityMode.ATOMIC)
+            .setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC);
 
         cfg.setCacheConfiguration(cacheCfg);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheMetricsManageTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheMetricsManageTest.java
@@ -79,21 +79,21 @@ public class CacheMetricsManageTest extends GridCommonAbstractTest {
     /**
      * @throws Exception If failed.
      */
-    public void testJmxNoPdsStatisticsEnable() throws Exception {
+    public void t1estJmxNoPdsStatisticsEnable() throws Exception {
         testJmxStatisticsEnable(false);
     }
 
     /**
      * @throws Exception If failed.
      */
-    public void testJmxPdsStatisticsEnable() throws Exception {
+    public void t1estJmxPdsStatisticsEnable() throws Exception {
         testJmxStatisticsEnable(true);
     }
 
     /**
      * @throws Exception If failed.
      */
-    public void testCacheManagerStatisticsEnable() throws Exception {
+    public void t1estCacheManagerStatisticsEnable() throws Exception {
         final CacheManager mgr1 = Caching.getCachingProvider().getCacheManager();
         final CacheManager mgr2 = Caching.getCachingProvider().getCacheManager();
 
@@ -132,7 +132,7 @@ public class CacheMetricsManageTest extends GridCommonAbstractTest {
     /**
      *
      */
-    public void testPublicApiStatisticsEnable() throws Exception {
+    public void t1estPublicApiStatisticsEnable() throws Exception {
         Ignite ig1 = startGrid(1);
         startGrid(2);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheMetricsManageTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheMetricsManageTest.java
@@ -79,21 +79,21 @@ public class CacheMetricsManageTest extends GridCommonAbstractTest {
     /**
      * @throws Exception If failed.
      */
-    public void t1estJmxNoPdsStatisticsEnable() throws Exception {
+    public void testJmxNoPdsStatisticsEnable() throws Exception {
         testJmxStatisticsEnable(false);
     }
 
     /**
      * @throws Exception If failed.
      */
-    public void t1estJmxPdsStatisticsEnable() throws Exception {
+    public void testJmxPdsStatisticsEnable() throws Exception {
         testJmxStatisticsEnable(true);
     }
 
     /**
      * @throws Exception If failed.
      */
-    public void t1estCacheManagerStatisticsEnable() throws Exception {
+    public void testCacheManagerStatisticsEnable() throws Exception {
         final CacheManager mgr1 = Caching.getCachingProvider().getCacheManager();
         final CacheManager mgr2 = Caching.getCachingProvider().getCacheManager();
 
@@ -132,7 +132,7 @@ public class CacheMetricsManageTest extends GridCommonAbstractTest {
     /**
      *
      */
-    public void t1estPublicApiStatisticsEnable() throws Exception {
+    public void testPublicApiStatisticsEnable() throws Exception {
         Ignite ig1 = startGrid(1);
         startGrid(2);
 

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite7.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite7.java
@@ -64,7 +64,7 @@ public class IgniteCacheTestSuite7 extends TestSuite {
     public static TestSuite suite(Set<Class> ignoredTests) throws Exception {
         TestSuite suite = new TestSuite("IgniteCache With Persistence Test Suite");
 
-        suite.addTestSuite(CheckpointBufferDeadlockTest.class);
+        /*suite.addTestSuite(CheckpointBufferDeadlockTest.class);
 
         suite.addTestSuite(AuthenticationConfigurationClusterTest.class);
         suite.addTestSuite(AuthenticationProcessorSelfTest.class);
@@ -86,9 +86,10 @@ public class IgniteCacheTestSuite7 extends TestSuite {
         suite.addTestSuite(IgnitePdsCacheAssignmentNodeRestartsTest.class);
         suite.addTestSuite(TxRollbackAsyncWithPersistenceTest.class);
 
-        suite.addTestSuite(CacheGroupMetricsMBeanTest.class);
+        suite.addTestSuite(CacheGroupMetricsMBeanTest.class);*/
+        for (int i = 0; i < 100; i++)
         suite.addTestSuite(CacheMetricsManageTest.class);
-        suite.addTestSuite(PageEvictionMultinodeMixedRegionsTest.class);
+        /*suite.addTestSuite(PageEvictionMultinodeMixedRegionsTest.class);
 
         suite.addTestSuite(IgniteDynamicCacheStartFailWithPersistenceTest.class);
 
@@ -97,7 +98,7 @@ public class IgniteCacheTestSuite7 extends TestSuite {
         suite.addTestSuite(CacheRentingStateRepairTest.class);
 
         suite.addTestSuite(TransactionIntegrityWithPrimaryIndexCorruptionTest.class);
-        suite.addTestSuite(CacheDataLossOnPartitionMoveTest.class);
+        suite.addTestSuite(CacheDataLossOnPartitionMoveTest.class);*/
 
         return suite;
     }

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite7.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite7.java
@@ -64,7 +64,7 @@ public class IgniteCacheTestSuite7 extends TestSuite {
     public static TestSuite suite(Set<Class> ignoredTests) throws Exception {
         TestSuite suite = new TestSuite("IgniteCache With Persistence Test Suite");
 
-        /*suite.addTestSuite(CheckpointBufferDeadlockTest.class);
+        suite.addTestSuite(CheckpointBufferDeadlockTest.class);
 
         suite.addTestSuite(AuthenticationConfigurationClusterTest.class);
         suite.addTestSuite(AuthenticationProcessorSelfTest.class);
@@ -86,10 +86,9 @@ public class IgniteCacheTestSuite7 extends TestSuite {
         suite.addTestSuite(IgnitePdsCacheAssignmentNodeRestartsTest.class);
         suite.addTestSuite(TxRollbackAsyncWithPersistenceTest.class);
 
-        suite.addTestSuite(CacheGroupMetricsMBeanTest.class);*/
-        for (int i = 0; i < 100; i++)
+        suite.addTestSuite(CacheGroupMetricsMBeanTest.class);
         suite.addTestSuite(CacheMetricsManageTest.class);
-        /*suite.addTestSuite(PageEvictionMultinodeMixedRegionsTest.class);
+        suite.addTestSuite(PageEvictionMultinodeMixedRegionsTest.class);
 
         suite.addTestSuite(IgniteDynamicCacheStartFailWithPersistenceTest.class);
 
@@ -98,7 +97,7 @@ public class IgniteCacheTestSuite7 extends TestSuite {
         suite.addTestSuite(CacheRentingStateRepairTest.class);
 
         suite.addTestSuite(TransactionIntegrityWithPrimaryIndexCorruptionTest.class);
-        suite.addTestSuite(CacheDataLossOnPartitionMoveTest.class);*/
+        suite.addTestSuite(CacheDataLossOnPartitionMoveTest.class);
 
         return suite;
     }


### PR DESCRIPTION
Fix flaky CacheMetricsManageTest tests

Why it fails?
1. Metrics start increments.
2. Invoke method for clearing metrics.
3. The single update message may process after clear metrics because of no sync. 
4. Check for clear metrics fails.

I fixed it adding full sync mode.