### PR TITLE
IGNITE-9995: Fix bugs in windows launch bat script

### DIFF
--- a/bin/include/build-classpath.bat
+++ b/bin/include/build-classpath.bat
@@ -25,7 +25,7 @@
 
 @echo off
 
-for /D %%F in (modules\*) do if not %%F == "modules" call :includeToClassPath %%F
+if not %cd% == %IGNITE_HOME% for /D %%F in (%cd%\modules\*) do if not %%F == "%cd%\modules" call :includeToClassPath %%F
 
 for /F %%F in ('dir /A:D /b "%IGNITE_HOME%\modules\*" /b') do call :includeToClassPath "%IGNITE_HOME%\modules\%%F"
 goto :eof


### PR DESCRIPTION
Problems:
If user is under ignite source dir, launching ignite will cause "Input
line is too long" error. While if user switch to another dir and lanunch
ignite, this error will disappear.

Analyze:
This is because in the first scenario, the current working dir is just
he IGNITE_HOME, this will cause ignite adding same pathes to classpath
twice, thus causing a line in cmd too long.

Solution:
Avoiding adding the same path to classpath twice if current working dir
is the same as IGNITE_HOME.
Besides, we use the full path name instead of relative path name if
current working dir is not the same as IGNITE_HOME.