### PR TITLE
IGNITE-8788: Make PojoFieldAccessor Serializable

### DIFF
--- a/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/common/PropertyMappingHelper.java
+++ b/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/common/PropertyMappingHelper.java
@@ -34,8 +34,8 @@ import org.apache.ignite.cache.store.cassandra.persistence.PojoFieldAccessor;
 import org.apache.ignite.cache.store.cassandra.serializer.Serializer;
 
 /**
- * Helper class providing bunch of methods to discover fields of POJO objects and
- * map builtin Java types to appropriate Cassandra types.
+ * Helper class providing bunch of methods to discover fields of POJO objects and map builtin Java types to appropriate
+ * Cassandra types.
  */
 public class PropertyMappingHelper {
     /** Bytes array Class type. */
@@ -69,7 +69,6 @@ public class PropertyMappingHelper {
      * Maps Cassandra type to specified Java type.
      *
      * @param clazz java class.
-     *
      * @return Cassandra type.
      */
     public static DataType.Name getCassandraType(Class clazz) {
@@ -81,26 +80,19 @@ public class PropertyMappingHelper {
      *
      * @param clazz class from which to get property accessor.
      * @param prop name of the property.
-     *
      * @return property accessor.
      */
     public static PojoFieldAccessor getPojoFieldAccessor(Class clazz, String prop) {
-        PropertyDescriptor[] descriptors = PropertyUtils.getPropertyDescriptors(clazz);
-
-        if (descriptors != null) {
-            for (PropertyDescriptor descriptor : descriptors) {
-                if (descriptor.getName().equals(prop)) {
-                    Field field = null;
-
-                    try {
-                        field = clazz.getDeclaredField(prop);
-                    }
-                    catch (Throwable ignore) {
-                    }
-
-                    return new PojoFieldAccessor(descriptor, field);
-                }
+        final PropertyDescriptor descriptor = getPropertyDescriptor(clazz, prop);
+        if (null != descriptor) {
+            Field field = null;
+            try {
+                field = clazz.getDeclaredField(prop);
             }
+            catch (final Exception ignored) {
+                // ignored
+            }
+            return new PojoFieldAccessor(descriptor, field);
         }
 
         try {
@@ -112,13 +104,31 @@ public class PropertyMappingHelper {
     }
 
     /**
+     * Returns property descriptor by class property name.
+     *
+     * @param clazz class from which to get property accessor.
+     * @param prop name of the property.
+     * @return property accessor or null if not found
+     */
+    public static PropertyDescriptor getPropertyDescriptor(final Class clazz, final String prop) {
+        final PropertyDescriptor[] descriptors = PropertyUtils.getPropertyDescriptors(clazz);
+        if (descriptors != null) {
+            for (final PropertyDescriptor descriptor : descriptors) {
+                if (descriptor.getName().equals(prop)) {
+                    return descriptor;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Returns value of specific column in the row returned by CQL statement.
      *
      * @param row row returned by CQL statement.
      * @param col column name.
      * @param clazz java class to which column value should be casted.
      * @param serializer serializer to use if column stores BLOB otherwise could be null.
-     *
      * @return row column value.
      */
     public static Object getCassandraColumnValue(Row row, String col, Class clazz, Serializer serializer) {
@@ -131,7 +141,7 @@ public class PropertyMappingHelper {
         if (int.class.equals(clazz)) {
             if (row.isNull(col)) {
                 throw new IllegalArgumentException("Can't cast null value from Cassandra table column '" + col +
-                        "' to " + "int value used in domain object model");
+                    "' to " + "int value used in domain object model");
             }
 
             return row.getInt(col);
@@ -143,7 +153,7 @@ public class PropertyMappingHelper {
         if (short.class.equals(clazz)) {
             if (row.isNull(col)) {
                 throw new IllegalArgumentException("Can't cast null value from Cassandra table column '" + col +
-                        "' to " + "short value used in domain object model");
+                    "' to " + "short value used in domain object model");
             }
 
             return row.getShort(col);
@@ -155,7 +165,7 @@ public class PropertyMappingHelper {
         if (long.class.equals(clazz)) {
             if (row.isNull(col)) {
                 throw new IllegalArgumentException("Can't cast null value from Cassandra table column '" + col +
-                        "' to " + "long value used in domain object model");
+                    "' to " + "long value used in domain object model");
             }
 
             return row.getLong(col);
@@ -167,7 +177,7 @@ public class PropertyMappingHelper {
         if (double.class.equals(clazz)) {
             if (row.isNull(col)) {
                 throw new IllegalArgumentException("Can't cast null value from Cassandra table column '" + col +
-                        "' to " + "double value used in domain object model");
+                    "' to " + "double value used in domain object model");
             }
 
             return row.getDouble(col);
@@ -179,7 +189,7 @@ public class PropertyMappingHelper {
         if (boolean.class.equals(clazz)) {
             if (row.isNull(col)) {
                 throw new IllegalArgumentException("Can't cast null value from Cassandra table column '" + col +
-                        "' to " + "boolean value used in domain object model");
+                    "' to " + "boolean value used in domain object model");
             }
 
             return row.getBool(col);
@@ -191,7 +201,7 @@ public class PropertyMappingHelper {
         if (float.class.equals(clazz)) {
             if (row.isNull(col)) {
                 throw new IllegalArgumentException("Can't cast null value from Cassandra table column '" + col +
-                        "' to " + "float value used in domain object model");
+                    "' to " + "float value used in domain object model");
             }
 
             return row.getFloat(col);

--- a/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/persistence/PojoField.java
+++ b/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/persistence/PojoField.java
@@ -22,15 +22,14 @@ import com.datastax.driver.core.Row;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.List;
-
-import org.apache.ignite.cache.store.cassandra.common.PropertyMappingHelper;
 import org.apache.ignite.cache.query.annotations.QuerySqlField;
+import org.apache.ignite.cache.store.cassandra.common.PropertyMappingHelper;
 import org.apache.ignite.cache.store.cassandra.serializer.Serializer;
 import org.w3c.dom.Element;
 
 /**
- * Descriptor for particular field in a POJO object, specifying how this field
- * should be written to or loaded from Cassandra.
+ * Descriptor for particular field in a POJO object, specifying how this field should be written to or loaded from
+ * Cassandra.
  */
 public abstract class PojoField implements Serializable {
     /** Name attribute of XML element describing Pojo field. */
@@ -45,17 +44,17 @@ public abstract class PojoField implements Serializable {
     /** Field column name in Cassandra table. */
     private String col;
 
-    /** Field column DDL.  */
+    /** Field column DDL. */
     private String colDDL;
 
     /** Indicator for calculated field. */
     private Boolean calculated;
 
     /** Field property accessor. */
-    private transient PojoFieldAccessor accessor;
+    private PojoFieldAccessor accessor;
 
     /**
-     *  Checks if list contains POJO field with the specified name.
+     * Checks if list contains POJO field with the specified name.
      *
      * @param fields list of POJO fields.
      * @param fieldName field name.
@@ -105,7 +104,7 @@ public abstract class PojoField implements Serializable {
         QuerySqlField sqlField = (QuerySqlField)accessor.getAnnotation(QuerySqlField.class);
 
         col = sqlField != null && sqlField.name() != null && !sqlField.name().isEmpty() ?
-                sqlField.name() : name.toLowerCase();
+            sqlField.name() : name.toLowerCase();
 
         init(accessor);
     }
@@ -141,10 +140,10 @@ public abstract class PojoField implements Serializable {
     }
 
     /**
-     * Indicates if it's a calculated field - field which value just generated based on other field values.
-     * Such field will be stored in Cassandra as all other POJO fields, but it's value shouldn't be read from
-     * Cassandra - cause it's again just generated based on other field values. One of the good applications of such
-     * kind of fields - Cassandra materialized views build on top of other tables.
+     * Indicates if it's a calculated field - field which value just generated based on other field values. Such field
+     * will be stored in Cassandra as all other POJO fields, but it's value shouldn't be read from Cassandra - cause
+     * it's again just generated based on other field values. One of the good applications of such kind of fields -
+     * Cassandra materialized views build on top of other tables.
      *
      * @return {@code true} if it's auto generated field, {@code false} if not.
      */
@@ -156,8 +155,8 @@ public abstract class PojoField implements Serializable {
     }
 
     /**
-     * Gets field value as an object having Cassandra compatible type.
-     * This it could be stored directly into Cassandra without any conversions.
+     * Gets field value as an object having Cassandra compatible type. This it could be stored directly into Cassandra
+     * without any conversions.
      *
      * @param obj Object instance.
      * @param serializer {@link org.apache.ignite.cache.store.cassandra.serializer.Serializer} to use.

--- a/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/persistence/PojoFieldAccessor.java
+++ b/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/persistence/PojoFieldAccessor.java
@@ -17,27 +17,49 @@
 
 package org.apache.ignite.cache.store.cassandra.persistence;
 
-import org.apache.ignite.IgniteException;
-
 import java.beans.PropertyDescriptor;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cache.store.cassandra.common.PropertyMappingHelper;
 
 /**
- * Property accessor provides read/write access to POJO object properties defined through:
- *  1) Getter/setter methods
- *  2) Raw class members
+ * Property accessor provides read/write access to POJO object properties defined through: 1) Getter/setter methods 2)
+ * Raw class members
  */
-public class PojoFieldAccessor {
-    /** Java Bean property descriptor */
-    private PropertyDescriptor desc;
+public class PojoFieldAccessor implements Serializable {
 
-    /** Object field associated with property descriptor. Used just to get annotations which
-     * applied not to property descriptor, but directly to object field associated with the property. */
-    private Field descField;
+    private static final long serialVersionUID = -3000846017630156918L;
 
-    /** Object field */
-    private Field field;
+    /**
+     *
+     */
+    private final String pojoClassName;
+
+    /**
+     *
+     */
+    private final String pojoFieldName;
+
+    /**
+     * Java Bean property descriptor
+     */
+    private transient PropertyDescriptor desc;
+
+    /**
+     * Object field associated with property descriptor. Used just to get annotations which applied not to property
+     * descriptor, but directly to object field associated with the property.
+     */
+    private transient Field descField;
+
+    /**
+     * Object field
+     */
+    private transient Field field;
 
     /**
      * Constructs object instance from Java Bean property descriptor, providing access to getter/setter.
@@ -48,17 +70,21 @@ public class PojoFieldAccessor {
     public PojoFieldAccessor(PropertyDescriptor desc, Field field) {
         if (desc.getReadMethod() == null) {
             throw new IllegalArgumentException("Field '" + desc.getName() +
-                    "' of the class instance '" + desc.getPropertyType().getName() +
-                    "' doesn't provide getter method");
+                "' of the class instance '" + desc.getPropertyType().getName() +
+                "' doesn't provide getter method");
         }
 
         desc.getReadMethod().setAccessible(true);
 
-        if (desc.getWriteMethod() != null)
+        if (desc.getWriteMethod() != null) {
             desc.getWriteMethod().setAccessible(true);
+        }
 
         this.desc = desc;
         this.descField = field;
+
+        pojoClassName = desc.getReadMethod().getDeclaringClass().getName();
+        pojoFieldName = desc.getName();
     }
 
     /**
@@ -69,6 +95,9 @@ public class PojoFieldAccessor {
     public PojoFieldAccessor(Field field) {
         field.setAccessible(true);
         this.field = field;
+
+        pojoClassName = field.getDeclaringClass().getName();
+        pojoFieldName = field.getName();
     }
 
     /**
@@ -95,18 +124,21 @@ public class PojoFieldAccessor {
      * @return annotation.
      */
     public Annotation getAnnotation(Class clazz) {
-        if (field != null)
+        if (field != null) {
             return field.getAnnotation(clazz);
+        }
 
         Annotation ann = desc.getReadMethod().getAnnotation(clazz);
 
-        if (ann != null)
+        if (ann != null) {
             return ann;
+        }
 
         ann = desc.getWriteMethod() == null ? null : desc.getWriteMethod().getAnnotation(clazz);
 
-        if (ann != null)
+        if (ann != null) {
             return ann;
+        }
 
         return descField == null ? null : descField.getAnnotation(clazz);
     }
@@ -123,7 +155,7 @@ public class PojoFieldAccessor {
         }
         catch (Throwable e) {
             throw new IgniteException("Failed to get value of the field '" + getName() + "' from the instance " +
-                    " of '" + obj.getClass().toString() + "' class", e);
+                " of '" + obj.getClass().toString() + "' class", e);
         }
     }
 
@@ -134,19 +166,22 @@ public class PojoFieldAccessor {
      * @param val value to assign.
      */
     public void setValue(Object obj, Object val) {
-        if (isReadOnly())
+        if (isReadOnly()) {
             throw new IgniteException("Can't assign value to read-only field '" + getName() + "' of the instance " +
-                    " of '" + obj.getClass().toString() + "' class");
+                " of '" + obj.getClass().toString() + "' class");
+        }
 
         try {
-            if (desc != null)
+            if (desc != null) {
                 desc.getWriteMethod().invoke(obj, val);
-            else
+            }
+            else {
                 field.set(obj, val);
+            }
         }
         catch (Throwable e) {
             throw new IgniteException("Failed to set value of the field '" + getName() + "' of the instance " +
-                    " of '" + obj.getClass().toString() + "' class", e);
+                " of '" + obj.getClass().toString() + "' class", e);
         }
     }
 
@@ -157,5 +192,29 @@ public class PojoFieldAccessor {
      */
     public Class getFieldType() {
         return desc != null ? desc.getPropertyType() : field.getType();
+    }
+
+    /* Default implementation of writeObject for Serialization */
+    private void writeObject(final ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+    }
+
+    /* Default implementation of writeObject for Serialization */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+
+        final Class<?> pojoCls = getClass().getClassLoader().loadClass(pojoClassName);
+        desc = PropertyMappingHelper.getPropertyDescriptor(pojoCls, pojoFieldName);
+        if (null == desc) {
+            try {
+                field = pojoCls.getDeclaredField(pojoFieldName);
+                field.setAccessible(true);
+            }
+            catch (final NoSuchFieldException e) {
+                throw new ClassNotFoundException(
+                    "Unable to load class " + pojoClassName + " with declared field " + pojoFieldName, e
+                );
+            }
+        }
     }
 }

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/PojoFieldAccessorSerializationTest.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/PojoFieldAccessorSerializationTest.java
@@ -1,0 +1,63 @@
+package org.apache.ignite.tests;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import org.apache.ignite.cache.store.cassandra.persistence.PojoFieldAccessor;
+import org.apache.ignite.cache.store.cassandra.serializer.JavaSerializer;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for PojoField serialization.
+ */
+public class PojoFieldAccessorSerializationTest {
+
+    private static final String NAME_VALUE = "pojo";
+    private static final String NAME_FIELD = "name";
+
+    private static class Pojo {
+
+        private String name;
+
+        public Pojo(final String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Serialization test.
+     */
+    @Test
+    public void serializationTestWithFieldConstructor() throws NoSuchFieldException {
+        final Field field = Pojo.class.getDeclaredField(NAME_FIELD);
+        final PojoFieldAccessor src = new PojoFieldAccessor(field);
+        final JavaSerializer serializer = new JavaSerializer();
+
+        final ByteBuffer buff = serializer.serialize(src);
+        final PojoFieldAccessor _src = (PojoFieldAccessor)serializer.deserialize(buff);
+
+        final String name = _src.getName();
+        assertEquals("Incorrectly serialized PojoFieldAccessor name-property", NAME_FIELD, name);
+        final Class<?> clazz = _src.getFieldType();
+        assertEquals("Incorrectly serialized PojoFieldAccessor class-property", clazz, String.class);
+    }
+
+    /**
+     * Serialization test.
+     */
+    @Test
+    public void serializationTestWithPropertyDescriptorConstructor() throws NoSuchFieldException {
+        final Field field = Pojo.class.getDeclaredField(NAME_FIELD);
+        final PojoFieldAccessor src = new PojoFieldAccessor(field);
+        final JavaSerializer serializer = new JavaSerializer();
+
+        final ByteBuffer buff = serializer.serialize(src);
+        final PojoFieldAccessor _src = (PojoFieldAccessor)serializer.deserialize(buff);
+
+        final String name = _src.getName();
+        assertEquals("Incorrectly serialized PojoFieldAccessor name-property", NAME_FIELD, name);
+        final Class<?> clazz = _src.getFieldType();
+        assertEquals("Incorrectly serialized PojoFieldAccessor class-property", clazz, String.class);
+    }
+}

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/PojoFieldSerializationTest.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/PojoFieldSerializationTest.java
@@ -1,0 +1,77 @@
+package org.apache.ignite.tests;
+
+import java.nio.ByteBuffer;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.apache.ignite.cache.store.cassandra.common.PropertyMappingHelper;
+import org.apache.ignite.cache.store.cassandra.persistence.PojoField;
+import org.apache.ignite.cache.store.cassandra.persistence.PojoFieldAccessor;
+import org.apache.ignite.cache.store.cassandra.serializer.JavaSerializer;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for PojoField serialization.
+ */
+public class PojoFieldSerializationTest {
+
+    private static final String NAME_VALUE = "pojo";
+    private static final String NAME_FIELD = "name";
+
+    private static class MockPojoField extends PojoField {
+
+        public MockPojoField(final Element el, final Class<?> pojoCls) {
+            super(el, pojoCls);
+        }
+
+        public MockPojoField(final PojoFieldAccessor accessor) {
+            super(accessor);
+        }
+    }
+
+    private static class Pojo {
+
+        private String name;
+
+        public Pojo(final String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Serialization test.
+     */
+    @Test
+    public void serializationTestWithAccessorConstructor() {
+        final MockPojoField src = new MockPojoField(PropertyMappingHelper.getPojoFieldAccessor(Pojo.class, NAME_FIELD));
+        final JavaSerializer serializer = new JavaSerializer();
+
+        final ByteBuffer buff = serializer.serialize(src);
+        final MockPojoField _src = (MockPojoField)serializer.deserialize(buff);
+
+        final String value = (String)_src.getValueFromObject(new Pojo(NAME_VALUE), null);
+        assertEquals("Incorrectly serialized PojoField failed to access value", NAME_VALUE, value);
+    }
+
+    /**
+     * Serialization test.
+     */
+    @Test
+    public void serializationTestWithElementConstructor() throws ParserConfigurationException {
+        final Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        final Element el = document.createElement("field");
+        el.setAttribute(NAME_FIELD, NAME_FIELD);
+        el.setAttribute("col", NAME_FIELD);
+        final MockPojoField src = new MockPojoField(el, Pojo.class);
+        final JavaSerializer serializer = new JavaSerializer();
+
+        final ByteBuffer buff = serializer.serialize(src);
+        final MockPojoField _src = (MockPojoField)serializer.deserialize(buff);
+
+        final String value = (String)_src.getValueFromObject(new Pojo(NAME_VALUE), null);
+        assertEquals("Incorrectly serialized PojoField failed to access value", NAME_VALUE, value);
+    }
+}


### PR DESCRIPTION
Changes PojoFieldAccessor to be Serializable, thus preventing the NPE when the CacheStore is deserialized.