### PR TITLE
IGNITE-11715 Allow extra options to be passed in to ignite.sh from Docker

### DIFF
--- a/docker/apache-ignite/run.sh
+++ b/docker/apache-ignite/run.sh
@@ -40,7 +40,7 @@ if [ "$IGNITE_QUIET" = "false" ]; then
 fi
 
 if [ -z $CONFIG_URI ]; then
-  $IGNITE_HOME/bin/ignite.sh $QUIET
+  $IGNITE_HOME/bin/ignite.sh $QUIET ${IGNITE_OPTIONS:-}
 else
-  $IGNITE_HOME/bin/ignite.sh $QUIET $CONFIG_URI
+  $IGNITE_HOME/bin/ignite.sh $QUIET ${IGNITE_OPTIONS:-} $CONFIG_URI
 fi


### PR DESCRIPTION
Ticket was specifically about `-nojmx` flag but I don't think there's a good reason to limit it to that.