### PR TITLE
IGNITE-10657: ctx.security().onSessionExpired method is now called on…

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerAbstractConnectionContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerAbstractConnectionContext.java
@@ -126,4 +126,11 @@ public abstract class ClientListenerAbstractConnectionContext implements ClientL
 
         return authCtx;
     }
+
+    /** {@inheritDoc} */
+    @Override public void onDisconnected() {
+        if (ctx.security().enabled())
+            ctx.security().onSessionExpired(secCtx.subject().id());
+    }
+
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/jdbc/JdbcConnectionContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/jdbc/JdbcConnectionContext.java
@@ -207,5 +207,7 @@ public class JdbcConnectionContext extends ClientListenerAbstractConnectionConte
     /** {@inheritDoc} */
     @Override public void onDisconnected() {
         handler.onDisconnect();
+
+        super.onDisconnected();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcConnectionContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcConnectionContext.java
@@ -188,5 +188,7 @@ public class OdbcConnectionContext extends ClientListenerAbstractConnectionConte
     /** {@inheritDoc} */
     @Override public void onDisconnected() {
         handler.onDisconnect();
+
+        super.onDisconnected();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientConnectionContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientConnectionContext.java
@@ -143,6 +143,8 @@ public class ClientConnectionContext extends ClientListenerAbstractConnectionCon
     /** {@inheritDoc} */
     @Override public void onDisconnected() {
         resReg.clean();
+
+        super.onDisconnected();
     }
 
     /**


### PR DESCRIPTION
… thin clients disconnect.

At the moment all classes that implement ClientListenerAbstractConnectionContext don't call the ctx.security().onSessionExpired(subjid) on disconect.

It provides the leaking of the memory related to resources that were generated during authentification.