### PR TITLE
IGNITE-11521: Add a lifecycle event before joining the cluster

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -294,6 +294,7 @@ import static org.apache.ignite.internal.IgniteVersionUtils.VER;
 import static org.apache.ignite.internal.IgniteVersionUtils.VER_STR;
 import static org.apache.ignite.lifecycle.LifecycleEventType.AFTER_NODE_START;
 import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_NODE_START;
+import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_CLUSTER_CONNECTION;
 
 /**
  * Ignite kernal.
@@ -1091,6 +1092,8 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
             // Check whether physical RAM is not exceeded.
             checkPhysicalRam();
+
+            notifyLifecycleBeans(BEFORE_CLUSTER_CONNECTION);
 
             // Suggest configuration optimizations.
             suggestOptimizations(cfg);

--- a/modules/core/src/main/java/org/apache/ignite/lifecycle/LifecycleEventType.java
+++ b/modules/core/src/main/java/org/apache/ignite/lifecycle/LifecycleEventType.java
@@ -34,6 +34,12 @@ public enum LifecycleEventType {
     BEFORE_NODE_START,
 
     /**
+     * Invoked after node has been initialized but before connecting
+     * to the cluster. At this point it can register local listeners.
+     */
+    BEFORE_CLUSTER_CONNECTION,
+
+    /**
      * Invoked after node startup is complete. Node is fully
      * initialized and fully functional.
      */

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridLifecycleBeanSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridLifecycleBeanSelfTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 import static org.apache.ignite.lifecycle.LifecycleEventType.AFTER_NODE_START;
 import static org.apache.ignite.lifecycle.LifecycleEventType.AFTER_NODE_STOP;
+import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_CLUSTER_CONNECTION;
 import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_NODE_START;
 import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_NODE_STOP;
 
@@ -108,6 +109,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
             assertEquals(IgniteState.STARTED, G.state(getTestIgniteInstanceName()));
 
             assertEquals(1, bean.count(BEFORE_NODE_START));
+            assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
             assertEquals(1, bean.count(AFTER_NODE_START));
             assertEquals(0, bean.count(BEFORE_NODE_STOP));
             assertEquals(0, bean.count(AFTER_NODE_STOP));
@@ -120,6 +122,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         assertEquals(IgniteState.STOPPED, G.state(getTestIgniteInstanceName()));
 
         assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(1, bean.count(AFTER_NODE_START));
         assertEquals(1, bean.count(BEFORE_NODE_STOP));
         assertEquals(1, bean.count(AFTER_NODE_STOP));
@@ -139,6 +142,22 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
     @Test
     public void testOtherErrorBeforeStart() throws Exception {
         checkBeforeStart(false);
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testGridErrorBeforeConnecting() throws Exception {
+        checkBeforeClusterConnection(true);
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testOtherErrorBeforConnecting() throws Exception {
+        checkBeforeClusterConnection(false);
     }
 
     /**
@@ -179,8 +198,37 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         }
 
         assertEquals(0, bean.count(BEFORE_NODE_START));
+        assertEquals(0, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(0, bean.count(AFTER_NODE_START));
         assertEquals(0, bean.count(BEFORE_NODE_STOP));
+        assertEquals(1, bean.count(AFTER_NODE_STOP));
+    }
+
+    /**
+     * @param gridErr Grid error flag.
+     * @throws Exception If failed.
+     */
+    private void checkBeforeClusterConnection(boolean gridErr) throws Exception {
+        bean = new LifeCycleExceptionBean(BEFORE_CLUSTER_CONNECTION, gridErr);
+
+        try {
+            startGrid();
+
+            assertTrue(false); // Should never get here.
+        }
+        catch (IgniteCheckedException expected) {
+            info("Got expected exception: " + expected);
+
+            assertEquals(IgniteState.STOPPED, G.state(getTestIgniteInstanceName()));
+        }
+        finally {
+            stopAllGrids();
+        }
+
+        assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(0, bean.count(BEFORE_CLUSTER_CONNECTION));
+        assertEquals(0, bean.count(AFTER_NODE_START));
+        assertEquals(1, bean.count(BEFORE_NODE_STOP));
         assertEquals(1, bean.count(AFTER_NODE_STOP));
     }
 
@@ -206,6 +254,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         }
 
         assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(0, bean.count(AFTER_NODE_START));
         assertEquals(1, bean.count(BEFORE_NODE_STOP));
         assertEquals(1, bean.count(AFTER_NODE_STOP));
@@ -219,6 +268,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         checkOnStop(BEFORE_NODE_STOP, true);
 
         assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(1, bean.count(AFTER_NODE_START));
         assertEquals(0, bean.count(BEFORE_NODE_STOP));
         assertEquals(1, bean.count(AFTER_NODE_STOP));
@@ -232,6 +282,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         checkOnStop(BEFORE_NODE_STOP, false);
 
         assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(1, bean.count(AFTER_NODE_START));
         assertEquals(0, bean.count(BEFORE_NODE_STOP));
         assertEquals(1, bean.count(AFTER_NODE_STOP));
@@ -245,6 +296,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         checkOnStop(AFTER_NODE_STOP, true);
 
         assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(1, bean.count(AFTER_NODE_START));
         assertEquals(1, bean.count(BEFORE_NODE_STOP));
         assertEquals(0, bean.count(AFTER_NODE_STOP));
@@ -258,6 +310,7 @@ public class GridLifecycleBeanSelfTest extends GridCommonAbstractTest {
         checkOnStop(AFTER_NODE_STOP, false);
 
         assertEquals(1, bean.count(BEFORE_NODE_START));
+        assertEquals(1, bean.count(BEFORE_CLUSTER_CONNECTION));
         assertEquals(1, bean.count(AFTER_NODE_START));
         assertEquals(1, bean.count(BEFORE_NODE_STOP));
         assertEquals(0, bean.count(AFTER_NODE_STOP));

--- a/modules/core/src/test/java/org/apache/ignite/internal/IgniteLocalNodeMapBeforeStartTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/IgniteLocalNodeMapBeforeStartTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import static org.apache.ignite.lifecycle.LifecycleEventType.AFTER_NODE_START;
 import static org.apache.ignite.lifecycle.LifecycleEventType.AFTER_NODE_STOP;
+import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_CLUSTER_CONNECTION;
 import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_NODE_START;
 import static org.apache.ignite.lifecycle.LifecycleEventType.BEFORE_NODE_STOP;
 
@@ -53,8 +54,9 @@ public class IgniteLocalNodeMapBeforeStartTest extends GridCommonAbstractTest {
             // No-op.
         }
 
-        assertTrue(lifecycleBean.evtQueue.size() == 4);
+        assertTrue(lifecycleBean.evtQueue.size() == 5);
         assertTrue(lifecycleBean.evtQueue.poll() == BEFORE_NODE_START);
+        assertTrue(lifecycleBean.evtQueue.poll() == BEFORE_CLUSTER_CONNECTION);
         assertTrue(lifecycleBean.evtQueue.poll() == AFTER_NODE_START);
         assertTrue(lifecycleBean.evtQueue.poll() == BEFORE_NODE_STOP);
         assertTrue(lifecycleBean.evtQueue.poll() == AFTER_NODE_STOP);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/LifecycleTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/LifecycleTest.cs
@@ -46,6 +46,9 @@ namespace Apache.Ignite.Core.Tests
         /** Events: before start. */
         internal static IList<Event> BeforeStartEvts;
 
+        /** Events: before connection. */
+        internal static IList<Event> BeforeConnectionEvts;
+
         /** Events: after start. */
         internal static IList<Event> AfterStartEvts;
 
@@ -64,6 +67,7 @@ namespace Apache.Ignite.Core.Tests
             ThrowErr = false;
 
             BeforeStartEvts = new List<Event>();
+            BeforeConnectionEvts = new List<Event>();
             AfterStartEvts = new List<Event>();
             BeforeStopEvts = new List<Event>();
             AfterStopEvts = new List<Event>();
@@ -77,7 +81,7 @@ namespace Apache.Ignite.Core.Tests
         {
             Ignition.StopAll(true);
         }
-        
+
         /// <summary>
         /// Test without Java beans.
         /// </summary>
@@ -91,6 +95,10 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreEqual(2, BeforeStartEvts.Count);
             CheckEvent(BeforeStartEvts[0], null, null, 0, null);
             CheckEvent(BeforeStartEvts[1], null, null, 0, null);
+
+            Assert.AreEqual(2, BeforeConnectionEvts.Count);
+            CheckEvent(BeforeConnectionEvts[0], null, null, 0, null);
+            CheckEvent(BeforeConnectionEvts[1], null, null, 0, null);
 
             Assert.AreEqual(2, AfterStartEvts.Count);
             CheckEvent(AfterStartEvts[0], grid, grid, 0, null);
@@ -107,6 +115,7 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreEqual(1, stoppedCnt);
 
             Assert.AreEqual(2, BeforeStartEvts.Count);
+            Assert.AreEqual(2, BeforeConnectionEvts.Count);
             Assert.AreEqual(2, AfterStartEvts.Count);
 
             Assert.AreEqual(2, BeforeStopEvts.Count);
@@ -134,6 +143,12 @@ namespace Apache.Ignite.Core.Tests
             CheckEvent(BeforeStartEvts[2], null, null, 0, null);
             CheckEvent(BeforeStartEvts[3], null, null, 0, null);
 
+            Assert.AreEqual(4, BeforeConnectionEvts.Count);
+            CheckEvent(BeforeConnectionEvts[0], null, null, 0, null);
+            CheckEvent(BeforeConnectionEvts[1], null, null, 1, "1");
+            CheckEvent(BeforeConnectionEvts[2], null, null, 0, null);
+            CheckEvent(BeforeConnectionEvts[3], null, null, 0, null);
+
             Assert.AreEqual(4, AfterStartEvts.Count);
             CheckEvent(AfterStartEvts[0], grid, grid, 0, null);
             CheckEvent(AfterStartEvts[1], grid, grid, 1, "1");
@@ -152,6 +167,7 @@ namespace Apache.Ignite.Core.Tests
             Ignition.Stop(grid.Name, false);
 
             Assert.AreEqual(4, BeforeStartEvts.Count);
+            Assert.AreEqual(4, BeforeConnectionEvts.Count);
             Assert.AreEqual(4, AfterStartEvts.Count);
 
             Assert.AreEqual(4, BeforeStopEvts.Count);
@@ -251,6 +267,11 @@ namespace Apache.Ignite.Core.Tests
             {
                 case LifecycleEventType.BeforeNodeStart:
                     LifecycleTest.BeforeStartEvts.Add(evt);
+
+                    break;
+
+                case LifecycleEventType.BeforeClusterConnection:
+                    LifecycleTest.BeforeConnectionEvts.Add(evt);
 
                     break;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Lifecycle/LifecycleEventType.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Lifecycle/LifecycleEventType.cs
@@ -32,6 +32,12 @@ namespace Apache.Ignite.Core.Lifecycle
         BeforeNodeStart,
 
         /// <summary>
+        /// Invoked after node has been initialized but before connecting
+        /// to the cluster. At this point it can register local listeners.
+        /// </summary>
+        BeforeClusterConnection,
+
+        /// <summary>
         /// Invoked after node startup is complete. Node is fully initialized and fully functional.
         /// </summary>
         AfterNodeStart,

--- a/modules/spring/src/test/java/org/apache/ignite/internal/GridFactorySelfTest.java
+++ b/modules/spring/src/test/java/org/apache/ignite/internal/GridFactorySelfTest.java
@@ -332,9 +332,10 @@ public class GridFactorySelfTest extends GridCommonAbstractTest {
         List<String> igniteInstanceNames = bean.getIgniteInstanceNames();
 
         assert evts.get(0) == LifecycleEventType.BEFORE_NODE_START : "Invalid lifecycle event: " + evts.get(0);
-        assert evts.get(1) == LifecycleEventType.AFTER_NODE_START : "Invalid lifecycle event: " + evts.get(1);
-        assert evts.get(2) == LifecycleEventType.BEFORE_NODE_STOP : "Invalid lifecycle event: " + evts.get(2);
-        assert evts.get(3) == LifecycleEventType.AFTER_NODE_STOP : "Invalid lifecycle event: " + evts.get(3);
+        assert evts.get(1) == LifecycleEventType.BEFORE_CLUSTER_CONNECTION : "Invalid lifecycle event: " + evts.get(1);
+        assert evts.get(2) == LifecycleEventType.AFTER_NODE_START : "Invalid lifecycle event: " + evts.get(2);
+        assert evts.get(3) == LifecycleEventType.BEFORE_NODE_STOP : "Invalid lifecycle event: " + evts.get(3);
+        assert evts.get(4) == LifecycleEventType.AFTER_NODE_STOP : "Invalid lifecycle event: " + evts.get(4);
 
         checkIgniteInstanceNameEquals(igniteInstanceNames.get(0), igniteInstanceName);
         checkIgniteInstanceNameEquals(igniteInstanceNames.get(1), igniteInstanceName);


### PR DESCRIPTION
For example, this allows the user to register a local listener before
the node joins the cluster. Without this change, the listener might have
missed some events such as 'EVT_CACHE_OBJECT_*'.

The new lifecycle event is called BEFORE_CLUSTER_CONNNECTION.

See the discussion in
http://apache-ignite-users.70518.x6.nabble.com/Register-listeners-before-joining-the-cluster-td25944.html#none