### PR TITLE
IGNITE-7153: Fix parser to handle incomplete Redis packet

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/processors/rest/protocols/tcp/redis/RedisProtocolConnectSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/processors/rest/protocols/tcp/redis/RedisProtocolConnectSelfTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.rest.protocols.tcp.redis;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import redis.clients.jedis.Jedis;
 
@@ -68,6 +69,23 @@ public class RedisProtocolConnectSelfTest extends RedisCommonAbstractTest {
 
             jedis.select(0);
             Assert.assertEquals("v0", jedis.get("k0"));
+        }
+    }
+
+    //IGNITE-7153
+    public void testSetBigObject1() throws Exception {
+        String randomString1 = RandomStringUtils.random(8 << 10, true, true); //8192
+        String randomString2 = RandomStringUtils.random(10 << 10, true, true); //10240
+        String randomString3 = RandomStringUtils.random(8 << 11, true, true); //16384
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set("b1".getBytes(), randomString1.getBytes());
+            Assert.assertEquals(randomString1, jedis.get("b1"));
+
+            jedis.set("b2".getBytes(), randomString2.getBytes());
+            Assert.assertEquals(randomString2, jedis.get("b2"));
+
+            jedis.set("b3".getBytes(), randomString3.getBytes());
+            Assert.assertEquals(randomString3, jedis.get("b3"));
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/protocols/tcp/redis/GridRedisProtocolParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/protocols/tcp/redis/GridRedisProtocolParser.java
@@ -17,10 +17,13 @@
 
 package org.apache.ignite.internal.processors.rest.protocols.tcp.redis;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.internal.processors.rest.protocols.tcp.GridTcpRestParser;
 
 /**
  * Parser to decode/encode Redis protocol (RESP) requests.
@@ -110,6 +113,60 @@ public class GridRedisProtocolParser {
             throw new IgniteCheckedException("Invalid request syntax!");
 
         return new String(bulkStr);
+    }
+
+    /*
+     * A validation method to check packet completeness.
+     * return true if and only if
+     * 1. First byte is ARRAY (43)
+     * 2. Last two bytes are CR(13) LF(10)
+     *
+     * Otherwise, return false representing this is an incomplete packet with three possible scenarios:
+     * 1. A beginning packet with leading ARRAY byte
+     * 2. A continual packet with ending CRLF bytes.
+     * 3. A continual packet with neither conditions above.
+     */
+    public static boolean validatePacket(ByteBuffer buf) {
+        return validatePacketHeader(buf) && validatePacketFooter(buf);
+    }
+
+    public static boolean validatePacketHeader(ByteBuffer buf) {
+        boolean result = true;
+
+        //mark at initial position
+        buf.mark();
+
+        if(buf.get() != ARRAY) {
+            result = false;
+        }
+
+        //reset to initial position
+        buf.reset();
+
+        return result;
+    }
+
+    public static boolean validatePacketFooter(ByteBuffer buf) {
+        boolean result = true;
+
+        //mark at initial position
+        buf.mark();
+
+
+        int limit = buf.limit();
+
+        assert limit > 2;
+
+        //check the final CR(last -2 ) and LF(last -1) byte
+        if (buf.get(limit - 2) != CR || buf.get(limit - 1) != LF) {
+            result = false;
+        }
+
+
+        //reset to initial position
+        buf.reset();
+
+        return result;
     }
 
     /**


### PR DESCRIPTION
Add validation method to check packet completeness

Add logic to store incomplete packet temporarily and assemble them until
the final CRLF is seen.

Implement test cases for data = 8k, 10k and 16k