### PR TITLE
IGNITE-12000 Stabilize flaky IgniteSqlQueryMinMaxTest

### DIFF
--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/IgniteSqlQueryMinMaxTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/h2/IgniteSqlQueryMinMaxTest.java
@@ -47,6 +47,8 @@ public class IgniteSqlQueryMinMaxTest extends AbstractIndexingCommonTest {
     @Override protected void afterTest() throws Exception {
         super.afterTest();
 
+        awaitPartitionMapExchange(true, false, null);
+
         stopAllGrids();
     }
 


### PR DESCRIPTION
Await evictions before stopping nodes in IgniteSqlQueryMinMaxTest to make test stable