### PR TITLE
IGNITE-11662: proper classloader to unmarshal joining node data

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridClusterStateProcessor.java
@@ -964,7 +964,7 @@ public class GridClusterStateProcessor extends GridProcessorAdapter implements I
         DiscoveryDataClusterState joiningNodeState;
 
         try {
-            joiningNodeState = marsh.unmarshal((byte[]) discoData.joiningNodeData(), Thread.currentThread().getContextClassLoader());
+            joiningNodeState = marsh.unmarshal((byte[]) discoData.joiningNodeData(), U.resolveClassLoader(ctx.config()));
         } catch (IgniteCheckedException e) {
             String msg = "Error on unmarshalling discovery data " +
                 "from node " + node.consistentId() + ": " + e.getMessage() +


### PR DESCRIPTION
This is fix for IGNITE-11662: when run in OSGI Ignite must use correct classloader created in ignite-osgi bundle, and not app classloader.