### PR TITLE
IGNITE-10900 Print warn message when a node doesn't have an explicit …

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -2176,6 +2176,9 @@ public class IgnitionEx {
                     "on start?) [segPlc=" + segPlc + ", wait=false]");
             }
 
+            if(CU.isPersistenceEnabled(cfg) && myCfg.getConsistentId() == null)
+                U.warn(log, "Found potential configuration problem (forgot to set explicit consistent ID when persistence is enabled)");
+
             myCfg.setTransactionConfiguration(myCfg.getTransactionConfiguration() != null ?
                 new TransactionConfiguration(myCfg.getTransactionConfiguration()) : null);
 


### PR DESCRIPTION
…consistent ID and peristence is enabled.