### PR TITLE
IGNITE-11668: Exclude org.apache.ignite.osgi.classloaders from imports

### DIFF
--- a/modules/osgi/pom.xml
+++ b/modules/osgi/pom.xml
@@ -124,6 +124,7 @@
                 <configuration>
                     <instructions>
                         <Fragment-Host>org.apache.ignite.ignite-core</Fragment-Host>
+                        <Import-Package>!org.apache.ignite.osgi.classloaders,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This self-import caused failure in Karaf 4.2.0 during restart.