### PR TITLE
IGNITE-11716 Fix a typo in template.

### DIFF
--- a/modules/web-console/frontend/app/configuration/components/page-configure-advanced/components/cluster-edit-form/templates/memory.pug
+++ b/modules/web-console/frontend/app/configuration/components/page-configure-advanced/components/cluster-edit-form/templates/memory.pug
@@ -165,11 +165,11 @@ ng-show='$ctrl.available(["2.0.0", "2.3.0"])'
                                             model: '$item.pageEvictionMode',
                                             name: '"MemoryPolicyPageEvictionMode"',
                                             placeholder: 'DISABLED',
-                                            options: '[\
-                                                {value: "DISABLED", label: "DISABLED"},\
-                                                {value: "RANDOM_LRU", label: "RANDOM_LRU"},\
-                                                [value: "RANDOM_2_LRU", label: "RANDOM_2_LRU"}\
-                                            ]',
+                                            options: `[
+                                                {value: "DISABLED", label: "DISABLED"},
+                                                {value: "RANDOM_LRU", label: "RANDOM_LRU"},
+                                                {value: "RANDOM_2_LRU", label: "RANDOM_2_LRU"}
+                                            ]`,
                                             tip: 'An algorithm for memory pages eviction\
                                                  <ul>\
                                                     <li>DISABLED - Eviction is disabled</li>\


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-11716
@akuznetsov-gridgain please review. The issue was caused by `]` instead of `}` in Pug template.