### PR TITLE
IGNITE-9914 logic how to get subjectId for tasks was fixed.

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/TaskEventSubjectIdSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/TaskEventSubjectIdSelfTest.java
@@ -308,6 +308,9 @@ public class TaskEventSubjectIdSelfTest extends GridCommonAbstractTest {
     }
 
     /**
+     * Events for class tasks that was started from external clients should contain
+     * client subject id instead of the node where it was started. This test checks it.
+     *
      * @throws Exception If failed.
      */
     public void testClient() throws Exception {
@@ -328,7 +331,7 @@ public class TaskEventSubjectIdSelfTest extends GridCommonAbstractTest {
         assert evt != null;
 
         assertEquals(EVT_TASK_STARTED, evt.type());
-        assertEquals(nodeId, evt.subjectId());
+        assertEquals(client.id(), evt.subjectId());
 
         assert it.hasNext();
 
@@ -337,7 +340,7 @@ public class TaskEventSubjectIdSelfTest extends GridCommonAbstractTest {
         assert evt != null;
 
         assertEquals(EVT_TASK_REDUCED, evt.type());
-        assertEquals(nodeId, evt.subjectId());
+        assertEquals(client.id(), evt.subjectId());
 
         assert it.hasNext();
 
@@ -346,7 +349,7 @@ public class TaskEventSubjectIdSelfTest extends GridCommonAbstractTest {
         assert evt != null;
 
         assertEquals(EVT_TASK_FINISHED, evt.type());
-        assertEquals(nodeId, evt.subjectId());
+        assertEquals(client.id(), evt.subjectId());
 
         assert !it.hasNext();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/task/GridTaskProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/task/GridTaskProcessor.java
@@ -702,7 +702,10 @@ public class GridTaskProcessor extends GridProcessorAdapter implements IgniteCha
             top = nodes != null ? F.nodeIds(nodes) : null;
         }
 
-        UUID subjId = getThreadContext(TC_SUBJ_ID);
+        UUID subjId = (UUID)map.get(TC_SUBJ_ID);
+
+        if(subjId == null)
+            subjId = getThreadContext(TC_SUBJ_ID);
 
         if (subjId == null)
             subjId = ctx.localNodeId();

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridJobSubjectIdSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridJobSubjectIdSelfTest.java
@@ -37,6 +37,8 @@ import org.apache.ignite.resources.TaskSessionResource;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.jetbrains.annotations.Nullable;
 
+import static org.apache.ignite.internal.processors.task.GridTaskThreadContextKey.TC_SUBJ_ID;
+
 /**
  * Test job subject ID propagation.
  */
@@ -59,6 +61,7 @@ public class GridJobSubjectIdSelfTest extends GridCommonAbstractTest {
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {
         node1 = startGrid(1);
+
         node2 = startGrid(2);
     }
 
@@ -67,7 +70,14 @@ public class GridJobSubjectIdSelfTest extends GridCommonAbstractTest {
         stopAllGrids();
 
         node1 = null;
+
         node2 = null;
+
+        evtSubjId = null;
+
+        taskSubjId = null;
+
+        jobSubjId = null;
     }
 
     /**
@@ -91,7 +101,37 @@ public class GridJobSubjectIdSelfTest extends GridCommonAbstractTest {
         node1.compute().execute(new Task(node2.cluster().localNode().id()), null);
 
         assertEquals(taskSubjId, jobSubjId);
+
         assertEquals(taskSubjId, evtSubjId);
+    }
+
+    /**
+     * Test job subject ID propagation in case if was changed.
+     *
+     * @throws Exception If failed.
+     */
+    public void testModifiedSubjectId() throws Exception {
+        node1.events().localListen(new IgnitePredicate<Event>() {
+            @Override public boolean apply(Event evt) {
+                JobEvent evt0 = (JobEvent)evt;
+
+                assert evtSubjId == null;
+
+                evtSubjId = evt0.taskSubjectId();
+
+                return false;
+            }
+        }, EventType.EVT_JOB_STARTED);
+
+        UUID uuid = new UUID(100, 100);
+
+        ((IgniteEx) node1).context().task().setThreadContextIfNotNull(TC_SUBJ_ID, uuid);
+
+        ((IgniteEx) node1).context().task().execute(new Task(node1.cluster().localNode().id()), null).get();
+
+        assertEquals(uuid, jobSubjId);
+
+        assertEquals(uuid, evtSubjId);
     }
 
     /**


### PR DESCRIPTION
In case if the task was initialized from the remote client as web console then taskEvent.subjectId() will return the incorrect value. 

It will contain the subject id for the node where this task was deployed.

Ignite already have the thread local store for subject id but looks like we have a problem in GridTaskProcessor:

UUID subjId = getThreadContext(TC_SUBJ_ID);

But it always is null because of the correct value for TC_SUBJ_ID stored in 

Map<GridTaskThreadContextKey, Object> map = thCtx.get();

So it should be changed to 

UUID subjId = (UUID)map.get(TC_SUBJ_ID);