### PR TITLE
adding hibernate-5.3 module

### DIFF
--- a/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheConfigurationSelfTest.java
+++ b/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheConfigurationSelfTest.java
@@ -47,7 +47,6 @@ import org.junit.runners.JUnit4;
 import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_ACCESS_TYPE_PROPERTY;
-import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_CACHE_NAME_PROPERTY;
 import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.IGNITE_INSTANCE_NAME_PROPERTY;
 import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.REGION_CACHE_PROPERTY;
 import static org.hibernate.cfg.AvailableSettings.CACHE_REGION_FACTORY;
@@ -82,9 +81,6 @@ public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTes
 
     /** */
     public static final String CONNECTION_URL = "jdbc:h2:mem:example;DB_CLOSE_DELAY=-1";
-
-    /** If {@code true} then sets default cache in configuration. */
-    private boolean dfltCache;
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -163,9 +159,6 @@ public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTes
         cfg.setProperty(REGION_CACHE_PROPERTY + TIMESTAMP_CACHE, TIMESTAMP_CACHE);
         cfg.setProperty(REGION_CACHE_PROPERTY + QUERY_CACHE, QUERY_CACHE);
 
-        if (dfltCache)
-            cfg.setProperty(DFLT_CACHE_NAME_PROPERTY, "cache3");
-
         return cfg;
     }
 
@@ -175,16 +168,6 @@ public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTes
     @Test
     public void testPerRegionCacheProperty() {
         testCacheUsage(1, 1, 0, 1, 1);
-    }
-
-    /**
-     * Tests property {@link HibernateAccessStrategyFactory#DFLT_CACHE_NAME_PROPERTY}.
-     */
-    @Test
-    public void testDefaultCache() {
-        dfltCache = true;
-
-        testCacheUsage(1, 1, 2, 0, 0);
     }
 
     /**

--- a/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheMultiJvmTest.java
+++ b/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheMultiJvmTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.ignite.cache.hibernate;
 
-import java.util.Map;
-import javax.persistence.Cacheable;
-import javax.persistence.Id;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCompute;
 import org.apache.ignite.IgniteLogger;
@@ -40,8 +37,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import javax.persistence.Cacheable;
+import javax.persistence.Id;
+import java.util.Map;
+
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
-import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_CACHE_NAME_PROPERTY;
 import static org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest.CONNECTION_URL;
 import static org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest.hibernateProperties;
 import static org.hibernate.cache.spi.access.AccessType.NONSTRICT_READ_WRITE;
@@ -246,7 +246,8 @@ public class HibernateL2CacheMultiJvmTest extends GridCommonAbstractTest {
             for (Map.Entry<String, String> e : hibernateProperties(nodeName, NONSTRICT_READ_WRITE.name()).entrySet())
                 cfg.setProperty(e.getKey(), e.getValue());
 
-            cfg.setProperty(DFLT_CACHE_NAME_PROPERTY, CACHE_NAME);
+// XXX
+//            cfg.setProperty(DFLT_CACHE_NAME_PROPERTY, CACHE_NAME);
 
             return cfg;
         }

--- a/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheConfigurationSelfTest.java
+++ b/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheConfigurationSelfTest.java
@@ -40,13 +40,9 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
-import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_CACHE_NAME_PROPERTY;
 import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.REGION_CACHE_PROPERTY;
 import static org.hibernate.cfg.AvailableSettings.CACHE_REGION_FACTORY;
 import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
@@ -58,7 +54,6 @@ import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
 /**
  * Tests Hibernate L2 cache configuration.
  */
-@RunWith(JUnit4.class)
 public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTest {
     /** */
     public static final String ENTITY1_NAME = Entity1.class.getName();
@@ -80,9 +75,6 @@ public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTes
 
     /** */
     public static final String CONNECTION_URL = "jdbc:h2:mem:example;DB_CLOSE_DELAY=-1";
-
-    /** If {@code true} then sets default cache in configuration. */
-    private boolean dfltCache;
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -160,28 +152,14 @@ public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTes
         cfg.setProperty(REGION_CACHE_PROPERTY + TIMESTAMP_CACHE, TIMESTAMP_CACHE);
         cfg.setProperty(REGION_CACHE_PROPERTY + QUERY_CACHE, QUERY_CACHE);
 
-        if (dfltCache)
-            cfg.setProperty(DFLT_CACHE_NAME_PROPERTY, "cache3");
-
         return cfg;
     }
 
     /**
      * Tests property {@link HibernateAccessStrategyFactory#REGION_CACHE_PROPERTY}.
      */
-    @Test
     public void testPerRegionCacheProperty() {
         testCacheUsage(1, 1, 0, 1, 1);
-    }
-
-    /**
-     * Tests property {@link HibernateAccessStrategyFactory#DFLT_CACHE_NAME_PROPERTY}.
-     */
-    @Test
-    public void testDefaultCache() {
-        dfltCache = true;
-
-        testCacheUsage(1, 1, 2, 0, 0);
     }
 
     /**

--- a/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheMultiJvmTest.java
+++ b/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheMultiJvmTest.java
@@ -36,12 +36,8 @@ import org.hibernate.Transaction;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
-import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_CACHE_NAME_PROPERTY;
 import static org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest.CONNECTION_URL;
 import static org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest.hibernateProperties;
 import static org.hibernate.cache.spi.access.AccessType.NONSTRICT_READ_WRITE;
@@ -49,7 +45,6 @@ import static org.hibernate.cache.spi.access.AccessType.NONSTRICT_READ_WRITE;
 /**
  *
  */
-@RunWith(JUnit4.class)
 public class HibernateL2CacheMultiJvmTest extends GridCommonAbstractTest {
     /** */
     private static final String CACHE_NAME = "hibernateCache";
@@ -93,7 +88,6 @@ public class HibernateL2CacheMultiJvmTest extends GridCommonAbstractTest {
     /**
      * @throws Exception If failed.
      */
-    @Test
     public void testL2Cache() throws Exception {
         Ignite srv = ignite(0);
 
@@ -229,7 +223,6 @@ public class HibernateL2CacheMultiJvmTest extends GridCommonAbstractTest {
                 builder.applySetting(e.getKey(), e.getValue());
 
             builder.applySetting("hibernate.connection.url", CONNECTION_URL);
-            builder.applySetting(DFLT_CACHE_NAME_PROPERTY, CACHE_NAME);
 
             MetadataSources metadataSources = new MetadataSources(builder.build());
 

--- a/modules/hibernate-5.3/modules/core/src/test/config/benchmark/spring-cache-client-benchmark-1.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/benchmark/spring-cache-client-benchmark-1.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("path-to-this-file/example-benchmark.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with benchmark.
+    </description>
+
+    <!--
+        Configuration below demonstrates how to setup caches within grid nodes.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <!-- Set to local host address just for examples. -->
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ConnectorConfiguration">
+                <property name="port" value="11211"/>
+            </bean>
+        </property>
+
+        <!--<property name="peerClassLoadingEnabled" value="false"/>-->
+
+        <property name="cacheConfiguration">
+            <!--
+                Specify list of cache configurations here. Any property from
+                CacheConfiguration interface can be configured here.
+                Note that absolutely all configuration properties are optional.
+            -->
+            <list>
+                <!--
+                    Partitioned cache example configuration.
+                -->
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="swapEnabled" value="false"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+
+                    <property name="nearConfiguration">
+                        <bean class="org.apache.ignite.configuration.NearCacheConfiguration" />
+                    </property>
+
+                    <!--
+                        This shows how to configure number of backups. The below configuration
+                        sets the number of backups to 1 (which is default).
+                    -->
+                    <property name="backups" value="1"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="includeEventTypes">
+            <list>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FINISHED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_MAPPED"/>
+            </list>
+        </property>
+        <property name="includeProperties"><list/></property>
+
+        <!--
+            Uncomment this to provide TCP discovery SPI (predefined addresses).
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/benchmark/spring-cache-client-benchmark-2.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/benchmark/spring-cache-client-benchmark-2.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("path-to-this-file/example-benchmark.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with benchmark.
+    </description>
+
+    <!--
+        Configuration below demonstrates how to setup caches within grid nodes.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <!-- Set to local host address just for examples. -->
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ConnectorConfiguration">
+                <property name="port" value="11212"/>
+            </bean>
+        </property>
+
+        <!--<property name="peerClassLoadingEnabled" value="false"/>-->
+
+        <property name="cacheConfiguration">
+            <!--
+                Specify list of cache configurations here. Any property from
+                CacheConfiguration interface can be configured here.
+                Note that absolutely all configuration properties are optional.
+            -->
+            <list>
+                <!--
+                    Partitioned cache example configuration.
+                -->
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="swapEnabled" value="false"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+
+                    <property name="nearConfiguration">
+                        <bean class="org.apache.ignite.configuration.NearCacheConfiguration" />
+                    </property>
+
+                    <!--
+                        This shows how to configure number of backups. The below configuration
+                        sets the number of backups to 1 (which is default).
+                    -->
+                    <property name="backups" value="1"/>
+                </bean>
+
+            </list>
+        </property>
+
+        <!--
+            Uncomment this to provide TCP discovery SPI (predefined addresses).
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/benchmark/spring-cache-client-benchmark-3.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/benchmark/spring-cache-client-benchmark-3.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("path-to-this-file/example-benchmark.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with benchmark.
+    </description>
+
+    <!--
+        Configuration below demonstrates how to setup caches within grid nodes.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <!-- Set to local host address just for examples. -->
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ConnectorConfiguration">
+                <property name="port" value="11213"/>
+            </bean>
+        </property>
+
+        <!--<property name="peerClassLoadingEnabled" value="false"/>-->
+
+        <property name="cacheConfiguration">
+            <!--
+                Specify list of cache configurations here. Any property from
+                CacheConfiguration interface can be configured here.
+                Note that absolutely all configuration properties are optional.
+            -->
+            <list>
+                <!--
+                    Partitioned cache example configuration.
+                -->
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="swapEnabled" value="false"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+
+                    <property name="nearConfiguration">
+                        <bean class="org.apache.ignite.configuration.NearCacheConfiguration" />
+                    </property>
+
+                    <!--
+                        This shows how to configure number of backups. The below configuration
+                        sets the number of backups to 1 (which is default).
+                    -->
+                    <property name="backups" value="1"/>
+                </bean>
+
+            </list>
+        </property>
+
+        <!--
+            Uncomment this to provide TCP discovery SPI (predefined addresses).
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/cache-load.properties
+++ b/modules/hibernate-5.3/modules/core/src/test/config/cache-load.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+transactions=true
+operations.per.tx=2
+isolation=READ_COMMITTED
+concurrency=OPTIMISTIC
+threads=2
+write.ratio=0.5
+duration=60000
+value.size=1024

--- a/modules/hibernate-5.3/modules/core/src/test/config/class_list_exploit_excluded.txt
+++ b/modules/hibernate-5.3/modules/core/src/test/config/class_list_exploit_excluded.txt
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Intentionally empty.

--- a/modules/hibernate-5.3/modules/core/src/test/config/class_list_exploit_included.txt
+++ b/modules/hibernate-5.3/modules/core/src/test/config/class_list_exploit_included.txt
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.ignite.spi.discovery.tcp.DiscoveryUnmarshalVulnerabilityTest$Exploit
+org.apache.ignite.stream.socket.SocketStreamerUnmarshalVulnerabilityTest$Exploit
+org.apache.ignite.internal.processors.rest.TcpRestUnmarshalVulnerabilityTest$Exploit

--- a/modules/hibernate-5.3/modules/core/src/test/config/default-spring-url-testing.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/default-spring-url-testing.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Grid configuration for checking ability to start grid with a config provided by url.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <description>Main Spring file for grid configuration.</description>
+
+    <!--
+        Grid default configuration.
+
+        All configuration properties are commented. Uncomment any property to
+        provide a non-default value for it.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <!--
+            Specify grid instance name.
+        -->
+        <property name="igniteInstanceName" value="grid_with_url_config"/>
+
+        <property name="connectorConfiguration"><null/></property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/discovery-stress.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/discovery-stress.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <property name="cacheConfiguration">
+            <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                <property name="name" value="default"/>
+                <property name="cacheMode" value="PARTITIONED"/>
+                <property name="rebalanceMode" value="SYNC"/>
+                <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+
+                <property name="evictionPolicy">
+                    <bean class="org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicy">
+                        <property name="maxSize" value="20000000"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="networkTimeout" value="10000"/>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="networkTimeout" value="10000"/>
+                <property name="ackTimeout" value="10000"/>
+                <property name="reconnectCount" value="3"/>
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>fosters-210:47500</value>
+                                <value>fosters-211:47500</value>
+                                <value>fosters-212:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/example-cache.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/example-cache.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file to Ignite:
+    Ignition.start("examples/config/example-cache.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="connectorConfiguration"><null/></property>
+
+        <!-- Set to local host address just for examples. -->
+        <property name="localHost" value="127.0.0.1"/>
+
+        <!-- Set to true to enable grid-aware class loading for examples, default is false. -->
+        <property name="peerClassLoadingEnabled" value="true"/>
+
+        <property name="marshaller">
+            <bean class="org.apache.ignite.internal.binary.BinaryMarshaller" />
+        </property>
+
+        <!-- Enable cache events for examples. -->
+        <property name="includeEventTypes">
+            <util:constant static-field="org.apache.ignite.events.EventType.EVTS_CACHE"/>
+        </property>
+
+        <!-- Cache configurations (all properties are optional). -->
+        <property name="cacheConfiguration">
+            <list>
+                <!-- Partitioned cache example configuration (Atomic mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="partitioned"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <!-- Partitioned cache example configuration (Transactional mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="partitioned_tx"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="backups" value="1"/>
+                    <property name="nearConfiguration">
+                        <bean class="org.apache.ignite.configuration.NearCacheConfiguration">
+                        </bean>
+                    </property>
+                </bean>
+
+                <!-- Replicated cache example configuration (Atomic mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="replicated"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                </bean>
+
+                <!-- Replicated cache example configuration (Transactional mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="replicated_tx"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                </bean>
+
+                  <!-- Local cache example configuration (Atomic mode). -->
+                  <bean parent="cache-template">
+                      <property name="name" value="local"/>
+                      <property name="cacheMode" value="LOCAL"/>
+                      <property name="atomicityMode" value="ATOMIC"/>
+                  </bean>
+
+                <!-- Local cache example configuration (Transactional mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="local_tx"/>
+                    <property name="cacheMode" value="LOCAL"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="dataStorageConfiguration">
+            <bean class="org.apache.ignite.configuration.DataStorageConfiguration">
+                <property name="defaultDataRegionConfiguration">
+                    <bean class="org.apache.ignite.configuration.DataRegionConfiguration">
+                        <property name="maxSize" value="#{200L*1024*1024}"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <!-- Uncomment multicast IP finder to enable multicast-based discovery of initial nodes. -->
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <!-- Template for all example cache configurations. -->
+    <bean id="cache-template" abstract="true" class="org.apache.ignite.configuration.CacheConfiguration">
+        <!-- Set synchronous rebalancing (default is asynchronous). -->
+        <property name="rebalanceMode" value="SYNC"/>
+
+        <!-- Set to FULL_SYNC for examples, default is PRIMARY_SYNC. -->
+        <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+    </bean>
+</beans>
+

--- a/modules/hibernate-5.3/modules/core/src/test/config/examples.properties
+++ b/modules/hibernate-5.3/modules/core/src/test/config/examples.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ScalarCacheAffinityExample1=examples/config/example-ignite.xml
+ScalarCacheAffinityExample2=examples/config/example-ignite.xml
+ScalarCacheAffinitySimpleExample=examples/config/example-ignite.xml
+ScalarCacheExample=examples/config/example-ignite.xml
+ScalarCacheQueryExample=examples/config/example-ignite.xml
+ScalarCountGraphTrianglesExample=examples/config/example-ignite.xml
+ScalarPopularNumbersRealTimeExample=examples/config/example-ignite.xml
+DataRegionExample=examples/config/example-data-regions.xml

--- a/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site-loopback-secondary.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site-loopback-secondary.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  - Secondary file system configuration for loopback tests.
+-->
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+        <value>igfs://127.0.0.1:11500/</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v1.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.AbstractFileSystem.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v2.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.127.0.0.1:11500.endpoint.no_embed</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.127.0.0.1:11500.endpoint.no_local_shmem</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.block.size</name>
+        <value>1024</value>
+    </property>
+</configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site-loopback.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site-loopback.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  - Primary file system configuration for loopback tests.
+-->
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+        <value>igfs:///</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v1.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.AbstractFileSystem.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v2.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.igfs..endpoint.no_local_shmem</name>
+        <value>true</value>
+    </property>
+</configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site-secondary.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site-secondary.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  - Secondary file system configuration for shmem tests.
+-->
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+        <value>igfs://127.0.0.1:11500/</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v1.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.AbstractFileSystem.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v2.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.127.0.0.1:11500.endpoint.no_embed</name>
+        <value>true</value>
+    </property>
+</configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/hadoop/core-site.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  - Primary file system configuration for shmem tests.
+-->
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+        <value>igfs:///</value>
+    </property>
+
+    <property>
+        <name>fs.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v1.IgniteHadoopFileSystem</value>
+    </property>
+
+    <property>
+        <name>fs.AbstractFileSystem.igfs.impl</name>
+        <value>org.apache.ignite.hadoop.fs.v2.IgniteHadoopFileSystem</value>
+    </property>
+</configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/igfs-loopback.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/igfs-loopback.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-igfs-loopback.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignite:
+    Ignition.start("path-to-this-file/example-igfs-loopback.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util
+       http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with client available endpoints.
+    </description>
+
+    <!--
+        Initialize property configurer so we can reference environment variables.
+    -->
+    <bean id="propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_FALLBACK"/>
+        <property name="searchSystemEnvironment" value="true"/>
+    </bean>
+
+    <!--
+        Configuration below demonstrates how to setup a IGFS node with file data.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="fileSystemConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.FileSystemConfiguration">
+                    <property name="name" value="igfs"/>
+
+                    <!-- Must correlate with cache affinity mapper. -->
+                    <property name="blockSize" value="#{128 * 1024}"/>
+                    <property name="perNodeBatchSize" value="512"/>
+                    <property name="perNodeParallelBatchCount" value="16"/>
+
+                    <!-- Disabled by default until GG-4112 will be fixed. -->
+                    <property name="prefetchBlocks" value="32"/>
+
+                    <!-- Loopback endpoint. -->
+                    <property name="ipcEndpointConfiguration">
+                        <bean class="org.apache.ignite.igfs.IgfsIpcEndpointConfiguration">
+                            <property name="type" value="TCP" />
+                        </bean>
+                    </property>
+
+                </bean>
+            </list>
+        </property>
+
+        <!--
+            Disable events.
+        -->
+        <property name="includeEventTypes">
+            <list>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FINISHED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_MAPPED"/>
+            </list>
+        </property>
+
+        <!--
+            TCP discovery SPI (uses VM-shared IP-finder).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <!-- Override default IP-finder.-->
+                <property name="ipFinder">
+                    <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/igfs-shmem.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/igfs-shmem.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-igfs-shmem.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("path-to-this-file/example-igfs-shmem.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/util
+       http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with client available endpoints.
+    </description>
+
+    <!--
+        Initialize property configurer so we can reference environment variables.
+    -->
+    <bean id="propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_FALLBACK"/>
+        <property name="searchSystemEnvironment" value="true"/>
+    </bean>
+
+    <!--
+        Configuration below demonstrates how to setup a IGFS node with file data.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="fileSystemConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.FileSystemConfiguration">
+                    <property name="name" value="igfs"/>
+
+                    <!-- Must correlate with cache affinity mapper. -->
+                    <property name="blockSize" value="#{128 * 1024}"/>
+                    <property name="perNodeBatchSize" value="512"/>
+                    <property name="perNodeParallelBatchCount" value="16"/>
+
+                    <!-- Disabled by default until GG-4112 will be fixed. -->
+                    <property name="prefetchBlocks" value="32"/>
+
+                    <!-- Shared memory endpoint. -->
+                    <property name="ipcEndpointConfiguration">
+                        <bean class="org.apache.ignite.igfs.IgfsIpcEndpointConfiguration">
+                            <property name="type" value="SHMEM" />
+                            <property name="port" value="10500" />
+                        </bean>
+                    </property>
+                </bean>
+            </list>
+        </property>
+
+        <!--
+            Disable events.
+        -->
+        <property name="includeEventTypes">
+            <list>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FINISHED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_MAPPED"/>
+            </list>
+        </property>
+
+        <!--
+            TCP discovery SPI (uses VM-shared IP-finder).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <!-- Override default IP-finder.-->
+                <property name="ipFinder">
+                    <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/io-manager-benchmark.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/io-manager-benchmark.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="communicationSpi">
+            <bean class="org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi">
+                <property name="sharedMemoryPort" value="-1"/>
+            </bean>
+        </property>
+
+        <!-- Various optimisations. -->
+        <property name="peerClassLoadingEnabled" value="false"/>
+        <property name="connectorConfiguration"><null/></property>
+        <property name="cacheSanityCheckEnabled" value="false"/>
+
+        <property name="includeEventTypes">
+            <list/>
+        </property>
+
+        <!-- Configure load balancing SPI in the way that do not require extra event subscription. -->
+        <property name="loadBalancingSpi">
+            <bean class="org.apache.ignite.spi.loadbalancing.roundrobin.RoundRobinLoadBalancingSpi">
+                <property name="perTask" value="false"/>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/job-loadtest/client.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/job-loadtest/client.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+        Base Spring file for grid configuration.
+    </description>
+
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="userAttributes">
+            <util:map>
+                <entry key="segment" value="client"/>
+            </util:map>
+        </property>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="deploymentMode" value="CONTINUOUS"/>
+
+        <property name="failoverSpi">
+            <bean class="org.apache.ignite.spi.failover.jobstealing.JobStealingFailoverSpi">
+                <property name="maximumFailoverAttempts" value="10"/>
+            </bean>
+        </property>
+
+        <property name="collisionSpi">
+            <bean class="org.apache.ignite.spi.collision.jobstealing.JobStealingCollisionSpi">
+                <property name="activeJobsThreshold" value="10" />
+                <property name="waitJobsThreshold" value="100" />
+                <property name="maximumStealingAttempts" value="5"/>
+            </bean>
+        </property>
+
+        <property name="communicationSpi">
+            <bean class="org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi">
+                <property name="messageThreads" value="30"/>
+                <property name="maxOpenClients" value="60"/>
+            </bean>
+        </property>
+
+        <!-- Disable pools -->
+        <property name="publicThreadPoolSize" value="20"/>
+
+        <property name="systemThreadPoolSize" value="20"/>
+
+        <property name="peerClassLoadingThreadPoolSize" value="2"/>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/job-loadtest/job-loadtest.properties
+++ b/modules/hibernate-5.3/modules/core/src/test/config/job-loadtest/job-loadtest.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+client.nodes.count=2
+server.nodes.count=2
+
+threads.per.client=5
+cancel.rate=10
+submit.delay=10000
+
+jobs.count=40
+jobs.test.duration=5000
+jobs.test.completion.delay=5000
+jobs.failure.probability=0.01

--- a/modules/hibernate-5.3/modules/core/src/test/config/job-loadtest/server.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/job-loadtest/server.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+        Base Spring file for grid configuration.
+    </description>
+
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="userAttributes">
+            <util:map>
+                <entry key="segment" value="server"/>
+            </util:map>
+        </property>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="deploymentMode" value="CONTINUOUS"/>
+
+        <property name="publicThreadPoolSize" value="300"/>
+
+        <property name="failoverSpi">
+            <bean class="org.apache.ignite.spi.failover.jobstealing.JobStealingFailoverSpi">
+                <property name="maximumFailoverAttempts" value="10"/>
+            </bean>
+        </property>
+
+        <property name="collisionSpi">
+            <bean class="org.apache.ignite.spi.collision.jobstealing.JobStealingCollisionSpi">
+                <property name="activeJobsThreshold" value="300" />
+                <property name="waitJobsThreshold" value="300" />
+                <property name="maximumStealingAttempts" value="5"/>
+            </bean>
+        </property>
+
+        <property name="communicationSpi">
+            <bean class="org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi">
+                <property name="messageThreads" value="30"/>
+                <property name="maxOpenClients" value="60"/>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/jobs-load-base.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/jobs-load-base.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+        Base Spring file for grid configuration.
+    </description>
+
+    <bean abstract="true" id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <!--
+            Uncomment this to provide TCP discovery SPI (predefined addresses).
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="cacheConfiguration">
+            <list/>
+        </property>
+
+        <property name="includeEventTypes">
+            <list/>
+        </property>
+
+        <property name="deploymentMode" value="SHARED"/>
+
+        <property name="publicThreadPoolSize" value="#{T(java.lang.Runtime).getRuntime().availableProcessors() / 2}"/>
+
+        <property name="systemThreadPoolSize" value="#{T(java.lang.Runtime).getRuntime().availableProcessors() / 2}"/>
+
+        <property name="loadBalancingSpi">
+            <bean class="org.apache.ignite.spi.loadbalancing.roundrobin.RoundRobinLoadBalancingSpi">
+                <property name="perTask" value="false"/>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/jobs-load-client.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/jobs-load-client.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="jobs-load-base.xml"/>
+
+    <bean class="org.apache.ignite.configuration.IgniteConfiguration" parent="grid.cfg"/>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/jobs-load-server.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/jobs-load-server.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <import resource="jobs-load-base.xml"/>
+
+    <bean class="org.apache.ignite.configuration.IgniteConfiguration" parent="grid.cfg">
+        <property name="userAttributes">
+            <util:map>
+                <entry key="segment" value="server"/>
+            </util:map>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/cache-benchmark.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/cache-benchmark.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="swapEnabled" value="false"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+                </bean>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="local"/>
+
+                    <property name="cacheMode" value="LOCAL"/>
+
+                    <property name="swapEnabled" value="false"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="includeEventTypes">
+            <list>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FINISHED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_MAPPED"/>
+            </list>
+        </property>
+        <property name="includeProperties"><list/></property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/cache-client-benchmark.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/cache-client-benchmark.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="local"/>
+
+                    <property name="cacheMode" value="LOCAL"/>
+
+                    <property name="swapEnabled" value="false"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_ASYNC"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="includeEventTypes">
+            <list>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FAILED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_TASK_FINISHED"/>
+                <util:constant static-field="org.apache.ignite.events.EventType.EVT_JOB_MAPPED"/>
+            </list>
+        </property>
+        <property name="includeProperties"><list/></property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-49-server-production.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-49-server-production.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+    </description>
+
+    <import resource="dsi-load-base.xml"/>
+
+    <bean class="org.apache.ignite.configuration.IgniteConfiguration" parent="grid.cfg">
+        <property name="userAttributes">
+            <util:map>
+                <entry key="segment" value="server"/>
+            </util:map>
+        </property>
+
+
+        <property name="cacheConfiguration">
+            <util:list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="PARTITIONED_CACHE"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="rebalanceMode" value="SYNC"/>
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+                    <property name="evictionPolicy">
+                        <bean
+                                class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="500000"/>
+                        </bean>
+                    </property>
+                    <!-- 1 backup -->
+                    <property name="backups" value="1"/>
+                    <property name="affinity">
+                        <bean class="org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction">
+                            <property name="excludeNeighbors" value="true"/>
+                        </bean>
+                    </property>
+                    <property name="indexFixedTyping" value="true"/>
+                    <property name="atomicSequenceReserveSize" value="100000"/>
+                    <property name="evictSynchronized" value="false"/>
+                    <property name="swapEnabled" value="false"/>
+                    <property name="defaultTxConcurrency" value="PESSIMISTIC"/>
+                    <property name="defaultTxIsolation" value="REPEATABLE_READ"/>
+                    <property name="dgcSuspectLockTimeout" value="60000"/>
+                    <property name="indexAnalyzeSampleSize" value="100"/>
+                </bean>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="REPLICATED_CACHE"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="rebalanceMode" value="NONE"/>
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+                    <property name="swapEnabled" value="false"/>
+                    <property name="indexFixedTyping" value="false"/>
+                </bean>
+            </util:list>
+        </property>
+    </bean>
+
+
+    <util:list id="lifecycleBeans">
+        <!-- <bean class="org.apache.ignite.lifecycle.LifecycleBean" /> -->
+    </util:list>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-load-base.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-load-base.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+        Base Spring file for grid configuration.
+    </description>
+
+    <bean abstract="true" id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="dsi"/>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean
+                            class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+
+                <property name="ackTimeout" value="4000"/>
+                <property name="socketTimeout" value="4000"/>
+            </bean>
+        </property>
+
+        <property name="metricsUpdateFrequency" value="6000"/>
+
+        <property name="lifecycleBeans" ref="lifecycleBeans"/>
+
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="deploymentMode" value="CONTINUOUS"/>
+
+        <property name="publicThreadPoolSize" value="#{T(java.lang.Runtime).getRuntime().availableProcessors() * 4}"/>
+
+        <property name="systemThreadPoolSize" value="#{T(java.lang.Runtime).getRuntime().availableProcessors() * 8}"/>
+
+        <property name="failoverSpi">
+            <bean class="org.apache.ignite.spi.failover.always.AlwaysFailoverSpi">
+                <property name="maximumFailoverAttempts" value="1"/>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-load-client.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-load-client.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+    </description>
+
+    <import resource="dsi-load-base.xml"/>
+
+    <bean class="org.apache.ignite.configuration.IgniteConfiguration" parent="grid.cfg">
+        <property name="userAttributes">
+            <util:map>
+                <entry key="segment" value="client"/>
+            </util:map>
+        </property>
+
+        <property name="cacheConfiguration">
+            <util:list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="REPLICATED_CACHE"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="rebalanceMode" value="NONE"/>
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+                    <property name="swapEnabled" value="false"/>
+                </bean>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="CLIENT_PARTITIONED_CACHE"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="rebalanceMode" value="SYNC"/>
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+                    <property name="swapEnabled" value="false"/>
+                    <property name="atomicSequenceReserveSize" value="100000"/>
+                </bean>
+            </util:list>
+        </property>
+    </bean>
+
+    <util:list id="lifecycleBeans">
+    </util:list>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-load-server.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/dsi-load-server.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>
+    </description>
+
+    <import resource="dsi-load-base.xml"/>
+
+    <bean class="org.apache.ignite.configuration.IgniteConfiguration" parent="grid.cfg">
+        <property name="userAttributes">
+            <util:map>
+                <entry key="segment" value="server"/>
+            </util:map>
+        </property>
+
+        <property name="cacheConfiguration">
+            <util:list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="REPLICATED_CACHE"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="rebalanceMode" value="NONE"/>
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+                    <property name="swapEnabled" value="false"/>
+                </bean>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="PARTITIONED_CACHE"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="rebalanceMode" value="SYNC"/>
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <!--Eviction settings-->
+                    <property name="evictSynchronizedConcurrencyLevel" value="4"/>
+                    <property name="evictSynchronized" value="false"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicy">
+                            <property name="maxSize" value="5000"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                    <property name="atomicSequenceReserveSize" value="100000"/>
+                    <property name="swapEnabled" value="false"/>
+                    <property name="defaultTxConcurrency" value="PESSIMISTIC"/>
+                    <property name="defaultTxIsolation" value="REPEATABLE_READ"/>
+                    <property name="dgcSuspectLockTimeout" value="60000"/>
+                    <property name="nearConfiguration">
+                        <bean class="org.apache.ignite.configuration.NearCacheConfiguration" />
+                    </property>
+                </bean>
+            </util:list>
+        </property>
+    </bean>
+
+    <util:list id="lifecycleBeans">
+        <bean class="org.apache.ignite.loadtests.dsi.GridDsiLifecycleBean"/>
+    </util:list>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/load/merge-sort-base.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/load/merge-sort-base.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <description>Main Spring file for Worker grid configuration.</description>
+
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="networkTimeout" value="20000"/>
+
+        <!--
+            Events and Performance
+            Note that by default all events in Ignite are enabled and therefore generated and stored by
+            whatever event storage SPI is configured. Ignite can and often does generate thousands events per
+            seconds under the load and therefore it creates a significant additional load on the system. If
+            these events are not needed by the application this load is unnecessary and leads to significant
+            performance degradation.
+
+            It is highly recommended to enable only those events that your application logic requires by using
+            either IgniteConfiguration.getExcludeEventTypes() or IgniteConfiguration.getIncludeEventTypes() methods
+            in Ignite configuration. Note that certain events are required for Ignite's internal operations
+            and such events will still be generated but not stored by event storage SPI if they are disabled in
+            Ignite configuration.
+        -->
+        <property name="includeEventTypes">
+            <list/>
+        </property>
+
+        <!-- Disable cache. -->
+        <property name="cacheConfiguration">
+            <list/>
+        </property>
+
+        <!-- Disable properties. -->
+        <property name="includeProperties">
+            <list/>
+        </property>
+
+        <!-- Disable pools -->
+        <property name="publicThreadPoolSize" value="100"/>
+
+        <property name="systemThreadPoolSize" value="100"/>
+
+        <property name="peerClassLoadingThreadPoolSize" value="100"/>
+
+        <property name="metricsUpdateFrequency" value="10000"/>
+
+        <property name="failureDetectionTimeout" value="60000"/>
+
+        <!-- Discovery SPI configuration. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="networkTimeout" value="20000"/>
+                <property name="socketTimeout" value="5000"/>
+                <property name="ackTimeout" value="5000"/>
+
+                <property name="statisticsPrintFrequency" value="60000"/>
+
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="loadBalancingSpi">
+            <bean class="org.apache.ignite.spi.loadbalancing.roundrobin.RoundRobinLoadBalancingSpi">
+                <property name="perTask" value="false"/>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/loaders/grid-cfg-2-grids.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/loaders/grid-cfg-2-grids.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<!--
+    Command line grid configuration.
+-->
+<beans>
+    <description>Main Spring file for grid configuration.</description>
+
+    <!--
+        Grid configuration.
+    -->
+    <bean id="grid.cfg.1" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="grid-factory-test-1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="multicastGroup" value="228.111.111.111"/>
+                        <property name="multicastPort" value="54535"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <bean id="grid.cfg.2" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="grid-factory-test-2"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="multicastGroup" value="228.111.111.111"/>
+                        <property name="multicastPort" value="54535"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/loaders/grid-cfg.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/loaders/grid-cfg.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+
+<!--
+    Command line grid configuration.
+-->
+<beans>
+    <description>Main Spring file for grid configuration.</description>
+
+    <!--
+        Grid configuration.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <!-- Grid with default name. -->
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="multicastGroup" value="228.111.111.222"/>
+                        <property name="multicastPort" value="54522"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="lifecycleBeans">
+            <list>
+                <bean class="org.apache.ignite.startup.cmdline.GridCommandLineLoaderTest.KillerLifecycleBean" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="grid.cfg.2" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="gridName2"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                        <property name="multicastGroup" value="228.111.111.222"/>
+                        <property name="multicastPort" value="54522"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="lifecycleBeans">
+            <list>
+                <bean class="org.apache.ignite.startup.cmdline.GridCommandLineLoaderTest.KillerLifecycleBean" />
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/log4j-test.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/log4j-test.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN"
+    "http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/xml/doc-files/log4j.dtd">
+<!--
+    Log4j configuration.
+-->
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <!--
+        Logs System.out messages to console.
+    -->
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <!-- Log to STDOUT. -->
+        <param name="Target" value="System.out"/>
+
+        <!-- Log from DEBUG and higher. -->
+        <param name="Threshold" value="TRACE"/>
+
+        <!-- The default pattern: Date Priority [Category] Message\n -->
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d{ISO8601}][%-5p][%t][%c@%L] %m%n"/>
+        </layout>
+
+        <!-- Do not log beyond INFO level. -->
+        <filter class="org.apache.log4j.varia.LevelRangeFilter">
+            <param name="levelMin" value="TRACE"/>
+            <param name="levelMax" value="INFO"/>
+        </filter>
+    </appender>
+
+    <!--
+        Logs all System.err messages to console.
+    -->
+    <appender name="CONSOLE_ERR" class="org.apache.log4j.ConsoleAppender">
+        <!-- Log to STDERR. -->
+        <param name="Target" value="System.err"/>
+
+        <!-- Log from WARN and higher. -->
+        <param name="Threshold" value="WARN"/>
+
+        <!-- The default pattern: Date Priority [Category] Message\n -->
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d{ISO8601}][%-5p][%t][%c{1}@%L] %m%n"/>
+        </layout>
+    </appender>
+
+    <!-- Disable all open source debugging. -->
+    <category name="org">
+        <level value="INFO"/>
+    </category>
+
+    <category name="org.apache.ignite.cache.hibernate">
+        <level value="DEBUG"/>
+    </category>
+
+    <!-- used following debugging on TRACE to diagnose statistics issue relating to the update-timestamps-cache -->
+    <category name="org.apache.ignite.cache.hibernate.HibernateRegionFactory">
+        <level value="INFO"/>
+    </category>
+
+    <category name="org.hibernate.cache.internal.TimestampsCacheEnabledImpl">
+        <level value="INFO"/>
+    </category>
+
+    <category name="org.hibernate.cache.internal.QueryResultsCacheImpl">
+        <level value="INFO"/>
+    </category>
+
+    <category name="org.hibernate.stat.internal.StatisticsImpl">
+        <level value="INFO"/>
+    </category>
+    <!-- END -->
+
+    <category name="org.eclipse.jetty">
+        <level value="INFO"/>
+    </category>
+
+    <!-- Default settings. -->
+    <root>
+        <!-- Print at info by default. -->
+        <level value="INFO"/>
+
+        <!-- Append to file and console. -->
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CONSOLE_ERR"/>
+    </root>
+</log4j:configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/log4j2-test.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/log4j2-test.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<Configuration>
+    <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
+            <ThresholdFilter level="ERROR" onMatch="DENY" onMismatch="ACCEPT"/>
+        </Console>
+
+        <Console name="CONSOLE_ERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
+        </Console>
+
+        <Routing name="FILE">
+            <Routes pattern="$${sys:nodeId}">
+                <Route>
+                    <RollingFile name="Rolling-${sys:nodeId}" fileName="${sys:IGNITE_HOME}/work/log/ignite-${sys:nodeId}.log"
+                                 filePattern="${sys:IGNITE_HOME}/work/log/ignite-${sys:nodeId}-%i-%d{yyyy-MM-dd}.log.gz">
+                        <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
+                        <Policies>
+                            <TimeBasedTriggeringPolicy interval="6" modulate="true" />
+                            <SizeBasedTriggeringPolicy size="10 MB" />
+                        </Policies>
+                    </RollingFile>
+                </Route>
+            </Routes>
+        </Routing>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org" level="INFO"/>
+        <Logger name="org.eclipse.jetty" level="INFO"/>
+
+        <Root level="INFO">
+            <AppenderRef ref="CONSOLE" level="DEBUG"/>
+            <AppenderRef ref="CONSOLE_ERR" level="WARN"/>
+            <AppenderRef ref="FILE" level="DEBUG"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/log4j2-test.xml~
+++ b/modules/hibernate-5.3/modules/core/src/test/config/log4j2-test.xml~
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN"
+    "http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/xml/doc-files/log4j.dtd">
+<Configuration status="debug" strict="true" name="XMLConfigTest"
+               packages="org.apache.ignite.logger.log4j2">
+  <Filter type="ThresholdFilter" level="TRACE"/>
+  <Appenders>
+    <Appender type="Console" name="CONSOLE_ERR">
+    </Appender>
+	<Routing name="Routing">	
+	   <Routes pattern="$${ctx:ROUTINGKEY}">
+	   <Route key="$${ctx:ROUTINGKEY}">
+		  <RollingFile name="Rolling-default" fileName="work/log/default.log"
+					filePattern="work/log/${date:yyyy-MM}/default-%d{yyyy-MM-dd}-%i.log.gz">
+			<PatternLayout>
+		  <pattern>[%d{ABSOLUTE}][%-5p][%t][%c{1}] %m%n</pattern>
+			</PatternLayout>
+			<Policies>
+			  <TimeBasedTriggeringPolicy interval="6" modulate="true" />
+			  <SizeBasedTriggeringPolicy size="10 MB" />
+			</Policies>
+		  </RollingFile>
+		</Route>
+	   <Route>
+		  <RollingFile name="Rolling-${ctx:ROUTINGKEY}" fileName="work/log/ignite-${ctx:ROUTINGKEY}.log"
+					filePattern="work/log/${date:yyyy-MM}/ignite-${ctx:ROUTINGKEY}-%d{yyyy-MM-dd}-%i.log.gz">
+		<PatternLayout>
+		  <pattern>[%d{ABSOLUTE}][%-5p] $${ctx:nodeidmsg}[%t][%c{1}]%msg%n</pattern>
+		</PatternLayout>
+		<Policies>
+		  <TimeBasedTriggeringPolicy interval="6" modulate="true" />
+		  <SizeBasedTriggeringPolicy size="10 MB" />
+		</Policies>
+		  </RollingFile>
+		</Route>
+		  </Routes>
+		</Routing>
+	</Appenders>
+  <Loggers>
+    <Logger name="org.springframework" level="warn"/>
+    <Logger name="rg.eclipse.jetty" level="warn"/>
+    <Logger name="org.eclipse.jetty.util.log" level="warn"/>
+    <Logger name="org.eclipse.jetty.util.component" level="warn"/>
+    <Logger name="com.amazonaws" level="warn"/>
+    <Root level="TRACE">
+    	<AppenderRef ref="Routing"/>
+   </Root>
+  </Loggers>
+</Configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/log4j2-verbose-test.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/log4j2-verbose-test.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<Configuration>
+    <Appenders>
+        <Console name="CONSOLE_ERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
+        </Console>
+
+        <Routing name="FILE">
+            <Routes pattern="$${sys:nodeId}">
+                <Route>
+                    <RollingFile name="Rolling-${sys:nodeId}" fileName="${sys:IGNITE_HOME}/work/log/ignite-${sys:nodeId}.log"
+                                 filePattern="${sys:IGNITE_HOME}/work/log/ignite-${sys:nodeId}-%i-%d{yyyy-MM-dd}.log.gz">
+                        <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
+                        <Policies>
+                            <TimeBasedTriggeringPolicy interval="6" modulate="true" />
+                            <SizeBasedTriggeringPolicy size="10 MB" />
+                        </Policies>
+                    </RollingFile>
+                </Route>
+            </Routes>
+        </Routing>
+    </Appenders>
+
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="CONSOLE_ERR" level="WARN"/>
+            <AppenderRef ref="FILE" level="DEBUG"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spark/spark-config.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spark/spark-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="clientMode" value="true"/>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500..47504</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-load.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-load.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("path-to-this-file/example-benchmark.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with benchmark.
+    </description>
+
+    <!--
+        Configuration below demonstrates how to setup a collision and failover SPI's
+        to enable work stealing from overloaded nodes to underloaded nodes.
+
+        Note that for job stealing to work, you must always use both,
+        GridJobStealingCollisionSpi and GridJobStealingFailoverSPI.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="cacheConfiguration">
+            <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                <property name="name" value="test-cache"/>
+                <property name="cacheMode" value="PARTITIONED"/>
+
+                <property name="rebalanceMode" value="SYNC"/>
+            </bean>
+        </property>
+
+        <property name="networkTimeout" value="10000"/>
+
+        <!--
+            Uncomment this to provide TCP discovery SPI (predefined addresses).
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-put-remove-load.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-put-remove-load.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="peerClassLoadingEnabled" value="false"/>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="cache"/>
+
+                    <property name="swapEnabled" value="false"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="includeEventTypes">
+            <list/>
+        </property>
+
+        <property name="loadBalancingSpi">
+            <bean class="org.apache.ignite.spi.loadbalancing.roundrobin.RoundRobinLoadBalancingSpi">
+                <property name="perTask" value="false"/>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-swap.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-swap.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="cacheConfiguration">
+            <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                <property name="name" value="test-cache"/>
+
+                <property name="cacheMode" value="LOCAL"/>
+
+                <property name="swapEnabled" value="true"/>
+
+                <property name="evictionPolicy">
+                    <bean class="org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicy">
+                        <property name="maxSize" value="10000"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="networkTimeout" value="10000"/>
+
+        <property name="swapSpaceSpi">
+            <bean class="org.apache.ignite.spi.swapspace.file.FileSwapSpaceSpi">
+                <property name="rootFolderPath" value="/Users/yzhdanov/tmp/swap-test"/>
+                <property name="taskQueueCapacity" value="100000"/>
+                <property name="poolSize" value="2"/>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-teststore.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-cache-teststore.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="cacheConfiguration">
+            <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                <property name="name" value="test-cache"/>
+
+                <property name="cacheMode" value="PARTITIONED"/>
+
+                <property name="swapEnabled" value="false"/>
+
+                <property name="evictionPolicy">
+                    <bean class="org.apache.ignite.cache.eviction.fifo.FifoEvictionPolicy">
+                        <property name="maxSize" value="10000"/>
+                    </bean>
+                </property>
+
+                <property name="store">
+                    <bean class="org.apache.ignite.cache.store.GridGeneratingTestStore"/>
+                </property>
+            </bean>
+        </property>
+
+        <property name="networkTimeout" value="10000"/>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-multicache.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-multicache.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} path-to-this-file/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("path-to-this-file/example-benchmark.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with benchmark.
+    </description>
+
+    <!--
+        Configuration below demonstrates how to setup a collision and failover SPI's
+        to enable work stealing from overloaded nodes to underloaded nodes.
+
+        Note that for job stealing to work, you must always use both,
+        GridJobStealingCollisionSpi and GridJobStealingFailoverSPI.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="deploymentMode" value="CONTINUOUS"/>
+
+        <!-- Set to local host address just for examples. -->
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="cacheConfiguration">
+            <!--
+                Specify list of cache configurations here. Any property from
+                CacheConfiguration interface can be configured here.
+                Note that absolutely all configuration properties are optional.
+            -->
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned1"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned2"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned3"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned4"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned5"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned6"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned7"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned8"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+
+                    <property name="onheapCacheEnabled" value="true"/>
+
+                    <property name="evictionPolicy">
+                        <bean class="org.apache.ignite.cache.eviction.lru.LruEvictionPolicy">
+                            <property name="maxSize" value="100"/>
+                        </bean>
+                    </property>
+
+                    <property name="backups" value="1"/>
+                </bean>
+            </list>
+        </property>
+
+
+        <!--
+            Uncomment this to provide TCP discovery SPI (predefined addresses).
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+        -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!--
+                                    List all IP/port configurations that potentially
+                                    can be started first in examples. We are assuming
+                                    grid of size 10 or less.
+                                -->
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                                <value>127.0.0.1:47505</value>
+                                <value>127.0.0.1:47506</value>
+                                <value>127.0.0.1:47507</value>
+                                <value>127.0.0.1:47508</value>
+                                <value>127.0.0.1:47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <!--
+            Uncomment to provide custom configuration for executor service.
+            By default thread pool size is 100.
+            All threads are pre-started and are available for use.
+        -->
+        <property name="publicThreadPoolSize" value="10"/>
+
+        <!--
+            Uncomment to provide custom configuration for System executor service.
+            By default the thread pool size is 5 which should be good enough.
+            Threads are not started unless used.
+        -->
+        <property name="systemThreadPoolSize" value="10"/>
+
+        <!--
+            Uncomment to provide custom configuration for P2P executor service.
+            By default the thread pool size is 20 which should be good enough.
+            Threads are not started unless used.
+        -->
+        <property name="peerClassLoadingThreadPoolSize" value="2"/>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-start-nodes-attr.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-start-nodes-attr.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="userAttributes">
+            <map>
+                <entry key="grid.node.ssh.started" value="true"/>
+            </map>
+        </property>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="marshaller">
+            <bean class="org.apache.ignite.internal.binary.BinaryMarshaller" />
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="cacheConfiguration">
+            <list/>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/spring-start-nodes.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/spring-start-nodes.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="marshaller">
+            <bean class="org.apache.ignite.internal.binary.BinaryMarshaller" />
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <property name="cacheConfiguration">
+            <list/>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/start-nodes.ini
+++ b/modules/hibernate-5.3/modules/core/src/test/config/start-nodes.ini
@@ -1,0 +1,46 @@
+;Licensed to the Apache Software Foundation (ASF) under one or more
+;contributor license agreements.  See the NOTICE file distributed with
+;this work for additional information regarding copyright ownership.
+;The ASF licenses this file to You under the Apache License, Version 2.0
+;(the "License"); you may not use this file except in compliance with
+;the License.  You may obtain a copy of the License at
+;
+;http://www.apache.org/licenses/LICENSE-2.0
+;
+;Unless required by applicable law or agreed to in writing, software
+;distributed under the License is distributed on an "AS IS" BASIS,
+;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;See the License for the specific language governing permissions and
+;limitations under the License.
+
+[host1]
+host=192.168.1.1
+port=1
+uname=uname1
+passwd=passwd1
+key=key1
+nodes=1
+igniteHome=ggHome1
+cfg=cfg1
+script=script1
+
+[host2]
+host=192.168.1.2
+port=2
+uname=uname2
+passwd=passwd2
+key=key2
+nodes=2
+igniteHome=ggHome2
+cfg=cfg2
+script=script2
+
+[defaults]
+port=3
+uname=uname3
+passwd=passwd3
+key=key3
+nodes=3
+igniteHome=ggHome3
+cfg=cfg3
+script=script3

--- a/modules/hibernate-5.3/modules/core/src/test/config/store/jdbc/ignite-jdbc-type.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/store/jdbc/ignite-jdbc-type.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    JdbcType beans.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean class="org.apache.ignite.cache.store.jdbc.JdbcType">
+        <property name="cacheName" value="default"/>
+        <property name="databaseSchema" value="PUBLIC"/>
+        <property name="databaseTable" value="ORGANIZATION"/>
+        <property name="keyType" value="org.apache.ignite.cache.store.jdbc.model.OrganizationKey"/>
+        <property name="valueType" value="org.apache.ignite.cache.store.jdbc.model.Organization"/>
+        <property name="keyFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="id"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+            </list>
+        </property>
+        <property name="valueFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="id"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="NAME"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                    </property>
+                    <property name="javaFieldName" value="name"/>
+                    <property name="javaFieldType" value="java.lang.String"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="CITY"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                    </property>
+                    <property name="javaFieldName" value="city"/>
+                    <property name="javaFieldType" value="java.lang.String"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.apache.ignite.cache.store.jdbc.JdbcType">
+        <property name="cacheName" value="default"/>
+        <property name="databaseSchema" value="PUBLIC"/>
+        <property name="databaseTable" value="PERSON"/>
+        <property name="keyType" value="org.apache.ignite.cache.store.jdbc.model.PersonKey"/>
+        <property name="valueType" value="org.apache.ignite.cache.store.jdbc.model.Person"/>
+        <property name="keyFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="id"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+            </list>
+        </property>
+        <property name="valueFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="id"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ORG_ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="orgId"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="NAME"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                    </property>
+                    <property name="javaFieldName" value="name"/>
+                    <property name="javaFieldType" value="java.lang.String"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.apache.ignite.cache.store.jdbc.JdbcType">
+        <property name="cacheName" value="default"/>
+        <property name="databaseSchema" value="PUBLIC"/>
+        <property name="databaseTable" value="PERSON_COMPLEX"/>
+        <property name="keyType" value="org.apache.ignite.cache.store.jdbc.model.PersonComplexKey"/>
+        <property name="valueType" value="org.apache.ignite.cache.store.jdbc.model.Person"/>
+        <property name="keyFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="id"/>
+                    <property name="javaFieldType" value="int"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ORG_ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="orgId"/>
+                    <property name="javaFieldType" value="int"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="CITY_ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="cityId"/>
+                    <property name="javaFieldType" value="int"/>
+                </bean>
+            </list>
+        </property>
+        <property name="valueFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="id"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="ORG_ID"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="orgId"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="NAME"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                    </property>
+                    <property name="javaFieldName" value="name"/>
+                    <property name="javaFieldType" value="java.lang.String"/>
+                </bean>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="salary"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldName" value="salary"/>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.apache.ignite.cache.store.jdbc.JdbcType">
+        <property name="cacheName" value="default"/>
+        <property name="databaseSchema" value="PUBLIC"/>
+        <property name="databaseTable" value="STRING_ENTRIES"/>
+        <property name="keyType" value="java.lang.String"/>
+        <property name="valueType" value="java.lang.String"/>
+        <property name="keyFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="KEY"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                    </property>
+                </bean>
+            </list>
+        </property>
+        <property name="valueFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="VAL"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.VARCHAR"/>
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.apache.ignite.cache.store.jdbc.JdbcType">
+        <property name="cacheName" value="default"/>
+        <property name="databaseSchema" value="PUBLIC"/>
+        <property name="databaseTable" value="UUID_ENTRIES"/>
+        <property name="keyType" value="java.util.UUID"/>
+        <property name="valueType" value="java.util.UUID"/>
+        <property name="keyFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="KEY"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.BINARY"/>
+                    </property>
+                    <property name="javaFieldType" value="java.util.UUID"/>
+                </bean>
+            </list>
+        </property>
+        <property name="valueFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="VAL"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.BINARY"/>
+                    </property>
+                    <property name="javaFieldType" value="java.util.UUID"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean class="org.apache.ignite.cache.store.jdbc.JdbcType">
+        <property name="cacheName" value="default"/>
+        <property name="databaseSchema" value="PUBLIC"/>
+        <property name="databaseTable" value="TIMESTAMP_ENTRIES"/>
+        <property name="keyType" value="java.sql.Timestamp"/>
+        <property name="valueType" value="java.lang.Integer"/>
+        <property name="keyFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="KEY"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.TIMESTAMP"/>
+                    </property>
+                    <property name="javaFieldType" value="java.sql.Timestamp"/>
+                </bean>
+            </list>
+        </property>
+        <property name="valueFields">
+            <list>
+                <bean class="org.apache.ignite.cache.store.jdbc.JdbcTypeField">
+                    <property name="databaseFieldName" value="VAL"/>
+                    <property name="databaseFieldType">
+                        <util:constant static-field="java.sql.Types.INTEGER"/>
+                    </property>
+                    <property name="javaFieldType" value="java.lang.Integer"/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/streamer/average/spring-streamer-average-base.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/streamer/average/spring-streamer-average-base.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("examples/config/example-cache.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- Import base configuration file. -->
+    <import resource="../spring-streamer-base.xml"/>
+
+    <!--
+        Configuration below demonstrates how to setup caches within grid nodes.
+    -->
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration" parent="base.grid.cfg">
+        <property name="streamerConfiguration">
+            <list>
+                <bean class="org.apache.ignite.streamer.StreamerConfiguration">
+                    <property name="windows">
+                        <bean class="org.apache.ignite.streamer.window.StreamerBoundedSizeWindow">
+                            <property name="maximumSize" value="500"/>
+                            <property name="indexes">
+                                <list>
+                                    <bean class="org.apache.ignite.streamer.index.tree.StreamerTreeIndexProvider">
+                                        <property name="updater">
+                                            <bean class="org.apache.ignite.loadtests.streamer.IndexUpdater"/>
+                                        </property>
+                                    </bean>
+                                </list>
+                            </property>
+                        </bean>
+                    </property>
+                    <property name="stages">
+                        <list>
+                            <bean class="org.apache.ignite.loadtests.streamer.average.TestStage"/>
+                        </list>
+                    </property>
+                    <property name="maximumConcurrentSessions" value="1000"/>
+                    <property name="router" ref="router.cfg" />
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <!--
+        Load closures.
+    -->
+    <bean class="org.apache.ignite.loadtests.streamer.GridStreamerLoad">
+        <property name="closures">
+            <list>
+                <bean class="org.apache.ignite.loadtests.streamer.EventClosure" />
+                <bean class="org.apache.ignite.loadtests.streamer.QueryClosure" />
+            </list>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/streamer/average/spring-streamer-average-local.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/streamer/average/spring-streamer-average-local.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("examples/config/example-cache.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- Import base configuration file. -->
+    <import resource="spring-streamer-average-base.xml"/>
+
+    <!-- Local router configuration. -->
+    <bean id="router.cfg" class="org.apache.ignite.streamer.router.StreamerLocalEventRouter"/>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/streamer/average/spring-streamer-average-random.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/streamer/average/spring-streamer-average-random.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("examples/config/example-cache.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- Import base configuration file. -->
+    <import resource="spring-streamer-average-base.xml"/>
+
+    <!-- Local router configuration. -->
+    <bean id="router.cfg" class="org.apache.ignite.streamer.router.StreamerRandomEventRouter"/>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/streamer/spring-streamer-base.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/streamer/spring-streamer-base.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup grid cache.
+
+    When starting a standalone Ignite node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file into Ignition:
+    Ignition.start("examples/config/example-cache.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!--
+        Optional description.
+    -->
+    <description>
+        Spring file for grid configuration with benchmark.
+    </description>
+
+    <!--
+        Configuration below demonstrates how to setup caches within grid nodes.
+    -->
+    <bean id="base.grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration" abstract="true">
+        <property name="deploymentMode" value="SHARED"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="localHost" ref="localHost"/>
+
+        <!--
+            TCP discovery SPI configuration with predefined addresses.
+            Use the addresses list to provide IP addresses of initial nodes in the grid
+            (at least one address must be provided).
+
+            Note:
+            =====
+            If running in distributed environment, you should change IP addresses to the actual IP addresses
+            of the servers on your network. Not all addresses need to be specified, only the addresses
+            of one or more servers which will always be started first.
+        -->
+        <property name="discoverySpi" ref="discoSpi"/>
+    </bean>
+
+    <beans profile="default">
+        <bean id="localHost" class="java.lang.String">
+            <constructor-arg value="127.0.0.1"/>
+        </bean>
+
+        <property name="failureDetectionTimeout" value="45000"/>
+        <property name="metricsUpdateFrequency" value="15000"/>
+
+        <bean id="discoSpi" class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+            <property name="ackTimeout" value="5000"/>
+            <property name="socketTimeout" value="5000"/>
+            <property name="reconnectCount" value="5"/>
+
+            <property name="ipFinder">
+                <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <property name="addresses">
+                        <list>
+                            <value>127.0.0.1:47500</value>
+                        </list>
+                    </property>
+                </bean>
+            </property>
+        </bean>
+    </beans>
+    <beans profile="fosters">
+        <!-- Empty local host value. -->
+        <bean id="localHost" class="java.lang.String"/>
+
+        <bean id="discoSpi" class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+            <property name="ipFinder">
+                <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <property name="addresses">
+                        <list>
+                            <value>10.1.10.210</value>
+                            <value>10.1.10.211</value>
+                            <value>10.1.10.212</value>
+                            <value>10.1.10.213</value>
+                            <value>10.1.10.214</value>
+                            <value>10.1.10.215</value>
+                        </list>
+                    </property>
+                </bean>
+            </property>
+        </bean>
+    </beans>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/tests.properties
+++ b/modules/hibernate-5.3/modules/core/src/test/config/tests.properties
@@ -1,0 +1,148 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Local address to bind to.
+local.ip=127.0.0.1
+
+# TCP communication port
+comm.tcp.port=30010
+
+# JBoss JNDI
+# JBoss context factory for JNDI connection establishing.
+jboss.jndi.context.factory=org.jnp.interfaces.NamingContextFactory
+# JBoss specific parameter for JNDI connection establishing.
+jboss.jndi.pkg.prefixes=org.jboss.naming:org.jnp.interfaces
+# URL of JBoss server for the 1st node.
+jboss.jndi.node1.provider.url=jnp://localhost:1199
+# URL of JBoss server for the 2nd node.
+jboss.jndi.node2.provider.url=jnp://localhost:1299
+# JBoss Discovery test max wait time.
+jboss.disco.test.wait=180000
+
+# Deployment configuration paths.
+# You will either need to override deploy.uri.dir or supply CLASSES_URI as system property.
+#
+# Path to keystore with private and public keys.
+deploy.uri.secure.keystore=@{IGNITE_HOME}/modules/tests/config/securedeploy/keystore
+# Temporary dir where deployment unit stored before deploy.
+deploy.uri.tmpdir=${java.io.tmpdir}/gg
+# Deployment dir for file scanner test with different types of GAR's.
+deploy.uri.file2.path=${java.io.tmpdir}/gg/verification/
+# URI string.
+deploy.uri.file2=file://freq=200@localhost/${java.io.tmpdir}/gg/verification/
+# File scanner URI for local file deployment.
+deploy.uri.file=file://localhost/@{IGNITE_HOME}/modules/extdata/uri/target/file/
+# FTP scanner URI for FTP deployment.
+deploy.uri.ftp=ftp://ftptest:iddqd@94.72.60.102:21/test/deployment
+# Classes scanner URI for classes deployment. Must be overridden for every user.
+deploy.uri.cls=${CLASSES_URI}
+# Http scanner URI for HTTP deployment.
+deploy.uri.http=http://216.93.179.140/ignite/test/deployment/
+# Http scanner URI for secure SSL HTTPs deployment.
+deploy.uri.https=https://216.93.179.140:8445/ignite/test/deployment/
+# Directory with descriptors to construct GAR files.
+deploy.gar.descriptor.dir=modules/urideploy/src/test/java/org/apache/ignite/spi/deployment/uri/META-INF
+
+# Directory with a number of descriptors for the Ant gar task.
+ant.gar.descriptor.dir=modules/extdata/p2p/META-INF
+# Temporary directory for the Ant task resulting GAR file.
+ant.gar.tmpdir=${java.io.tmpdir}/gg
+# The same as p2p.uri.cls but without protocol
+ant.gar.srcdir=@{IGNITE_HOME}/modules/extdata/uri/target/classes/
+
+# GAR paths to use in URI deployment SPI tests
+ant.urideployment.gar.uri=file://freq=5000@localhost/EXTDATA/uri/target/deploy
+ant.urideployment.gar.file=modules/extdata/uri/target/deploy/uri.gar
+ant.urideployment.gar.libs-file=modules/extdata/uri/target/deploy2/uri-libs.gar
+ant.urideployment.gar.classes-file=modules/extdata/uri/target/deploy2/uri-classes.gar
+ant.urideployment.gar.path=modules/extdata/uri/target/deploy/
+ant.urideployment.gar.path.tmp=modules/extdata/uri/target/deploy_tmp/
+
+# Classpath directory for GridP2PUserVersionChangeSelfTest
+ant.userversion.class.dir=@{IGNITE_HOME}/modules/tests/java/
+
+# Multicast discovery self test.
+discovery.mbeanserver.selftest.baseport=50000
+
+# TCP communication self test.
+comm.mbeanserver.selftest.baseport=50100
+
+# Kernel tests.
+grid.comm.selftest.sender.timeout=1000
+grid.comm.selftest.timeout=10000
+
+#P2P tests
+#Overwrite this property. It should point to P2P module compilation directory.
+p2p.uri.cls=file://localhost/@{IGNITE_HOME}/modules/extdata/p2p/target/classes/
+p2p.uri.cls.second=file://localhost/@{IGNITE_HOME}/modules/extdata/uri/target/classes/
+
+# AOP tests.
+# Connector port for RMI.
+connector.rmi.port=7657
+# Connector port for XFire Web Service.
+connector.ws.port=9090
+
+# Load test duration in minutes.
+load.test.duration=500
+load.test.threadnum=50
+load.test.nodenum=5
+
+# Loaders tests
+loader.self.test.config=modules/core/src/test/config/loaders/grid-cfg.xml
+loader.self.multipletest.config=modules/core/src/test/config/loaders/grid-cfg-2-grids.xml
+loader.self.test.jboss.config=modules/core/src/test/config/loaders/grid-cfg.xml
+
+# WebSphere jmx properties
+websphere.jmx.connector.host=localhost
+websphere.jmx.connector.port=8880
+websphere.jmx.connector.security=false
+websphere.jmx.username=
+websphere.jmx.pwd=
+
+# GlassFish jmx properties for GlassFish Loader
+glassfish.jmx.rmi.connector.port=8686
+glassfish.jmx.username=admin
+glassfish.jmx.password=adminadmin
+
+# Tomcat jmx properties for Servlet Loader
+tomcat.jmx.rmi.connector.port=1097
+
+# Marshaller for tests
+#marshaller.class=org.apache.ignite.marshaller.jdk.GridJdkMarshaller
+
+# EC2 configuration for tests
+#amazon.access.key=
+#amazon.secret.key=
+
+# SSH config.
+ssh.username=uname
+ssh.password=passwd
+
+# SSL tests keystore.
+ssl.keystore.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/server.jks
+ssl.keystore.password=123456
+
+# node01 signed with trust-one, node02 and node03 by trust-two, trust-both contains both CAs
+ssl.keystore.node01.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/ca/node01.jks
+ssl.keystore.node02.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/ca/node02.jks
+ssl.keystore.node03.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/ca/node03.jks
+ssl.keystore.trustone.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/ca/trust-one.jks
+ssl.keystore.trusttwo.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/ca/trust-two.jks
+ssl.keystore.trustboth.path=@{IGNITE_HOME}/modules/clients/src/test/keystore/ca/trust-both.jks
+
+# Hadoop home directory.
+hadoop.home=@{HADOOP_HOME}

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache-base.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache-base.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean abstract="true" id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <!-- Set to true to enable distributed class loading for examples, default is false. -->
+        <property name="peerClassLoadingEnabled" value="true"/>
+
+        <property name="marshaller">
+            <bean class="org.apache.ignite.internal.binary.BinaryMarshaller" />
+        </property>
+
+        <!-- Enable cache events for examples. -->
+        <property name="includeEventTypes">
+            <util:constant static-field="org.apache.ignite.events.EventType.EVTS_CACHE"/>
+        </property>
+
+        <!-- Cache configurations (all properties are optional). -->
+        <property name="cacheConfiguration">
+            <list>
+                <!-- Partitioned cache example configuration (Atomic mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="partitioned"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="backups" value="1"/>
+
+                    <property name="indexedTypes">
+                        <list>
+                            <!-- Key and value type for SQL table Long. -->
+                            <value>java.lang.Integer</value>
+                            <value>java.lang.Long</value>
+                        </list>
+                    </property>
+                </bean>
+
+                <!-- Partitioned cache example configuration (Atomic mode, PRIMARY write order mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="partitioned_primary"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <!-- Partitioned cache example configuration (Transactional mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="partitioned_tx"/>
+                    <property name="cacheMode" value="PARTITIONED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                    <property name="nearConfiguration">
+                        <bean class="org.apache.ignite.configuration.NearCacheConfiguration"/>
+                    </property>
+                    <property name="backups" value="1"/>
+                </bean>
+
+                <!-- Replicated cache example configuration (Atomic mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="replicated"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="indexedTypes">
+                        <list>
+                            <!-- Key and value type for SQL table DimStore. -->
+                            <value>java.lang.Integer</value>
+                            <value>java.lang.Integer</value>
+                        </list>
+                    </property>
+                </bean>
+
+                <!-- Replicated cache example configuration (Transactional mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="replicated_tx"/>
+                    <property name="cacheMode" value="REPLICATED"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                </bean>
+
+                <!-- Local cache example configuration (Atomic mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="local"/>
+                    <property name="cacheMode" value="LOCAL"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                </bean>
+
+                <!-- Local cache example configuration (Transactional mode). -->
+                <bean parent="cache-template">
+                    <property name="name" value="local_tx"/>
+                    <property name="cacheMode" value="LOCAL"/>
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+                </bean>
+            </list>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <!-- Template for all example cache configurations. -->
+    <bean id="cache-template" abstract="true" class="org.apache.ignite.configuration.CacheConfiguration">
+        <!-- Set synchronous rebalancing (default is asynchronous). -->
+        <property name="rebalanceMode" value="SYNC"/>
+
+        <!-- Set to FULL_SYNC for examples, default is PRIMARY_SYNC. -->
+        <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache-client.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache-client.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- Imports Ignite configuration -->
+    <import resource="example-cache-base.xml"/>
+
+    <bean parent="ignite.cfg">
+        <property name="clientMode" value="true"/>
+
+        <property name="igniteInstanceName" value="client"/>
+
+        <property name="cacheConfiguration">
+            <list/>
+        </property>
+    </bean>
+
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    Ignite Spring configuration file to startup ignite cache.
+
+    When starting a standalone node, you need to execute the following command:
+    {IGNITE_HOME}/bin/ignite.{bat|sh} examples/config/example-cache.xml
+
+    When starting Ignite from Java IDE, pass path to this file to Ignition:
+    Ignition.start("examples/config/example-cache.xml");
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- Imports Ignite configuration -->
+    <import resource="example-cache-base.xml"/>
+
+    <bean parent="ignite.cfg">
+    </bean>
+
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache2.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/example-cache2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <!-- Imports Ignite configuration -->
+    <import resource="example-cache-base.xml"/>
+
+    <bean parent="ignite.cfg">
+        <property name="igniteInstanceName" value="grid2"/>
+    </bean>
+
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/spring-cache-1.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/spring-cache-1.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="grid-1"/>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="ATOMIC"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="backups" value="1"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned_tx"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="backups" value="1"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="replicated"/>
+
+                    <property name="cacheMode" value="REPLICATED"/>
+
+                    <property name="atomicityMode" value="ATOMIC"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/spring-cache-2.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/spring-cache-2.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="grid-2"/>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="ATOMIC"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="backups" value="1"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned_tx"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="backups" value="1"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="replicated"/>
+
+                    <property name="cacheMode" value="REPLICATED"/>
+
+                    <property name="atomicityMode" value="ATOMIC"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/modules/core/src/test/config/websession/spring-cache-3.xml
+++ b/modules/hibernate-5.3/modules/core/src/test/config/websession/spring-cache-3.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="grid-3"/>
+
+        <property name="localHost" value="127.0.0.1"/>
+
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="ATOMIC"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="backups" value="1"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="partitioned_tx"/>
+
+                    <property name="cacheMode" value="PARTITIONED"/>
+
+                    <property name="atomicityMode" value="TRANSACTIONAL"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="backups" value="1"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="replicated"/>
+
+                    <property name="cacheMode" value="REPLICATED"/>
+
+                    <property name="atomicityMode" value="ATOMIC"/>
+
+                    <property name="writeSynchronizationMode" value="FULL_SYNC"/>
+
+                    <property name="rebalanceMode" value="SYNC"/>
+                </bean>
+            </list>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                                <value>127.0.0.1:47501</value>
+                                <value>127.0.0.1:47502</value>
+                                <value>127.0.0.1:47503</value>
+                                <value>127.0.0.1:47504</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/pom.xml
+++ b/modules/hibernate-5.3/pom.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+    POM file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.ignite</groupId>
+        <artifactId>ignite-parent</artifactId>
+        <version>1</version>
+        <relativePath>../../parent</relativePath>
+    </parent>
+
+    <artifactId>ignite-hibernate_5.3</artifactId>
+    <version>2.7.0-SNAPSHOT</version>
+    <url>http://ignite.apache.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-hibernate-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.3.7.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-jta</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ow2.jotm</groupId>
+            <artifactId>jotm-core</artifactId>
+            <version>2.1.9</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-dbcp</groupId>
+            <artifactId>commons-dbcp</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.resource</groupId>
+            <artifactId>connector-api</artifactId>
+            <version>1.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-spring</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-log4j</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.8</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>lgpl</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/main/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+            <testResource>
+                <directory>src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+
+        <plugins>
+            <!-- Generate the OSGi MANIFEST.MF for this bundle. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/HibernateKeyWrapper.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/HibernateKeyWrapper.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import java.io.Serializable;
+import org.apache.ignite.internal.util.typedef.internal.S;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.persister.entity.EntityPersister;
+
+/**
+ * Hibernate cache key wrapper.
+ */
+public class HibernateKeyWrapper implements Serializable {
+    /** Key. */
+    private final Object key;
+
+    /** Entry. */
+    private final String entry;
+
+    /** */
+    private final String tenantId;
+
+    /**
+     * @param key Key.
+     * @param entry Entry.
+     * @param tenantId Tenant ID.
+     */
+    HibernateKeyWrapper(Object key, String entry, String tenantId) {
+        this.key = key;
+        this.entry = entry;
+        this.tenantId = tenantId;
+    }
+
+    /**
+     * @return ID.
+     */
+    Object id() {
+        return key;
+    }
+
+    /**
+     * @param id ID.
+     * @param persister Persister.
+     * @param tenantIdentifier Tenant ID.
+     * @return Cache key.
+     * @see DefaultCacheKeysFactory#staticCreateCollectionKey(Object, CollectionPersister, SessionFactoryImplementor, String)
+     */
+    static Object staticCreateCollectionKey(Object id,
+        CollectionPersister persister,
+        String tenantIdentifier) {
+        return new HibernateKeyWrapper(id, persister.getRole(), tenantIdentifier);
+    }
+
+    /**
+     * @param id ID.
+     * @param persister Persister.
+     * @param tenantIdentifier Tenant ID.
+     * @return Cache key.
+     * @see DefaultCacheKeysFactory#staticCreateEntityKey(Object, EntityPersister, SessionFactoryImplementor, String)
+     */
+    public static Object staticCreateEntityKey(Object id, EntityPersister persister, String tenantIdentifier) {
+        return new HibernateKeyWrapper(id, persister.getRootEntityName(), tenantIdentifier);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        HibernateKeyWrapper that = (HibernateKeyWrapper) o;
+
+        return (key != null ? key.equals(that.key) : that.key == null) &&
+            (entry != null ? entry.equals(that.entry) : that.entry == null) &&
+            (tenantId != null ? tenantId.equals(that.tenantId) : that.tenantId == null);
+    }
+
+    /** {@inheritDoc} */
+    @Override public int hashCode() {
+        int res = key != null ? key.hashCode() : 0;
+        res = 31 * res + (entry != null ? entry.hashCode() : 0);
+        res = 31 * res + (tenantId != null ? tenantId.hashCode() : 0);
+        return res;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(HibernateKeyWrapper.class, this);
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/HibernateRegion.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/HibernateRegion.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCheckedException;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.ExtendedStatisticsSupport;
+import org.hibernate.cache.spi.Region;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.support.AbstractRegion;
+
+import static java.lang.String.format;
+
+/**
+ * Implementation of {@link Region}. This interface defines base contract for all L2 cache regions.
+ */
+public abstract class HibernateRegion extends AbstractRegion implements ExtendedStatisticsSupport {
+
+    /** Cache instance. */
+    protected final HibernateCacheProxy cache;
+
+    /** Grid instance. */
+    protected Ignite ignite;
+
+    public HibernateRegion(RegionFactory factory, String name, Ignite ignite, HibernateCacheProxy cache) {
+        super(name, factory);
+        this.ignite = ignite;
+        this.cache = cache;
+    }
+
+    @Override
+    public void clear() {
+        try {
+            cache.clear();
+        } catch (IgniteCheckedException e) {
+            throw new CacheException(format("problem clearing cache (%s): %s", cache.name(), e.getMessage()), e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void destroy() throws CacheException {
+        // No-op.
+    }
+
+    @Override
+    public long getElementCountInMemory() {
+        return cache.offHeapEntriesCount();
+    }
+
+    @Override
+    public long getElementCountOnDisk() {
+        return cache.sizeLong();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        return cache.offHeapAllocatedSize();
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/HibernateRegionFactory.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/HibernateRegionFactory.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.cfg.spi.DomainDataRegionBuildingContext;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.QueryResultsRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.TimestampsRegion;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.support.RegionNameQualifier;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_ACCESS_TYPE_PROPERTY;
+import static org.hibernate.cache.spi.access.AccessType.NONSTRICT_READ_WRITE;
+
+/**
+ * Hibernate L2 cache region factory.
+ * <p>
+ * Following Hibernate settings should be specified to enable second level cache and to use this
+ * region factory for caching:
+ * <pre name="code" class="brush: xml; gutter: false;">
+ * hibernate.cache.use_second_level_cache=true
+ * hibernate.cache.region.factory_class=org.apache.ignite.cache.hibernate.HibernateRegionFactory
+ * </pre>
+ * Note that before region factory is started you need to start properly configured Ignite node in the same JVM.
+ * For example to start Ignite node one of loader provided in {@code org.apache.ignite.grid.startup} package can be used.
+ * <p>
+ * Name of Ignite instance to be used for region factory must be specified as following Hibernate property:
+ * <pre name="code" class="brush: xml; gutter: false;">
+ * org.apache.ignite.hibernate.ignite_instance_name=&lt;Ignite instance name&gt;
+ * </pre>
+ * Each Hibernate cache region must be associated with some {@link IgniteInternalCache}, by default it is assumed that
+ * for each cache region there is a {@link IgniteInternalCache} with the same name. Also it is possible to define
+ * region to cache mapping using properties with prefix {@code org.apache.ignite.hibernate.region_cache}.
+ * For example if for region with name "region1" cache with name "cache1" should be used then following
+ * Hibernate property should be specified:
+ * <pre name="code" class="brush: xml; gutter: false;">
+ * org.apache.ignite.hibernate.region_cache.region1=cache1
+ * </pre>
+ */
+public class HibernateRegionFactory implements RegionFactory {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /** */
+    static final HibernateExceptionConverter EXCEPTION_CONVERTER = new HibernateExceptionConverter() {
+        @Override
+        public RuntimeException convert(Exception e) {
+            return new CacheException(e);
+        }
+    };
+
+    /** Default region access type. */
+    private AccessType dfltAccessType;
+
+    /** Key transformer. */
+    private final HibernateKeyTransformer hibernate4transformer = new HibernateKeyTransformer() {
+        @Override
+        public Object transform(Object key) {
+            return key;
+        }
+    };
+
+    /** */
+    private final HibernateAccessStrategyFactory accessStgyFactory =
+        new HibernateAccessStrategyFactory(hibernate4transformer, EXCEPTION_CONVERTER);
+    private SessionFactoryOptions options;
+
+    /**
+     * @return Access strategy factory.
+     */
+    HibernateAccessStrategyFactory accessStrategyFactory() {
+        return accessStgyFactory;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void stop() {
+        // No-op.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void start(SessionFactoryOptions settings, Map configValues) throws CacheException {
+        String accessType = configValues.getOrDefault(
+            DFLT_ACCESS_TYPE_PROPERTY, NONSTRICT_READ_WRITE.name()).toString();
+        dfltAccessType = AccessType.valueOf(accessType);
+        accessStgyFactory.start(configValues);
+        this.options = settings;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isMinimalPutsEnabledByDefault() {
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AccessType getDefaultAccessType() {
+        return dfltAccessType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long nextTimestamp() {
+        return Instant.now().toEpochMilli();
+    }
+
+    @Override
+    public String qualify(String regionName) {
+        return RegionNameQualifier.INSTANCE.qualify(regionName, options);
+    }
+
+    @Override
+    public DomainDataRegion buildDomainDataRegion(DomainDataRegionConfig regionConfig,
+                                                  DomainDataRegionBuildingContext buildingContext) {
+        IgniteDomainDataRegion igniteDomainDataRegion = new IgniteDomainDataRegion(
+            regionConfig, this, null, buildingContext, accessStgyFactory);
+        return igniteDomainDataRegion;
+    }
+
+    @Override
+    public QueryResultsRegion buildQueryResultsRegion(String regionName, SessionFactoryImplementor sessionFactory) {
+        IgniteQueryResultsRegion igniteQueryResultsRegion = new IgniteQueryResultsRegion(
+            this, regionName, accessStgyFactory.node(), accessStgyFactory.regionCache(regionName));
+        return igniteQueryResultsRegion;
+    }
+
+    @Override
+    public TimestampsRegion buildTimestampsRegion(String regionName, SessionFactoryImplementor sessionFactory) {
+        IgniteTimestampsRegion igniteTimestampsRegion = new IgniteTimestampsRegion(
+            this, regionName, accessStgyFactory.node(), accessStgyFactory.regionCache(regionName));
+        return igniteTimestampsRegion;
+    }
+
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteCachedDomainDataAccess.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteCachedDomainDataAccess.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.CachedDomainDataAccess;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Implementation of L2 cache access strategy delegating to {@link HibernateAccessStrategyAdapter}.
+ */
+public abstract class IgniteCachedDomainDataAccess extends HibernateRegion implements CachedDomainDataAccess {
+    /** */
+    protected final HibernateAccessStrategyAdapter stgy;
+    private DomainDataRegion domainDataRegion;
+
+    /**
+     * @param stgy Access strategy implementation.
+     * @param domainDataRegion
+     * @param cache
+     */
+    protected IgniteCachedDomainDataAccess(HibernateAccessStrategyAdapter stgy,
+                                           RegionFactory regionFactory,
+                                           DomainDataRegion domainDataRegion,
+                                           Ignite ignite, HibernateCacheProxy cache) {
+        super(regionFactory, cache.name(), ignite, cache);
+        this.stgy = stgy;
+        this.domainDataRegion = domainDataRegion;
+    }
+
+    @Override
+    public DomainDataRegion getRegion() {
+        return domainDataRegion;
+    }
+
+    @Override
+    public Object get(SharedSessionContractImplementor session, Object key) throws CacheException {
+        return stgy.get(key);
+    }
+
+    @Override
+    public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, Object version) throws CacheException {
+        stgy.putFromLoad(key, value);
+        return true;
+    }
+
+    @Override
+    public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, Object version, boolean minimalPutOverride) throws CacheException {
+        stgy.putFromLoad(key, value);
+        return true;
+    }
+
+    @Override
+    public SoftLock lockItem(SharedSessionContractImplementor session, Object key, Object version) throws CacheException {
+        stgy.lock(key);
+        return null;
+    }
+
+    @Override
+    public void unlockItem(SharedSessionContractImplementor session, Object key, SoftLock lock) throws CacheException {
+        stgy.unlock(key);
+    }
+
+    @Override
+    public void remove(SharedSessionContractImplementor session, Object key) throws CacheException {
+        stgy.remove(key);
+    }
+
+    /** {@inheritDoc} */
+    @Nullable
+    @Override
+    public SoftLock lockRegion() throws CacheException {
+        stgy.lockRegion();
+
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unlockRegion(SoftLock lock) throws CacheException {
+        stgy.unlockRegion();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void removeAll(SharedSessionContractImplementor session) throws CacheException {
+        stgy.removeAll();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void evict(Object key) throws CacheException {
+        stgy.evict(key);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void evictAll() throws CacheException {
+        stgy.evictAll();
+    }
+
+    @Override
+    public boolean contains(Object key) {
+        return stgy.get(key) != null;
+    }
+
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteCollectionDataAccess.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteCollectionDataAccess.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.collection.CollectionPersister;
+
+public class IgniteCollectionDataAccess extends IgniteCachedDomainDataAccess implements CollectionDataAccess {
+
+
+    private final AccessType accessType;
+
+    public IgniteCollectionDataAccess(HibernateAccessStrategyAdapter stgy, AccessType accessType,
+                                      RegionFactory regionFactory,
+                                      DomainDataRegion domainDataRegion, Ignite ignite,
+                                      HibernateCacheProxy cache) {
+        super(stgy, regionFactory, domainDataRegion, ignite, cache);
+        this.accessType = accessType;
+    }
+
+    @Override
+    public AccessType getAccessType() {
+        return accessType;
+    }
+
+    @Override
+    public Object generateCacheKey(Object id, CollectionPersister persister, SessionFactoryImplementor factory,
+                                   String tenantIdentifier) {
+        return HibernateKeyWrapper.staticCreateCollectionKey(id, persister, tenantIdentifier);
+    }
+
+    @Override
+    public Object getCacheKeyId(Object cacheKey) {
+        return ((HibernateKeyWrapper)cacheKey).id();
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteDomainDataRegion.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteDomainDataRegion.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.cfg.spi.CollectionDataCachingConfig;
+import org.hibernate.cache.cfg.spi.DomainDataRegionBuildingContext;
+import org.hibernate.cache.cfg.spi.DomainDataRegionConfig;
+import org.hibernate.cache.cfg.spi.EntityDataCachingConfig;
+import org.hibernate.cache.cfg.spi.NaturalIdDataCachingConfig;
+import org.hibernate.cache.spi.CacheKeysFactory;
+import org.hibernate.cache.spi.ExtendedStatisticsSupport;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.cache.spi.access.NaturalIdDataAccess;
+import org.hibernate.cache.spi.support.AbstractDomainDataRegion;
+
+public class IgniteDomainDataRegion extends AbstractDomainDataRegion implements ExtendedStatisticsSupport {
+
+    private final HibernateCacheProxy cache;
+    private HibernateAccessStrategyFactory strategyFactory;
+
+    public IgniteDomainDataRegion(DomainDataRegionConfig regionConfig,
+                                  RegionFactory regionFactory,
+                                  CacheKeysFactory defaultKeysFactory,
+                                  DomainDataRegionBuildingContext buildingContext,
+                                  HibernateAccessStrategyFactory strategyFactory) {
+        super(regionConfig, regionFactory, defaultKeysFactory, buildingContext);
+        this.strategyFactory = strategyFactory;
+        this.cache = strategyFactory.regionCache(getName());
+        super.completeInstantiation(regionConfig, buildingContext);
+    }
+
+    @Override
+    protected EntityDataAccess generateEntityAccess(EntityDataCachingConfig entityAccessConfig) {
+        AccessType accessType = entityAccessConfig.getAccessType();
+        Ignite ignite = strategyFactory.node();
+        switch (accessType) {
+            case READ_ONLY:
+                HibernateAccessStrategyAdapter readOnlyStrategy =
+                    strategyFactory.createReadOnlyStrategy(cache);
+                return new IgniteEntityDataAccess(readOnlyStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case NONSTRICT_READ_WRITE:
+                HibernateAccessStrategyAdapter nonStrictReadWriteStrategy =
+                    strategyFactory.createNonStrictReadWriteStrategy(cache);
+                return new IgniteEntityDataAccess(nonStrictReadWriteStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case READ_WRITE:
+                HibernateAccessStrategyAdapter readWriteStrategy =
+                    strategyFactory.createReadWriteStrategy(cache);
+                return new IgniteEntityDataAccess(readWriteStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case TRANSACTIONAL:
+                HibernateAccessStrategyAdapter transactionalStrategy =
+                    strategyFactory.createTransactionalStrategy(cache);
+                return new IgniteEntityDataAccess(transactionalStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            default:
+                throw new IllegalArgumentException("Unknown Hibernate access type: " + accessType);
+        }
+    }
+
+    @Override
+    protected CollectionDataAccess generateCollectionAccess(CollectionDataCachingConfig cachingConfig) {
+        HibernateCacheProxy cache = strategyFactory.regionCache(getName());
+        AccessType accessType = cachingConfig.getAccessType();
+        Ignite ignite = strategyFactory.node();
+        switch (accessType) {
+            case READ_ONLY:
+                HibernateAccessStrategyAdapter readOnlyStrategy =
+                    strategyFactory.createReadOnlyStrategy(cache);
+                return new IgniteCollectionDataAccess(readOnlyStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case NONSTRICT_READ_WRITE:
+                HibernateAccessStrategyAdapter nonStrictReadWriteStrategy =
+                    strategyFactory.createNonStrictReadWriteStrategy(cache);
+                return new IgniteCollectionDataAccess(nonStrictReadWriteStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case READ_WRITE:
+                HibernateAccessStrategyAdapter readWriteStrategy =
+                    strategyFactory.createReadWriteStrategy(cache);
+                return new IgniteCollectionDataAccess(readWriteStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case TRANSACTIONAL:
+                HibernateAccessStrategyAdapter transactionalStrategy =
+                    strategyFactory.createTransactionalStrategy(cache);
+                return new IgniteCollectionDataAccess(transactionalStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            default:
+                throw new IllegalArgumentException("Unknown Hibernate access type: " + accessType);
+        }
+    }
+
+    @Override
+    protected NaturalIdDataAccess generateNaturalIdAccess(NaturalIdDataCachingConfig naturalIdAccessConfig) {
+        HibernateCacheProxy cache = strategyFactory.regionCache(getName());
+        AccessType accessType = naturalIdAccessConfig.getAccessType();
+        Ignite ignite = strategyFactory.node();
+        switch (accessType) {
+            case READ_ONLY:
+                HibernateAccessStrategyAdapter readOnlyStrategy =
+                    strategyFactory.createReadOnlyStrategy(cache);
+                return new IgniteNaturalIdDataAccess(readOnlyStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case NONSTRICT_READ_WRITE:
+                HibernateAccessStrategyAdapter nonStrictReadWriteStrategy =
+                    strategyFactory.createNonStrictReadWriteStrategy(cache);
+                return new IgniteNaturalIdDataAccess(nonStrictReadWriteStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case READ_WRITE:
+                HibernateAccessStrategyAdapter readWriteStrategy =
+                    strategyFactory.createReadWriteStrategy(cache);
+                return new IgniteNaturalIdDataAccess(readWriteStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            case TRANSACTIONAL:
+                HibernateAccessStrategyAdapter transactionalStrategy =
+                    strategyFactory.createTransactionalStrategy(cache);
+                return new IgniteNaturalIdDataAccess(transactionalStrategy, accessType, getRegionFactory(),
+                    this, ignite, cache);
+
+            default:
+                throw new IllegalArgumentException("Unknown Hibernate access type: " + accessType);
+        }
+    }
+
+    @Override
+    public void destroy() throws CacheException {
+        // no-op
+    }
+
+    @Override
+    public long getElementCountInMemory() {
+        return cache.offHeapEntriesCount();
+    }
+
+    @Override
+    public long getElementCountOnDisk() {
+        return cache.sizeLong();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        return cache.offHeapAllocatedSize();
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteEntityDataAccess.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteEntityDataAccess.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+public class IgniteEntityDataAccess extends IgniteCachedDomainDataAccess implements EntityDataAccess {
+
+    private final AccessType accessType;
+
+    public IgniteEntityDataAccess(HibernateAccessStrategyAdapter stgy, AccessType accessType,
+                                  RegionFactory regionFactory,
+                                  DomainDataRegion domainDataRegion, Ignite ignite,
+                                  HibernateCacheProxy cache) {
+        super(stgy, regionFactory, domainDataRegion, ignite, cache);
+        this.accessType = accessType;
+    }
+
+    @Override
+    public Object generateCacheKey(Object id, EntityPersister persister, SessionFactoryImplementor factory,
+                                   String tenantIdentifier) {
+        return HibernateKeyWrapper.staticCreateEntityKey(id, persister, tenantIdentifier);
+    }
+
+    @Override
+    public Object getCacheKeyId(Object cacheKey) {
+        return ((HibernateKeyWrapper) cacheKey).id();
+    }
+
+    @Override
+    public boolean insert(SharedSessionContractImplementor session, Object key, Object value, Object version) {
+        return stgy.insert(key, value);
+    }
+
+    @Override
+    public boolean afterInsert(SharedSessionContractImplementor session, Object key, Object value, Object version) {
+        return stgy.afterInsert(key, value);
+    }
+
+    @Override
+    public boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion) {
+        return stgy.update(key, value);
+    }
+
+    @Override
+    public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+        return stgy.afterUpdate(key, value);
+    }
+
+    @Override
+    public AccessType getAccessType() {
+        return accessType;
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteGeneralDataRegion.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteGeneralDataRegion.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteLogger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.DirectAccessRegion;
+import org.hibernate.cache.spi.QueryResultsRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.TimestampsRegion;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.jetbrains.annotations.Nullable;
+
+import static java.lang.String.format;
+
+/**
+ * Implementation of {@link DirectAccessRegion}. This interface defines common contract for {@link QueryResultsRegion}
+ * and {@link TimestampsRegion}.
+ */
+public class IgniteGeneralDataRegion extends HibernateRegion implements DirectAccessRegion {
+    private final IgniteLogger log;
+
+    /**
+     * @param factory Region factory.
+     * @param name Region name.
+     * @param ignite Grid.
+     * @param cache Region cache.
+     */
+    IgniteGeneralDataRegion(RegionFactory factory, String name,
+                            Ignite ignite, HibernateCacheProxy cache) {
+        super(factory, name, ignite, cache);
+        this.log = ignite.log().getLogger(getClass());
+    }
+
+    /** {@inheritDoc} */
+    @Nullable
+    @Override
+    public Object getFromCache(Object key, SharedSessionContractImplementor ses) throws CacheException {
+        try {
+            Object rtn = cache.get(key);
+            if (log.isDebugEnabled()) {
+                log.debug(format("get from cache: %s, miss: %s, key: %s", cache.name(), rtn == null, key));
+            }
+            return rtn;
+        } catch (IgniteCheckedException e) {
+            throw new CacheException(e);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void putIntoCache(Object key, Object val, SharedSessionContractImplementor ses) throws CacheException {
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug(format("put into cache: %s, key: %s, val: %s", cache.name(), key, val));
+            }
+            cache.put(key, val);
+        } catch (IgniteCheckedException e) {
+            throw new CacheException(e);
+        }
+    }
+
+    @Override
+    public void clear() {
+        try {
+            cache.clear();
+        } catch (IgniteCheckedException e) {
+            throw new CacheException(format("problem clearing cache: %s", e.getMessage()), e);
+        }
+    }
+
+    @Override
+    public void destroy() throws CacheException {
+        // no-op
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteNaturalIdDataAccess.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteNaturalIdDataAccess.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cache.spi.DomainDataRegion;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cache.spi.access.NaturalIdDataAccess;
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+
+public class IgniteNaturalIdDataAccess extends IgniteCachedDomainDataAccess implements NaturalIdDataAccess {
+
+    private final AccessType accessType;
+
+    public IgniteNaturalIdDataAccess(HibernateAccessStrategyAdapter stgy, AccessType accessType,
+                                     RegionFactory regionFactory,
+                                     DomainDataRegion domainDataRegion, Ignite ignite,
+                                     HibernateCacheProxy cache) {
+        super(stgy, regionFactory, domainDataRegion, ignite, cache);
+        this.accessType = accessType;
+    }
+
+    @Override
+    public AccessType getAccessType() {
+        return accessType;
+    }
+
+    @Override
+    public Object generateCacheKey(Object[] naturalIdValues, EntityPersister persister, SharedSessionContractImplementor ses) {
+        return DefaultCacheKeysFactory.staticCreateNaturalIdKey(naturalIdValues, persister, ses);
+    }
+
+    @Override
+    public Object[] getNaturalIdValues(Object cacheKey) {
+        return DefaultCacheKeysFactory.staticGetNaturalIdValues(cacheKey);
+    }
+
+    @Override
+    public boolean insert(SharedSessionContractImplementor ses, Object key, Object val) throws CacheException {
+        return this.stgy.insert(key, val);
+    }
+
+    @Override
+    public boolean afterInsert(SharedSessionContractImplementor ses, Object key, Object val) throws CacheException {
+        return this.stgy.afterInsert(key, val);
+    }
+
+    @Override
+    public boolean update(SharedSessionContractImplementor ses, Object key, Object val) throws CacheException {
+        return this.stgy.update(key, val);
+    }
+
+    @Override
+    public boolean afterUpdate(SharedSessionContractImplementor ses, Object key, Object val, SoftLock lock) throws CacheException {
+        return this.stgy.afterUpdate(key, val);
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteQueryResultsRegion.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteQueryResultsRegion.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.spi.QueryResultsRegion;
+import org.hibernate.query.Query;
+
+/**
+ * Implementation of {@link QueryResultsRegion}. This region is used to store query results.
+ * <p>
+ * Query results caching can be enabled in the Hibernate configuration file:
+ * <pre name="code" class="xml">
+ * &lt;hibernate-configuration&gt;
+ *     &lt;!-- Enable L2 cache. --&gt;
+ *     &lt;property name="cache.use_second_level_cache"&gt;true&lt;/property&gt;
+ *
+ *     &lt;!-- Enable query cache. --&gt;
+ *     &lt;property name="cache.use_second_level_cache"&gt;true&lt;/property&gt;
+
+ *     &lt;!-- Use Ignite as L2 cache provider. --&gt;
+ *     &lt;property name="cache.region.factory_class"&gt;org.apache.ignite.cache.hibernate.HibernateRegionFactory&lt;/property&gt;
+ *
+ *     &lt;!-- Specify entity. --&gt;
+ *     &lt;mapping class="com.example.Entity"/&gt;
+ *
+ *     &lt;!-- Enable L2 cache with nonstrict-read-write access strategy for entity. --&gt;
+ *     &lt;class-cache class="com.example.Entity" usage="nonstrict-read-write"/&gt;
+ * &lt;/hibernate-configuration&gt;
+ * </pre>
+ * By default queries are not cached even after enabling query caching, to enable results caching for a particular
+ * query, call {@link Query#setCacheable(boolean)}:
+ * <pre name="code" class="java">
+ *     Session ses = getSession();
+ *
+ *     Query qry = ses.createQuery("...");
+ *
+ *     qry.setCacheable(true); // Enable L2 cache for query.
+ * </pre>
+ * Note: the query cache does not cache the state of the actual entities in the cache, it caches only identifier
+ * values. For this reason, the query cache should always be used in conjunction with
+ * the second-level cache for those entities expected to be cached as part of a query result cache
+ */
+public class IgniteQueryResultsRegion extends IgniteGeneralDataRegion implements QueryResultsRegion {
+    /**
+     * @param factory Region factory.
+     * @param name Region name.
+     * @param ignite Grid.
+     * @param cache Region cache.
+     */
+    public IgniteQueryResultsRegion(HibernateRegionFactory factory, String name,
+                                    Ignite ignite, HibernateCacheProxy cache) {
+        super(factory, name, ignite, cache);
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteTimestampsRegion.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/IgniteTimestampsRegion.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.TimestampsRegion;
+
+/**
+ * Implementation of {@link TimestampsRegion}. This region is automatically created when query
+ * caching is enabled and it holds most recent updates timestamps to queryable tables.
+ * Name of timestamps region is {@link RegionFactory#DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME}.
+ */
+public class IgniteTimestampsRegion extends IgniteGeneralDataRegion implements TimestampsRegion {
+
+    /**
+     * @param factory Region factory.
+     * @param regionName Region name.
+     * @param cache Region cache.
+     */
+    public IgniteTimestampsRegion(RegionFactory factory, String regionName, Ignite ignite, HibernateCacheProxy cache) {
+        super(factory, regionName, ignite, cache);
+    }
+
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/package-info.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/hibernate/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <!-- Package description. -->
+ * Contains implementation of Hibernate L2 cache. Refer to
+ * <i>org.apache.ignite.examples.datagrid.hibernate.HibernateL2CacheExample</i> for more information on how to
+ * configure and use Ignite with Hibernate.
+ */
+package org.apache.ignite.cache.hibernate;

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStore.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStore.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.cache.store.CacheStore;
+import org.apache.ignite.cache.store.CacheStoreAdapter;
+import org.apache.ignite.cache.store.CacheStoreSession;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.IgniteInterruptedCheckedException;
+import org.apache.ignite.internal.util.tostring.GridToStringExclude;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.marshaller.Marshaller;
+import org.apache.ignite.marshaller.jdk.JdkMarshaller;
+import org.apache.ignite.resources.CacheStoreSessionResource;
+import org.apache.ignite.resources.IgniteInstanceResource;
+import org.apache.ignite.resources.LoggerResource;
+import org.apache.ignite.transactions.Transaction;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.jetbrains.annotations.Nullable;
+
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriterException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link CacheStore} implementation backed by Hibernate. This implementation
+ * stores objects in underlying database in {@code BLOB} format.
+ * <h2 class="header">Configuration</h2>
+ * Either {@link #setSessionFactory(SessionFactory)} or
+ * {@link #setHibernateConfigurationPath(String)} or
+ * {@link #setHibernateProperties(Properties)} should be set.
+ * <p>
+ * If session factory is provided it should contain
+ * {@link CacheHibernateBlobStoreEntry} persistent class (via provided
+ * mapping file {@code GridCacheHibernateStoreEntry.hbm.xml} or by
+ * adding {@link CacheHibernateBlobStoreEntry} to annotated classes
+ * of session factory.
+ * <p>
+ * Path to hibernate configuration may be either an URL or a file path or
+ * a classpath resource. This configuration file should include provided
+ * mapping {@code GridCacheHibernateStoreEntry.hbm.xml} or include annotated
+ * class {@link CacheHibernateBlobStoreEntry}.
+ * <p>
+ * If hibernate properties are provided, mapping
+ * {@code GridCacheHibernateStoreEntry.hbm.xml} is included automatically.
+ * <p>
+ * Use {@link CacheHibernateBlobStoreFactory} factory to pass {@link CacheHibernateBlobStore} to {@link CacheConfiguration}.
+ */
+public class CacheHibernateBlobStore<K, V> extends CacheStoreAdapter<K, V> {
+    /**
+     * Default connection URL
+     * (value is <tt>jdbc:h2:mem:hibernateCacheStore;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=5000</tt>).
+     */
+    public static final String DFLT_CONN_URL = "jdbc:h2:mem:hibernateCacheStore;DB_CLOSE_DELAY=-1;" +
+        "DEFAULT_LOCK_TIMEOUT=5000";
+
+    /** Default show SQL property value (value is <tt>true</tt>). */
+    public static final String DFLT_SHOW_SQL = "false";
+
+    /** Default <tt>hibernate.hbm2ddl.auto</tt> property value (value is <tt>true</tt>). */
+    public static final String DFLT_HBM2DDL_AUTO = "update";
+
+    /** Session attribute name. */
+    private static final String ATTR_SES = "HIBERNATE_STORE_SESSION";
+
+    /** Name of Hibarname mapping resource. */
+    private static final String MAPPING_RESOURCE =
+            "org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.hbm.xml";
+
+    /** Marshaller. */
+    private static final Marshaller marsh = new JdkMarshaller();
+
+    /** Init guard. */
+    @GridToStringExclude
+    private final AtomicBoolean initGuard = new AtomicBoolean();
+
+    /** Init latch. */
+    @GridToStringExclude
+    private final CountDownLatch initLatch = new CountDownLatch(1);
+
+    /** Hibernate properties. */
+    @GridToStringExclude
+    private Properties hibernateProps;
+
+    /** Session factory. */
+    @GridToStringExclude
+    private SessionFactory sesFactory;
+
+    /** Path to hibernate configuration file. */
+    private String hibernateCfgPath;
+
+    /** Log. */
+    @LoggerResource
+    private IgniteLogger log;
+
+    /** Auto-injected store session. */
+    @CacheStoreSessionResource
+    private CacheStoreSession ses;
+
+    /** Ignite instance. */
+    @IgniteInstanceResource
+    private Ignite ignite;
+
+    /** {@inheritDoc} */
+    @Override
+    @SuppressWarnings({"unchecked", "RedundantTypeArguments"})
+    public V load(K key) {
+        init();
+
+        Transaction tx = transaction();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Store load [key=" + key + ", tx=" + tx + ']');
+        }
+
+        Session ses = session(tx);
+
+        try {
+            CacheHibernateBlobStoreEntry entry = ses.get(CacheHibernateBlobStoreEntry.class, toBytes(key));
+            if (entry == null) {
+                return null;
+            }
+            return fromBytes(entry.getValue());
+        }
+        catch (IgniteCheckedException | HibernateException e) {
+            rollback(ses, tx);
+            throw new CacheLoaderException("Failed to load value from cache store with key: " + key, e);
+        }
+        finally {
+            end(ses, tx);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void write(javax.cache.Cache.Entry<? extends K, ? extends V> entry) {
+        init();
+
+        Transaction tx = transaction();
+
+        K key = entry.getKey();
+        V val = entry.getValue();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Store put [key=" + key + ", val=" + val + ", tx=" + tx + ']');
+        }
+
+        if (val == null) {
+            delete(key);
+
+            return;
+        }
+
+        Session ses = session(tx);
+
+        try {
+            CacheHibernateBlobStoreEntry entry0 = new CacheHibernateBlobStoreEntry(toBytes(key), toBytes(val));
+            ses.saveOrUpdate(entry0);
+        }
+        catch (IgniteCheckedException | HibernateException e) {
+            rollback(ses, tx);
+            throw new CacheWriterException("Failed to put value to cache store [key=" + key + ", val" + val + "]", e);
+        }
+        finally {
+            end(ses, tx);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings({"JpaQueryApiInspection", "JpaQlInspection"})
+    @Override public void delete(Object key) {
+        init();
+
+        Transaction tx = transaction();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Store remove [key=" + key + ", tx=" + tx + ']');
+        }
+
+        Session ses = session(tx);
+        try {
+            Object obj = ses.get(CacheHibernateBlobStoreEntry.class, toBytes(key));
+            if (obj != null) {
+                ses.delete(obj);
+            }
+        }
+        catch (IgniteCheckedException | HibernateException e) {
+            rollback(ses, tx);
+            throw new CacheWriterException("Failed to remove value from cache store with key: " + key, e);
+        }
+        finally {
+            end(ses, tx);
+        }
+    }
+
+    /**
+     * Rolls back hibernate session.
+     *
+     * @param ses Hibernate session.
+     * @param tx Cache ongoing transaction.
+     */
+    private void rollback(SharedSessionContract ses, Transaction tx) {
+        // Rollback only if there is no cache transaction,
+        // otherwise sessionEnd() will do all required work.
+        if (tx == null) {
+            org.hibernate.Transaction hTx = ses.getTransaction();
+            if (hTx != null && hTx.getStatus().canRollback()) {
+                hTx.rollback();
+            }
+        }
+    }
+
+    /**
+     * Ends hibernate session.
+     *
+     * @param ses Hibernate session.
+     * @param tx Cache ongoing transaction.
+     */
+    private void end(Session ses, Transaction tx) {
+        // Commit only if there is no cache transaction,
+        // otherwise sessionEnd() will do all required work.
+        if (tx == null) {
+            org.hibernate.Transaction hTx = ses.getTransaction();
+
+            if (hTx != null && hTx.getStatus() == TransactionStatus.ACTIVE) {
+                hTx.commit();
+            }
+            ses.close();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void sessionEnd(boolean commit) {
+        init();
+
+        Transaction tx = transaction();
+
+        Map<String, Session> props = session().properties();
+
+        Session ses = props.remove(ATTR_SES);
+
+        if (ses != null) {
+            org.hibernate.Transaction hTx = ses.getTransaction();
+
+            if (hTx != null) {
+                try {
+                    if (commit) {
+                        ses.flush();
+                        hTx.commit();
+                    }
+                    else {
+                        hTx.rollback();
+                    }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Transaction ended [xid=" + tx.xid() + ", commit=" + commit + ']');
+                    }
+                }
+                catch (HibernateException e) {
+                    throw new CacheWriterException("Failed to end transaction [xid=" + tx.xid() +
+                        ", commit=" + commit + ']', e);
+                }
+                finally {
+                    ses.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets Hibernate session.
+     *
+     * @param tx Cache transaction.
+     * @return Session.
+     */
+    Session session(@Nullable Transaction tx) {
+        Session ses;
+
+        if (tx != null) {
+            Map<String, Session> props = session().properties();
+
+            ses = props.get(ATTR_SES);
+
+            if (ses == null) {
+                ses = sesFactory.openSession();
+
+                ses.beginTransaction();
+
+                // Store session in transaction metadata, so it can be accessed
+                // for other operations on the same transaction.
+                props.put(ATTR_SES, ses);
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Hibernate session open [ses=" + ses + ", tx=" + tx.xid() + "]");
+                }
+            }
+        }
+        else {
+            ses = sesFactory.openSession();
+
+            ses.beginTransaction();
+        }
+
+        return ses;
+    }
+
+    /**
+     * Sets session factory.
+     *
+     * @param sesFactory Session factory.
+     */
+    public void setSessionFactory(SessionFactory sesFactory) {
+        this.sesFactory = sesFactory;
+    }
+
+    /**
+     * Sets hibernate configuration path.
+     * <p>
+     * This may be either URL or file path or classpath resource.
+     *
+     * @param hibernateCfgPath URL or file path or classpath resource
+     *      pointing to hibernate configuration XML file.
+     */
+    public void setHibernateConfigurationPath(String hibernateCfgPath) {
+        this.hibernateCfgPath = hibernateCfgPath;
+    }
+
+    /**
+     * Sets Hibernate properties.
+     *
+     * @param hibernateProps Hibernate properties.
+     */
+    public void setHibernateProperties(Properties hibernateProps) {
+        this.hibernateProps = hibernateProps;
+    }
+
+    /**
+     * Initializes store.
+     *
+     * @throws IgniteException If failed to initialize.
+     */
+    private void init() throws IgniteException {
+        if (initGuard.compareAndSet(false, true)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Initializing cache store.");
+            }
+            try {
+                if (sesFactory != null) {
+                    // Session factory has been provided - nothing to do.
+                    return;
+                }
+                if (!F.isEmpty(hibernateCfgPath)) {
+                    try {
+                        URL url = new URL(hibernateCfgPath);
+
+                        sesFactory = new Configuration().configure(url).buildSessionFactory();
+
+                        if (log.isDebugEnabled()) {
+                            log.debug("Configured session factory using URL: " + url);
+                        }
+
+                        // Session factory has been successfully initialized.
+                        return;
+                    }
+                    catch (MalformedURLException e) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Caught malformed URL exception: " + e.getMessage());
+                        }
+                    }
+
+                    // Provided path is not a valid URL. File?
+                    File cfgFile = new File(hibernateCfgPath);
+
+                    if (cfgFile.exists()) {
+                        sesFactory = new Configuration().configure(cfgFile).buildSessionFactory();
+
+                        if (log.isDebugEnabled()) {
+                            log.debug("Configured session factory using file: " + hibernateCfgPath);
+                        }
+
+                        // Session factory has been successfully initialized.
+                        return;
+                    }
+
+                    // Provided path is not a file. Classpath resource?
+                    sesFactory = new Configuration().configure(hibernateCfgPath).buildSessionFactory();
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("Configured session factory using classpath resource: " + hibernateCfgPath);
+                    }
+                }
+                else {
+                    if (hibernateProps == null) {
+                        U.warn(log, "No Hibernate configuration has been provided for store (will use default).");
+
+                        hibernateProps = new Properties();
+
+                        hibernateProps.setProperty("hibernate.connection.url", DFLT_CONN_URL);
+                        hibernateProps.setProperty("hibernate.show_sql", DFLT_SHOW_SQL);
+                        hibernateProps.setProperty("hibernate.hbm2ddl.auto", DFLT_HBM2DDL_AUTO);
+                        /*
+                         * fixes IGNITE-1757 - number of threads configured in
+                         *                     GridAbstractCacheStoreSelfTest.testSimpleMultithreading() is 37
+                         */
+                        hibernateProps.setProperty("hibernate.connection.pool_size", "50");
+                    }
+
+                    Configuration cfg = new Configuration();
+
+                    cfg.setProperties(hibernateProps);
+
+                    assert resourceAvailable(MAPPING_RESOURCE) : MAPPING_RESOURCE;
+
+                    cfg.addResource(MAPPING_RESOURCE);
+
+                    sesFactory = cfg.buildSessionFactory();
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("Configured session factory using properties: " + hibernateProps);
+                    }
+                }
+            }
+            catch (HibernateException e) {
+                throw new IgniteException("Failed to initialize store.", e);
+            }
+            finally {
+                initLatch.countDown();
+            }
+        }
+        else if (initLatch.getCount() > 0) {
+            try {
+                U.await(initLatch);
+            }
+            catch (IgniteInterruptedCheckedException e) {
+                throw new IgniteException(e);
+            }
+        }
+
+        if (sesFactory == null) {
+            throw new IgniteException("Cache store was not properly initialized.");
+        }
+    }
+
+    /**
+     * Checks availability of a classpath resource.
+     *
+     * @param name Resource name.
+     * @return {@code true} if resource is available and ready for read, {@code false} otherwise.
+     */
+    private boolean resourceAvailable(String name) {
+        InputStream cfgStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
+
+        if (cfgStream == null) {
+            log.error("Classpath resource not found: " + name);
+            return false;
+        }
+
+        try {
+            // Read a single byte to force actual content access by JVM.
+            cfgStream.read();
+            return true;
+        }
+        catch (IOException e) {
+            log.error("Failed to read classpath resource: " + name, e);
+            return false;
+        }
+        finally {
+            U.close(cfgStream, log);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(CacheHibernateBlobStore.class, this);
+    }
+
+    /**
+     * Serialize object to byte array using marshaller.
+     *
+     * @param obj Object to convert to byte array.
+     * @return Byte array.
+     * @throws IgniteCheckedException If failed to convert.
+     */
+    protected byte[] toBytes(Object obj) throws IgniteCheckedException {
+        return U.marshal(marsh, obj);
+    }
+
+    /**
+     * Deserialize object from byte array using marshaller.
+     *
+     * @param bytes Bytes to deserialize.
+     * @param <X> Result object type.
+     * @return Deserialized object.
+     * @throws IgniteCheckedException If failed.
+     */
+    protected <X> X fromBytes(byte[] bytes) throws IgniteCheckedException {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        return U.unmarshal(marsh, bytes, getClass().getClassLoader());
+    }
+
+    /**
+     * @return Current transaction.
+     */
+    @Nullable private Transaction transaction() {
+        CacheStoreSession ses = session();
+        return ses != null ? ses.transaction() : null;
+    }
+
+    /**
+     * @return Store session.
+     */
+    private CacheStoreSession session() {
+        return ses;
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Entry that is used by {@link CacheHibernateBlobStore} implementation.
+ * <p>
+ * Note that this is a reference implementation for tests only.
+ * When running on production systems use concrete key-value types to
+ * get better performance.
+ */
+@Entity
+@Table(name = "ENTRIES")
+public class CacheHibernateBlobStoreEntry {
+    /** Key (use concrete key type in production). */
+    @Id
+    @Column(length = 65535)
+    private byte[] key;
+
+    /** Value (use concrete value type in production). */
+    @Column(length = 65535)
+    private byte[] val;
+
+    /**
+     * Constructor.
+     */
+    CacheHibernateBlobStoreEntry() {
+        // No-op.
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param key Key.
+     * @param val Value.
+     */
+    CacheHibernateBlobStoreEntry(byte[] key, byte[] val) {
+        this.key = key;
+        this.val = val;
+    }
+
+    /**
+     * @return Key.
+     */
+    public byte[] getKey() {
+        return key;
+    }
+
+    /**
+     * @param key Key.
+     */
+    public void setKey(byte[] key) {
+        this.key = key;
+    }
+
+    /**
+     * @return Value.
+     */
+    public byte[] getValue() {
+        return val;
+    }
+
+    /**
+     * @param val Value.
+     */
+    public void setValue(byte[] val) {
+        this.val = val;
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreFactory.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreFactory.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import java.util.Properties;
+import javax.cache.configuration.Factory;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.IgniteComponentType;
+import org.apache.ignite.internal.util.spring.IgniteSpringHelper;
+import org.apache.ignite.internal.util.tostring.GridToStringExclude;
+import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.resources.SpringApplicationContextResource;
+import org.hibernate.SessionFactory;
+
+/**
+ * {@link Factory} implementation for {@link CacheHibernateBlobStore}.
+ *
+ * Use this factory to pass {@link CacheHibernateBlobStore} to {@link CacheConfiguration}.
+ *
+ * <h2 class="header">Java Example</h2>
+ * In this example existing session factory is provided.
+ * <pre name="code" class="java">
+ *     ...
+ *     CacheHibernateBlobStoreFactory&lt;String, String&gt; factory = new CacheHibernateBlobStoreFactory&lt;String, String&gt;();
+ *
+ *     factory.setSessionFactory(sesFactory);
+ *     ...
+ * </pre>
+ *
+ * <h2 class="header">Spring Example (using Spring ORM)</h2>
+ * <pre name="code" class="xml">
+ *   ...
+ *   &lt;bean id=&quot;cache.hibernate.store.factory&quot;
+ *       class=&quot;org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreFactory&quot;&gt;
+ *       &lt;property name=&quot;sessionFactory&quot;&gt;
+ *           &lt;bean class=&quot;org.springframework.orm.hibernate3.LocalSessionFactoryBean&quot;&gt;
+ *               &lt;property name=&quot;hibernateProperties&quot;&gt;
+ *                   &lt;value&gt;
+ *                       connection.url=jdbc:h2:mem:
+ *                       show_sql=true
+ *                       hbm2ddl.auto=true
+ *                       hibernate.dialect=org.hibernate.dialect.H2Dialect
+ *                   &lt;/value&gt;
+ *               &lt;/property&gt;
+ *               &lt;property name=&quot;mappingResources&quot;&gt;
+ *                   &lt;list&gt;
+ *                       &lt;value&gt;
+ *                           org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.hbm.xml
+ *                       &lt;/value&gt;
+ *                   &lt;/list&gt;
+ *               &lt;/property&gt;
+ *           &lt;/bean&gt;
+ *       &lt;/property&gt;
+ *   &lt;/bean&gt;
+ *   ...
+ * </pre>
+ *
+ * <h2 class="header">Spring Example (using Spring ORM and persistent annotations)</h2>
+ * <pre name="code" class="xml">
+ *     ...
+ *     &lt;bean id=&quot;cache.hibernate.store.factory1&quot;
+ *         class=&quot;org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreFactory&quot;&gt;
+ *         &lt;property name=&quot;sessionFactory&quot;&gt;
+ *             &lt;bean class=&quot;org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean&quot;&gt;
+ *                 &lt;property name=&quot;hibernateProperties&quot;&gt;
+ *                     &lt;value&gt;
+ *                         connection.url=jdbc:h2:mem:
+ *                         show_sql=true
+ *                         hbm2ddl.auto=true
+ *                         hibernate.dialect=org.hibernate.dialect.H2Dialect
+ *                     &lt;/value&gt;
+ *                 &lt;/property&gt;
+ *                 &lt;property name=&quot;annotatedClasses&quot;&gt;
+ *                     &lt;list&gt;
+ *                         &lt;value&gt;
+ *                             org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreEntry
+ *                         &lt;/value&gt;
+ *                     &lt;/list&gt;
+ *                 &lt;/property&gt;
+ *             &lt;/bean&gt;
+ *         &lt;/property&gt;
+ *     &lt;/bean&gt;
+ *     ...
+ * </pre>
+ *
+ * <h2 class="header">Spring Example</h2>
+ * <pre name="code" class="xml">
+ *     ...
+ *     &lt;bean id=&quot;cache.hibernate.store.factory2&quot;
+ *         class=&quot;org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreFactory&quot;&gt;
+ *         &lt;property name=&quot;hibernateProperties&quot;&gt;
+ *             &lt;props&gt;
+ *                 &lt;prop key=&quot;connection.url&quot;&gt;jdbc:h2:mem:&lt;/prop&gt;
+ *                 &lt;prop key=&quot;hbm2ddl.auto&quot;&gt;update&lt;/prop&gt;
+ *                 &lt;prop key=&quot;show_sql&quot;&gt;true&lt;/prop&gt;
+ *             &lt;/props&gt;
+ *         &lt;/property&gt;
+ *     &lt;/bean&gt;
+ *     ...
+ * </pre>
+ * <p>
+ * <img src="http://ignite.apache.org/images/spring-small.png">
+ * <br>
+ * For information about Spring framework visit <a href="http://www.springframework.org/">www.springframework.org</a>
+ */
+public class CacheHibernateBlobStoreFactory<K, V> implements Factory<CacheHibernateBlobStore<K, V>> {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /** Session factory. */
+    @GridToStringExclude
+    private transient SessionFactory sesFactory;
+
+    /** Session factory bean name. */
+    private String sesFactoryBean;
+
+    /** Path to hibernate configuration file. */
+    private String hibernateCfgPath;
+
+    /** Hibernate properties. */
+    @GridToStringExclude
+    private Properties hibernateProps;
+
+    /** Application context. */
+    @SpringApplicationContextResource
+    private Object appContext;
+
+    /** {@inheritDoc} */
+    @Override public CacheHibernateBlobStore<K, V> create() {
+        CacheHibernateBlobStore<K, V> store = new CacheHibernateBlobStore<>();
+
+        store.setHibernateConfigurationPath(hibernateCfgPath);
+        store.setHibernateProperties(hibernateProps);
+
+        if (sesFactory != null) {
+            store.setSessionFactory(sesFactory);
+        }
+        else if (sesFactoryBean != null) {
+            if (appContext == null) {
+                throw new IgniteException("Spring application context resource is not injected.");
+            }
+            IgniteSpringHelper spring;
+
+            try {
+                spring = IgniteComponentType.SPRING.create(false);
+                SessionFactory sesFac = spring.loadBeanFromAppContext(appContext, sesFactoryBean);
+                store.setSessionFactory(sesFac);
+            }
+            catch (IgniteCheckedException e) {
+                throw new IgniteException("Failed to load bean in application context [beanName=" + sesFactoryBean +
+                        ", igniteConfig=" + appContext + ']');
+            }
+        }
+
+        return store;
+    }
+
+    /**
+     * Sets session factory.
+     *
+     * @param sesFactory Session factory.
+     * @return {@code This} for chaining.
+     * @see CacheHibernateBlobStore#setSessionFactory(SessionFactory)
+     */
+    public CacheHibernateBlobStoreFactory<K, V> setSessionFactory(SessionFactory sesFactory) {
+        this.sesFactory = sesFactory;
+        return this;
+    }
+
+    /**
+     * Sets name of the data source bean.
+     *
+     * @param sesFactory Session factory bean name.
+     * @return {@code This} for chaining.
+     * @see CacheHibernateBlobStore#setSessionFactory(SessionFactory)
+     */
+    public CacheHibernateBlobStoreFactory<K, V> setSessionFactoryBean(String sesFactory) {
+        this.sesFactoryBean = sesFactory;
+        return this;
+    }
+
+    /**
+     * Sets hibernate configuration path.
+     * <p>
+     * This may be either URL or file path or classpath resource.
+     *
+     * @param hibernateCfgPath URL or file path or classpath resource
+     *      pointing to hibernate configuration XML file.
+     * @return {@code This} for chaining.
+     * @see CacheHibernateBlobStore#setHibernateConfigurationPath(String)
+     */
+    public CacheHibernateBlobStoreFactory<K, V> setHibernateConfigurationPath(String hibernateCfgPath) {
+        this.hibernateCfgPath = hibernateCfgPath;
+        return this;
+    }
+
+    /**
+     * Sets Hibernate properties.
+     *
+     * @param hibernateProps Hibernate properties.
+     * @return {@code This} for chaining.
+     * @see CacheHibernateBlobStore#setHibernateProperties(Properties)
+     */
+    public CacheHibernateBlobStoreFactory<K, V> setHibernateProperties(Properties hibernateProps) {
+        this.hibernateProps = hibernateProps;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(CacheHibernateBlobStoreFactory.class, this);
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateStoreSessionListener.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/CacheHibernateStoreSessionListener.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.cache.store.CacheStore;
+import org.apache.ignite.cache.store.CacheStoreSession;
+import org.apache.ignite.cache.store.CacheStoreSessionListener;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lifecycle.LifecycleAware;
+import org.apache.ignite.resources.LoggerResource;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+import javax.cache.integration.CacheWriterException;
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Hibernate-based cache store session listener.
+ * <p>
+ * This listener creates a new Hibernate session for each store
+ * session. If there is an ongoing cache transaction, a corresponding
+ * Hibernate transaction is created as well.
+ * <p>
+ * The Hibernate session is saved as a store session
+ * {@link CacheStoreSession#attachment() attachment}.
+ * The listener guarantees that the session will be
+ * available for any store operation. If there is an
+ * ongoing cache transaction, all operations within this
+ * transaction will share a DB transaction.
+ * <p>
+ * As an example, here is how the {@link CacheStore#write(javax.cache.Cache.Entry)}
+ * method can be implemented if {@link CacheHibernateStoreSessionListener}
+ * is configured:
+ * <pre name="code" class="java">
+ * private static class Store extends CacheStoreAdapter&lt;Integer, Integer&gt; {
+ *     &#64;CacheStoreSessionResource
+ *     private CacheStoreSession ses;
+ *
+ *     &#64;Override public void write(Cache.Entry&lt;? extends Integer, ? extends Integer&gt; entry) throws CacheWriterException {
+ *         // Get Hibernate session from the current store session.
+ *         Session hibSes = ses.attachment();
+ *
+ *         // Persist the value.
+ *         hibSes.persist(entry.getValue());
+ *     }
+ * }
+ * </pre>
+ * Hibernate session will be automatically created by the listener
+ * at the start of the session and closed when it ends.
+ * <p>
+ * {@link CacheHibernateStoreSessionListener} requires that either
+ * {@link #setSessionFactory(SessionFactory)} session factory}
+ * or {@link #setHibernateConfigurationPath(String) Hibernate configuration file}
+ * is provided. If non of them is set, exception is thrown. Is both are provided,
+ * session factory will be used.
+ */
+public class CacheHibernateStoreSessionListener implements CacheStoreSessionListener, LifecycleAware {
+    /** Hibernate session factory. */
+    private SessionFactory sesFactory;
+
+    /** Hibernate configuration file path. */
+    private String hibernateCfgPath;
+
+    /** Logger. */
+    @LoggerResource
+    private IgniteLogger log;
+
+    /** Whether to close session on stop. */
+    private boolean closeSesOnStop;
+
+    /**
+     * Sets Hibernate session factory.
+     * <p>
+     * Either session factory or configuration file is required.
+     * If none is provided, exception will be thrown on startup.
+     *
+     * @param sesFactory Session factory.
+     */
+    public void setSessionFactory(SessionFactory sesFactory) {
+        this.sesFactory = sesFactory;
+    }
+
+    /**
+     * Gets Hibernate session factory.
+     *
+     * @return Session factory.
+     */
+    public SessionFactory getSessionFactory() {
+        return sesFactory;
+    }
+
+    /**
+     * Sets hibernate configuration path.
+     * <p>
+     * Either session factory or configuration file is required.
+     * If none is provided, exception will be thrown on startup.
+     *
+     * @param hibernateCfgPath Hibernate configuration path.
+     */
+    public void setHibernateConfigurationPath(String hibernateCfgPath) {
+        this.hibernateCfgPath = hibernateCfgPath;
+    }
+
+    /**
+     * Gets hibernate configuration path.
+     *
+     * @return Hibernate configuration path.
+     */
+    public String getHibernateConfigurationPath() {
+        return hibernateCfgPath;
+    }
+
+    private static String getStackTrace(final Throwable throwable) {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw, true);
+        throwable.printStackTrace(pw);
+        return sw.getBuffer().toString();
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("deprecation")
+    @Override public void start() throws IgniteException {
+        if (sesFactory == null && F.isEmpty(hibernateCfgPath)) {
+            throw new IgniteException("Either session factory or Hibernate configuration file is required by " +
+                getClass().getSimpleName() + '.');
+        }
+
+        if (!F.isEmpty(hibernateCfgPath)) {
+            if (sesFactory == null) {
+                try {
+                    URL url = new URL(hibernateCfgPath);
+                    sesFactory = new Configuration().configure(url).buildSessionFactory();
+                }
+                catch (MalformedURLException ignored) {
+                    log.trace(ignored.getMessage(), getStackTrace(ignored));
+                }
+
+                if (sesFactory == null) {
+                    File cfgFile = new File(hibernateCfgPath);
+                    if (cfgFile.exists()) {
+                        sesFactory = new Configuration().configure(cfgFile).buildSessionFactory();
+                    }
+                }
+
+                if (sesFactory == null) {
+                    sesFactory = new Configuration().configure(hibernateCfgPath).buildSessionFactory();
+                }
+                if (sesFactory == null) {
+                    throw new IgniteException("Failed to resolve Hibernate configuration file: " + hibernateCfgPath);
+                }
+                closeSesOnStop = true;
+            }
+            else {
+                U.warn(log, "Hibernate configuration file configured in " + getClass().getSimpleName() +
+                    " will be ignored (session factory is already set).");
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void stop() throws IgniteException {
+        if (closeSesOnStop && sesFactory != null && !sesFactory.isClosed()) {
+            sesFactory.close();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void onSessionStart(CacheStoreSession ses) {
+        if (ses.attachment() == null) {
+            try {
+                Session hibSes = sesFactory.openSession();
+                ses.attach(hibSes);
+                if (ses.isWithinTransaction()) {
+                    hibSes.beginTransaction();
+                }
+            }
+            catch (HibernateException e) {
+                throw new CacheWriterException("Failed to start store session [tx=" + ses.transaction() + ']', e);
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void onSessionEnd(CacheStoreSession ses, boolean commit) {
+        Session hibSes = ses.attach(null);
+
+        if (hibSes != null) {
+            try {
+                Transaction tx = hibSes.getTransaction();
+                if (commit) {
+                    if (hibSes.isDirty()) {
+                        hibSes.flush();
+                    }
+                    if (tx.getStatus() == TransactionStatus.ACTIVE) {
+                        tx.commit();
+                    }
+                }
+                else if (tx.getStatus().canRollback()) {
+                    tx.rollback();
+                }
+            }
+            catch (HibernateException e) {
+                throw new CacheWriterException("Failed to end store session [tx=" + ses.transaction() + ']', e);
+            }
+            finally {
+                hibSes.close();
+            }
+        }
+    }
+}

--- a/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/package-info.java
+++ b/modules/hibernate-5.3/src/main/java/org/apache/ignite/cache/store/hibernate/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <!-- Package description. -->
+ * Contains reference Hibernate-based cache store implementation.
+ */
+package org.apache.ignite.cache.store.hibernate;

--- a/modules/hibernate-5.3/src/main/resources/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.hbm.xml
+++ b/modules/hibernate-5.3/src/main/resources/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.hbm.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.apache.ignite.examples.datagrid.store" default-access="field">
+    <class name="org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreEntry" table="ENTRIES">
+        <id name="key"/>
+
+        <property name="val"/>
+    </class>
+</hibernate-mapping>

--- a/modules/hibernate-5.3/src/test/config/factory-cache.xml
+++ b/modules/hibernate-5.3/src/test/config/factory-cache.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="simpleSessionFactory"
+          class="org.apache.ignite.cache.store.hibernate.CacheHibernateStoreFactorySelfTest$DummySessionFactoryExt"/>
+
+    <bean id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="test"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="backups" value="1"/>
+                    <property name="cacheStoreFactory">
+                        <bean class="org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreFactory">
+                            <property name="sessionFactoryBean" value = "simpleSessionFactory"/>
+                        </bean>
+                    </property>
+                </bean>
+            </list>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/src/test/config/factory-cache1.xml
+++ b/modules/hibernate-5.3/src/test/config/factory-cache1.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="simpleSessionFactory1"
+          class="org.apache.ignite.cache.store.hibernate.CacheHibernateStoreFactorySelfTest$DummySessionFactory"/>
+
+    <bean id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="igniteInstanceName" value="ignite1"/>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="test"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="backups" value="1"/>
+                    <property name="cacheStoreFactory">
+                        <bean class="org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreFactory">
+                            <property name="sessionFactoryBean" value = "simpleSessionFactory1"/>
+                        </bean>
+                    </property>
+                </bean>
+            </list>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/src/test/config/factory-incorrect-store-cache.xml
+++ b/modules/hibernate-5.3/src/test/config/factory-incorrect-store-cache.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="ignite.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="failureHandler">
+            <bean class="org.apache.ignite.failure.NoOpFailureHandler"/>
+        </property>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="test"/>
+                    <property name="atomicityMode" value="ATOMIC"/>
+                    <property name="backups" value="1"/>
+                    <property name="cacheStoreFactory">
+                        <bean class="org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreFactory">
+                            <property name="sessionFactoryBean" value = "simpleSessionFactory1"/>
+                        </bean>
+                    </property>
+                </bean>
+            </list>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500..47509</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheConfigurationSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheConfigurationSelfTest.java
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteKernal;
+import org.apache.ignite.internal.processors.cache.IgniteCacheProxy;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Configuration;
+
+import javax.cache.Cache;
+import javax.persistence.Cacheable;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
+import static org.apache.ignite.cache.CacheMode.PARTITIONED;
+import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.REGION_CACHE_PROPERTY;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cfg.AvailableSettings.CACHE_REGION_FACTORY;
+import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
+import static org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO;
+import static org.hibernate.cfg.AvailableSettings.RELEASE_CONNECTIONS;
+import static org.hibernate.cfg.AvailableSettings.USE_QUERY_CACHE;
+import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
+
+/**
+ * Tests Hibernate L2 cache configuration.
+ */
+public class HibernateL2CacheConfigurationSelfTest extends GridCommonAbstractTest {
+    /** */
+    public static final String ENTITY1_NAME = Entity1.class.getName();
+
+    /** */
+    public static final String ENTITY2_NAME = Entity2.class.getName();
+
+    /** */
+    public static final String ENTITY3_NAME = Entity3.class.getName();
+
+    /** */
+    public static final String ENTITY4_NAME = Entity4.class.getName();
+
+    /** */
+    public static final String CONNECTION_URL = "jdbc:h2:mem:example;DB_CLOSE_DELAY=-1";
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        startGrid(0);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        stopAllGrids();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        for (IgniteCacheProxy<?, ?> cache : ((IgniteKernal)grid(0)).caches())
+            cache.clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        TcpDiscoverySpi discoSpi = new TcpDiscoverySpi();
+
+        discoSpi.setIpFinder(new TcpDiscoveryVmIpFinder(true));
+
+        cfg.setDiscoverySpi(discoSpi);
+
+        cfg.setCacheConfiguration(cacheConfiguration(ENTITY3_NAME),
+            cacheConfiguration(ENTITY4_NAME),
+            cacheConfiguration("cache1"),
+            cacheConfiguration("cache2"),
+            cacheConfiguration("cache3"),
+            cacheConfiguration(DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME),
+            cacheConfiguration(DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME));
+
+        return cfg;
+    }
+
+    /**
+     * @param cacheName Cache name.
+     * @return Cache configuration.
+     */
+    private CacheConfiguration cacheConfiguration(String cacheName) {
+        CacheConfiguration cfg = new CacheConfiguration();
+        cfg.setName(cacheName);
+        cfg.setCacheMode(PARTITIONED);
+        cfg.setAtomicityMode(ATOMIC);
+        cfg.setStatisticsEnabled(true);
+        return cfg;
+    }
+    /**
+     * @param igniteInstanceName Ignite instance name.
+     * @return Hibernate configuration.
+     */
+    protected Configuration hibernateConfiguration(String igniteInstanceName) {
+        Configuration cfg = new Configuration();
+
+        cfg.addAnnotatedClass(Entity1.class);
+        cfg.addAnnotatedClass(Entity2.class);
+        cfg.addAnnotatedClass(Entity3.class);
+        cfg.addAnnotatedClass(Entity4.class);
+
+        cfg.setProperty(HibernateAccessStrategyFactory.DFLT_ACCESS_TYPE_PROPERTY, AccessType.NONSTRICT_READ_WRITE.name());
+
+        cfg.setProperty(HBM2DDL_AUTO, "create");
+
+        cfg.setProperty(GENERATE_STATISTICS, "true");
+
+        cfg.setProperty(USE_SECOND_LEVEL_CACHE, "true");
+
+        cfg.setProperty(USE_QUERY_CACHE, "true");
+
+        cfg.setProperty(CACHE_REGION_FACTORY, HibernateRegionFactory.class.getName());
+
+        cfg.setProperty(RELEASE_CONNECTIONS, "on_close");
+
+        cfg.setProperty(HibernateAccessStrategyFactory.IGNITE_INSTANCE_NAME_PROPERTY, igniteInstanceName);
+
+        cfg.setProperty(REGION_CACHE_PROPERTY + ENTITY1_NAME, "cache1");
+        cfg.setProperty(REGION_CACHE_PROPERTY + ENTITY2_NAME, "cache2");
+        cfg.setProperty(REGION_CACHE_PROPERTY + DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME, DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME);
+        cfg.setProperty(REGION_CACHE_PROPERTY + DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME, DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME);
+
+        return cfg;
+    }
+
+    /**
+     * Tests property {@link HibernateAccessStrategyFactory#REGION_CACHE_PROPERTY}.
+     */
+    public void testPerRegionCacheProperty() {
+        testCacheUsage(1, 1, 0, 1, 1);
+    }
+
+    /**
+     * @param expCache1 Expected size of cache with name 'cache1'.
+     * @param expCache2 Expected size of cache with name 'cache2'.
+     * @param expCache3 Expected size of cache with name 'cache3'.
+     * @param expCacheE3 Expected size of cache with name {@link #ENTITY3_NAME}.
+     * @param expCacheE4 Expected size of cache with name {@link #ENTITY4_NAME}.
+     */
+    @SuppressWarnings("unchecked")
+    private void testCacheUsage(int expCache1, int expCache2, int expCache3, int expCacheE3, int expCacheE4) {
+        SessionFactory sesFactory = startHibernate(getTestIgniteInstanceName(0));
+
+        try {
+            Session ses = sesFactory.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+
+                ses.save(new Entity1());
+                ses.save(new Entity2());
+                ses.save(new Entity3());
+                ses.save(new Entity4());
+
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            ses = sesFactory.openSession();
+
+            try {
+                List<Entity1> list1 = getResultsList(ses, Entity1.class);
+
+                assertEquals(1, list1.size());
+
+                for (Entity1 e : list1) {
+                    ses.load(ENTITY1_NAME, e.getId());
+                    assertNotNull(e.getId());
+                }
+
+                List<Entity2> list2 = getResultsList(ses, Entity2.class);
+
+                assertEquals(1, list2.size());
+
+                for (Entity2 e : list2)
+                    assertNotNull(e.getId());
+
+                List<Entity3> list3 = getResultsList(ses, Entity3.class);
+
+                assertEquals(1, list3.size());
+
+                for (Entity3 e : list3)
+                    assertNotNull(e.getId());
+
+                List<Entity4> list4 = getResultsList(ses, Entity4.class);
+
+                assertEquals(1, list4.size());
+
+                for (Entity4 e : list4)
+                    assertNotNull(e.getId());
+            }
+            finally {
+                ses.close();
+            }
+
+            IgniteCache<Object, Object> cache1 = grid(0).cache("cache1");
+            IgniteCache<Object, Object> cache2 = grid(0).cache("cache2");
+            IgniteCache<Object, Object> cache3 = grid(0).cache("cache3");
+            IgniteCache<Object, Object> cacheE3 = grid(0).cache(ENTITY3_NAME);
+            IgniteCache<Object, Object> cacheE4 = grid(0).cache(ENTITY4_NAME);
+
+            assertEquals("Unexpected entries: " + toSet(cache1.iterator()), expCache1, cache1.size());
+            assertEquals("Unexpected entries: " + toSet(cache2.iterator()), expCache2, cache2.size());
+            assertEquals("Unexpected entries: " + toSet(cache3.iterator()), expCache3, cache3.size());
+            assertEquals("Unexpected entries: " + toSet(cacheE3.iterator()), expCacheE3, cacheE3.size());
+            assertEquals("Unexpected entries: " + toSet(cacheE4.iterator()), expCacheE4, cacheE4.size());
+        }
+        finally {
+            sesFactory.close();
+        }
+    }
+
+    private <T> List<T> getResultsList(Session ses, Class<T> entityClass) {
+        CriteriaBuilder builder = ses.getCriteriaBuilder();
+        CriteriaQuery<T> query = builder.createQuery(entityClass);
+        Root<T> root = query.from(entityClass);
+        query.select(root);
+        return ses.createQuery(query).getResultList();
+    }
+
+    /**
+     *
+     */
+    private <K, V> Set<Cache.Entry<K, V>> toSet(Iterator<Cache.Entry<K, V>> iter){
+        Set<Cache.Entry<K, V>> set = new HashSet<>();
+
+        while (iter.hasNext())
+            set.add(iter.next());
+
+        return set;
+    }
+
+    /**
+     * @param igniteInstanceName Name of the grid providing caches.
+     * @return Session factory.
+     */
+    private SessionFactory startHibernate(String igniteInstanceName) {
+        Configuration cfg = hibernateConfiguration(igniteInstanceName);
+
+        StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+
+        builder.applySetting("hibernate.connection.url", CONNECTION_URL);
+        builder.applySetting("hibernate.show_sql", false);
+        builder.applySettings(cfg.getProperties());
+
+        return cfg.buildSessionFactory(builder.build());
+    }
+
+    /**
+     * Test Hibernate entity1.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity1 {
+        /** */
+        private int id;
+
+        /**
+         * @return ID.
+         */
+        @Id
+        @GeneratedValue
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    /**
+     * Test Hibernate entity2.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity2 {
+        /** */
+        private int id;
+
+        /**
+         * @return ID.
+         */
+        @Id
+        @GeneratedValue
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    /**
+     * Test Hibernate entity3.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity3 {
+        /** */
+        private int id;
+
+        /**
+         * @return ID.
+         */
+        @Id
+        @GeneratedValue
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    /**
+     * Test Hibernate entity4.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity4 {
+        /** */
+        private int id;
+
+        /**
+         * @return ID.
+         */
+        @Id
+        @GeneratedValue
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheMultiJvmTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheMultiJvmTest.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCompute;
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.binary.BinaryMarshaller;
+import org.apache.ignite.lang.IgniteRunnable;
+import org.apache.ignite.resources.IgniteInstanceResource;
+import org.apache.ignite.resources.LoggerResource;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Id;
+import java.util.Map;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
+import static org.apache.ignite.cache.CacheMode.PARTITIONED;
+import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
+import static org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest.CONNECTION_URL;
+import static org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest.hibernateProperties;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cache.spi.access.AccessType.NONSTRICT_READ_WRITE;
+
+/**
+ *
+ */
+public class HibernateL2CacheMultiJvmTest extends GridCommonAbstractTest {
+    /** */
+    private static final String CACHE_NAME = "hibernateCache";
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        if (!getTestIgniteInstanceName(0).equals(igniteInstanceName)) {
+            cfg.setClientMode(true);
+        }
+
+
+        cfg.setCacheConfiguration(
+            cacheConfiguration(CACHE_NAME),
+            cacheConfiguration(DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME),
+            cacheConfiguration(Entity1.class.getName()),
+            cacheConfiguration(Entity2.class.getName()),
+            cacheConfiguration(Entity3.class.getName())
+        );
+
+        cfg.setMarshaller(new BinaryMarshaller());
+
+        cfg.setPeerClassLoadingEnabled(false);
+
+        return cfg;
+    }
+
+    private CacheConfiguration cacheConfiguration(String cacheName) {
+        CacheConfiguration cfg = new CacheConfiguration();
+        cfg.setName(cacheName);
+        cfg.setCacheMode(PARTITIONED);
+        cfg.setAtomicityMode(ATOMIC);
+        cfg.setWriteSynchronizationMode(FULL_SYNC);
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected boolean isMultiJvm() {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        super.beforeTestsStarted();
+
+        startGrid(0);
+
+        startGrid(1);
+        startGrid(2);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        stopAllGrids();
+
+        super.afterTestsStopped();
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testL2Cache() throws Exception {
+        Ignite srv = ignite(0);
+
+        {
+            IgniteCompute client1Compute =
+                srv.compute(srv.cluster().forNodeId(ignite(1).cluster().localNode().id()));
+
+            client1Compute.run(new HibernateInsertRunnable());
+        }
+
+        {
+            IgniteCompute client2Compute =
+                srv.compute(srv.cluster().forNodeId(ignite(2).cluster().localNode().id()));
+
+            client2Compute.run(new HibernateLoadRunnable());
+        }
+
+        {
+            IgniteCompute srvCompute = srv.compute(srv.cluster().forLocal());
+
+            srvCompute.run(new HibernateLoadRunnable());
+        }
+    }
+
+    /**
+     *
+     */
+    private static class HibernateInsertRunnable extends HibernateBaseRunnable {
+        /** {@inheritDoc} */
+        @Override public void run() {
+            SessionFactory sesFactory = startHibernate(ignite.name());
+
+            Session ses = sesFactory.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+
+                for (int i = 0; i < 1; i++) {
+                    {
+                        Entity1 e = new Entity1();
+                        e.setId(i);
+                        e.setName("name-" + i);
+
+                        ses.save(e);
+                    }
+
+                    {
+                        Entity2 e = new Entity2();
+                        e.setId(String.valueOf(i));
+                        e.setName("name-" + i);
+
+                        ses.save(e);
+                    }
+
+                    {
+                        Entity3 e = new Entity3();
+                        e.setId(i);
+                        e.setName("name-" + i);
+
+                        ses.save(e);
+                    }
+                }
+
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    private static class HibernateLoadRunnable extends HibernateBaseRunnable {
+        /** {@inheritDoc} */
+        @Override public void run() {
+            SessionFactory sesFactory = startHibernate(ignite.name());
+
+            Session ses = sesFactory.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+
+                for (int i = 0; i < 1; i++) {
+                    {
+                        Entity1 e = (Entity1)ses.load(Entity1.class, i);
+
+                        log.info("Found: " + e.getName());
+                    }
+                    {
+                        Entity2 e = (Entity2)ses.load(Entity2.class, String.valueOf(i));
+
+                        log.info("Found: " + e.getName());
+                    }
+                    {
+                        Entity3 e = (Entity3)ses.load(Entity3.class, (double)i);
+
+                        log.info("Found: " + e.getName());
+                    }
+                }
+
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+        }
+    }
+
+    /**
+     *
+     */
+    private abstract static class HibernateBaseRunnable implements IgniteRunnable {
+        /** */
+        @IgniteInstanceResource
+        protected Ignite ignite;
+
+        /** */
+        @LoggerResource
+        IgniteLogger log;
+
+        /**
+         * @param nodeName Name of the grid providing caches.
+         * @return Session factory.
+         */
+        SessionFactory startHibernate(String nodeName) {
+            log.info("Start hibernate on node: " + nodeName);
+
+            StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+
+            for (Map.Entry<String, String> e : hibernateProperties(nodeName, NONSTRICT_READ_WRITE.name()).entrySet())
+                builder.applySetting(e.getKey(), e.getValue());
+
+            builder.applySetting("hibernate.connection.url", CONNECTION_URL);
+
+            MetadataSources metadataSources = new MetadataSources(builder.build());
+
+            metadataSources.addAnnotatedClass(Entity1.class);
+            metadataSources.addAnnotatedClass(Entity2.class);
+            metadataSources.addAnnotatedClass(Entity3.class);
+
+            return metadataSources.buildMetadata().buildSessionFactory();
+        }
+    }
+
+    /**
+     * Test Hibernate entity1.
+     */
+    @javax.persistence.Entity
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity1 {
+        /** */
+        @Id
+        private int id;
+
+        /** */
+        private String name;
+
+        /**
+         * @return ID.
+         */
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Entity1 entity1 = (Entity1)o;
+
+            return id == entity1.id;
+        }
+
+        /** {@inheritDoc} */
+        @Override public int hashCode() {
+            return id;
+        }
+    }
+
+    /**
+     * Test Hibernate entity1.
+     */
+    @javax.persistence.Entity
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity2 {
+        /** */
+        @Id
+        private String id;
+
+        /** */
+        private String name;
+
+        /**
+         * @return ID.
+         */
+        public String getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Entity2 entity2 = (Entity2)o;
+
+            return id.equals(entity2.id);
+        }
+
+        /** {@inheritDoc} */
+        @Override public int hashCode() {
+            return id.hashCode();
+        }
+    }
+
+    /**
+     * Test Hibernate entity1.
+     */
+    @javax.persistence.Entity
+    @Cacheable
+    @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    public static class Entity3 {
+        /** */
+        @Id
+        private double id;
+
+        /** */
+        private String name;
+
+        /**
+         * @return ID.
+         */
+        public double getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(double id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Entity3 entity3 = (Entity3)o;
+
+            return Double.compare(entity3.id, id) == 0;
+        }
+
+        /** {@inheritDoc} */
+        @Override public int hashCode() {
+            long temp = Double.doubleToLongBits(id);
+            return (int)(temp ^ (temp >>> 32));
+        }
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheSelfTest.java
@@ -1,0 +1,1764 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteKernal;
+import org.apache.ignite.internal.processors.cache.IgniteCacheProxy;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.hibernate.ObjectNotFoundException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.spi.RegionFactory;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.RootClass;
+import org.hibernate.query.Query;
+import org.hibernate.stat.CacheRegionStatistics;
+
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.OptimisticLockException;
+import javax.persistence.PersistenceException;
+import javax.persistence.SharedCacheMode;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
+import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
+import static org.apache.ignite.cache.CacheMode.PARTITIONED;
+import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
+import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.DFLT_ACCESS_TYPE_PROPERTY;
+import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.IGNITE_INSTANCE_NAME_PROPERTY;
+import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.REGION_CACHE_PROPERTY;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_MODE;
+import static org.hibernate.cfg.Environment.CACHE_REGION_FACTORY;
+import static org.hibernate.cfg.Environment.GENERATE_STATISTICS;
+import static org.hibernate.cfg.Environment.HBM2DDL_AUTO;
+import static org.hibernate.cfg.Environment.RELEASE_CONNECTIONS;
+import static org.hibernate.cfg.Environment.USE_QUERY_CACHE;
+import static org.hibernate.cfg.Environment.USE_SECOND_LEVEL_CACHE;
+
+/**
+ *
+ * Tests Hibernate L2 cache.
+ */
+public class HibernateL2CacheSelfTest extends GridCommonAbstractTest {
+    /** */
+    private static final TcpDiscoveryIpFinder IP_FINDER = new TcpDiscoveryVmIpFinder(true);
+
+    /** */
+    public static final String CONNECTION_URL = "jdbc:h2:mem:example;DB_CLOSE_DELAY=-1";
+
+    /** */
+    public static final String ENTITY_NAME = Entity.class.getName();
+
+    /** */
+    public static final String ENTITY2_NAME = Entity2.class.getName();
+
+    /** */
+    public static final String VERSIONED_ENTITY_NAME = VersionedEntity.class.getName();
+
+    /** */
+    public static final String CHILD_ENTITY_NAME = ChildEntity.class.getName();
+
+    /** */
+    public static final String PARENT_ENTITY_NAME = ParentEntity.class.getName();
+
+    /** */
+    public static final String CHILD_COLLECTION_REGION = ENTITY_NAME + ".children";
+
+    /** */
+    public static final String NATURAL_ID_REGION =
+        "org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest$Entity##NaturalId";
+
+    /** */
+    public static final String NATURAL_ID_REGION2 =
+        "org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest$Entity2##NaturalId";
+
+    /** */
+    private SessionFactory sesFactory1;
+
+    /** */
+    private SessionFactory sesFactory2;
+
+    /**
+     * First Hibernate test entity.
+     */
+    @javax.persistence.Entity
+    @NaturalIdCache
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    public static class Entity {
+        /** */
+        private int id;
+
+        /** */
+        private String name;
+
+        /** */
+        private Collection<ChildEntity> children;
+
+        /**
+         * Default constructor required by Hibernate.
+         */
+        public Entity() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param name Name.
+         */
+        public Entity(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        @NaturalId(mutable = true)
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /**
+         * @return Children.
+         */
+        @OneToMany(cascade=javax.persistence.CascadeType.ALL, fetch=FetchType.LAZY)
+        @JoinColumn(name="ENTITY_ID")
+        public Collection<ChildEntity> getChildren() {
+            return children;
+        }
+
+        /**
+         * @param children Children.
+         */
+        public void setChildren(Collection<ChildEntity> children) {
+            this.children = children;
+        }
+    }
+
+    /**
+     * Second Hibernate test entity.
+     */
+    @javax.persistence.Entity
+    @NaturalIdCache
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    public static class Entity2 {
+        /** */
+        private int id;
+
+        /** */
+        private String name;
+
+        /** */
+        private Collection<ChildEntity> children;
+
+        /**
+         * Default constructor required by Hibernate.
+         */
+        public Entity2() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param name Name.
+         */
+        public Entity2(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        @NaturalId(mutable = true)
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Hibernate child entity referenced by {@link Entity}.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings("PublicInnerClass")
+    public static class ChildEntity {
+        /** */
+        private int id;
+
+        /**
+         * Default constructor required by Hibernate.
+         */
+        public ChildEntity() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         */
+        public ChildEntity(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        @GeneratedValue
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    /**
+     * Hibernate entity referencing {@link Entity}.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings("PublicInnerClass")
+    public static class ParentEntity {
+        /** */
+        private int id;
+
+        /** */
+        private Entity entity;
+
+        /**
+         * Default constructor required by Hibernate.
+         */
+        public ParentEntity() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param entity Referenced entity.
+         */
+        public ParentEntity(int id, Entity entity) {
+            this.id = id;
+            this.entity = entity;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Referenced entity.
+         */
+        @OneToOne
+        public Entity getEntity() {
+            return entity;
+        }
+
+        /**
+         * @param entity Referenced entity.
+         */
+        public void setEntity(Entity entity) {
+            this.entity = entity;
+        }
+    }
+
+    /**
+     * Hibernate entity.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    public static class VersionedEntity {
+        /** */
+        private int id;
+
+        /** */
+        private long ver;
+
+        /**
+         * Default constructor required by Hibernate.
+         */
+        public VersionedEntity() {
+        }
+
+        /**
+         * @param id ID.
+         */
+        public VersionedEntity(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Version.
+         */
+        @javax.persistence.Version
+        public long getVersion() {
+            return ver;
+        }
+
+        /**
+         * @param ver Version.
+         */
+        public void setVersion(long ver) {
+            this.ver = ver;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        TcpDiscoverySpi discoSpi = new TcpDiscoverySpi();
+
+        discoSpi.setIpFinder(IP_FINDER);
+
+        cfg.setDiscoverySpi(discoSpi);
+
+        cfg.setCacheConfiguration(generalRegionConfiguration(DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME),
+            generalRegionConfiguration(DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME),
+            transactionalRegionConfiguration(ENTITY_NAME),
+            transactionalRegionConfiguration(ENTITY2_NAME),
+            transactionalRegionConfiguration(VERSIONED_ENTITY_NAME),
+            transactionalRegionConfiguration(PARENT_ENTITY_NAME),
+            transactionalRegionConfiguration(CHILD_ENTITY_NAME),
+            transactionalRegionConfiguration(CHILD_COLLECTION_REGION),
+            transactionalRegionConfiguration(NATURAL_ID_REGION),
+            transactionalRegionConfiguration(NATURAL_ID_REGION2));
+
+        return cfg;
+    }
+
+    /**
+     * @param regionName Region name.
+     * @return Cache configuration for {@link IgniteGeneralDataRegion}.
+     */
+    private CacheConfiguration generalRegionConfiguration(String regionName) {
+        CacheConfiguration cfg = new CacheConfiguration();
+        cfg.setName(regionName);
+        cfg.setCacheMode(PARTITIONED);
+        cfg.setAtomicityMode(ATOMIC);
+        cfg.setWriteSynchronizationMode(FULL_SYNC);
+        cfg.setBackups(1);
+        cfg.setStatisticsEnabled(true);
+//        cfg.setAffinity(new RendezvousAffinityFunction(false, 10));
+        return cfg;
+    }
+
+    /**
+     * @param regionName Region name.
+     * @return Transactional Cache configuration
+     */
+    protected CacheConfiguration transactionalRegionConfiguration(String regionName) {
+        CacheConfiguration cfg = new CacheConfiguration();
+        cfg.setName(regionName);
+        cfg.setCacheMode(PARTITIONED);
+        cfg.setAtomicityMode(TRANSACTIONAL);
+        cfg.setWriteSynchronizationMode(FULL_SYNC);
+        cfg.setBackups(1);
+        cfg.setStatisticsEnabled(true);
+        cfg.setAffinity(new RendezvousAffinityFunction(false, 10));
+        return cfg;
+    }
+
+    /**
+     * @return Hibernate registry builder.
+     */
+    protected StandardServiceRegistryBuilder registryBuilder() {
+        StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+
+        builder.applySetting("hibernate.connection.url", CONNECTION_URL);
+
+        return builder;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        startGrids(2);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        stopAllGrids();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        cleanup();
+    }
+
+    /**
+     * @return Hibernate L2 cache access types to test.
+     */
+    protected AccessType[] accessTypes() {
+        return new AccessType[]{AccessType.READ_ONLY, AccessType.NONSTRICT_READ_WRITE, AccessType.READ_WRITE};
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testCollectionCache() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testCollectionCache(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    @SuppressWarnings("unchecked")
+    private void testCollectionCache(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        Map<Integer, Integer> idToChildCnt = new HashMap<>();
+
+        try {
+            Session ses = sesFactory1.openSession();
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < 3; i++) {
+                    Entity e = new Entity(i, "name-" + i);
+                    Collection<ChildEntity> children = new ArrayList<>();
+                    for (int j = 0; j < 3; j++) {
+                        children.add(new ChildEntity());
+                    }
+                    e.setChildren(children);
+                    idToChildCnt.put(e.getId(), e.getChildren().size());
+                    ses.save(e);
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            // Load children, this should populate cache.
+
+            ses = sesFactory1.openSession();
+
+            try {
+                List<Entity> list = ses.createCriteria(ENTITY_NAME).list();
+                assertEquals(idToChildCnt.size(), list.size());
+                for (Entity e : list) {
+                    assertEquals((int) idToChildCnt.get(e.getId()), e.getChildren().size());
+                }
+            }
+            finally {
+                ses.close();
+            }
+
+            assertCollectionCache(sesFactory2, idToChildCnt, 3, 0);
+            assertCollectionCache(sesFactory1, idToChildCnt, 3, 0);
+
+            if (accessType == AccessType.READ_ONLY) {
+                return;
+            }
+
+            // Update children for one entity.
+
+            ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                e1.getChildren().remove(e1.getChildren().iterator().next());
+                ses.update(e1);
+                idToChildCnt.put(e1.getId(), e1.getChildren().size());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertCollectionCache(sesFactory2, idToChildCnt, 2, 1); // After update collection cache entry is removed.
+            assertCollectionCache(sesFactory1, idToChildCnt, 3, 0); // 'assertCollectionCache' loads children in cache.
+
+            // Update children for the same entity using another SessionFactory.
+
+            ses = sesFactory2.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                e1.getChildren().remove(e1.getChildren().iterator().next());
+                ses.update(e1);
+                idToChildCnt.put(e1.getId(), e1.getChildren().size());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertCollectionCache(sesFactory2, idToChildCnt, 2, 1); // After update collection cache entry is removed.
+            assertCollectionCache(sesFactory1, idToChildCnt, 3, 0); // 'assertCollectionCache' loads children in cache.
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testEntityCache() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testEntityCache(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testEntityCache(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        Map<Integer, String> idToName = new HashMap<>();
+
+        try {
+            Session ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < 2; i++) {
+                    String name = "name-" + i;
+                    ses.save(new Entity(i, name));
+                    idToName.put(i, name);
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName, 100);
+
+            if (accessType == AccessType.READ_ONLY)
+                return;
+
+            ses = sesFactory1.openSession();
+
+            try {
+                // Updates and inserts in single transaction.
+                Transaction tx = ses.beginTransaction();
+                Entity e0 = (Entity)ses.load(Entity.class, 0);
+                e0.setName("name-0-changed1");
+                ses.update(e0);
+                idToName.put(0, e0.getName());
+                ses.save(new Entity(2, "name-2"));
+                idToName.put(2, "name-2");
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                e1.setName("name-1-changed1");
+                ses.update(e1);
+                idToName.put(1, e1.getName());
+                ses.save(new Entity(3, "name-3"));
+                idToName.put(3, "name-3");
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName);
+
+            ses = sesFactory1.openSession();
+
+            try {
+                // Updates, inserts and deletes in single transaction.
+                Transaction tx = ses.beginTransaction();
+                ses.save(new Entity(4, "name-4"));
+                idToName.put(4, "name-4");
+                Entity e0 = (Entity)ses.load(Entity.class, 0);
+                e0.setName("name-0-changed2");
+                ses.update(e0);
+                idToName.put(e0.getId(), e0.getName());
+                ses.delete(ses.load(Entity.class, 1));
+                idToName.remove(1);
+                Entity e2 = (Entity)ses.load(Entity.class, 2);
+                e2.setName("name-2-changed1");
+                ses.update(e2);
+                idToName.put(e2.getId(), e2.getName());
+                ses.delete(ses.load(Entity.class, 3));
+                idToName.remove(3);
+                ses.save(new Entity(5, "name-5"));
+                idToName.put(5, "name-5");
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName, 1, 3);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName, 1, 3);
+
+            // Try to update the same entity using another SessionFactory.
+
+            ses = sesFactory2.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                Entity e0 = (Entity)ses.load(Entity.class, 0);
+                e0.setName("name-0-changed3");
+                ses.update(e0);
+                idToName.put(e0.getId(), e0.getName());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName);
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testTwoEntitiesSameCache() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testTwoEntitiesSameCache(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testTwoEntitiesSameCache(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        try {
+            Session ses = sesFactory1.openSession();
+
+            Map<Integer, String> idToName1 = new HashMap<>();
+            Map<Integer, String> idToName2 = new HashMap<>();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < 2; i++) {
+                    String name = "name-" + i;
+                    ses.save(new Entity(i, name));
+                    ses.save(new Entity2(i, name));
+                    idToName1.put(i, name);
+                    idToName2.put(i, name);
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName1, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName1, 100);
+
+            assertEntityCache(ENTITY2_NAME, sesFactory2, idToName2, 100);
+            assertEntityCache(ENTITY2_NAME, sesFactory1, idToName2, 100);
+
+            if (accessType == AccessType.READ_ONLY)
+                return;
+
+            ses = sesFactory1.openSession();
+
+            try {
+                // Updates both entities in single transaction.
+                Transaction tx = ses.beginTransaction();
+                Entity e = (Entity)ses.load(Entity.class, 0);
+                e.setName("name-0-changed1");
+                ses.update(e);
+                Entity2 e2 = (Entity2)ses.load(Entity2.class, 0);
+                e2.setName("name-e2-0-changed1");
+                ses.update(e2);
+                idToName1.put(0, e.getName());
+                idToName2.put(0, e2.getName());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName1, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName1, 100);
+
+            assertEntityCache(ENTITY2_NAME, sesFactory2, idToName2, 100);
+            assertEntityCache(ENTITY2_NAME, sesFactory1, idToName2, 100);
+
+            ses = sesFactory1.openSession();
+            try {
+                // Remove entity1 and insert entity2 in single transaction.
+                Transaction tx = ses.beginTransaction();
+                Entity e = (Entity)ses.load(Entity.class, 0);
+                ses.delete(e);
+                Entity2 e2 = new Entity2(2, "name-2");
+                ses.save(e2);
+                idToName1.remove(0);
+                idToName2.put(2, e2.getName());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName1, 0, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName1, 0, 100);
+
+            assertEntityCache(ENTITY2_NAME, sesFactory2, idToName2, 100);
+            assertEntityCache(ENTITY2_NAME, sesFactory1, idToName2, 100);
+
+            ses = sesFactory1.openSession();
+
+            Transaction tx = ses.beginTransaction();
+            try {
+                // Update, remove, insert in single transaction, transaction fails.
+                Entity e = (Entity)ses.load(Entity.class, 1);
+                e.setName("name-1-changed1");
+                ses.update(e); // Valid update.
+                ses.save(new Entity(2, "name-2")); // Valid insert.
+                ses.delete(ses.load(Entity2.class, 0)); // Valid delete.
+                Entity2 e2 = (Entity2)ses.load(Entity2.class, 1);
+                e2.setName("name-2");  // Invalid update, not-unique name.
+                ses.update(e2);
+                tx.commit();
+                fail("Commit must fail.");
+            }
+            catch (PersistenceException e) {
+                assertEquals(ConstraintViolationException.class, e.getCause().getClass());
+                log.info("Expected exception: " + e);
+                tx.rollback();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName1, 0, 2, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName1, 0, 2, 100);
+
+            assertEntityCache(ENTITY2_NAME, sesFactory2, idToName2, 100);
+            assertEntityCache(ENTITY2_NAME, sesFactory1, idToName2, 100);
+
+            ses = sesFactory2.openSession();
+            try {
+                // Update, remove, insert in single transaction.
+                tx = ses.beginTransaction();
+                Entity e = (Entity)ses.load(Entity.class, 1);
+                e.setName("name-1-changed1");
+                ses.update(e);
+                idToName1.put(1, e.getName());
+                ses.save(new Entity(2, "name-2"));
+                idToName1.put(2, "name-2");
+                ses.delete(ses.load(Entity2.class, 0));
+                idToName2.remove(0);
+                Entity2 e2 = (Entity2)ses.load(Entity2.class, 1);
+                e2.setName("name-e2-2-changed");
+                ses.update(e2);
+                idToName2.put(1, e2.getName());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName1, 0, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName1, 0, 100);
+
+            assertEntityCache(ENTITY2_NAME, sesFactory2, idToName2, 0, 100);
+            assertEntityCache(ENTITY2_NAME, sesFactory1, idToName2, 0, 100);
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testVersionedEntity() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testVersionedEntity(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testVersionedEntity(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        try {
+            Session ses = sesFactory1.openSession();
+            VersionedEntity e0 = new VersionedEntity(0);
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                ses.save(e0);
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            ses = sesFactory1.openSession();
+            long ver;
+            try {
+                ver = ((VersionedEntity)ses.load(VersionedEntity.class, 0)).getVersion();
+            }
+            finally {
+                ses.close();
+            }
+
+            CacheRegionStatistics stats1 =
+                sesFactory1.getStatistics().getCacheRegionStatistics(VERSIONED_ENTITY_NAME);
+            CacheRegionStatistics stats2 =
+                sesFactory2.getStatistics().getCacheRegionStatistics(VERSIONED_ENTITY_NAME);
+
+            assertEquals(1, stats1.getElementCountInMemory());
+            assertEquals(1, stats2.getElementCountInMemory());
+
+            ses = sesFactory2.openSession();
+            try {
+                assertEquals(ver, ((VersionedEntity)ses.load(VersionedEntity.class, 0)).getVersion());
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(1, stats2.getElementCountInMemory());
+            assertEquals(1, stats2.getHitCount());
+
+            if (accessType == AccessType.READ_ONLY) {
+                return;
+            }
+            e0.setVersion(ver - 1);
+            ses = sesFactory1.openSession();
+            Transaction tx = ses.beginTransaction();
+            try {
+                ses.update(e0);
+                tx.commit();
+                fail("Commit must fail.");
+            }
+            catch (OptimisticLockException e) {
+                log.info("Expected exception: " + e);
+            }
+            finally {
+                tx.rollback();
+                ses.close();
+            }
+
+            sesFactory1.getStatistics().clear();
+            stats1 = sesFactory1.getStatistics().getCacheRegionStatistics(VERSIONED_ENTITY_NAME);
+            ses = sesFactory1.openSession();
+            try {
+                assertEquals(ver, ((VersionedEntity)ses.load(VersionedEntity.class, 0)).getVersion());
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(1, stats1.getElementCountInMemory());
+            assertEquals(1, stats1.getHitCount());
+            assertEquals(1, stats2.getElementCountInMemory());
+            assertEquals(1, stats2.getHitCount());
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testNaturalIdCache() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testNaturalIdCache(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testNaturalIdCache(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        Map<String, Integer> nameToId = new HashMap<>();
+
+        try {
+            Session ses = sesFactory1.openSession();
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < 3; i++) {
+                    String name = "name-" + i;
+                    ses.save(new Entity(i, name));
+                    nameToId.put(name, i);
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            ses = sesFactory1.openSession();
+
+            try {
+                for (Map.Entry<String, Integer> e : nameToId.entrySet()) {
+                    ((Entity) ses.bySimpleNaturalId(Entity.class).load(e.getKey())).getId();
+                }
+            }
+            finally {
+                ses.close();
+            }
+
+            assertNaturalIdCache(sesFactory2, nameToId, "name-100");
+            assertNaturalIdCache(sesFactory1, nameToId, "name-100");
+
+            if (accessType == AccessType.READ_ONLY)
+                return;
+
+            // Update naturalId.
+
+            ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                nameToId.remove(e1.getName());
+                e1.setName("name-1-changed1");
+                nameToId.put(e1.getName(), e1.getId());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertNaturalIdCache(sesFactory2, nameToId, "name-1");
+            assertNaturalIdCache(sesFactory1, nameToId, "name-1");
+
+            // Update entity using another SessionFactory.
+
+            ses = sesFactory2.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                nameToId.remove(e1.getName());
+                e1.setName("name-1-changed2");
+                nameToId.put(e1.getName(), e1.getId());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertNaturalIdCache(sesFactory2, nameToId, "name-1-changed1");
+            assertNaturalIdCache(sesFactory1, nameToId, "name-1-changed1");
+
+            // Try invalid NaturalId update.
+
+            ses = sesFactory1.openSession();
+
+            Transaction tx = ses.beginTransaction();
+
+            try {
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                e1.setName("name-0"); // Invalid update (duplicated name).
+                tx.commit();
+                fail("Commit must fail.");
+            }
+            catch (PersistenceException e) {
+                assertEquals(ConstraintViolationException.class, e.getCause().getClass());
+                log.info("Expected exception: " + e);
+
+                tx.rollback();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertNaturalIdCache(sesFactory2, nameToId);
+            assertNaturalIdCache(sesFactory1, nameToId);
+
+            // Delete entity.
+
+            ses = sesFactory2.openSession();
+
+            try {
+                tx = ses.beginTransaction();
+                Entity e2 = (Entity)ses.load(Entity.class, 2);
+                ses.delete(e2);
+                nameToId.remove(e2.getName());
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertNaturalIdCache(sesFactory2, nameToId, "name-2");
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testEntityCacheTransactionFails() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testEntityCacheTransactionFails(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testEntityCacheTransactionFails(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        Map<Integer, String> idToName = new HashMap<>();
+
+        try {
+            Session ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < 3; i++) {
+                    String name = "name-" + i;
+                    ses.save(new Entity(i, name));
+                    idToName.put(i, name);
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName, 100);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName, 100);
+
+            ses = sesFactory1.openSession();
+
+            Transaction tx = ses.beginTransaction();
+
+            try {
+                ses.save(new Entity(3, "name-3")); // Valid insert.
+                ses.save(new Entity(0, "name-0")); // Invalid insert (duplicated ID).
+                tx.commit();
+                fail("Commit must fail.");
+            }
+            catch (PersistenceException e) {
+                assertEquals(ConstraintViolationException.class, e.getCause().getClass());
+                log.info("Expected exception: " + e);
+
+                tx.rollback();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName, 3);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName, 3);
+
+            if (accessType == AccessType.READ_ONLY)
+                return;
+
+            ses = sesFactory1.openSession();
+
+            tx = ses.beginTransaction();
+
+            try {
+                Entity e0 = (Entity)ses.load(Entity.class, 0);
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+
+                e0.setName("name-10"); // Valid update.
+                e1.setName("name-2"); // Invalid update (violates unique constraint).
+
+                ses.update(e0);
+                ses.update(e1);
+
+                tx.commit();
+
+                fail("Commit must fail.");
+            }
+            catch (PersistenceException e) {
+                assertEquals(ConstraintViolationException.class, e.getCause().getClass());
+                log.info("Expected exception: " + e);
+
+                tx.rollback();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName);
+
+            ses = sesFactory1.openSession();
+
+            try {
+                // Create parent entity referencing Entity with ID = 0.
+                tx = ses.beginTransaction();
+                ses.save(new ParentEntity(0, (Entity) ses.load(Entity.class, 0)));
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            ses = sesFactory1.openSession();
+
+            tx = ses.beginTransaction();
+
+            try {
+                ses.save(new Entity(3, "name-3")); // Valid insert.
+                Entity e1 = (Entity)ses.load(Entity.class, 1);
+                e1.setName("name-10"); // Valid update.
+                ses.delete(ses.load(Entity.class, 0)); // Invalid delete (there is a parent entity referencing it).
+                tx.commit();
+                fail("Commit must fail.");
+            }
+            catch (PersistenceException e) {
+                assertEquals(ConstraintViolationException.class, e.getCause().getClass());
+                log.info("Expected exception: " + e);
+
+                tx.rollback();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName, 3);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName, 3);
+
+            ses = sesFactory1.openSession();
+
+            tx = ses.beginTransaction();
+
+            try {
+                ses.delete(ses.load(Entity.class, 1)); // Valid delete.
+                idToName.remove(1);
+                ses.delete(ses.load(Entity.class, 0)); // Invalid delete (there is a parent entity referencing it).
+                tx.commit();
+                fail("Commit must fail.");
+            }
+            catch (PersistenceException e) {
+                assertEquals(ConstraintViolationException.class, e.getCause().getClass());
+                log.info("Expected exception: " + e);
+                tx.rollback();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEntityCache(ENTITY_NAME, sesFactory2, idToName);
+            assertEntityCache(ENTITY_NAME, sesFactory1, idToName);
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testQueryCache() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testQueryCache(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testQueryCache(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        try {
+            Session ses = sesFactory1.openSession();
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < 5; i++) {
+                    ses.save(new Entity(i, "name-" + i));
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            // This sleep is needed in the case that the transaction above completes and the next transaction
+            // starts in less than 1 ms, meaning the transaction timestamps are the same.
+            // In this scenario the entity update time == query cache update time since the times are stored
+            // using the transaction start time.  If those values are equal then the query cache will not be
+            // used in the third transaction and the failure will manifest itself in this assertion
+            // 'assertEquals(2, sesFactory2.getStatistics().getQueryCacheHitCount());'
+            // This behavior is in TimestampsCacheEnabledImpl.isUpToDate() line: if ( lastUpdate >= timestamp ) {...}
+            // It is not a hibernate bug, ms just doesn't have the best time resolution.
+            // The way to fix it may be to update the HibernateRegionFactory.nextTimestamp()
+            // to return a microsecond timestamp.  This may be doable in java 9.
+            Thread.sleep(1);
+
+            // Run some queries.
+
+            ses = sesFactory1.openSession();
+            try {
+                Query qry1 = ses.createQuery("from " + ENTITY_NAME + " where id > 2");
+                qry1.setCacheable(true);
+                assertEquals(2, qry1.list().size());
+                Query qry2 = ses.createQuery("from " + ENTITY_NAME + " where name = 'name-0'");
+                qry2.setCacheable(true);
+                assertEquals(1, qry2.list().size());
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(0, sesFactory1.getStatistics().getQueryCacheHitCount());
+            assertEquals(2, sesFactory1.getStatistics().getQueryCacheMissCount());
+            assertEquals(2, sesFactory1.getStatistics().getQueryCachePutCount());
+
+            // Run queries using another SessionFactory.  The first two queries should now be cached
+
+            ses = sesFactory2.openSession();
+            try {
+                Query qry1 = ses.createQuery("from " + ENTITY_NAME + " where id > 2");
+                qry1.setCacheable(true);
+                assertEquals(2, qry1.list().size());
+                Query qry2 = ses.createQuery("from " + ENTITY_NAME + " where name = 'name-0'");
+                qry2.setCacheable(true);
+                assertEquals(1, qry2.list().size());
+                Query qry3 = ses.createQuery("from " + ENTITY_NAME + " where id > 1");
+                qry3.setCacheable(true);
+                assertEquals(3, qry3.list().size());
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(2, sesFactory2.getStatistics().getQueryCacheHitCount());
+            assertEquals(1, sesFactory2.getStatistics().getQueryCacheMissCount());
+            assertEquals(1, sesFactory2.getStatistics().getQueryCachePutCount());
+
+            // Update entity, it should invalidate query cache.
+
+            ses = sesFactory1.openSession();
+            try {
+                Transaction tx = ses.beginTransaction();
+                ses.save(new Entity(5, "name-5"));
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            // Run queries.
+
+            ses = sesFactory1.openSession();
+            sesFactory1.getStatistics().clear();
+            try {
+                Query qry1 = ses.createQuery("from " + ENTITY_NAME + " where id > 2");
+                qry1.setCacheable(true);
+                assertEquals(3, qry1.list().size());
+                Query qry2 = ses.createQuery("from " + ENTITY_NAME + " where name = 'name-0'");
+                qry2.setCacheable(true);
+                assertEquals(1, qry2.list().size());
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(0, sesFactory1.getStatistics().getQueryCacheHitCount());
+            assertEquals(2, sesFactory1.getStatistics().getQueryCacheMissCount());
+            assertEquals(2, sesFactory1.getStatistics().getQueryCachePutCount());
+
+            // Clear query cache using another SessionFactory.
+
+            sesFactory2.getCache().evictDefaultQueryRegion();
+            ses = sesFactory1.openSession();
+            // Run queries again.
+            sesFactory1.getStatistics().clear();
+            try {
+                Query qry1 = ses.createQuery("from " + ENTITY_NAME + " where id > 2");
+                qry1.setCacheable(true);
+                assertEquals(3, qry1.list().size());
+                Query qry2 = ses.createQuery("from " + ENTITY_NAME + " where name = 'name-0'");
+                qry2.setCacheable(true);
+                assertEquals(1, qry2.list().size());
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(0, sesFactory1.getStatistics().getQueryCacheHitCount());
+            assertEquals(2, sesFactory1.getStatistics().getQueryCacheMissCount());
+            assertEquals(2, sesFactory1.getStatistics().getQueryCachePutCount());
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testRegionClear() throws Exception {
+        for (AccessType accessType : accessTypes()) {
+            testRegionClear(accessType);
+        }
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testRegionClear(AccessType accessType) throws Exception {
+        createSessionFactories(accessType);
+
+        try {
+            final int ENTITY_CNT = 100;
+
+            Session ses = sesFactory1.openSession();
+            try {
+                Transaction tx = ses.beginTransaction();
+                for (int i = 0; i < ENTITY_CNT; i++) {
+                    Entity e = new Entity(i, "name-" + i);
+                    Collection<ChildEntity> children = new ArrayList<>();
+                    for (int j = 0; j < 3; j++) {
+                        children.add(new ChildEntity());
+                    }
+                    e.setChildren(children);
+                    ses.save(e);
+                }
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            loadEntities(sesFactory2, ENTITY_CNT);
+
+            CacheRegionStatistics stats1 = sesFactory1.getStatistics().getCacheRegionStatistics(ENTITY_NAME);
+            CacheRegionStatistics stats2 = sesFactory2.getStatistics().getCacheRegionStatistics(ENTITY_NAME);
+
+            CacheRegionStatistics idStats1 =
+                sesFactory1.getStatistics().getCacheRegionStatistics(NATURAL_ID_REGION);
+            CacheRegionStatistics idStats2 =
+                sesFactory2.getStatistics().getCacheRegionStatistics(NATURAL_ID_REGION);
+
+            CacheRegionStatistics colStats1 =
+                sesFactory1.getStatistics().getDomainDataRegionStatistics(CHILD_COLLECTION_REGION);
+            CacheRegionStatistics colStats2 =
+                sesFactory2.getStatistics().getDomainDataRegionStatistics(CHILD_COLLECTION_REGION);
+
+            assertEquals(ENTITY_CNT, stats1.getElementCountInMemory());
+            assertEquals(ENTITY_CNT, stats2.getElementCountInMemory());
+
+            assertEquals(ENTITY_CNT, idStats1.getElementCountInMemory());
+            assertEquals(ENTITY_CNT, idStats2.getElementCountInMemory());
+
+            assertEquals(ENTITY_CNT, colStats1.getElementCountInMemory());
+            assertEquals(ENTITY_CNT, colStats2.getElementCountInMemory());
+
+            // Test cache is cleared after update query.
+
+            ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+                ses.createQuery("delete from " + ENTITY_NAME + " where name='no such name'").executeUpdate();
+                ses.createQuery("delete from " + ChildEntity.class.getName() + " where id=-1").executeUpdate();
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            assertEquals(0, stats1.getElementCountInMemory());
+            assertEquals(0, stats2.getElementCountInMemory());
+
+            assertEquals(0, idStats1.getElementCountInMemory());
+            assertEquals(0, idStats2.getElementCountInMemory());
+
+            assertEquals(0, colStats1.getElementCountInMemory());
+            assertEquals(0, colStats2.getElementCountInMemory());
+
+            // Load some data in cache.
+
+            loadEntities(sesFactory1, 10);
+
+            assertEquals(10, stats1.getElementCountInMemory());
+            assertEquals(10, stats2.getElementCountInMemory());
+            assertEquals(10, idStats1.getElementCountInMemory());
+            assertEquals(10, idStats2.getElementCountInMemory());
+
+            // Test evictAll method.
+
+            sesFactory2.getCache().evictEntityRegion(ENTITY_NAME);
+
+            assertEquals(0, stats1.getElementCountInMemory());
+            assertEquals(0, stats2.getElementCountInMemory());
+
+            sesFactory2.getCache().evictNaturalIdRegion(ENTITY_NAME);
+
+            assertEquals(0, idStats1.getElementCountInMemory());
+            assertEquals(0, idStats2.getElementCountInMemory());
+
+            sesFactory2.getCache().evictCollectionRegion(CHILD_COLLECTION_REGION);
+
+            assertEquals(0, colStats1.getElementCountInMemory());
+            assertEquals(0, colStats2.getElementCountInMemory());
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @param sesFactory Session factory.
+     * @param nameToId Name-ID mapping.
+     * @param absentNames Absent entities' names.
+     */
+    private void assertNaturalIdCache(SessionFactory sesFactory, Map<String, Integer> nameToId, String... absentNames) {
+        sesFactory.getStatistics().clear();
+
+        CacheRegionStatistics stats = sesFactory.getStatistics().getCacheRegionStatistics(NATURAL_ID_REGION);
+
+        long hitBefore = stats.getHitCount();
+        long missBefore = stats.getMissCount();
+        final Session ses = sesFactory.openSession();
+
+        try {
+            for (Map.Entry<String, Integer> e : nameToId.entrySet()) {
+                assertEquals((int) e.getValue(), ((Entity) ses.bySimpleNaturalId(Entity.class).load(e.getKey())).getId());
+            }
+            for (String name : absentNames) {
+                assertNull((ses.bySimpleNaturalId(Entity.class).load(name)));
+            }
+            assertEquals(nameToId.size() + hitBefore, stats.getHitCount());
+            assertEquals(absentNames.length + missBefore, stats.getMissCount());
+        }
+        finally {
+            ses.close();
+        }
+    }
+
+    /**
+     * @param sesFactory Session factory.
+     * @param idToChildCnt Number of children per entity.
+     * @param expHit Expected cache hits.
+     * @param expMiss Expected cache misses.
+     */
+    @SuppressWarnings("unchecked")
+    private void assertCollectionCache(SessionFactory sesFactory, Map<Integer, Integer> idToChildCnt, int expHit,
+        int expMiss) {
+        sesFactory.getStatistics().clear();
+        Session ses = sesFactory.openSession();
+        try {
+            for(Map.Entry<Integer, Integer> e : idToChildCnt.entrySet()) {
+                Entity entity = (Entity)ses.load(Entity.class, e.getKey());
+                assertEquals((int)e.getValue(), entity.getChildren().size());
+            }
+        }
+        finally {
+            ses.close();
+        }
+
+        CacheRegionStatistics stats = sesFactory.getStatistics().getCacheRegionStatistics(CHILD_COLLECTION_REGION);
+
+        assertEquals(expHit, stats.getHitCount());
+
+        assertEquals(expMiss, stats.getMissCount());
+    }
+
+    /**
+     * @param sesFactory Session factory.
+     * @param cnt Number of entities to load.
+     */
+    private void loadEntities(SessionFactory sesFactory, int cnt) {
+        Session ses = sesFactory.openSession();
+
+        try {
+            for (int i = 0; i < cnt; i++) {
+                Entity e = (Entity)ses.load(Entity.class, i);
+                assertEquals("name-" + i, e.getName());
+                assertFalse(e.getChildren().isEmpty());
+                ses.bySimpleNaturalId(Entity.class).load(e.getName());
+            }
+        }
+        finally {
+            ses.close();
+        }
+    }
+
+    /**
+     * @param entityName Entity name.
+     * @param sesFactory Session factory.
+     * @param idToName ID to name mapping.
+     * @param absentIds Absent entities' IDs.
+     */
+    private void assertEntityCache(String entityName, SessionFactory sesFactory, Map<Integer, String> idToName,
+                                   Integer... absentIds) {
+        assert entityName.equals(ENTITY_NAME) || entityName.equals(ENTITY2_NAME) : entityName;
+
+        sesFactory.getStatistics().clear();
+
+        final Session ses = sesFactory.openSession();
+
+        final boolean entity1 = entityName.equals(ENTITY_NAME);
+
+        try {
+            if (entity1) {
+                for (Map.Entry<Integer, String> e : idToName.entrySet()) {
+                    assertEquals(e.getValue(), ((Entity) ses.load(Entity.class, e.getKey())).getName());
+                }
+            } else {
+                for (Map.Entry<Integer, String> e : idToName.entrySet()) {
+                    assertEquals(e.getValue(), ((Entity2) ses.load(Entity2.class, e.getKey())).getName());
+                }
+            }
+
+            for (final int id : absentIds) {
+                GridTestUtils.assertThrows(log, new Callable<Void>() {
+                    @Override public Void call() throws Exception {
+                        if (entity1) {
+                            ((Entity) ses.load(Entity.class, id)).getName();
+                        } else {
+                            ((Entity2) ses.load(Entity2.class, id)).getName();
+                        }
+                        return null;
+                    }
+                }, ObjectNotFoundException.class, null);
+            }
+
+            CacheRegionStatistics stats = sesFactory.getStatistics().getCacheRegionStatistics(entityName);
+            assertEquals(idToName.size(), stats.getHitCount());
+            assertEquals(absentIds.length, stats.getMissCount());
+        }
+        finally {
+            ses.close();
+        }
+    }
+
+    /**
+     * Creates session factories.
+     *
+     * @param accessType Cache access type.
+     */
+    private void createSessionFactories(AccessType accessType) {
+        sesFactory1 = startHibernate(accessType, getTestIgniteInstanceName(0));
+
+        sesFactory2 = startHibernate(accessType, getTestIgniteInstanceName(1));
+    }
+
+    /**
+     * Starts Hibernate.
+     *
+     * @param accessType Cache access type.
+     * @param igniteInstanceName Ignite instance name.
+     * @return Session factory.
+     */
+    private SessionFactory startHibernate(org.hibernate.cache.spi.access.AccessType accessType, String igniteInstanceName) {
+        StandardServiceRegistryBuilder builder = registryBuilder();
+
+        for (Map.Entry<String, String> e : hibernateProperties(igniteInstanceName, accessType.name()).entrySet()) {
+            builder.applySetting(e.getKey(), e.getValue());
+        }
+
+        // Use the same cache for Entity and Entity2.
+        builder.applySetting(REGION_CACHE_PROPERTY + ENTITY2_NAME, ENTITY_NAME);
+
+        StandardServiceRegistry srvcRegistry = builder.build();
+
+        MetadataSources metadataSources = new MetadataSources(srvcRegistry);
+
+        for (Class entityClass : getAnnotatedClasses()) {
+            metadataSources.addAnnotatedClass(entityClass);
+        }
+
+        Metadata metadata = metadataSources.buildMetadata();
+
+        for (PersistentClass entityBinding : metadata.getEntityBindings()) {
+            if (!entityBinding.isInherited()) {
+                ((RootClass) entityBinding).setCacheConcurrencyStrategy(accessType.getExternalName());
+            }
+        }
+
+        for (org.hibernate.mapping.Collection collectionBinding : metadata.getCollectionBindings()) {
+            collectionBinding.setCacheConcurrencyStrategy(accessType.getExternalName());
+        }
+
+        return metadata.buildSessionFactory();
+    }
+
+    /**
+     * @return Entities classes.
+     */
+    private Class[] getAnnotatedClasses() {
+        return new Class[]{Entity.class, Entity2.class, VersionedEntity.class, ChildEntity.class, ParentEntity.class};
+    }
+
+    /**
+     * Closes session factories and clears data from caches.
+     *
+     * @throws Exception If failed.
+     */
+    private void cleanup() throws Exception {
+        if (sesFactory1 != null) {
+            sesFactory1.close();
+        }
+
+        sesFactory1 = null;
+
+        if (sesFactory2 != null) {
+            sesFactory2.close();
+        }
+
+        sesFactory2 = null;
+
+        for (IgniteCacheProxy<?, ?> cache : ((IgniteKernal)grid(0)).caches()) {
+            cache.clear();
+        }
+    }
+
+    /**
+     * @param igniteInstanceName Node name.
+     * @param dfltAccessType Default cache access type.
+     * @return Properties map.
+     */
+    static Map<String, String> hibernateProperties(String igniteInstanceName, String dfltAccessType) {
+        Map<String, String> map = new HashMap<>();
+
+        map.put(HBM2DDL_AUTO, "create");
+        map.put(JPA_SHARED_CACHE_MODE, SharedCacheMode.ALL.name());
+        map.put(GENERATE_STATISTICS, "true");
+        map.put(USE_SECOND_LEVEL_CACHE, "true");
+        map.put(USE_QUERY_CACHE, "true");
+        map.put(CACHE_REGION_FACTORY, HibernateRegionFactory.class.getName());
+        map.put(RELEASE_CONNECTIONS, "on_close");
+        map.put(IGNITE_INSTANCE_NAME_PROPERTY, igniteInstanceName);
+        map.put(DFLT_ACCESS_TYPE_PROPERTY, dfltAccessType);
+
+        return map;
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheStrategySelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheStrategySelfTest.java
@@ -1,0 +1,565 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.cache.Cache;
+import javax.persistence.Cacheable;
+import javax.persistence.Id;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteKernal;
+import org.apache.ignite.internal.processors.cache.IgniteCacheProxy;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.hamcrest.core.Is;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.RootClass;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
+import static org.apache.ignite.cache.CacheMode.PARTITIONED;
+import static org.apache.ignite.cache.hibernate.HibernateAccessStrategyFactory.REGION_CACHE_PROPERTY;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cache.spi.RegionFactory.DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME;
+import static org.hibernate.cfg.AvailableSettings.USE_STRUCTURED_CACHE;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests Hibernate L2 cache configuration.
+ */
+@SuppressWarnings("unchecked")
+public class HibernateL2CacheStrategySelfTest extends GridCommonAbstractTest {
+    /** */
+    private static final String ENTITY1_NAME = Entity1.class.getName();
+
+    /** */
+    private static final String ENTITY2_NAME = Entity2.class.getName();
+
+    /** */
+    private static final String ENTITY3_NAME = Entity3.class.getName();
+
+    /** */
+    private static final String ENTITY4_NAME = Entity4.class.getName();
+
+    /** */
+    private static final String CONNECTION_URL = "jdbc:h2:mem:example;DB_CLOSE_DELAY=-1";
+
+    /** */
+    private SessionFactory sesFactory1;
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        startGrid(0);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        stopAllGrids();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        for (IgniteCacheProxy<?, ?> cache : ((IgniteKernal)grid(0)).caches())
+            cache.clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        ((TcpDiscoverySpi)cfg.getDiscoverySpi()).setIpFinder(new TcpDiscoveryVmIpFinder(true));
+
+        cfg.setCacheConfiguration(cacheConfiguration(ENTITY3_NAME),
+            cacheConfiguration(ENTITY4_NAME),
+            cacheConfiguration("cache1"),
+            cacheConfiguration("cache2"),
+            cacheConfiguration(DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME),
+            cacheConfiguration(DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME));
+
+        return cfg;
+    }
+
+    /**
+     * @param cacheName Cache name.
+     * @return Cache configuration.
+     */
+    private CacheConfiguration cacheConfiguration(String cacheName) {
+        CacheConfiguration cfg = new CacheConfiguration();
+
+        cfg.setName(cacheName);
+        cfg.setCacheMode(PARTITIONED);
+        cfg.setAtomicityMode(TRANSACTIONAL);
+
+        return cfg;
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testEntityCacheReadWrite() throws Exception {
+        for (AccessType accessType : new AccessType[]{AccessType.READ_WRITE, AccessType.NONSTRICT_READ_WRITE})
+            testEntityCacheReadWrite(accessType);
+    }
+
+    /**
+     * @param accessType Cache access type.
+     * @throws Exception If failed.
+     */
+    private void testEntityCacheReadWrite(AccessType accessType) throws Exception {
+        log.info("Test access type: " + accessType);
+
+        sesFactory1 = startHibernate(accessType, getTestIgniteInstanceName(0));
+
+        try {
+            // 1 Adding.
+            Session ses = sesFactory1.openSession();
+
+            try {
+                Transaction tr = ses.beginTransaction();
+
+                ses.save(new Entity1(1, "entity-1#name-1"));
+                ses.save(new Entity2(1, "entity-2#name-1"));
+
+                tr.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            loadEntities(sesFactory1);
+
+            assertEquals(1, grid(0).cache("cache1").size());
+            assertEquals(1, grid(0).cache("cache2").size());
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache1", 1), Is.is("entity-1#name-1"));
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache2", 1), Is.is("entity-2#name-1"));
+
+            // 2. Updating and adding.
+            ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+
+                Entity1 e1 = (Entity1)ses.load(Entity1.class, 1);
+
+                e1.setName("entity-1#name-1#UPDATED-1");
+
+                ses.update(e1);
+
+                ses.save(new Entity2(2, "entity-2#name-2#ADDED"));
+
+                tx.commit();
+            }
+            finally {
+                ses.close();
+            }
+
+            loadEntities(sesFactory1);
+
+            assertEquals(1, grid(0).cache("cache1").size());
+            assertEquals(2, grid(0).cache("cache2").size());
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache1", 1), Is.is("entity-1#name-1#UPDATED-1"));
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache2", 1), Is.is("entity-2#name-1"));
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache2", 2), Is.is("entity-2#name-2#ADDED"));
+
+            // 3. Updating, adding, updating.
+            ses = sesFactory1.openSession();
+
+            try {
+                Transaction tx = ses.beginTransaction();
+
+                Entity2 e2_1 = (Entity2)ses.load(Entity2.class, 1);
+
+                e2_1.setName("entity-2#name-1#UPDATED-1");
+
+                ses.update(e2_1);
+
+                ses.save(new Entity1(2, "entity-1#name-2#ADDED"));
+
+                Entity1 e1_1 = (Entity1)ses.load(Entity1.class, 1);
+
+                e1_1.setName("entity-1#name-1#UPDATED-2");
+
+                ses.update(e1_1);
+
+                tx.commit();
+
+            }
+            finally {
+                ses.close();
+            }
+
+            loadEntities(sesFactory1);
+
+            assertEquals(2, grid(0).cache("cache1").size());
+            assertEquals(2, grid(0).cache("cache2").size());
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache2", 1), Is.is("entity-2#name-1#UPDATED-1"));
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache1", 2), Is.is("entity-1#name-2#ADDED"));
+            assertThat(getEntityNameFromRegion(sesFactory1, "cache1", 1), Is.is("entity-1#name-1#UPDATED-2"));
+
+            ses = sesFactory1.openSession();
+
+            sesFactory1.getStatistics().logSummary();
+
+            ses.close();
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * @param sesFactory Session factory.
+     */
+    private void loadEntities(SessionFactory sesFactory) {
+        Session ses = sesFactory.openSession();
+
+        try {
+            List<Entity1> list1 = ses.createCriteria(ENTITY1_NAME).list();
+
+            for (Entity1 e1 : list1)
+                assertNotNull(e1.getName());
+
+            List<Entity2> list2 = ses.createCriteria(ENTITY2_NAME).list();
+
+            for (Entity2 e2 : list2)
+                assertNotNull(e2.getName());
+        }
+        finally {
+            ses.close();
+        }
+    }
+
+    /**
+     * @param sesFactory Session Factory.
+     * @param regionName Region Name.
+     * @param id Id.
+     * @return Entity Name.
+     */
+    private String getEntityNameFromRegion(SessionFactory sesFactory, String regionName, int id) {
+        Session ses = sesFactory.openSession();
+
+        try {
+            for (Cache.Entry<Object, Object> entry : grid(0).cache(regionName)) {
+                if (((HibernateKeyWrapper)entry.getKey()).id().equals(id))
+                    return (String) ((HashMap) entry.getValue()).get("name");
+            }
+
+            return null;
+        }
+        finally {
+            ses.close();
+        }
+    }
+
+    /**
+     * @param accessType Cache access typr.
+     * @param igniteInstanceName Name of the grid providing caches.
+     * @return Session factory.
+     */
+    private SessionFactory startHibernate(AccessType accessType, String igniteInstanceName) {
+        StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+
+        builder.applySetting("hibernate.connection.url", CONNECTION_URL);
+
+        for (Map.Entry<String, String> e : HibernateL2CacheSelfTest.hibernateProperties(igniteInstanceName, accessType.name()).entrySet())
+            builder.applySetting(e.getKey(), e.getValue());
+
+        builder.applySetting(USE_STRUCTURED_CACHE, "true");
+        builder.applySetting(REGION_CACHE_PROPERTY + ENTITY1_NAME, "cache1");
+        builder.applySetting(REGION_CACHE_PROPERTY + ENTITY2_NAME, "cache2");
+        builder.applySetting(REGION_CACHE_PROPERTY + DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME, DEFAULT_UPDATE_TIMESTAMPS_REGION_UNQUALIFIED_NAME);
+        builder.applySetting(REGION_CACHE_PROPERTY + DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME, DEFAULT_QUERY_RESULTS_REGION_UNQUALIFIED_NAME);
+
+        MetadataSources metadataSources = new MetadataSources(builder.build());
+
+        metadataSources.addAnnotatedClass(Entity1.class);
+        metadataSources.addAnnotatedClass(Entity2.class);
+        metadataSources.addAnnotatedClass(Entity3.class);
+        metadataSources.addAnnotatedClass(Entity4.class);
+
+        Metadata metadata = metadataSources.buildMetadata();
+
+        for (PersistentClass entityBinding : metadata.getEntityBindings()) {
+            if (!entityBinding.isInherited())
+                ((RootClass)entityBinding).setCacheConcurrencyStrategy(accessType.getExternalName());
+        }
+
+        return metadata.buildSessionFactory();
+    }
+
+    /**
+     * Test Hibernate entity1.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    public static class Entity1 {
+        /** */
+        private int id;
+
+        /** */
+        private String name;
+
+        /**
+         *
+         */
+        public Entity1() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param name Name.
+         */
+        Entity1(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Test Hibernate entity2.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    public static class Entity2 {
+        /** */
+        private int id;
+
+        /** */
+        private String name;
+
+        /**
+         *
+         */
+        public Entity2() {
+           // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param name Name.
+         */
+        Entity2(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Test Hibernate entity3.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    public static class Entity3 {
+        /** */
+        private int id;
+
+        /** */
+        private String name;
+
+        /**
+         *
+         */
+        public Entity3() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param name Name.
+         */
+        public Entity3(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Test Hibernate entity4.
+     */
+    @javax.persistence.Entity
+    @SuppressWarnings({"PublicInnerClass", "UnnecessaryFullyQualifiedName"})
+    @Cacheable
+    public static class Entity4 {
+        /** */
+        private int id;
+
+        /** */
+        private String name;
+
+        /**
+         *
+         */
+        public Entity4() {
+            // No-op.
+        }
+
+        /**
+         * @param id ID.
+         * @param name Name.
+         */
+        public Entity4(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        /**
+         * @return ID.
+         */
+        @Id
+        public int getId() {
+            return id;
+        }
+
+        /**
+         * @param id ID.
+         */
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        /**
+         * @return Name.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name Name.
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Closes session factories and clears data from caches.
+     *
+     * @throws Exception If failed.
+     */
+    private void cleanup() throws Exception {
+        if (sesFactory1 != null)
+            sesFactory1.close();
+
+        sesFactory1 = null;
+
+        for (IgniteCacheProxy<?, ?> cache : ((IgniteKernal)grid(0)).caches())
+            cache.clear();
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import java.util.Collections;
+import javax.cache.configuration.Factory;
+import javax.transaction.Synchronization;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+import org.apache.commons.dbcp.managed.BasicManagedDataSource;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.h2.jdbcx.JdbcDataSource;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.transaction.jta.platform.internal.AbstractJtaPlatform;
+import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
+import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.jotm.Jotm;
+
+/**
+ *
+ * Tests Hibernate L2 cache with TRANSACTIONAL access mode (Hibernate and Cache are configured
+ * to used the same TransactionManager).
+ */
+public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfTest {
+    /** */
+    private static Jotm jotm;
+
+    /**
+     */
+    private static class TestJtaPlatform extends AbstractJtaPlatform {
+        /** {@inheritDoc} */
+        @Override protected TransactionManager locateTransactionManager() {
+            return jotm.getTransactionManager();
+        }
+
+        /** {@inheritDoc} */
+        @Override protected UserTransaction locateUserTransaction() {
+            return jotm.getUserTransaction();
+        }
+    }
+
+    /**
+     */
+    @SuppressWarnings("PublicInnerClass")
+    public static class TestTmFactory implements Factory<TransactionManager> {
+        /** */
+        private static final long serialVersionUID = 0;
+
+        /** {@inheritDoc} */
+        @Override public TransactionManager create() {
+            return jotm.getTransactionManager();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        jotm = new Jotm(true, false);
+
+        super.beforeTestsStarted();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        super.afterTestsStopped();
+
+        if (jotm != null)
+            jotm.stop();
+
+        jotm = null;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.getTransactionConfiguration().setTxManagerFactory(new TestTmFactory());
+        cfg.getTransactionConfiguration().setUseJtaSynchronization(useJtaSynchronization());
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected CacheConfiguration transactionalRegionConfiguration(String regionName) {
+        CacheConfiguration cfg = super.transactionalRegionConfiguration(regionName);
+
+        cfg.setNearConfiguration(null);
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Nullable @Override protected StandardServiceRegistryBuilder registryBuilder() {
+        StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();
+
+        DatasourceConnectionProviderImpl connProvider = new DatasourceConnectionProviderImpl();
+
+        BasicManagedDataSource dataSrc = new BasicManagedDataSource(); // JTA-aware data source.
+
+        dataSrc.setTransactionManager(jotm.getTransactionManager());
+
+        dataSrc.setDefaultAutoCommit(false);
+
+        JdbcDataSource h2DataSrc = new JdbcDataSource();
+
+        h2DataSrc.setURL(CONNECTION_URL);
+
+        dataSrc.setXaDataSourceInstance(h2DataSrc);
+
+        connProvider.setDataSource(dataSrc);
+
+        connProvider.configure(Collections.emptyMap());
+
+        builder.addService(ConnectionProvider.class, connProvider);
+
+        builder.addService(JtaPlatform.class, new TestJtaPlatform());
+
+        builder.applySetting(Environment.TRANSACTION_COORDINATOR_STRATEGY, JtaTransactionCoordinatorBuilderImpl.class.getName());
+
+        return builder;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected AccessType[] accessTypes() {
+        return new AccessType[]{AccessType.TRANSACTIONAL};
+    }
+
+    /**
+     * @return Whether to use {@link Synchronization}.
+     */
+    protected boolean useJtaSynchronization() {
+        return false;
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalUseSyncSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalUseSyncSelfTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.hibernate;
+
+import javax.transaction.Synchronization;
+
+/**
+ * Tests Hibernate L2 cache with TRANSACTIONAL access mode and {@link Synchronization}
+ * instead of XA resource.
+ */
+public class HibernateL2CacheTransactionalUseSyncSelfTest extends HibernateL2CacheTransactionalSelfTest {
+    /** {@inheritDoc} */
+    @Override protected boolean useJtaSynchronization() {
+        return true;
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreNodeRestartTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreNodeRestartTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.cache.store.CacheStore;
+import org.apache.ignite.configuration.NearCacheConfiguration;
+import org.apache.ignite.internal.processors.cache.integration.IgniteCacheStoreNodeRestartAbstractTest;
+
+public class CacheHibernateBlobStoreNodeRestartTest extends IgniteCacheStoreNodeRestartAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected CacheStore getStore() {
+        return new CacheHibernateBlobStore();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected CacheMode cacheMode() {
+        return CacheMode.PARTITIONED;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected CacheAtomicityMode atomicityMode() {
+        return CacheAtomicityMode.ATOMIC;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected NearCacheConfiguration nearConfiguration() {
+        return null;
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreSelfTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.testframework.junits.cache.GridAbstractCacheStoreSelfTest;
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Cache store test.
+ */
+public class CacheHibernateBlobStoreSelfTest extends
+    GridAbstractCacheStoreSelfTest<CacheHibernateBlobStore<Object, Object>> {
+    /**
+     * @throws Exception If failed.
+     */
+    public CacheHibernateBlobStoreSelfTest() throws Exception {
+        // No-op.
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        Session s = store.session(null);
+
+        if (s == null)
+            return;
+
+        try {
+            s.createQuery("delete from " + CacheHibernateBlobStoreEntry.class.getSimpleName())
+                    .setFlushMode(FlushMode.ALWAYS).executeUpdate();
+
+            Transaction hTx = s.getTransaction();
+
+            if (hTx != null && hTx.getStatus() == TransactionStatus.ACTIVE)
+                hTx.commit();
+        }
+        finally {
+            s.close();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected CacheHibernateBlobStore<Object, Object> store() {
+        return new CacheHibernateBlobStore<>();
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testConfigurationByUrl() throws Exception {
+        URL url = U.resolveIgniteUrl(CacheHibernateStoreFactorySelfTest.MODULE_PATH +
+            "/src/test/resources/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml");
+
+        assert url != null;
+
+        store.setHibernateConfigurationPath(url.toString());
+
+        // Store will be implicitly initialized.
+        store.load("key");
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testConfigurationByFile() throws Exception {
+        URL url = U.resolveIgniteUrl(CacheHibernateStoreFactorySelfTest.MODULE_PATH +
+                "/src/test/resources/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml");
+
+        assert url != null;
+
+        File file = new File(url.toURI());
+
+        store.setHibernateConfigurationPath(file.getAbsolutePath());
+
+        // Store will be implicitly initialized.
+        store.load("key");
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testConfigurationByResource() throws Exception {
+        store.setHibernateConfigurationPath("/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml");
+
+        // Store will be implicitly initialized.
+        store.load("key");
+    }
+
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateStoreFactorySelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateStoreFactorySelfTest.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.hibernate.Cache;
+import org.hibernate.HibernateException;
+import org.hibernate.Metamodel;
+import org.hibernate.Session;
+import org.hibernate.SessionBuilder;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hibernate.StatelessSessionBuilder;
+import org.hibernate.TypeHelper;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.engine.spi.FilterDefinition;
+import org.hibernate.metadata.ClassMetadata;
+import org.hibernate.metadata.CollectionMetadata;
+import org.hibernate.stat.Statistics;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.persistence.EntityGraph;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceUnitUtil;
+import javax.persistence.Query;
+import javax.persistence.SynchronizationType;
+import javax.persistence.criteria.CriteriaBuilder;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Test for Cache jdbc blob store factory.
+ */
+public class CacheHibernateStoreFactorySelfTest extends GridCommonAbstractTest {
+    /** Cache name. */
+    private static final String CACHE_NAME = "test";
+
+    /** */
+    static final String MODULE_PATH = "modules/hibernate-5.3/";
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testCacheConfiguration() throws Exception {
+        try (Ignite ignite1 = startGrid(0)) {
+            IgniteCache<Integer, String> cache1 = ignite1.getOrCreateCache(cacheConfiguration());
+
+            checkStore(cache1);
+        }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testXmlConfiguration() throws Exception {
+        try (Ignite ignite = Ignition.start(MODULE_PATH + "/src/test/config/factory-cache.xml")) {
+            try(Ignite ignite1 = Ignition.start(MODULE_PATH + "/src/test/config/factory-cache1.xml")) {
+                checkStore(ignite.<Integer, String>cache(CACHE_NAME), DummySessionFactoryExt.class);
+
+                checkStore(ignite1.<Integer, String>cache(CACHE_NAME), DummySessionFactory.class);
+            }
+        }
+    }
+
+
+    /**
+     * @throws Exception If failed.
+     */
+    public void testIncorrectBeanConfiguration() {
+        GridTestUtils.assertThrows(log, new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                String path = MODULE_PATH + "/src/test/config/factory-incorrect-store-cache.xml";
+                try (Ignite ignite = Ignition.start(path)) {
+                    ignite.cache(CACHE_NAME).getConfiguration(CacheConfiguration.class).getCacheStoreFactory().create();
+                }
+                return null;
+            }
+        }, IgniteException.class, "Failed to load bean in application context");
+    }
+
+    /**
+     * @return Cache configuration with store.
+     */
+    private CacheConfiguration<Integer, String> cacheConfiguration() {
+        CacheConfiguration<Integer, String> cfg = new CacheConfiguration<>(DEFAULT_CACHE_NAME);
+
+        CacheHibernateBlobStoreFactory<Integer, String> factory = new CacheHibernateBlobStoreFactory();
+
+        factory.setHibernateConfigurationPath("/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml");
+
+        cfg.setCacheStoreFactory(factory);
+
+        return cfg;
+    }
+
+    /**
+     * @param cache Ignite cache.
+     * @param dataSrcClass Data source class.
+     * @throws Exception If store parameters is not the same as in configuration xml.
+     */
+    private void checkStore(IgniteCache<Integer, String> cache, Class<?> dataSrcClass) throws Exception {
+        CacheHibernateBlobStore store = (CacheHibernateBlobStore)cache
+            .getConfiguration(CacheConfiguration.class).getCacheStoreFactory().create();
+
+        assertEquals(dataSrcClass,
+            GridTestUtils.getFieldValue(store, CacheHibernateBlobStore.class, "sesFactory").getClass());
+    }
+
+    /**
+     * @param cache Ignite cache.
+     * @throws Exception If store parameters is not the same as in configuration xml.
+     */
+    private void checkStore(IgniteCache<Integer, String> cache) throws Exception {
+        CacheHibernateBlobStore store = (CacheHibernateBlobStore)cache.getConfiguration(CacheConfiguration.class)
+            .getCacheStoreFactory().create();
+
+        assertEquals("/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml",
+            GridTestUtils.getFieldValue(store, CacheHibernateBlobStore.class, "hibernateCfgPath"));
+    }
+
+    /**
+     *
+     */
+    public static class DummySessionFactoryExt extends DummySessionFactory {
+        /** */
+        public DummySessionFactoryExt() {
+            // No-op.
+        }
+    }
+
+    /**
+     *
+     */
+    public static class DummySessionFactory implements SessionFactory {
+        /** {@inheritDoc} */
+        @Override public SessionFactoryOptions getSessionFactoryOptions() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public SessionBuilder withOptions() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Session openSession() throws HibernateException {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Session getCurrentSession() throws HibernateException {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public StatelessSessionBuilder withStatelessOptions() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public StatelessSession openStatelessSession() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public StatelessSession openStatelessSession(Connection conn) {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public ClassMetadata getClassMetadata(Class entityCls) {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public ClassMetadata getClassMetadata(String entityName) {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public CollectionMetadata getCollectionMetadata(String roleName) {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Map<String, ClassMetadata> getAllClassMetadata() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Map getAllCollectionMetadata() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Statistics getStatistics() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public void close() throws HibernateException {
+        }
+
+        @Override
+        public Map<String, Object> getProperties() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean isClosed() {
+            return false;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Cache getCache() {
+            return null;
+        }
+
+        @Override
+        public PersistenceUnitUtil getPersistenceUnitUtil() {
+            return null;
+        }
+
+        @Override
+        public void addNamedQuery(String name, Query query) {
+
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> cls) {
+            return null;
+        }
+
+        @Override
+        public <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph) {
+
+        }
+
+        /** {@inheritDoc} */
+        @Override public Set getDefinedFilterNames() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public FilterDefinition getFilterDefinition(String filterName) throws HibernateException {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean containsFetchProfileDefinition(String name) {
+            return false;
+        }
+
+        /** {@inheritDoc} */
+        @Override public TypeHelper getTypeHelper() {
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public Reference getReference() throws NamingException {
+            return null;
+        }
+
+        @Override
+        public <T> List<EntityGraph<? super T>> findEntityGraphsByType(Class<T> aClass) {
+            return null;
+        }
+
+        @Override
+        public EntityManager createEntityManager() {
+            return null;
+        }
+
+        @Override
+        public EntityManager createEntityManager(Map map) {
+            return null;
+        }
+
+        @Override
+        public EntityManager createEntityManager(SynchronizationType synchronizationType) {
+            return null;
+        }
+
+        @Override
+        public EntityManager createEntityManager(SynchronizationType synchronizationType, Map map) {
+            return null;
+        }
+
+        @Override
+        public CriteriaBuilder getCriteriaBuilder() {
+            return null;
+        }
+
+        @Override
+        public Metamodel getMetamodel() {
+            return null;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return false;
+        }
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateStoreSessionListenerSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/CacheHibernateStoreSessionListenerSelfTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.store.hibernate;
+
+import java.io.Serializable;
+import java.util.Map;
+import javax.cache.Cache;
+import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriterException;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.apache.ignite.cache.store.CacheStore;
+import org.apache.ignite.cache.store.CacheStoreAdapter;
+import org.apache.ignite.cache.store.CacheStoreSession;
+import org.apache.ignite.cache.store.CacheStoreSessionListener;
+import org.apache.ignite.cache.store.CacheStoreSessionListenerAbstractSelfTest;
+import org.apache.ignite.cache.store.jdbc.CacheJdbcStoreSessionListener;
+import org.apache.ignite.lang.IgniteBiInClosure;
+import org.apache.ignite.resources.CacheStoreSessionResource;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+
+/**
+ * Tests for {@link CacheJdbcStoreSessionListener}.
+ */
+public class CacheHibernateStoreSessionListenerSelfTest extends CacheStoreSessionListenerAbstractSelfTest {
+    /** {@inheritDoc} */
+    @Override protected Factory<? extends CacheStore<Integer, Integer>> storeFactory() {
+        return new Factory<CacheStore<Integer, Integer>>() {
+            @Override public CacheStore<Integer, Integer> create() {
+                return new Store();
+            }
+        };
+    }
+
+    /** {@inheritDoc} */
+    @Override protected Factory<CacheStoreSessionListener> sessionListenerFactory() {
+        return new Factory<CacheStoreSessionListener>() {
+            @Override public CacheStoreSessionListener create() {
+                CacheHibernateStoreSessionListener lsnr = new CacheHibernateStoreSessionListener();
+
+                SessionFactory sesFactory = new Configuration().
+                    setProperty("hibernate.connection.url", URL).
+                    addAnnotatedClass(Table1.class).
+                    addAnnotatedClass(Table2.class).
+                    buildSessionFactory();
+
+                lsnr.setSessionFactory(sesFactory);
+
+                return lsnr;
+            }
+        };
+    }
+
+    /**
+     */
+    private static class Store extends CacheStoreAdapter<Integer, Integer> {
+        /** */
+        private static String SES_CONN_KEY = "ses_conn";
+
+        /** */
+        @CacheStoreSessionResource
+        private CacheStoreSession ses;
+
+        /** {@inheritDoc} */
+        @Override public void loadCache(IgniteBiInClosure<Integer, Integer> clo, Object... args) {
+            loadCacheCnt.incrementAndGet();
+
+            checkSession();
+        }
+
+        /** {@inheritDoc} */
+        @Override public Integer load(Integer key) throws CacheLoaderException {
+            loadCnt.incrementAndGet();
+
+            checkSession();
+
+            return null;
+        }
+
+        /** {@inheritDoc} */
+        @Override public void write(Cache.Entry<? extends Integer, ? extends Integer> entry)
+            throws CacheWriterException {
+            writeCnt.incrementAndGet();
+
+            checkSession();
+
+            if (write.get()) {
+                Session hibSes = ses.attachment();
+
+                switch (ses.cacheName()) {
+                    case "cache1":
+                        hibSes.save(new Table1(entry.getKey(), entry.getValue()));
+
+                        break;
+
+                    case "cache2":
+                        if (fail.get())
+                            throw new CacheWriterException("Expected failure.");
+
+                        hibSes.save(new Table2(entry.getKey(), entry.getValue()));
+
+                        break;
+
+                    default:
+                        throw new CacheWriterException("Wring cache: " + ses.cacheName());
+                }
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public void delete(Object key) throws CacheWriterException {
+            deleteCnt.incrementAndGet();
+
+            checkSession();
+        }
+
+        /** {@inheritDoc} */
+        @Override public void sessionEnd(boolean commit) {
+            assertNull(ses.attachment());
+        }
+
+        /**
+         */
+        private void checkSession() {
+            Session hibSes = ses.attachment();
+
+            assertNotNull(hibSes);
+
+            assertTrue(hibSes.isOpen());
+
+            Transaction tx = hibSes.getTransaction();
+
+            assertNotNull(tx);
+
+            if (ses.isWithinTransaction())
+                assertEquals(TransactionStatus.ACTIVE, tx.getStatus());
+            else
+                assertFalse("Unexpected status: " + tx.getStatus(), tx.getStatus() == TransactionStatus.ACTIVE);
+
+            verifySameInstance(hibSes);
+        }
+
+        /**
+         * @param hibSes Session.
+         */
+        private void verifySameInstance(Session hibSes) {
+            Map<String, Session> props = ses.properties();
+
+            Session sesConn = props.get(SES_CONN_KEY);
+
+            if (sesConn == null)
+                props.put(SES_CONN_KEY, hibSes);
+            else {
+                assertSame(hibSes, sesConn);
+
+                reuseCnt.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     */
+    @Entity
+    @Table(name = "Table1")
+    private static class Table1 implements Serializable {
+        /** */
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private Integer id;
+
+        /** */
+        @Column(name = "key")
+        private int key;
+
+        /** */
+        @Column(name = "value")
+        private int value;
+
+        /**
+         * @param key Key.
+         * @param value Value.
+         */
+        private Table1(int key, int value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    /**
+     */
+    @Entity
+    @Table(name = "Table2")
+    private static class Table2 implements Serializable {
+        /** */
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private Integer id;
+
+        /** */
+        @Column(name = "key")
+        private int key;
+
+        /** */
+        @Column(name = "value")
+        private int value;
+
+        /**
+         * @param key Key.
+         * @param value Value.
+         */
+        private Table2(int key, int value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <!-- Show SQL. -->
+        <property name="show_sql">false</property>
+
+        <!-- Database connection settings (private in-memory database). -->
+        <property name="connection.url">jdbc:h2:mem:example;DB_CLOSE_DELAY=-1</property>
+
+        <!-- Only validate the database schema on startup in production mode. -->
+        <property name="hbm2ddl.auto">update</property>
+
+        <!-- H2 dialect. -->
+        <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
+
+        <!-- Mappings. -->
+        <mapping resource="org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.hbm.xml"/>
+    </session-factory>
+</hibernate-configuration>

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/package-info.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/store/hibernate/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <!-- Package description. -->
+ * Contains internal tests or test related classes and interfaces.
+ */
+package org.apache.ignite.cache.store.hibernate;

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteBinaryHibernate53TestSuite.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteBinaryHibernate53TestSuite.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.testsuites;
+
+import junit.framework.TestSuite;
+import org.apache.ignite.internal.binary.BinaryMarshaller;
+import org.apache.ignite.testframework.config.GridTestProperties;
+
+/**
+ *
+ */
+public class IgniteBinaryHibernate53TestSuite extends TestSuite {
+    /**
+     * @return Test suite.
+     * @throws Exception If failed.
+     */
+    public static TestSuite suite() throws Exception {
+        GridTestProperties.setProperty(GridTestProperties.MARSH_CLASS_NAME, BinaryMarshaller.class.getName());
+
+        return IgniteHibernate53TestSuite.suite();
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteBinaryHibernate5TestSuite.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteBinaryHibernate5TestSuite.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.testsuites;
+
+import junit.framework.TestSuite;
+import org.apache.ignite.internal.binary.BinaryMarshaller;
+import org.apache.ignite.testframework.config.GridTestProperties;
+
+/**
+ *
+ */
+public class IgniteBinaryHibernate5TestSuite extends TestSuite {
+    /**
+     * @return Test suite.
+     * @throws Exception If failed.
+     */
+    public static TestSuite suite() throws Exception {
+        GridTestProperties.setProperty(GridTestProperties.MARSH_CLASS_NAME, BinaryMarshaller.class.getName());
+
+        return IgniteHibernate5TestSuite.suite();
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteHibernate53TestSuite.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteHibernate53TestSuite.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.testsuites;
+
+import junit.framework.TestSuite;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheConfigurationSelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheStrategySelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheTransactionalSelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheTransactionalUseSyncSelfTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreNodeRestartTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreSelfTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateStoreFactorySelfTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateStoreSessionListenerSelfTest;
+
+/**
+ * Hibernate integration tests.
+ */
+public class IgniteHibernate53TestSuite extends TestSuite {
+    /**
+     * @return Test suite.
+     * @throws Exception Thrown in case of the failure.
+     */
+    public static TestSuite suite() throws Exception {
+        TestSuite suite = new TestSuite("Hibernate5 Integration Test Suite");
+
+        // Hibernate L2 cache.
+        suite.addTestSuite(HibernateL2CacheSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheTransactionalSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheTransactionalUseSyncSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheConfigurationSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheStrategySelfTest.class);
+
+        suite.addTestSuite(CacheHibernateBlobStoreSelfTest.class);
+
+        suite.addTestSuite(CacheHibernateBlobStoreNodeRestartTest.class);
+
+        suite.addTestSuite(CacheHibernateStoreSessionListenerSelfTest.class);
+
+        suite.addTestSuite(CacheHibernateStoreFactorySelfTest.class);
+
+        return suite;
+    }
+}

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteHibernate5TestSuite.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/testsuites/IgniteHibernate5TestSuite.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.testsuites;
+
+import junit.framework.TestSuite;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheConfigurationSelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheSelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheStrategySelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheTransactionalSelfTest;
+import org.apache.ignite.cache.hibernate.HibernateL2CacheTransactionalUseSyncSelfTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreNodeRestartTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateBlobStoreSelfTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateStoreFactorySelfTest;
+import org.apache.ignite.cache.store.hibernate.CacheHibernateStoreSessionListenerSelfTest;
+
+/**
+ * Hibernate integration tests.
+ */
+public class IgniteHibernate5TestSuite extends TestSuite {
+    /**
+     * @return Test suite.
+     * @throws Exception Thrown in case of the failure.
+     */
+    public static TestSuite suite() throws Exception {
+        TestSuite suite = new TestSuite("Hibernate5 Integration Test Suite");
+
+        // Hibernate L2 cache.
+        suite.addTestSuite(HibernateL2CacheSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheTransactionalSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheTransactionalUseSyncSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheConfigurationSelfTest.class);
+        suite.addTestSuite(HibernateL2CacheStrategySelfTest.class);
+
+        suite.addTestSuite(CacheHibernateBlobStoreSelfTest.class);
+
+        suite.addTestSuite(CacheHibernateBlobStoreNodeRestartTest.class);
+
+        suite.addTestSuite(CacheHibernateStoreSessionListenerSelfTest.class);
+
+        suite.addTestSuite(CacheHibernateStoreFactorySelfTest.class);
+
+        return suite;
+    }
+}

--- a/modules/hibernate-5.3/src/test/resources/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml
+++ b/modules/hibernate-5.3/src/test/resources/org/apache/ignite/cache/store/hibernate/hibernate.cfg.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <!-- Show SQL. -->
+        <property name="show_sql">false</property>
+
+        <!-- Database connection settings (private in-memory database). -->
+        <property name="connection.url">jdbc:h2:mem:example;DB_CLOSE_DELAY=-1</property>
+
+        <!-- Only validate the database schema on startup in production mode. -->
+        <property name="hbm2ddl.auto">update</property>
+
+        <!-- H2 dialect. -->
+        <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
+
+        <!-- Mappings. -->
+        <mapping resource="org/apache/ignite/cache/store/hibernate/CacheHibernateBlobStoreEntry.hbm.xml"/>
+    </session-factory>
+</hibernate-configuration>

--- a/modules/hibernate-core/src/main/java/org/apache/ignite/cache/hibernate/HibernateCacheProxy.java
+++ b/modules/hibernate-core/src/main/java/org/apache/ignite/cache/hibernate/HibernateCacheProxy.java
@@ -17,17 +17,6 @@
 
 package org.apache.ignite.cache.hibernate;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import javax.cache.Cache;
-import javax.cache.expiry.ExpiryPolicy;
-import javax.cache.processor.EntryProcessor;
-import javax.cache.processor.EntryProcessorResult;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cache.CacheEntry;
 import org.apache.ignite.cache.CacheMetrics;
@@ -47,27 +36,42 @@ import org.apache.ignite.transactions.TransactionConcurrency;
 import org.apache.ignite.transactions.TransactionIsolation;
 import org.jetbrains.annotations.Nullable;
 
+import javax.cache.Cache;
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorResult;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+
 /**
  * Hibernate cache proxy used to substitute hibernate keys with ignite keys.
  */
 public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> {
-    /** Delegate. */
-    private final IgniteInternalCache<Object, Object> delegate;
+    /** Delegate is lazily loaded which allows for creation of caches after the SPI is bootstrapped */
+    private final Supplier<IgniteInternalCache<Object, Object>> delegate;
 
     /** Transformer. */
     private final HibernateKeyTransformer keyTransformer;
+    private String cacheName;
 
     /**
+     * @param cacheName should match delegate.get().name().  Needed for lazy loading
      * @param delegate Delegate.
      * @param keyTransformer Key keyTransformer.
      */
-    HibernateCacheProxy(
-        IgniteInternalCache<Object, Object> delegate,
-        HibernateKeyTransformer keyTransformer
-    ) {
+    HibernateCacheProxy(String cacheName, Supplier<IgniteInternalCache<Object, Object>> delegate,
+                        HibernateKeyTransformer keyTransformer) {
+        assert cacheName != null;
         assert delegate != null;
         assert keyTransformer != null;
 
+        this.cacheName = cacheName;
         this.delegate = delegate;
         this.keyTransformer = keyTransformer;
     }
@@ -81,42 +85,42 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
 
     /** {@inheritDoc} */
     @Override public String name() {
-        return delegate.name();
+        return cacheName;
     }
 
     /** {@inheritDoc} */
     @Override public boolean skipStore() {
-        return delegate.skipStore();
+        return delegate.get().skipStore();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalCache setSkipStore(boolean skipStore) {
-        return delegate.setSkipStore(skipStore);
+        return delegate.get().setSkipStore(skipStore);
     }
 
     /** {@inheritDoc} */
     @Override public boolean isEmpty() {
-        return delegate.isEmpty();
+        return delegate.get().isEmpty();
     }
 
     /** {@inheritDoc} */
     @Override public boolean containsKey(Object key) {
-        return delegate.containsKey(keyTransformer.transform(key));
+        return delegate.get().containsKey(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> containsKeyAsync(Object key) {
-        return delegate.containsKeyAsync(keyTransformer.transform(key));
+        return delegate.get().containsKeyAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public boolean containsKeys(Collection keys) {
-        return delegate.containsKey(transform(keys));
+        return delegate.get().containsKey(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> containsKeysAsync(Collection keys) {
-        return delegate.containsKeysAsync(transform(keys));
+        return delegate.get().containsKeysAsync(transform(keys));
     }
 
     /** {@inheritDoc} */
@@ -124,147 +128,147 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         Object key,
         CachePeekMode[] peekModes
     ) throws IgniteCheckedException {
-        return delegate.localPeek(keyTransformer.transform(key), peekModes);
+        return delegate.get().localPeek(keyTransformer.transform(key), peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public Iterable<Cache.Entry<Object, Object>> localEntries(
         CachePeekMode[] peekModes
     ) throws IgniteCheckedException {
-        return delegate.localEntries(peekModes);
+        return delegate.get().localEntries(peekModes);
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public Object get(Object key) throws IgniteCheckedException {
-        return delegate.get(keyTransformer.transform(key));
+        return delegate.get().get(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public CacheEntry getEntry(Object key) throws IgniteCheckedException {
-        return delegate.getEntry(keyTransformer.transform(key));
+        return delegate.get().getEntry(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture getAsync(Object key) {
-        return delegate.getAsync(keyTransformer.transform(key));
+        return delegate.get().getAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<CacheEntry<Object, Object>> getEntryAsync(Object key) {
-        return delegate.getEntryAsync(keyTransformer.transform(key));
+        return delegate.get().getEntryAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public Map getAll(@Nullable Collection keys) throws IgniteCheckedException {
-        return delegate.getAll(transform(keys));
+        return delegate.get().getAll(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public Collection<CacheEntry<Object, Object>> getEntries(
         @Nullable Collection keys) throws IgniteCheckedException {
-        return delegate.getEntries(transform(keys));
+        return delegate.get().getEntries(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Map<Object, Object>> getAllAsync(@Nullable Collection keys) {
-        return delegate.getAllAsync(transform(keys));
+        return delegate.get().getAllAsync(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Collection<CacheEntry<Object,Object>>> getEntriesAsync(
         @Nullable Collection keys
     ) {
-        return delegate.getEntriesAsync(transform(keys));
+        return delegate.get().getEntriesAsync(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public Object getAndPut(Object key, Object val) throws IgniteCheckedException {
-        return delegate.getAndPut(keyTransformer.transform(key), val);
+        return delegate.get().getAndPut(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture getAndPutAsync(Object key, Object val) {
-        return delegate.getAndPutAsync(keyTransformer.transform(key), val);
+        return delegate.get().getAndPutAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public boolean put(Object key, Object val) throws IgniteCheckedException {
-        return delegate.put(keyTransformer.transform(key), val);
+        return delegate.get().put(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> putAsync(Object key, Object val) {
-        return delegate.putAsync(keyTransformer.transform(key), val);
+        return delegate.get().putAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public Object getAndPutIfAbsent(Object key, Object val) throws IgniteCheckedException {
-        return delegate.getAndPutIfAbsent(keyTransformer.transform(key), val);
+        return delegate.get().getAndPutIfAbsent(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture getAndPutIfAbsentAsync(Object key, Object val) {
-        return delegate.getAndPutIfAbsentAsync(keyTransformer.transform(key), val);
+        return delegate.get().getAndPutIfAbsentAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public boolean putIfAbsent(Object key, Object val) throws IgniteCheckedException {
-        return delegate.putIfAbsent(keyTransformer.transform(key), val);
+        return delegate.get().putIfAbsent(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> putIfAbsentAsync(Object key, Object val) {
-        return delegate.putIfAbsentAsync(keyTransformer.transform(key), val);
+        return delegate.get().putIfAbsentAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public Object getAndReplace(Object key, Object val) throws IgniteCheckedException {
-        return delegate.getAndReplace(keyTransformer.transform(key), val);
+        return delegate.get().getAndReplace(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture getAndReplaceAsync(Object key, Object val) {
-        return delegate.getAndReplaceAsync(keyTransformer.transform(key), val);
+        return delegate.get().getAndReplaceAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public boolean replace(Object key, Object val) throws IgniteCheckedException {
-        return delegate.replace(keyTransformer.transform(key), val);
+        return delegate.get().replace(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> replaceAsync(Object key, Object val) {
-        return delegate.replaceAsync(keyTransformer.transform(key), val);
+        return delegate.get().replaceAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public boolean replace(Object key, Object oldVal, Object newVal) throws IgniteCheckedException {
-        return delegate.replace(keyTransformer.transform(key), oldVal, newVal);
+        return delegate.get().replace(keyTransformer.transform(key), oldVal, newVal);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> replaceAsync(Object key, Object oldVal, Object newVal) {
-        return delegate.replaceAsync(keyTransformer.transform(key), oldVal, newVal);
+        return delegate.get().replaceAsync(keyTransformer.transform(key), oldVal, newVal);
     }
 
     /** {@inheritDoc} */
     @Override public void putAll(@Nullable Map m) throws IgniteCheckedException {
-        delegate.putAll(transform(m));
+        delegate.get().putAll(transform(m));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> putAllAsync(@Nullable Map m) {
-        return delegate.putAllAsync(transform(m));
+        return delegate.get().putAllAsync(transform(m));
     }
 
     /** {@inheritDoc} */
     @Override public Set keySet() {
-        return delegate.keySet();
+        return delegate.get().keySet();
     }
 
     /** {@inheritDoc} */
     @Override public Set<Cache.Entry<Object, Object>> entrySet() {
-        return delegate.entrySet();
+        return delegate.get().entrySet();
     }
 
     /** {@inheritDoc} */
@@ -272,7 +276,7 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         TransactionConcurrency concurrency,
         TransactionIsolation isolation
     ) {
-        return delegate.txStart(concurrency, isolation);
+        return delegate.get().txStart(concurrency, isolation);
     }
 
     /** {@inheritDoc} */
@@ -280,7 +284,7 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         TransactionConcurrency concurrency,
         TransactionIsolation isolation
     ) {
-        return delegate.txStartEx(concurrency, isolation);
+        return delegate.get().txStartEx(concurrency, isolation);
     }
 
     /** {@inheritDoc} */
@@ -290,337 +294,337 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         long timeout,
         int txSize
     ) {
-        return delegate.txStart(concurrency, isolation, timeout, txSize);
+        return delegate.get().txStart(concurrency, isolation, timeout, txSize);
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public GridNearTxLocal tx() {
-        return delegate.tx();
+        return delegate.get().tx();
     }
 
     /** {@inheritDoc} */
     @Override public boolean evict(Object key) {
-        return delegate.evict(keyTransformer.transform(key));
+        return delegate.get().evict(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public void evictAll(@Nullable Collection keys) {
-        delegate.evictAll(transform(keys));
+        delegate.get().evictAll(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public void clearLocally(boolean srv, boolean near, boolean readers) {
-        delegate.clearLocally(srv, near, readers);
+        delegate.get().clearLocally(srv, near, readers);
     }
 
     /** {@inheritDoc} */
     @Override public boolean clearLocally(Object key) {
-        return delegate.clearLocally(keyTransformer.transform(key));
+        return delegate.get().clearLocally(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public void clearLocallyAll(Set keys, boolean srv, boolean near, boolean readers) {
-        delegate.clearLocallyAll((Set<?>)transform(keys), srv, near, readers);
+        delegate.get().clearLocallyAll((Set<?>)transform(keys), srv, near, readers);
     }
 
     /** {@inheritDoc} */
     @Override public void clear(Object key) throws IgniteCheckedException {
-        delegate.clear(keyTransformer.transform(key));
+        delegate.get().clear(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public void clearAll(Set keys) throws IgniteCheckedException {
-        delegate.clearAll((Set<?>)transform(keys));
+        delegate.get().clearAll((Set<?>)transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public void clear() throws IgniteCheckedException {
-        delegate.clear();
+        delegate.get().clear();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> clearAsync() {
-        return delegate.clearAsync();
+        return delegate.get().clearAsync();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> clearAsync(Object key) {
-        return delegate.clearAsync(keyTransformer.transform(key));
+        return delegate.get().clearAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> clearAllAsync(Set keys) {
-        return delegate.clearAllAsync((Set<?>)transform(keys));
+        return delegate.get().clearAllAsync((Set<?>)transform(keys));
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public Object getAndRemove(Object key) throws IgniteCheckedException {
-        return delegate.getAndRemove(keyTransformer.transform(key));
+        return delegate.get().getAndRemove(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture getAndRemoveAsync(Object key) {
-        return delegate.getAndRemoveAsync(keyTransformer.transform(key));
+        return delegate.get().getAndRemoveAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public boolean remove(Object key) throws IgniteCheckedException {
-        return delegate.remove(keyTransformer.transform(key));
+        return delegate.get().remove(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> removeAsync(Object key) {
-        return delegate.removeAsync(keyTransformer.transform(key));
+        return delegate.get().removeAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public boolean remove(Object key, Object val) throws IgniteCheckedException {
-        return delegate.remove(keyTransformer.transform(key), val);
+        return delegate.get().remove(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> removeAsync(Object key, Object val) {
-        return delegate.removeAsync(keyTransformer.transform(key), val);
+        return delegate.get().removeAsync(keyTransformer.transform(key), val);
     }
 
     /** {@inheritDoc} */
     @Override public void removeAll(@Nullable Collection keys) throws IgniteCheckedException {
-        delegate.removeAll(transform(keys));
+        delegate.get().removeAll(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> removeAllAsync(@Nullable Collection keys) {
-        return delegate.removeAllAsync(transform(keys));
+        return delegate.get().removeAllAsync(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public void removeAll() throws IgniteCheckedException {
-        delegate.removeAll();
+        delegate.get().removeAll();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> removeAllAsync() {
-        return delegate.removeAllAsync();
+        return delegate.get().removeAllAsync();
     }
 
     /** {@inheritDoc} */
     @Override public boolean lock(Object key, long timeout) throws IgniteCheckedException {
-        return delegate.lock(keyTransformer.transform(key), timeout);
+        return delegate.get().lock(keyTransformer.transform(key), timeout);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> lockAsync(Object key, long timeout) {
-        return delegate.lockAsync(keyTransformer.transform(key), timeout);
+        return delegate.get().lockAsync(keyTransformer.transform(key), timeout);
     }
 
     /** {@inheritDoc} */
     @Override public boolean lockAll(@Nullable Collection keys, long timeout) throws IgniteCheckedException {
-        return delegate.lockAll(transform(keys), timeout);
+        return delegate.get().lockAll(transform(keys), timeout);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Boolean> lockAllAsync(@Nullable Collection keys, long timeout) {
-        return delegate.lockAllAsync(transform(keys), timeout);
+        return delegate.get().lockAllAsync(transform(keys), timeout);
     }
 
     /** {@inheritDoc} */
     @Override public void unlock(Object key) throws IgniteCheckedException {
-        delegate.unlock(keyTransformer.transform(key));
+        delegate.get().unlock(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public void unlockAll(@Nullable Collection keys) throws IgniteCheckedException {
-        delegate.unlockAll(transform(keys));
+        delegate.get().unlockAll(transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public boolean isLocked(Object key) {
-        return delegate.isLocked(keyTransformer.transform(key));
+        return delegate.get().isLocked(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public boolean isLockedByThread(Object key) {
-        return delegate.isLockedByThread(keyTransformer.transform(key));
+        return delegate.get().isLockedByThread(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public int size() {
-        return delegate.size();
+        return delegate.get().size();
     }
 
     /** {@inheritDoc} */
     @Override public long sizeLong() {
-        return delegate.sizeLong();
+        return delegate.get().sizeLong();
     }
 
     /** {@inheritDoc} */
     @Override public int localSize(CachePeekMode[] peekModes) throws IgniteCheckedException {
-        return delegate.localSize(peekModes);
+        return delegate.get().localSize(peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public long localSizeLong(CachePeekMode[] peekModes) throws IgniteCheckedException {
-        return delegate.localSizeLong(peekModes);
+        return delegate.get().localSizeLong(peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public long localSizeLong(int partition, CachePeekMode[] peekModes) throws IgniteCheckedException {
-        return delegate.localSizeLong(partition, peekModes);
+        return delegate.get().localSizeLong(partition, peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public int size(CachePeekMode[] peekModes) throws IgniteCheckedException {
-        return delegate.size(peekModes);
+        return delegate.get().size(peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public long sizeLong(CachePeekMode[] peekModes) throws IgniteCheckedException {
-        return delegate.sizeLong(peekModes);
+        return delegate.get().sizeLong(peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public long sizeLong(int partition, CachePeekMode[] peekModes) throws IgniteCheckedException {
-        return delegate.sizeLong(partition, peekModes);
+        return delegate.get().sizeLong(partition, peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Integer> sizeAsync(CachePeekMode[] peekModes) {
-        return delegate.sizeAsync(peekModes);
+        return delegate.get().sizeAsync(peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Long> sizeLongAsync(CachePeekMode[] peekModes) {
-        return delegate.sizeLongAsync(peekModes);
+        return delegate.get().sizeLongAsync(peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Long> sizeLongAsync(int partition, CachePeekMode[] peekModes) {
-        return delegate.sizeLongAsync(partition, peekModes);
+        return delegate.get().sizeLongAsync(partition, peekModes);
     }
 
     /** {@inheritDoc} */
     @Override public int nearSize() {
-        return delegate.nearSize();
+        return delegate.get().nearSize();
     }
 
     /** {@inheritDoc} */
     @Override public int primarySize() {
-        return delegate.primarySize();
+        return delegate.get().primarySize();
     }
 
     /** {@inheritDoc} */
     @Override public long primarySizeLong() {
-        return delegate.primarySizeLong();
+        return delegate.get().primarySizeLong();
     }
 
     /** {@inheritDoc} */
     @Override public CacheConfiguration configuration() {
-        return delegate.configuration();
+        return delegate.get().configuration();
     }
 
     /** {@inheritDoc} */
     @Override public Affinity affinity() {
-        return delegate.affinity();
+        return delegate.get().affinity();
     }
 
     /** {@inheritDoc} */
     @Override public CacheMetrics clusterMetrics() {
-        return delegate.clusterMetrics();
+        return delegate.get().clusterMetrics();
     }
 
     /** {@inheritDoc} */
     @Override public CacheMetrics clusterMetrics(ClusterGroup grp) {
-        return delegate.clusterMetrics(grp);
+        return delegate.get().clusterMetrics(grp);
     }
 
     /** {@inheritDoc} */
     @Override public CacheMetrics localMetrics() {
-        return delegate.localMetrics();
+        return delegate.get().localMetrics();
     }
 
     /** {@inheritDoc} */
     @Override public CacheMetricsMXBean clusterMxBean() {
-        return delegate.clusterMxBean();
+        return delegate.get().clusterMxBean();
     }
 
     /** {@inheritDoc} */
     @Override public CacheMetricsMXBean localMxBean() {
-        return delegate.localMxBean();
+        return delegate.get().localMxBean();
     }
 
     /** {@inheritDoc} */
     @Override public long offHeapEntriesCount() {
-        return delegate.offHeapEntriesCount();
+        return delegate.get().offHeapEntriesCount();
     }
 
     /** {@inheritDoc} */
     @Override public long offHeapAllocatedSize() {
-        return delegate.offHeapAllocatedSize();
+        return delegate.get().offHeapAllocatedSize();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> rebalance() {
-        return delegate.rebalance();
+        return delegate.get().rebalance();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalCache forSubjectId(UUID subjId) {
-        return delegate.forSubjectId(subjId);
+        return delegate.get().forSubjectId(subjId);
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public Object getForcePrimary(Object key) throws IgniteCheckedException {
-        return delegate.getForcePrimary(keyTransformer.transform(key));
+        return delegate.get().getForcePrimary(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture getForcePrimaryAsync(Object key) {
-        return delegate.getForcePrimaryAsync(keyTransformer.transform(key));
+        return delegate.get().getForcePrimaryAsync(keyTransformer.transform(key));
     }
 
     /** {@inheritDoc} */
     @Override public Map getAllOutTx(Set keys) throws IgniteCheckedException {
-        return delegate.getAllOutTx((Set<?>)transform(keys));
+        return delegate.get().getAllOutTx((Set<?>)transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Map<Object, Object>> getAllOutTxAsync(Set keys) {
-        return delegate.getAllOutTxAsync((Set<?>)transform(keys));
+        return delegate.get().getAllOutTxAsync((Set<?>)transform(keys));
     }
 
     /** {@inheritDoc} */
     @Override public boolean isIgfsDataCache() {
-        return delegate.isIgfsDataCache();
+        return delegate.get().isIgfsDataCache();
     }
 
     /** {@inheritDoc} */
     @Override public long igfsDataSpaceUsed() {
-        return delegate.igfsDataSpaceUsed();
+        return delegate.get().igfsDataSpaceUsed();
     }
 
     /** {@inheritDoc} */
     @Nullable @Override public ExpiryPolicy expiry() {
-        return delegate.expiry();
+        return delegate.get().expiry();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalCache withExpiryPolicy(ExpiryPolicy plc) {
-        return delegate.withExpiryPolicy(plc);
+        return delegate.get().withExpiryPolicy(plc);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalCache withNoRetries() {
-        return delegate.withNoRetries();
+        return delegate.get().withNoRetries();
     }
 
     /** {@inheritDoc} */
     @Override public <K1, V1> IgniteInternalCache<K1, V1> withAllowAtomicOpsInTx() {
-        return delegate.withAllowAtomicOpsInTx();
+        return delegate.get().withAllowAtomicOpsInTx();
     }
 
     /** {@inheritDoc} */
     @Override public GridCacheContext context() {
-        return delegate.context();
+        return delegate.get().context();
     }
 
     /** {@inheritDoc} */
@@ -628,7 +632,7 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         @Nullable IgniteBiPredicate p,
         @Nullable Object... args
     ) throws IgniteCheckedException {
-        delegate.localLoadCache(p, args);
+        delegate.get().localLoadCache(p, args);
     }
 
     /** {@inheritDoc} */
@@ -636,27 +640,27 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         @Nullable IgniteBiPredicate p,
         @Nullable Object... args
     ) {
-        return delegate.localLoadCacheAsync(p, args);
+        return delegate.get().localLoadCacheAsync(p, args);
     }
 
     /** {@inheritDoc} */
     @Override public Collection<Integer> lostPartitions() {
-        return delegate.lostPartitions();
+        return delegate.get().lostPartitions();
     }
 
     /** {@inheritDoc} */
     @Override public void preloadPartition(int part) throws IgniteCheckedException {
-        delegate.preloadPartition(part);
+        delegate.get().preloadPartition(part);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> preloadPartitionAsync(int part) throws IgniteCheckedException {
-        return delegate.preloadPartitionAsync(part);
+        return delegate.get().preloadPartitionAsync(part);
     }
 
     /** {@inheritDoc} */
     @Override public boolean localPreloadPartition(int part) throws IgniteCheckedException {
-        return delegate.localPreloadPartition(part);
+        return delegate.get().localPreloadPartition(part);
     }
 
     /** {@inheritDoc} */
@@ -666,27 +670,27 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         EntryProcessor entryProcessor,
         Object... args
     ) throws IgniteCheckedException {
-        return delegate.invoke(topVer, key, entryProcessor, args);
+        return delegate.get().invoke(topVer, key, entryProcessor, args);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Map> invokeAllAsync(Map map, Object... args) {
-        return delegate.invokeAllAsync(map, args);
+        return delegate.get().invokeAllAsync(map, args);
     }
 
     /** {@inheritDoc} */
     @Override public Map invokeAll(Map map, Object... args) throws IgniteCheckedException {
-        return delegate.invokeAll(map, args);
+        return delegate.get().invokeAll(map, args);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<Map> invokeAllAsync(Set keys, EntryProcessor entryProcessor, Object... args) {
-        return delegate.invokeAllAsync((Set<?>)transform(keys), entryProcessor, args);
+        return delegate.get().invokeAllAsync((Set<?>)transform(keys), entryProcessor, args);
     }
 
     /** {@inheritDoc} */
     @Override public Map invokeAll(Set keys, EntryProcessor entryProcessor, Object... args) throws IgniteCheckedException {
-        return delegate.invokeAll((Set<?>)transform(keys), entryProcessor, args);
+        return delegate.get().invokeAll((Set<?>)transform(keys), entryProcessor, args);
     }
 
     /** {@inheritDoc} */
@@ -695,7 +699,7 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         EntryProcessor entryProcessor,
         Object... args
     ) {
-        return delegate.invokeAsync(keyTransformer.transform(key), entryProcessor, args);
+        return delegate.get().invokeAsync(keyTransformer.transform(key), entryProcessor, args);
     }
 
     /** {@inheritDoc} */
@@ -704,7 +708,7 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         EntryProcessor entryProcessor,
         Object... args
     ) throws IgniteCheckedException {
-        return delegate.invoke(keyTransformer.transform(key), entryProcessor, args);
+        return delegate.get().invoke(keyTransformer.transform(key), entryProcessor, args);
     }
 
     /** {@inheritDoc} */
@@ -712,42 +716,42 @@ public class HibernateCacheProxy implements IgniteInternalCache<Object, Object> 
         boolean keepBinary,
         @Nullable IgniteBiPredicate p
     ) throws IgniteCheckedException {
-        return delegate.scanIterator(keepBinary, p);
+        return delegate.get().scanIterator(keepBinary, p);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> removeAllConflictAsync(Map drMap) throws IgniteCheckedException {
-        return delegate.removeAllConflictAsync(drMap);
+        return delegate.get().removeAllConflictAsync(drMap);
     }
 
     /** {@inheritDoc} */
     @Override public void removeAllConflict(Map drMap) throws IgniteCheckedException {
-        delegate.removeAllConflictAsync(drMap);
+        delegate.get().removeAllConflictAsync(drMap);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalFuture<?> putAllConflictAsync(Map drMap) throws IgniteCheckedException {
-        return delegate.putAllConflictAsync(drMap);
+        return delegate.get().putAllConflictAsync(drMap);
     }
 
     /** {@inheritDoc} */
     @Override public void putAllConflict(Map drMap) throws IgniteCheckedException {
-        delegate.putAllConflict(drMap);
+        delegate.get().putAllConflict(drMap);
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalCache keepBinary() {
-        return delegate.keepBinary();
+        return delegate.get().keepBinary();
     }
 
     /** {@inheritDoc} */
     @Override public IgniteInternalCache cache() {
-        return delegate.cache();
+        return delegate.get().cache();
     }
 
     /** {@inheritDoc} */
     @Override public Iterator iterator() {
-        return delegate.iterator();
+        return delegate.get().iterator();
     }
 
     /**

--- a/modules/hibernate-core/src/main/java/org/apache/ignite/cache/hibernate/HibernateReadOnlyAccessStrategy.java
+++ b/modules/hibernate-core/src/main/java/org/apache/ignite/cache/hibernate/HibernateReadOnlyAccessStrategy.java
@@ -20,6 +20,8 @@ package org.apache.ignite.cache.hibernate;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCheckedException;
 
+import static java.lang.String.format;
+
 /**
  * Implementation of READ_ONLY cache access strategy.
  * <p>
@@ -50,6 +52,7 @@ import org.apache.ignite.IgniteCheckedException;
  *
  */
 public class HibernateReadOnlyAccessStrategy extends HibernateAccessStrategyAdapter {
+
     /**
      * @param ignite Node.
      * @param cache Cache.
@@ -68,9 +71,11 @@ public class HibernateReadOnlyAccessStrategy extends HibernateAccessStrategyAdap
 
     /** {@inheritDoc} */
     @Override public boolean afterInsert(Object key, Object val) {
+        if (log.isDebugEnabled())
+            log.debug(format("put into cache %s afterInsert, key %s", cache.name(), key));
+
         try {
             cache.put(key, val);
-
             return true;
         }
         catch (IgniteCheckedException e) {

--- a/modules/hibernate-core/src/main/java/org/apache/ignite/cache/hibernate/HibernateTransactionalAccessStrategy.java
+++ b/modules/hibernate-core/src/main/java/org/apache/ignite/cache/hibernate/HibernateTransactionalAccessStrategy.java
@@ -22,6 +22,8 @@ import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
 import org.jetbrains.annotations.Nullable;
 
+import static java.lang.String.format;
+
 /**
  * Implementation of {TRANSACTIONAL cache access strategy.
  * <p>
@@ -67,6 +69,9 @@ public class HibernateTransactionalAccessStrategy extends HibernateAccessStrateg
 
     /** {@inheritDoc} */
     @Nullable @Override public Object get(Object key) {
+        if (log.isDebugEnabled())
+            log.debug(format("get from cache %s, key %s", cache.name(), key));
+
         try {
             return cache.get(key);
         }
@@ -77,6 +82,9 @@ public class HibernateTransactionalAccessStrategy extends HibernateAccessStrateg
 
     /** {@inheritDoc} */
     @Override public void putFromLoad(Object key, Object val) {
+        if (log.isDebugEnabled())
+            log.debug(format("put info cache %s, key %s, val %s", cache.name(), key, val));
+
         try {
             cache.put(key, val);
         }
@@ -97,9 +105,11 @@ public class HibernateTransactionalAccessStrategy extends HibernateAccessStrateg
 
     /** {@inheritDoc} */
     @Override public boolean update(Object key, Object val) {
+        if (log.isDebugEnabled())
+            log.debug(format("put info cache %s, key %s, val %s", cache.name(), key, val));
+
         try {
             cache.put(key, val);
-
             return true;
         }
         catch (IgniteCheckedException e) {
@@ -114,9 +124,11 @@ public class HibernateTransactionalAccessStrategy extends HibernateAccessStrateg
 
     /** {@inheritDoc} */
     @Override public boolean insert(Object key, Object val) {
+        if (log.isDebugEnabled())
+            log.debug(format("put info cache %s, key %s, val %s", cache.name(), key, val));
+
         try {
             cache.put(key, val);
-
             return true;
         }
         catch (IgniteCheckedException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
                 <module>modules/geospatial</module>
                 <module>modules/hibernate-4.2</module>
                 <module>modules/hibernate-5.1</module>
+                <module>modules/hibernate-5.3</module>
                 <module>modules/schedule</module>
                 <module>modules/web-console/web-agent</module>
                 <module>modules/yardstick</module>
@@ -244,6 +245,7 @@
             <modules>
                 <module>modules/hibernate-4.2</module>
                 <module>modules/hibernate-5.1</module>
+                <module>modules/hibernate-5.3</module>
                 <module>modules/geospatial</module>
                 <module>modules/schedule</module>
             </modules>


### PR DESCRIPTION
IGNITE-9893 IGNITE-1757 adding hibernate-5.3 module

This change is based on the hibernate-5.1 example with fixes to tests
that I ran into during developement

updates to the module:
1. added ability to allow for caches to be lazily loaded and created as a result
       of post-bootstrap scanning.
2. added org.apache.ignite.hibernate.verify_atomicity - relaxes the cache
       atomicMode check
3. HibernateCacheProxy - now accepts a Supplier which lazily loads the
       Ignite caches after the SPI is initialized
4. added org.apache.ignite.hibernate.cache_prefix - prepends all cache names
       when a cache is looked up in ignite
5. removed dflt cache as ignite 2.x does not allow mixed classes in one cache

All tests now pass as a result of fixing a couple bugs including IGNITE-1757