### PR TITLE
IGNITE-11166 Web agent: Host name verifier should be disabled in case of "-Dtrust.all=true".

### DIFF
--- a/modules/web-console/web-agent/src/main/java/org/apache/ignite/console/agent/AgentLauncher.java
+++ b/modules/web-console/web-agent/src/main/java/org/apache/ignite/console/agent/AgentLauncher.java
@@ -356,6 +356,9 @@ public class AgentLauncher {
                 cfg.serverTrustStorePassword()
             );
 
+            if (serverTrustAll)
+                builder.hostnameVerifier((hostname, session) -> true);
+
             SSLSocketFactory sslSocketFactory = sslSocketFactory(
                 cfg.serverKeyStore(),
                 cfg.serverKeyStorePassword(),

--- a/modules/web-console/web-agent/src/main/java/org/apache/ignite/console/agent/rest/RestExecutor.java
+++ b/modules/web-console/web-agent/src/main/java/org/apache/ignite/console/agent/rest/RestExecutor.java
@@ -103,6 +103,9 @@ public class RestExecutor implements AutoCloseable {
 
         X509TrustManager trustMgr = trustManager(Boolean.getBoolean("trust.all"), trustStorePath, trustStorePwd);
 
+        if (trustAll)
+            builder.hostnameVerifier((hostname, session) -> true);
+
         SSLSocketFactory sslSocketFactory = sslSocketFactory(
             keyStorePath, keyStorePwd,
             trustMgr,


### PR DESCRIPTION
…n case of trustAll flag enabled.