### PR TITLE
IGNITE-11103 Idle Verify --cache-filter ALL should include system caches.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
@@ -1939,8 +1939,8 @@ public class CommandHandler {
                     "processed by " + IDLE_VERIFY + " command. If cache names are specified, in form of regular " +
                     "expressions, only matching caches will be verified. Caches matched by regexes specified after " +
                     EXCLUDE_CACHES + " parameter will be excluded from verification. Using parameter " + CACHE_FILTER +
-                    " you can verify: only USER caches, only user PERSISTENT caches, only user NOT_PERSISTENT caches, " +
-                    ", only SYSTEM caches, or ALL of the above.";
+                    " you can verify: only " + USER + " caches, only user " + PERSISTENT + " caches, only user " +
+                    NOT_PERSISTENT + " caches, only " + SYSTEM + " caches, or " + ALL + " of the above.";
 
             case VALIDATE_INDEXES:
                 return "Validate indexes on an idle cluster and print out the keys that are missing in the indexes.";

--- a/modules/core/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
@@ -864,8 +864,8 @@ public class CommandHandler {
 
         usageCache(LIST, "regexPattern", op(or(GROUP, SEQUENCE)), OP_NODE_ID, op(CONFIG), op(OUTPUT_FORMAT, MULTI_LINE));
         usageCache(CONTENTION, "minQueueSize", OP_NODE_ID, op("maxPrint"));
-        usageCache(IDLE_VERIFY, op(DUMP), op(SKIP_ZEROS), op(CHECK_CRC),
-            op(EXCLUDE_CACHES, CACHES), op(CACHE_FILTER, or(CacheFilterEnum.values())), op(CACHES));
+        usageCache(IDLE_VERIFY, op(DUMP), op(SKIP_ZEROS), op(CHECK_CRC), op(EXCLUDE_CACHES, CACHES),
+            op(CACHE_FILTER, or("ALL|USER|SYSTEM|PERSISTENT|NON_PERSISTENT")), op(CACHES));
         usageCache(VALIDATE_INDEXES, op(CACHES), OP_NODE_ID, op(or(CHECK_FIRST + " N", CHECK_THROUGH + " K")));
         usageCache(DISTRIBUTION, or(NODE_ID, NULL), op(CACHES), op(USER_ATTRIBUTES, "attrName1,...,attrNameN"));
         usageCache(RESET_LOST_PARTITIONS, CACHES);
@@ -1931,9 +1931,8 @@ public class CommandHandler {
             case IDLE_VERIFY:
                 return "Verify counters and hash sums of primary and backup partitions for the specified caches/cache groups on an idle cluster and print out the differences, if any. " +
                     "Cache filtering options configure the set of caches that will be processed by " + IDLE_VERIFY + " command. " +
-                    "Default value for the set of cache names (or cache group names) is all cache groups. Default value for " + EXCLUDE_CACHES + " is empty set. " +
-                    "Default value for " + CACHE_FILTER + " is no filtering. Therefore, the set of all caches is sequently filtered by cache name " +
-                    "regexps, by cache type and after all by exclude regexps.";
+                    "Default value for the set of cache names (or cache group names) is all user cache groups. Default value for " + EXCLUDE_CACHES + " is empty set. " +
+                    "Therefore, the set of all caches is sequently filtered by cache name regexps, by cache type (if specified) and after that by exclude regexps.";
 
             case VALIDATE_INDEXES:
                 return "Validate indexes on an idle cluster and print out the keys that are missing in the indexes.";

--- a/modules/core/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
@@ -55,7 +55,6 @@ import org.apache.ignite.internal.client.GridClientFactory;
 import org.apache.ignite.internal.client.GridClientHandshakeException;
 import org.apache.ignite.internal.client.GridClientNode;
 import org.apache.ignite.internal.client.GridServerUnreachableException;
-import org.apache.ignite.internal.client.impl.GridClientImpl;
 import org.apache.ignite.internal.client.impl.connection.GridClientConnectionResetException;
 import org.apache.ignite.internal.client.ssl.GridSslBasicContextFactory;
 import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
@@ -182,6 +181,11 @@ import static org.apache.ignite.internal.commandline.cache.argument.ListCommandA
 import static org.apache.ignite.internal.commandline.cache.argument.ListCommandArg.SEQUENCE;
 import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_FIRST;
 import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_THROUGH;
+import static org.apache.ignite.internal.visor.verify.CacheFilterEnum.ALL;
+import static org.apache.ignite.internal.visor.verify.CacheFilterEnum.NOT_PERSISTENT;
+import static org.apache.ignite.internal.visor.verify.CacheFilterEnum.PERSISTENT;
+import static org.apache.ignite.internal.visor.verify.CacheFilterEnum.SYSTEM;
+import static org.apache.ignite.internal.visor.verify.CacheFilterEnum.USER;
 import static org.apache.ignite.internal.visor.verify.VisorViewCacheCmd.CACHES;
 import static org.apache.ignite.internal.visor.verify.VisorViewCacheCmd.GROUPS;
 import static org.apache.ignite.internal.visor.verify.VisorViewCacheCmd.SEQ;
@@ -865,7 +869,7 @@ public class CommandHandler {
         usageCache(LIST, "regexPattern", op(or(GROUP, SEQUENCE)), OP_NODE_ID, op(CONFIG), op(OUTPUT_FORMAT, MULTI_LINE));
         usageCache(CONTENTION, "minQueueSize", OP_NODE_ID, op("maxPrint"));
         usageCache(IDLE_VERIFY, op(DUMP), op(SKIP_ZEROS), op(CHECK_CRC), op(EXCLUDE_CACHES, CACHES),
-            op(CACHE_FILTER, or("ALL|USER|SYSTEM|PERSISTENT|NON_PERSISTENT")), op(CACHES));
+            op(CACHE_FILTER, or(ALL, USER, SYSTEM, PERSISTENT, NOT_PERSISTENT)), op(CACHES));
         usageCache(VALIDATE_INDEXES, op(CACHES), OP_NODE_ID, op(or(CHECK_FIRST + " N", CHECK_THROUGH + " K")));
         usageCache(DISTRIBUTION, or(NODE_ID, NULL), op(CACHES), op(USER_ATTRIBUTES, "attrName1,...,attrNameN"));
         usageCache(RESET_LOST_PARTITIONS, CACHES);
@@ -1929,10 +1933,14 @@ public class CommandHandler {
                 return "Show the keys that are point of contention for multiple transactions.";
 
             case IDLE_VERIFY:
-                return "Verify counters and hash sums of primary and backup partitions for the specified caches/cache groups on an idle cluster and print out the differences, if any. " +
-                    "Cache filtering options configure the set of caches that will be processed by " + IDLE_VERIFY + " command. " +
-                    "Default value for the set of cache names (or cache group names) is all user cache groups. Default value for " + EXCLUDE_CACHES + " is empty set. " +
-                    "Therefore, the set of all caches is sequently filtered by cache name regexps, by cache type (if specified) and after that by exclude regexps.";
+                return "Verify counters and hash sums of primary and backup partitions for the specified caches/cache " +
+                    "groups on an idle cluster and print out the differences, if any. When no parameters are specified, " +
+                    "all user caches are verified. Cache filtering options configure the set of caches that will be " +
+                    "processed by " + IDLE_VERIFY + " command. If cache names are specified, in form of regular " +
+                    "expressions, only matching caches will be verified. Caches matched by regexes specified after " +
+                    EXCLUDE_CACHES + " parameter will be excluded from verification. Using parameter " + CACHE_FILTER +
+                    " you can verify: only USER caches, only user PERSISTENT caches, only user NOT_PERSISTENT caches, " +
+                    ", only SYSTEM caches, or ALL of the above.";
 
             case VALIDATE_INDEXES:
                 return "Validate indexes on an idle cluster and print out the keys that are missing in the indexes.";

--- a/modules/core/src/main/java/org/apache/ignite/internal/commandline/cache/CacheArguments.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/commandline/cache/CacheArguments.java
@@ -76,7 +76,7 @@ public class CacheArguments {
     private boolean fullConfig;
 
     /** Cache filter. */
-    private CacheFilterEnum cacheFilterEnum = CacheFilterEnum.ALL;
+    private CacheFilterEnum cacheFilterEnum = CacheFilterEnum.DEFAULT;
 
     /** Check CRC sum on idle verify. */
     private boolean idleCheckCrc;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/IdleVerifyResultV2.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/IdleVerifyResultV2.java
@@ -190,13 +190,14 @@ public class IdleVerifyResultV2 extends VisorDataTransferObject {
     private void print(Consumer<String> printer, boolean printExceptionMessages) {
         boolean noMatchingCaches = false;
 
-        for (Exception e : exceptions.values())
+        for (Exception e : exceptions.values()) {
             if (e instanceof NoMatchingCachesException) {
                 noMatchingCaches = true;
                 succeeded = false;
 
                 break;
             }
+        }
 
         if (succeeded) {
             if (!F.isEmpty(exceptions)) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/VerifyBackupPartitionsDumpTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/VerifyBackupPartitionsDumpTask.java
@@ -38,6 +38,7 @@ import org.apache.ignite.compute.ComputeJobResultPolicy;
 import org.apache.ignite.compute.ComputeTaskAdapter;
 import org.apache.ignite.internal.processors.task.GridInternal;
 import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.visor.verify.CacheFilterEnum;
 import org.apache.ignite.internal.visor.verify.VisorIdleVerifyDumpTaskArg;
 import org.apache.ignite.internal.visor.verify.VisorIdleVerifyTaskArg;
 import org.apache.ignite.resources.IgniteInstanceResource;
@@ -203,13 +204,30 @@ public class VerifyBackupPartitionsDumpTask extends ComputeTaskAdapter<VisorIdle
         int skippedRecords,
         PrintWriter writer
     ) {
-        if (!F.isEmpty(conflictRes.exceptions())) {
-            int size = conflictRes.exceptions().size();
+        Map<ClusterNode, Exception> exceptions = conflictRes.exceptions();
+
+        if (!F.isEmpty(exceptions)) {
+            boolean noMatchingCaches = false;
+
+            for (Exception e : exceptions.values()) {
+                if (e instanceof NoMatchingCachesException) {
+                    noMatchingCaches = true;
+
+                    break;
+                }
+            }
+
+            int size = exceptions.size();
 
             writer.write("idle_verify failed on " + size + " node" + (size == 1 ? "" : "s") + ".\n");
+
+            if (noMatchingCaches)
+                writer.write("There are no caches matching given filter options.");
         }
 
-        writer.write("idle_verify check has finished, found " + partitions.size() + " partitions\n");
+        if (!partitions.isEmpty())
+            writer.write("idle_verify check has finished, found " + partitions.size() + " partitions\n");
+
         writer.write("idle_verify task was executed with the following args: " + taskArgsAsCmd() + "\n");
 
         if (skippedRecords > 0)
@@ -245,7 +263,7 @@ public class VerifyBackupPartitionsDumpTask extends ComputeTaskAdapter<VisorIdle
             }
         }
 
-        if (taskArg.getCacheFilterEnum() != null) {
+        if (taskArg.getCacheFilterEnum() != null && taskArg.getCacheFilterEnum() != CacheFilterEnum.DEFAULT) {
             result.append(CACHE_FILTER);
             result.append(" ");
             result.append(taskArg.getCacheFilterEnum());

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/verify/CacheFilterEnum.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/verify/CacheFilterEnum.java
@@ -25,8 +25,8 @@ import org.jetbrains.annotations.Nullable;
  * @see org.apache.ignite.internal.processors.cache.verify.VerifyBackupPartitionsTaskV2
  */
 public enum CacheFilterEnum {
-    /** All. */
-    ALL,
+    /** Default - user only, or all caches specified by name. */
+    DEFAULT,
 
     /** System. */
     SYSTEM,
@@ -35,7 +35,13 @@ public enum CacheFilterEnum {
     PERSISTENT,
 
     /** Not persistent. */
-    NOT_PERSISTENT;
+    NOT_PERSISTENT,
+
+    /** User. */
+    USER,
+
+    /** All. */
+    ALL;
 
     /** Enumerated values. */
     private static final CacheFilterEnum[] VALS = values();

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/verify/VisorIdleVerifyDumpTaskArg.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/verify/VisorIdleVerifyDumpTaskArg.java
@@ -116,7 +116,7 @@ public class VisorIdleVerifyDumpTaskArg extends VisorIdleVerifyTaskArg {
             if (protoVer >= V2)
                 cacheFilterEnum = CacheFilterEnum.fromOrdinal(in.readByte());
             else
-                cacheFilterEnum = CacheFilterEnum.ALL;
+                cacheFilterEnum = CacheFilterEnum.DEFAULT;
 
             if (protoVer >= V2)
                 excludeCaches(U.readSet(in));

--- a/modules/core/src/test/java/org/apache/ignite/util/GridCommandHandlerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/util/GridCommandHandlerTest.java
@@ -1608,7 +1608,7 @@ public class GridCommandHandlerTest extends GridCommonAbstractTest {
             true,
             "idle_verify check has finished, no conflicts have been found.",
             null,
-            "--cache", "idle_verify", ".*", "--exclude-caches", "wrong-.*"
+            "--cache", "idle_verify", ".*", "--exclude-caches", "wrong-.*", "--cache-filter", "DEFAULT"
         );
         testCacheIdleVerifyMultipleCacheFilterOptionsCommon(
             true,

--- a/modules/core/src/test/java/org/apache/ignite/util/GridCommandHandlerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/util/GridCommandHandlerTest.java
@@ -1348,6 +1348,34 @@ public class GridCommandHandlerTest extends GridCommonAbstractTest {
     }
 
     /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testCacheIdleVerifyNodeFilter() throws Exception {
+        IgniteEx ignite = startGrids(3);
+
+        ignite.cluster().active(true);
+
+        UUID lastNodeId = ignite.localNode().id();
+
+        ignite.createCache(new CacheConfiguration<>(DEFAULT_CACHE_NAME)
+            .setAffinity(new RendezvousAffinityFunction(false, 32))
+            .setNodeFilter(node -> !node.id().equals(lastNodeId))
+            .setBackups(1));
+
+        try (IgniteDataStreamer streamer = ignite.dataStreamer(DEFAULT_CACHE_NAME)) {
+            for (int i = 0; i < 100; i++)
+                streamer.addData(i, i);
+        }
+
+        injectTestSystemOut();
+
+        assertEquals(EXIT_CODE_OK, execute("--cache", "idle_verify", DEFAULT_CACHE_NAME));
+
+        assertContains(testOut.toString(), "no conflicts have been found");
+    }
+
+    /**
      * Tests that both update counter and hash conflicts are detected.
      *
      * @throws Exception If failed.
@@ -1530,13 +1558,13 @@ public class GridCommandHandlerTest extends GridCommonAbstractTest {
 
         testCacheIdleVerifyMultipleCacheFilterOptionsCommon(
             true,
-            "idle_verify check has finished",
+            "idle_verify check has finished, found 100 partitions",
             "idle_verify task was executed with the following args: --cache-filter SYSTEM --exclude-caches wrong.* ",
             "--cache", "idle_verify", "--dump", "--cache-filter", "SYSTEM", "--exclude-caches", "wrong.*"
         );
         testCacheIdleVerifyMultipleCacheFilterOptionsCommon(
             true,
-            "idle_verify check has finished, found 96 partitions",
+            "idle_verify check has finished, found 196 partitions",
             null,
             "--cache", "idle_verify", "--dump", ".*", "--exclude-caches", "wrong.*"
         );
@@ -1556,13 +1584,13 @@ public class GridCommandHandlerTest extends GridCommonAbstractTest {
             true,
             "idle_verify check has finished, found 160 partitions",
             null,
-            "--cache", "idle_verify", "--dump", "shared.*,wrong.*", "--cache-filter", "ALL"
+            "--cache", "idle_verify", "--dump", "shared.*,wrong.*", "--cache-filter", "USER"
         );
         testCacheIdleVerifyMultipleCacheFilterOptionsCommon(
             true,
-            "idle_verify check has finished, found 160 partitions",
+            "There are no caches matching given filter options.",
             null,
-            "--cache", "idle_verify", "--dump", "shared.*,wrong.*", "--cache-filter", "ALL"
+            "--cache", "idle_verify", "--dump", "shared.*,wrong.*", "--cache-filter", "SYSTEM"
         );
         testCacheIdleVerifyMultipleCacheFilterOptionsCommon(
             true,
@@ -2089,7 +2117,7 @@ public class GridCommandHandlerTest extends GridCommonAbstractTest {
         if (fileNameMatcher.find()) {
             String dumpWithConflicts = new String(Files.readAllBytes(Paths.get(fileNameMatcher.group(1))));
 
-            assertTrue(dumpWithConflicts.contains("idle_verify check has finished, found 0 partitions"));
+            assertTrue(dumpWithConflicts.contains("There are no caches matching given filter options."));
         }
         else
             fail("Should be found dump with conflicts");


### PR DESCRIPTION
Introduce USER and invisible DEFAULT cache filters.
DEFAULT now outputs all USER caches unless cache names specified, otherwise all that match them, including system.
Fix messages when no caches match filter and --dump supplied.