### PR TITLE
IGNITE-9809 Web console: more minor fixes

### DIFF
--- a/modules/web-console/e2e/testcafe/components/confirmation.js
+++ b/modules/web-console/e2e/testcafe/components/confirmation.js
@@ -17,10 +17,10 @@
 
 import {Selector, t} from 'testcafe';
 
-const body = Selector('.modal-body');
+const body = Selector('.modal').withText('Confirmation').find('.modal-body');
 const confirmButton = Selector('#confirm-btn-ok');
 const cancelButton = Selector('#confirm-btn-cancel');
-const closeButton = Selector('.modal .close');
+const closeButton = Selector('.modal').withText('Confirmation').find('.modal .close');
 
 export const confirmation = {
     body,

--- a/modules/web-console/e2e/testcafe/package.json
+++ b/modules/web-console/e2e/testcafe/package.json
@@ -33,7 +33,7 @@
     "objectid": "3.2.1",
     "path": "0.12.7",
     "sinon": "2.3.8",
-    "testcafe": "0.20.5",
+    "testcafe": "0.22.0",
     "testcafe-angular-selectors": "0.3.0",
     "testcafe-reporter-teamcity": "1.0.9",
     "type-detect": "4.0.3",

--- a/modules/web-console/frontend/app/components/page-configure/reduxDevtoolsIntegration.js
+++ b/modules/web-console/frontend/app/components/page-configure/reduxDevtoolsIntegration.js
@@ -36,6 +36,11 @@ const replacer = (key, value) => {
             __serializedType__: 'Symbol'
         };
     }
+    if (value instanceof Promise) {
+        return {
+            data: {}
+        };
+    }
     return value;
 };
 

--- a/modules/web-console/frontend/app/primitives/form-field/index.scss
+++ b/modules/web-console/frontend/app/primitives/form-field/index.scss
@@ -259,7 +259,7 @@
         &--postfix::after {
             content: attr(data-postfix);
             display: inline-flex;
-            place-self: center;
+            align-self: center;
             margin-left: 10px;
         }
 


### PR DESCRIPTION
1. Update confirmation E2E selectors so these work when multiple modals are opened.
2. Update TestCafe to 0.22.0.
3. Update reduxDevtoolsIntegration.js so it doesn't crash when there's a Promise in action payload.
4. Fix form-field postfix position in browsers that don't support [place-self](https://developer.mozilla.org/en-US/docs/Web/CSS/place-self) (Edge and Safari).