### PR TITLE
IGNITE-4111 Fix NPE on client connected before disco impl initialized

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -451,6 +451,10 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
 
     /** {@inheritDoc} */
     @Override public Collection<ClusterNode> getRemoteNodes() {
+        // Return empty nodes for resolving compatibility until implementation started.
+        if (impl == null)
+            return Collections.emptyList();
+
         return impl.getRemoteNodes();
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/IgniteTcpCommunicationConnectOnInitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/IgniteTcpCommunicationConnectOnInitTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.spi.communication.tcp;
+
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.nio.GridNioServer;
+import org.apache.ignite.internal.util.nio.GridNioServerListenerAdapter;
+import org.apache.ignite.internal.util.nio.GridNioSession;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.spi.communication.tcp.messages.HandshakeWaitMessage;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Testing {@link TcpCommunicationSpi} that will send the wait handshake message on received connections until SPI
+ * context initialized.
+ */
+@RunWith(JUnit4.class)
+public class IgniteTcpCommunicationConnectOnInitTest extends GridCommonAbstractTest {
+    /** */
+    private static final int START_PORT = 55443;
+
+    /** */
+    private volatile CountDownLatch commStartLatch;
+
+    /** */
+    private volatile int commSpiBoundedPort;
+
+    /** */
+    private volatile String commSpiSrvAddr;
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setCommunicationSpi(new TestCommunicationSpi());
+
+        return cfg;
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testClientConnectBeforeDiscoveryStarted() throws Exception {
+        GridNioServer<?> srvr = startServer();
+
+        try {
+            commStartLatch = new CountDownLatch(1);
+
+            GridTestUtils.runAsync(() -> {
+                startGrid(0);
+
+                return true;
+            });
+
+            assertTrue(commStartLatch.await(5_000, TimeUnit.MILLISECONDS));
+
+            SocketChannel ch = SocketChannel.open(new InetSocketAddress(commSpiSrvAddr, commSpiBoundedPort));
+
+            GridNioSession ses = srvr.createSession(ch, null, false, null).get();
+
+            boolean wait = GridTestUtils.waitForCondition(
+                () -> ses.bytesReceived() == HandshakeWaitMessage.MESSAGE_FULL_SIZE, 1000);
+
+            assertTrue("Handshake not started.", wait);
+        }
+        finally {
+            srvr.stop();
+        }
+    }
+
+    /**
+     * Starts custom server.
+     *
+     * @return Started server.
+     * @throws Exception If failed.
+     */
+    @SuppressWarnings("unchecked")
+    private GridNioServer<?> startServer() throws Exception {
+        int srvPort = START_PORT;
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                GridNioServerListenerAdapter lsnr = new GridNioServerListenerAdapter() {
+                    @Override public void onConnected(GridNioSession ses) {
+                        // No-op.
+                    }
+
+                    @Override public void onDisconnected(GridNioSession ses, @Nullable Exception e) {
+                        // No-op.
+                    }
+
+                    @Override public void onMessage(GridNioSession ses, Object msg) {
+                        // No-op.
+                    }
+                };
+
+                GridNioServer<?> srvr = GridNioServer.builder()
+                    .address(U.getLocalHost())
+                    .port(srvPort)
+                    .listener(lsnr)
+                    .logger(log)
+                    .selectorCount(Runtime.getRuntime().availableProcessors())
+                    .igniteInstanceName("nio-test-grid")
+                    .filters().build();
+
+                srvr.start();
+
+                return srvr;
+            }
+            catch (IgniteCheckedException e) {
+                if (i < 9 && e.hasCause(BindException.class)) {
+                    log.error("Failed to start server, will try another port [err=" + e + ", port=" + srvPort + ']');
+
+                    U.sleep(1000);
+
+                    srvPort++;
+                }
+                else
+                    throw e;
+            }
+        }
+
+        fail("Failed to start server.");
+
+        return null;
+    }
+
+    /** */
+    private class TestCommunicationSpi extends TcpCommunicationSpi {
+        /** {@inheritDoc} */
+        @Override public void spiStart(String igniteInstanceName) throws IgniteSpiException {
+            super.spiStart(igniteInstanceName);
+
+            commSpiBoundedPort = boundPort();
+
+            commSpiSrvAddr = getLocalAddress();
+
+            commStartLatch.countDown();
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/IgniteTcpCommunicationHandshakeWaitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/IgniteTcpCommunicationHandshakeWaitTest.java
@@ -17,24 +17,33 @@
 
 package org.apache.ignite.spi.communication.tcp;
 
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
+import org.apache.ignite.internal.util.nio.GridNioServer;
+import org.apache.ignite.internal.util.nio.GridNioServerListenerAdapter;
+import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.spi.communication.tcp.messages.HandshakeWaitMessage;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.messages.TcpDiscoveryAbstractMessage;
 import org.apache.ignite.spi.discovery.tcp.messages.TcpDiscoveryNodeAddFinishedMessage;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Testing {@link TcpCommunicationSpi} that will send the wait handshake message on received connections until SPI
@@ -48,10 +57,28 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
     private static final long DISCOVERY_MESSAGE_DELAY = 500;
 
     /** */
+    private static final int START_PORT = 55443;
+
+    /** */
+    private boolean customDiscoSpi;
+
+    /** */
     private final AtomicBoolean slowNet = new AtomicBoolean();
 
     /** */
     private final CountDownLatch latch = new CountDownLatch(1);
+
+    /** */
+    private boolean customCommSpi;
+
+    /** */
+    private volatile CountDownLatch commStartLatch;
+
+    /** */
+    private volatile int commSpiBoundedPort;
+
+    /** */
+    private volatile String commSpiSrvAddr;
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
@@ -59,11 +86,13 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
 
         cfg.setPeerClassLoadingEnabled(false);
 
-        TcpDiscoverySpi discoSpi = new SlowTcpDiscoverySpi();
+        if (customDiscoSpi) {
+            TcpDiscoverySpi discoSpi = new SlowTcpDiscoverySpi();
 
-        cfg.setDiscoverySpi(discoSpi);
+            cfg.setDiscoverySpi(discoSpi);
+        }
 
-        TcpCommunicationSpi commSpi = new TcpCommunicationSpi();
+        TcpCommunicationSpi commSpi = customCommSpi ? new TestCommunicationSpi() : new TcpCommunicationSpi();
 
         commSpi.setConnectTimeout(COMMUNICATION_TIMEOUT);
         commSpi.setMaxConnectTimeout(COMMUNICATION_TIMEOUT);
@@ -81,6 +110,8 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
      * @throws Exception If failed.
      */
     public void testHandshakeOnNodeJoining() throws Exception {
+        customDiscoSpi = true;
+
         System.setProperty(IgniteSystemProperties.IGNITE_ENABLE_FORCIBLE_NODE_KILL, "true");
 
         IgniteEx ignite = startGrid("srv1");
@@ -104,8 +135,98 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
         fut.get();
     }
 
+    /**
+     * @throws Exception If failed.
+     */
+    public void testClientConnectBeforeDiscoveryStarted() throws Exception {
+        customCommSpi = true;
+
+        GridNioServer<?> srvr = startServer();
+
+        try {
+            commStartLatch = new CountDownLatch(1);
+
+            GridTestUtils.runAsync(() -> {
+                startGrid(0);
+
+                return true;
+            });
+
+            assertTrue(commStartLatch.await(5_000, TimeUnit.MILLISECONDS));
+
+            SocketChannel ch = SocketChannel.open(new InetSocketAddress(commSpiSrvAddr, commSpiBoundedPort));
+
+            GridNioSession ses = srvr.createSession(ch, null, false, null).get();
+
+            boolean wait = GridTestUtils.waitForCondition(
+                () -> ses.bytesReceived() == HandshakeWaitMessage.MESSAGE_FULL_SIZE, 1000);
+
+            assertTrue("Handshake not started.", wait);
+        }
+        finally {
+            srvr.stop();
+        }
+    }
+
+    /**
+     * Starts custom server.
+     *
+     * @return Started server.
+     * @throws Exception If failed.
+     */
+    @SuppressWarnings("unchecked")
+    private GridNioServer<?> startServer() throws Exception {
+        int srvPort = START_PORT;
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                GridNioServerListenerAdapter lsnr = new GridNioServerListenerAdapter() {
+                    @Override public void onConnected(GridNioSession ses) {
+                        // No-op.
+                    }
+
+                    @Override public void onDisconnected(GridNioSession ses, @Nullable Exception e) {
+                        // No-op.
+                    }
+
+                    @Override public void onMessage(GridNioSession ses, Object msg) {
+                        // No-op.
+                    }
+                };
+
+                GridNioServer<?> srvr = GridNioServer.builder()
+                    .address(U.getLocalHost())
+                    .port(srvPort)
+                    .listener(lsnr)
+                    .logger(log)
+                    .selectorCount(Runtime.getRuntime().availableProcessors())
+                    .igniteInstanceName("nio-test-grid")
+                    .filters().build();
+
+                srvr.start();
+
+                return srvr;
+            }
+            catch (IgniteCheckedException e) {
+                if (i < 9 && e.hasCause(BindException.class)) {
+                    log.error("Failed to start server, will try another port [err=" + e + ", port=" + srvPort + ']');
+
+                    U.sleep(1000);
+
+                    srvPort++;
+                }
+                else
+                    throw e;
+            }
+        }
+
+        fail("Failed to start server.");
+
+        return null;
+    }
+
     /** {@inheritDoc} */
-    @Override protected void afterTestsStopped() throws Exception {
+    @Override protected void afterTest() {
         System.clearProperty(IgniteSystemProperties.IGNITE_ENABLE_FORCIBLE_NODE_KILL);
     }
 
@@ -126,6 +247,20 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
             }
 
             return super.ensured(msg);
+        }
+    }
+
+    /** */
+    private class TestCommunicationSpi extends TcpCommunicationSpi {
+        /** {@inheritDoc} */
+        @Override public void spiStart(String igniteInstanceName) throws IgniteSpiException {
+            super.spiStart(igniteInstanceName);
+
+            commSpiBoundedPort = boundPort();
+
+            commSpiSrvAddr = getLocalAddress();
+
+            commStartLatch.countDown();
         }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/IgniteTcpCommunicationHandshakeWaitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/communication/tcp/IgniteTcpCommunicationHandshakeWaitTest.java
@@ -17,33 +17,24 @@
 
 package org.apache.ignite.spi.communication.tcp;
 
-import java.net.BindException;
-import java.net.InetSocketAddress;
-import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
-import org.apache.ignite.internal.util.nio.GridNioServer;
-import org.apache.ignite.internal.util.nio.GridNioServerListenerAdapter;
-import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.spi.IgniteSpiException;
-import org.apache.ignite.spi.communication.tcp.messages.HandshakeWaitMessage;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.messages.TcpDiscoveryAbstractMessage;
 import org.apache.ignite.spi.discovery.tcp.messages.TcpDiscoveryNodeAddFinishedMessage;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Testing {@link TcpCommunicationSpi} that will send the wait handshake message on received connections until SPI
@@ -57,28 +48,10 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
     private static final long DISCOVERY_MESSAGE_DELAY = 500;
 
     /** */
-    private static final int START_PORT = 55443;
-
-    /** */
-    private boolean customDiscoSpi;
-
-    /** */
     private final AtomicBoolean slowNet = new AtomicBoolean();
 
     /** */
     private final CountDownLatch latch = new CountDownLatch(1);
-
-    /** */
-    private boolean customCommSpi;
-
-    /** */
-    private volatile CountDownLatch commStartLatch;
-
-    /** */
-    private volatile int commSpiBoundedPort;
-
-    /** */
-    private volatile String commSpiSrvAddr;
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
@@ -86,13 +59,11 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
 
         cfg.setPeerClassLoadingEnabled(false);
 
-        if (customDiscoSpi) {
-            TcpDiscoverySpi discoSpi = new SlowTcpDiscoverySpi();
+        TcpDiscoverySpi discoSpi = new SlowTcpDiscoverySpi();
 
-            cfg.setDiscoverySpi(discoSpi);
-        }
+        cfg.setDiscoverySpi(discoSpi);
 
-        TcpCommunicationSpi commSpi = customCommSpi ? new TestCommunicationSpi() : new TcpCommunicationSpi();
+        TcpCommunicationSpi commSpi = new TcpCommunicationSpi();
 
         commSpi.setConnectTimeout(COMMUNICATION_TIMEOUT);
         commSpi.setMaxConnectTimeout(COMMUNICATION_TIMEOUT);
@@ -110,8 +81,6 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
      * @throws Exception If failed.
      */
     public void testHandshakeOnNodeJoining() throws Exception {
-        customDiscoSpi = true;
-
         System.setProperty(IgniteSystemProperties.IGNITE_ENABLE_FORCIBLE_NODE_KILL, "true");
 
         IgniteEx ignite = startGrid("srv1");
@@ -135,98 +104,8 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
         fut.get();
     }
 
-    /**
-     * @throws Exception If failed.
-     */
-    public void testClientConnectBeforeDiscoveryStarted() throws Exception {
-        customCommSpi = true;
-
-        GridNioServer<?> srvr = startServer();
-
-        try {
-            commStartLatch = new CountDownLatch(1);
-
-            GridTestUtils.runAsync(() -> {
-                startGrid(0);
-
-                return true;
-            });
-
-            assertTrue(commStartLatch.await(5_000, TimeUnit.MILLISECONDS));
-
-            SocketChannel ch = SocketChannel.open(new InetSocketAddress(commSpiSrvAddr, commSpiBoundedPort));
-
-            GridNioSession ses = srvr.createSession(ch, null, false, null).get();
-
-            boolean wait = GridTestUtils.waitForCondition(
-                () -> ses.bytesReceived() == HandshakeWaitMessage.MESSAGE_FULL_SIZE, 1000);
-
-            assertTrue("Handshake not started.", wait);
-        }
-        finally {
-            srvr.stop();
-        }
-    }
-
-    /**
-     * Starts custom server.
-     *
-     * @return Started server.
-     * @throws Exception If failed.
-     */
-    @SuppressWarnings("unchecked")
-    private GridNioServer<?> startServer() throws Exception {
-        int srvPort = START_PORT;
-
-        for (int i = 0; i < 10; i++) {
-            try {
-                GridNioServerListenerAdapter lsnr = new GridNioServerListenerAdapter() {
-                    @Override public void onConnected(GridNioSession ses) {
-                        // No-op.
-                    }
-
-                    @Override public void onDisconnected(GridNioSession ses, @Nullable Exception e) {
-                        // No-op.
-                    }
-
-                    @Override public void onMessage(GridNioSession ses, Object msg) {
-                        // No-op.
-                    }
-                };
-
-                GridNioServer<?> srvr = GridNioServer.builder()
-                    .address(U.getLocalHost())
-                    .port(srvPort)
-                    .listener(lsnr)
-                    .logger(log)
-                    .selectorCount(Runtime.getRuntime().availableProcessors())
-                    .igniteInstanceName("nio-test-grid")
-                    .filters().build();
-
-                srvr.start();
-
-                return srvr;
-            }
-            catch (IgniteCheckedException e) {
-                if (i < 9 && e.hasCause(BindException.class)) {
-                    log.error("Failed to start server, will try another port [err=" + e + ", port=" + srvPort + ']');
-
-                    U.sleep(1000);
-
-                    srvPort++;
-                }
-                else
-                    throw e;
-            }
-        }
-
-        fail("Failed to start server.");
-
-        return null;
-    }
-
     /** {@inheritDoc} */
-    @Override protected void afterTest() {
+    @Override protected void afterTestsStopped() throws Exception {
         System.clearProperty(IgniteSystemProperties.IGNITE_ENABLE_FORCIBLE_NODE_KILL);
     }
 
@@ -247,20 +126,6 @@ public class IgniteTcpCommunicationHandshakeWaitTest extends GridCommonAbstractT
             }
 
             return super.ensured(msg);
-        }
-    }
-
-    /** */
-    private class TestCommunicationSpi extends TcpCommunicationSpi {
-        /** {@inheritDoc} */
-        @Override public void spiStart(String igniteInstanceName) throws IgniteSpiException {
-            super.spiStart(igniteInstanceName);
-
-            commSpiBoundedPort = boundPort();
-
-            commSpiSrvAddr = getLocalAddress();
-
-            commStartLatch.countDown();
         }
     }
 }


### PR DESCRIPTION
It happens when someone client connect before discovery impl started.
- add fix (return empty collection)
- add test