### PR TITLE
IGNITE-11671 Thin client: Client may hang when connected to a starting server

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioListener.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.internal.processors.odbc;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.configuration.ClientConnectorConfiguration;
@@ -65,7 +65,7 @@ public class ClientListenerNioListener extends GridNioServerListenerAdapter<byte
     public static final int CONN_CTX_META_KEY = GridNioSessionMetaKey.nextUniqueKey();
 
     /** Next connection id. */
-    private static AtomicInteger nextConnId = new AtomicInteger(1);
+    private static AtomicLong nextConnId = new AtomicLong(1);
 
     /** Busy lock. */
     private final GridSpinBusyLock busyLock;
@@ -328,10 +328,11 @@ public class ClientListenerNioListener extends GridNioServerListenerAdapter<byte
 
     /**
      * Generate unique connection id.
+     *
      * @return connection id.
      */
     private long nextConnectionId() {
-        return (ctx.discovery().localNode().order() << 32) + nextConnId.getAndIncrement();
+        return nextConnId.getAndIncrement();
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
@@ -529,8 +529,6 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
 
         /** {@inheritDoc} */
         @Override public boolean dropConnection(long id) {
-            assert (id >> 32) == ctx.discovery().localNode().order() : "Invalid connection id.";
-
             Collection<? extends GridNioSession> sessions = srv.sessions();
 
             for (GridNioSession ses : sessions) {

--- a/modules/core/src/test/java/org/apache/ignite/client/Config.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/Config.java
@@ -21,6 +21,7 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.UUID;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.ClientConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinder;
@@ -57,5 +58,13 @@ public class Config {
         igniteCfg.setIgniteInstanceName(UUID.randomUUID().toString());
 
         return igniteCfg;
+    }
+
+    /** */
+    public static ClientConfiguration getClientConfiguration() {
+        return new ClientConfiguration()
+            .setAddresses(SERVER)
+            .setSendBufferSize(0)
+            .setReceiveBufferSize(0);
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectToStartingNodeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectToStartingNodeTest.java
@@ -36,9 +36,11 @@ public class ConnectToStartingNodeTest {
     @Rule
     public Timeout globalTimeout = new Timeout((int)GridTestUtils.DFLT_TEST_TIMEOUT);
 
-    /** */
+    /**
+     * Test connect attempts to a starting node.
+     */
     @Test
-    public void test() throws Exception {
+    public void testConnectToStartingNode() {
         IgniteInternalFuture fut = GridTestUtils.runAsync(() -> {
             Ignition.start(getServerConfiguration());
         });

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectToStartingNodeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectToStartingNodeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import org.apache.ignite.Ignition;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import static org.apache.ignite.client.Config.getClientConfiguration;
+import static org.apache.ignite.client.Config.getServerConfiguration;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Checks that connection with starting node will be established.
+ */
+public class ConnectToStartingNodeTest {
+    /** Per test timeout */
+    @Rule
+    public Timeout globalTimeout = new Timeout((int)GridTestUtils.DFLT_TEST_TIMEOUT);
+
+    /** */
+    @Test
+    public void test() throws Exception {
+        IgniteInternalFuture fut = GridTestUtils.runAsync(() -> {
+            Ignition.start(getServerConfiguration());
+        });
+
+        IgniteClient client = null;
+
+        while (!fut.isDone()) {
+            try {
+                client = Ignition.startClient(getClientConfiguration());
+            }
+            catch (ClientConnectionException ignored) {
+                // No-op.
+            }
+        }
+
+        if (client == null)
+            client = Ignition.startClient(getClientConfiguration());
+
+        assertFalse(client.cacheNames().isEmpty());
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -45,6 +45,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import static org.apache.ignite.client.Config.getClientConfiguration;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -411,13 +412,5 @@ public class FunctionalTest {
             String.format("%s expected but no exception was received", ClientConnectionException.class.getName()),
             expEx
         );
-    }
-
-    /** */
-    private static ClientConfiguration getClientConfiguration() {
-        return new ClientConfiguration()
-            .setAddresses(Config.SERVER)
-            .setSendBufferSize(0)
-            .setReceiveBufferSize(0);
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/client/ClientTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/client/ClientTestSuite.java
@@ -35,7 +35,8 @@ import org.junit.runners.Suite;
     FunctionalQueryTest.class,
     IgniteBinaryQueryTest.class,
     SslParametersTest.class,
-    ConnectionTest.class
+    ConnectionTest.class,
+    ConnectToStartingNodeTest.class
 })
 public class ClientTestSuite {
     // No-op.


### PR DESCRIPTION
Connection id (long) consists of two 32-bits parts:
1. node order
2. Unique identifier (int)

I removed node order and make unique identifier long type.
Node order was used only for assertion on dropping a connection. Moreover, this assertion fails after 2^31 attempts to connect. 

It fixed NPE on a server side and a client hanging.