### PR TITLE
IGNITE-11014 Fix a typo in backup threshold property

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
@@ -1098,7 +1098,7 @@ public final class IgniteSystemProperties {
      * Size threshold to allocate and retain additional  HashMap to improve contains()
      * which leads to extra memory consumption.
      */
-    public static final String IGNITE_AFFINITY_BACKUPS_THRESHOLD = "IGNITE_AFFINITY_BACKUUPS_THRESHOLD";
+    public static final String IGNITE_AFFINITY_BACKUPS_THRESHOLD = "IGNITE_AFFINITY_BACKUPS_THRESHOLD";
 
     /**
      * Flag to disable memory optimization:


### PR DESCRIPTION
I was reading commits and noticed a typo in backup threshold property