### PR TITLE
IGNITE-10223: affinity list methods are added, tests are changed

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/affinity/Affinity.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/affinity/Affinity.java
@@ -17,11 +17,13 @@
 
 package org.apache.ignite.cache.affinity;
 
-import java.util.Collection;
-import java.util.Map;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.cluster.ClusterNode;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Provides affinity information to detect which node is primary and which nodes are
@@ -180,6 +182,9 @@ public interface Affinity<K> {
     @Nullable public ClusterNode mapKeyToNode(K key);
 
     /**
+     *
+     * @deprecated Use Affinity#mapKeyToPrimaryAndBackups(java.lang.Object) instead
+     *
      * Gets primary and backup nodes for the key. Note that primary node is always
      * first in the returned collection.
      *
@@ -188,7 +193,19 @@ public interface Affinity<K> {
      *      always first.
      * @throws IgniteException If there are no alive nodes for this cache.
      */
+    @Deprecated
     public Collection<ClusterNode> mapKeyToPrimaryAndBackups(K key);
+
+    /**
+     * Gets primary and backup nodes for the key. Primary node is always
+     * first in the returned list.
+     *
+     * @param key Key to get affinity nodes for.
+     * @return List of primary and backup nodes for the key with primary node
+     *      always first.
+     * @throws IgniteException If there are no alive nodes for this cache.
+     */
+    public List<ClusterNode> mapKeyToPrimaryAndBackupsList(K key);
 
     /**
      * Gets primary node for the given partition.
@@ -215,6 +232,7 @@ public interface Affinity<K> {
     public Map<Integer, ClusterNode> mapPartitionsToNodes(Collection<Integer> parts);
 
     /**
+     * @deprecated Use Affinity#mapPartitionToPrimaryAndBackupsList(int) instead
      * Gets primary and backup nodes for partition. Note that primary node is always
      * first in the returned collection.
      *
@@ -223,5 +241,17 @@ public interface Affinity<K> {
      *      always first.
      * @throws IgniteException If there are no alive nodes for this cache.
      */
+    @Deprecated
     public Collection<ClusterNode> mapPartitionToPrimaryAndBackups(int part);
+
+    /**
+     * Gets primary and backup nodes for partition. Note that primary node is always
+     * first in the returned list.
+     *
+     * @param part Partition to get affinity nodes for.
+     * @return List of primary and backup nodes for partition with primary node
+     *      always first.
+     * @throws IgniteException If there are no alive nodes for this cache.
+     */
+    public List<ClusterNode> mapPartitionToPrimaryAndBackupsList(int part);
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/affinity/GridAffinityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/affinity/GridAffinityProcessor.java
@@ -17,16 +17,6 @@
 
 package org.apache.ignite.internal.processors.affinity;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListMap;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
@@ -46,12 +36,7 @@ import org.apache.ignite.internal.cluster.ClusterGroupEmptyCheckedException;
 import org.apache.ignite.internal.cluster.ClusterTopologyCheckedException;
 import org.apache.ignite.internal.managers.eventstorage.GridLocalEventListener;
 import org.apache.ignite.internal.processors.GridProcessorAdapter;
-import org.apache.ignite.internal.processors.cache.CacheObject;
-import org.apache.ignite.internal.processors.cache.CacheObjectContext;
-import org.apache.ignite.internal.processors.cache.DynamicCacheDescriptor;
-import org.apache.ignite.internal.processors.cache.GridCacheAdapter;
-import org.apache.ignite.internal.processors.cache.GridCacheContext;
-import org.apache.ignite.internal.processors.cache.KeyCacheObject;
+import org.apache.ignite.internal.processors.cache.*;
 import org.apache.ignite.internal.processors.timeout.GridTimeoutObjectAdapter;
 import org.apache.ignite.internal.util.GridLeanMap;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
@@ -70,6 +55,9 @@ import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.lang.IgniteUuid;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import static org.apache.ignite.cache.CacheMode.LOCAL;
 import static org.apache.ignite.events.EventType.EVT_NODE_FAILED;
@@ -1050,8 +1038,27 @@ public class GridAffinityProcessor extends GridProcessorAdapter {
             }
         }
 
-        /** {@inheritDoc} */
+        /** @deprecated Use mapKeyToPrimaryAndBackupsList instead */
+        @Deprecated
         @Override public Collection<ClusterNode> mapKeyToPrimaryAndBackups(K key) {
+            ctx.gateway().readLock();
+
+            try {
+                AffinityInfo aff = cache();
+
+                return aff.assignment().get(GridAffinityProcessor.this.partition(cacheName, key, aff));
+            }
+            catch (IgniteCheckedException e) {
+                throw new IgniteException(e);
+            }
+            finally {
+                ctx.gateway().readUnlock();
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public List<ClusterNode> mapKeyToPrimaryAndBackupsList(K key) {
             ctx.gateway().readLock();
 
             try {
@@ -1106,8 +1113,25 @@ public class GridAffinityProcessor extends GridProcessorAdapter {
             }
         }
 
-        /** {@inheritDoc} */
+        /** @deprecated use mapPartitionToPrimaryAndBackupsList instead */
+        @Deprecated
         @Override public Collection<ClusterNode> mapPartitionToPrimaryAndBackups(int part) {
+            ctx.gateway().readLock();
+
+            try {
+                return cache().assignment().get(part);
+            }
+            catch (IgniteCheckedException e) {
+                throw new IgniteException(e);
+            }
+            finally {
+                ctx.gateway().readUnlock();
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public List<ClusterNode> mapPartitionToPrimaryAndBackupsList(int part) {
             ctx.gateway().readLock();
 
             try {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/affinity/GridCacheAffinityImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/affinity/GridCacheAffinityImpl.java
@@ -17,12 +17,6 @@
 
 package org.apache.ignite.internal.processors.cache.affinity;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.binary.BinaryObject;
@@ -37,6 +31,8 @@ import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
 
 /**
  * Affinity interface implementation.
@@ -218,7 +214,8 @@ public class GridCacheAffinityImpl<K, V> implements Affinity<K> {
         return res;
     }
 
-    /** {@inheritDoc} */
+    /** @deprecated Use mapKeyToPrimaryAndBackupsList(K) instead */
+    @Deprecated
     @Override public Collection<ClusterNode> mapKeyToPrimaryAndBackups(K key) {
         A.notNull(key, "key");
 
@@ -226,7 +223,26 @@ public class GridCacheAffinityImpl<K, V> implements Affinity<K> {
     }
 
     /** {@inheritDoc} */
+    @Override
+    public List<ClusterNode> mapKeyToPrimaryAndBackupsList(K key) {
+        A.notNull(key, "key");
+
+        return cctx.affinity().nodesByPartition(partition(key), topologyVersion());
+    }
+
+    @Deprecated
+    /**
+     * @deprecated Use GridCacheAffinityImpl#mapPartitionToPrimaryAndBackupsList(int) instead
+     */
     @Override public Collection<ClusterNode> mapPartitionToPrimaryAndBackups(int part) {
+        A.ensure(part >= 0 && part < partitions(), "part >= 0 && part < total partitions");
+
+        return cctx.affinity().nodesByPartition(part, topologyVersion());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<ClusterNode> mapPartitionToPrimaryAndBackupsList(int part) {
         A.ensure(part >= 0 && part < partitions(), "part >= 0 && part < total partitions");
 
         return cctx.affinity().nodesByPartition(part, topologyVersion());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/affinity/GridCacheAffinityProxy.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/affinity/GridCacheAffinityProxy.java
@@ -17,19 +17,17 @@
 
 package org.apache.ignite.internal.processors.cache.affinity;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.io.ObjectStreamException;
-import java.util.Collection;
-import java.util.Map;
 import org.apache.ignite.cache.affinity.Affinity;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.internal.processors.cache.CacheOperationContext;
 import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.GridCacheGateway;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Affinity interface implementation.
@@ -221,7 +219,8 @@ public class GridCacheAffinityProxy<K, V> implements Affinity<K>, Externalizable
         }
     }
 
-    /** {@inheritDoc} */
+    /** @deprecated use GridCacheAffinityProxy#mapKeyToPrimaryAndBackupsList(java.lang.Object) instead */
+    @Deprecated
     @Override public Collection<ClusterNode> mapKeyToPrimaryAndBackups(K key) {
         CacheOperationContext old = gate.enter(null);
 
@@ -234,11 +233,38 @@ public class GridCacheAffinityProxy<K, V> implements Affinity<K>, Externalizable
     }
 
     /** {@inheritDoc} */
+    @Override
+    public List<ClusterNode> mapKeyToPrimaryAndBackupsList(K key) {
+        CacheOperationContext old = gate.enter(null);
+
+        try {
+            return delegate.mapKeyToPrimaryAndBackupsList(key);
+        }
+        finally {
+            gate.leave(old);
+        }
+    }
+
+    /** @deprecated Use GridCacheAffinityProxy#mapPartitionToPrimaryAndBackupsList(int) */
+    @Deprecated
     @Override public Collection<ClusterNode> mapPartitionToPrimaryAndBackups(int part) {
         CacheOperationContext old = gate.enter(null);
 
         try {
             return delegate.mapPartitionToPrimaryAndBackups(part);
+        }
+        finally {
+            gate.leave(old);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<ClusterNode> mapPartitionToPrimaryAndBackupsList(int part) {
+        CacheOperationContext old = gate.enter(null);
+
+        try {
+            return delegate.mapPartitionToPrimaryAndBackupsList(part);
         }
         finally {
             gate.leave(old);

--- a/modules/core/src/test/java/org/apache/ignite/GridCacheAffinityBackupsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/GridCacheAffinityBackupsSelfTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.ignite;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.UUID;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
 import org.apache.ignite.cluster.ClusterNode;
@@ -27,6 +24,10 @@ import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.UUID;
 
 /**
  * Tests affinity function with different number of backups.
@@ -77,7 +78,7 @@ public class GridCacheAffinityBackupsSelfTest extends GridCommonAbstractTest {
             Collection<UUID> members = new HashSet<>();
 
             for (int i = 0; i < 10000; i++) {
-                Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackups(i);
+                Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackupsList(i);
 
                 assertEquals(backups + 1, nodes.size());
 

--- a/modules/core/src/test/java/org/apache/ignite/IgniteCacheAffinitySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/IgniteCacheAffinitySelfTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.ignite;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.affinity.Affinity;
@@ -33,6 +28,8 @@ import org.apache.ignite.configuration.NearCacheConfiguration;
 import org.apache.ignite.internal.processors.affinity.GridAffinityProcessor;
 import org.apache.ignite.internal.processors.cache.IgniteCacheAbstractTest;
 import org.junit.Test;
+
+import java.util.*;
 
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
@@ -169,7 +166,7 @@ public class IgniteCacheAffinitySelfTest extends IgniteCacheAbstractTest {
     }
 
     /**
-     * Check mapKeyToNode, mapKeyToPrimaryAndBackups methods.
+     * Check mapKeyToNode, mapKeyToPrimaryAndBackupsList methods.
      *
      * @param testAff Affinity1.
      * @param aff Affinity2.
@@ -178,12 +175,12 @@ public class IgniteCacheAffinitySelfTest extends IgniteCacheAbstractTest {
         for (int i = 0; i < 10000; i++) {
             assertEquals(testAff.mapKeyToNode(i).id(), aff.mapKeyToNode(i).id());
 
-            checkEqualCollection(testAff.mapKeyToPrimaryAndBackups(i), aff.mapKeyToPrimaryAndBackups(i));
+            checkEqualCollection(testAff.mapKeyToPrimaryAndBackupsList(i), aff.mapKeyToPrimaryAndBackupsList(i));
         }
     }
 
     /**
-     * Check mapPartitionToPrimaryAndBackups and mapPartitionToNode methods.
+     * Check mapPartitionToPrimaryAndBackupsListList and mapPartitionToNode methods.
      *
      * @param testAff Affinity1.
      * @param aff Affinity2.
@@ -194,8 +191,8 @@ public class IgniteCacheAffinitySelfTest extends IgniteCacheAbstractTest {
         for (int part = 0; part < aff.partitions(); ++part) {
             assertEquals(testAff.mapPartitionToNode(part).id(), aff.mapPartitionToNode(part).id());
 
-            checkEqualCollection(testAff.mapPartitionToPrimaryAndBackups(part),
-                aff.mapPartitionToPrimaryAndBackups(part));
+            checkEqualCollection(testAff.mapPartitionToPrimaryAndBackupsList(part),
+                aff.mapPartitionToPrimaryAndBackupsList(part));
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/cache/affinity/AffinityClientNodeSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/affinity/AffinityClientNodeSelfTest.java
@@ -160,10 +160,10 @@ public class AffinityClientNodeSelfTest extends GridCommonAbstractTest {
             Affinity<Object> aff = ignite.affinity(cacheName);
 
             for (int part = 0; part < aff.partitions(); part++) {
-                Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackups(part);
+                Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackupsList(part);
 
                 assertEquals(expNodes, nodes.size());
-                assertEquals(aff0.mapPartitionToPrimaryAndBackups(part), nodes);
+                assertEquals(aff0.mapPartitionToPrimaryAndBackupsList(part), nodes);
 
                 assertFalse(nodes.contains(clientNode));
 
@@ -172,7 +172,7 @@ public class AffinityClientNodeSelfTest extends GridCommonAbstractTest {
                 TestKey key = new TestKey(part, part + 1);
 
                 assertEquals(aff0.partition(key), aff.partition(key));
-                assertEquals(aff0.mapKeyToPrimaryAndBackups(key), aff.mapKeyToPrimaryAndBackups(key));
+                assertEquals(aff0.mapKeyToPrimaryAndBackupsList(key), aff.mapKeyToPrimaryAndBackupsList(key));
             }
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/cache/affinity/AffinityFunctionBackupFilterAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/affinity/AffinityFunctionBackupFilterAbstractSelfTest.java
@@ -183,7 +183,7 @@ public abstract class AffinityFunctionBackupFilterAbstractSelfTest extends GridC
         IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
 
         for (int i = 0; i < partCnt; i++) {
-            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackups(i);
+            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackupsList(i);
 
             assertEquals(2, nodes.size());
 
@@ -243,7 +243,7 @@ public abstract class AffinityFunctionBackupFilterAbstractSelfTest extends GridC
         IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
 
         for (int i = 0; i < partCnt; i++) {
-            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackups(i);
+            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackupsList(i);
 
             assertEquals(expectedNodesForEachPartition(), nodes.size());
 

--- a/modules/core/src/test/java/org/apache/ignite/cache/affinity/AffinityFunctionExcludeNeighborsAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/cache/affinity/AffinityFunctionExcludeNeighborsAbstractSelfTest.java
@@ -97,7 +97,7 @@ public abstract class AffinityFunctionExcludeNeighborsAbstractSelfTest extends G
      * @return Nodes.
      */
     private static Collection<? extends ClusterNode> nodes(Affinity<Object> aff, Object key) {
-        return aff.mapKeyToPrimaryAndBackups(key);
+        return aff.mapKeyToPrimaryAndBackupsList(key);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridAffinityNoCacheSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridAffinityNoCacheSelfTest.java
@@ -173,7 +173,7 @@ public class GridAffinityNoCacheSelfTest extends GridCommonAbstractTest {
 
         GridTestUtils.assertThrows(log, new Callable<Object>() {
             @Override public Object call() throws Exception {
-                return affinity.mapKeyToPrimaryAndBackups(key);
+                return affinity.mapKeyToPrimaryAndBackupsList(key);
             }
         }, IgniteException.class, EXPECTED_MSG);
 
@@ -191,7 +191,7 @@ public class GridAffinityNoCacheSelfTest extends GridCommonAbstractTest {
 
         GridTestUtils.assertThrows(log, new Callable<Object>() {
             @Override public Object call() throws Exception {
-                return affinity.mapPartitionToPrimaryAndBackups(0);
+                return affinity.mapPartitionToPrimaryAndBackupsList(0);
             }
         }, IgniteException.class, EXPECTED_MSG);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheInterceptorPartitionCounterRandomOperationsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheInterceptorPartitionCounterRandomOperationsTest.java
@@ -696,7 +696,7 @@ public class CacheInterceptorPartitionCounterRandomOperationsTest extends GridCo
         boolean rmv
     ) {
         Collection<ClusterNode> nodes = atomicityMode(cache) == TRANSACTIONAL ?
-                affinity(cache).mapKeyToPrimaryAndBackups(key) :
+                affinity(cache).mapKeyToPrimaryAndBackupsList(key) :
                 Collections.singletonList(affinity(cache).mapKeyToNode(key));
 
         assert !nodes.isEmpty();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/EntryVersionConsistencyReadThroughTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/EntryVersionConsistencyReadThroughTest.java
@@ -191,7 +191,7 @@ public class EntryVersionConsistencyReadThroughTest extends GridCommonAbstractTe
 
                 // Check entry versions consistency.
                 for (String key : keys) {
-                    Collection<ClusterNode> nodes = grid.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key);
+                    Collection<ClusterNode> nodes = grid.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key);
 
                     List<IgniteEx> grids = grids(nodes);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheAbstractFullApiSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheAbstractFullApiSelfTest.java
@@ -477,7 +477,7 @@ public abstract class GridCacheAbstractFullApiSelfTest extends GridCacheAbstract
         int globalSize = 0;
 
         for (String key : map.keySet())
-            globalSize += affinity(jcache()).mapKeyToPrimaryAndBackups(key).size();
+            globalSize += affinity(jcache()).mapKeyToPrimaryAndBackupsList(key).size();
 
         for (int i = 0; i < gridCount(); i++)
             assertEquals(globalSize, jcache(i).size(ALL));
@@ -3272,7 +3272,7 @@ public abstract class GridCacheAbstractFullApiSelfTest extends GridCacheAbstract
             for (int i = 0; i < cnt; i++) {
                 String key = String.valueOf(i);
 
-                if (grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key).contains(grid(g).localNode()))
+                if (grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key).contains(grid(g).localNode()))
                     assertEquals((Integer)i, peek(jcache(g), key));
                 else
                     assertNull(peek(jcache(g), key));
@@ -3307,7 +3307,7 @@ public abstract class GridCacheAbstractFullApiSelfTest extends GridCacheAbstract
             for (int i = 0; i < cnt; i++) {
                 String key = String.valueOf(i);
 
-                if (grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key).contains(grid(g).localNode()))
+                if (grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key).contains(grid(g).localNode()))
                     assertEquals((Integer)i, peek(jcache(g), key));
                 else
                     assertNull(peek(jcache(g), key));
@@ -5241,7 +5241,7 @@ public abstract class GridCacheAbstractFullApiSelfTest extends GridCacheAbstract
             boolean found = primaryIgnite(key).cache(DEFAULT_CACHE_NAME).localPeek(key) != null;
 
             if (keyToRmv.equals(key)) {
-                Collection<ClusterNode> nodes = grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key);
+                Collection<ClusterNode> nodes = grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key);
 
                 for (int j = 0; j < gridCount(); ++j) {
                     if (nodes.contains(grid(j).localNode()) && grid(j) != primaryIgnite(key))
@@ -6730,7 +6730,7 @@ public abstract class GridCacheAbstractFullApiSelfTest extends GridCacheAbstract
 
                 GridCacheEntryEx entry = ctx.isNear() ? ctx.near().dht().peekEx(key) : ctx.cache().peekEx(key);
 
-                if (ignite.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key).contains(((IgniteKernal)ignite).localNode())) {
+                if (ignite.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key).contains(((IgniteKernal)ignite).localNode())) {
                     assertNotNull(entry);
                     assertTrue(entry.deleted());
                 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheEntryVersionSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheEntryVersionSelfTest.java
@@ -98,7 +98,7 @@ public class GridCacheEntryVersionSelfTest extends GridCommonAbstractTest {
 
             for (Integer key : map.keySet()) {
                 info("Affinity nodes [key=" + key + ", nodes=" +
-                    F.viewReadOnly(grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key), F.node2id()) + ']');
+                    F.viewReadOnly(grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key), F.node2id()) + ']');
             }
 
             grid(0).cache(DEFAULT_CACHE_NAME).putAll(map);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheQueryInternalKeysSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheQueryInternalKeysSelfTest.java
@@ -82,7 +82,7 @@ public class GridCacheQueryInternalKeysSelfTest extends GridCacheAbstractSelfTes
             for (int i = 0; i < ENTRY_CNT; i++) {
                 GridCacheQueueHeaderKey internalKey = new GridCacheQueueHeaderKey("queue" + i);
 
-                Collection<ClusterNode> nodes = grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(internalKey);
+                Collection<ClusterNode> nodes = grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(internalKey);
 
                 for (ClusterNode n : nodes) {
                     Ignite g = findGridForNodeId(n.id());

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheValueConsistencyAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/GridCacheValueConsistencyAbstractSelfTest.java
@@ -128,7 +128,7 @@ public abstract class GridCacheValueConsistencyAbstractSelfTest extends GridCach
             for (int i = 0; i < keyCnt; i++) {
                 String key = "key" + i;
 
-                if (ignite(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key).contains(locNode)) {
+                if (ignite(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key).contains(locNode)) {
                     info("Node is reported as affinity node for key [key=" + key + ", nodeId=" + locNode.id() + ']');
 
                     assertEquals((Integer)i, cache0.localPeek(key));
@@ -190,7 +190,7 @@ public abstract class GridCacheValueConsistencyAbstractSelfTest extends GridCach
             for (int i = 0; i < keyCnt; i++) {
                 String key = "key" + i;
 
-                if (ignite(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key).contains(grid(g).localNode())) {
+                if (ignite(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key).contains(grid(g).localNode())) {
                     info("Node is reported as affinity node for key [key=" + key + ", nodeId=" + locNode.id() + ']');
 
                     assertEquals((Integer)i, cache0.localPeek(key));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheConfigVariationsFullApiTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheConfigVariationsFullApiTest.java
@@ -3335,7 +3335,7 @@ public class IgniteCacheConfigVariationsFullApiTest extends IgniteCacheConfigVar
             for (int i = 0; i < cnt; i++) {
                 String key = String.valueOf(i);
 
-                if (grid(0).affinity(cacheName()).mapKeyToPrimaryAndBackups(key).contains(grid(g).localNode()))
+                if (grid(0).affinity(cacheName()).mapKeyToPrimaryAndBackupsList(key).contains(grid(g).localNode()))
                     assertEquals(i, jcache(g).localPeek(key));
                 else
                     assertNull(jcache(g).localPeek(key));
@@ -5265,7 +5265,7 @@ public class IgniteCacheConfigVariationsFullApiTest extends IgniteCacheConfigVar
             boolean found = primaryIgnite(key).cache(cacheName()).localPeek(key) != null;
 
             if (keyToRmv.equals(key)) {
-                Collection<ClusterNode> nodes = grid(0).affinity(cacheName()).mapKeyToPrimaryAndBackups(key);
+                Collection<ClusterNode> nodes = grid(0).affinity(cacheName()).mapKeyToPrimaryAndBackupsList(key);
 
                 for (int j = 0; j < gridCount(); ++j) {
                     if (nodes.contains(grid(j).localNode()) && grid(j) != primaryIgnite(key))
@@ -6616,7 +6616,7 @@ public class IgniteCacheConfigVariationsFullApiTest extends IgniteCacheConfigVar
 
                 GridCacheEntryEx entry = ctx.isNear() ? ctx.near().dht().peekEx(key) : ctx.cache().peekEx(key);
 
-                if (ignite.affinity(cacheName).mapKeyToPrimaryAndBackups(key).contains(((IgniteKernal)ignite).localNode())) {
+                if (ignite.affinity(cacheName).mapKeyToPrimaryAndBackupsList(key).contains(((IgniteKernal)ignite).localNode())) {
                     assertNotNull(entry);
                     assertTrue(entry.deleted());
                 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteClientAffinityAssignmentSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteClientAffinityAssignmentSelfTest.java
@@ -166,7 +166,7 @@ public class IgniteClientAffinityAssignmentSelfTest extends GridCommonAbstractTe
                 Affinity<Object> checkAff = grid.affinity(DEFAULT_CACHE_NAME);
 
                 for (int p = 0; p < PARTS; p++)
-                    assertEquals(aff.mapPartitionToPrimaryAndBackups(p), checkAff.mapPartitionToPrimaryAndBackups(p));
+                    assertEquals(aff.mapPartitionToPrimaryAndBackupsList(p), checkAff.mapPartitionToPrimaryAndBackupsList(p));
             }
             catch (IllegalArgumentException ignored) {
                 // Skip the node without cache.

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteDynamicCacheStartSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteDynamicCacheStartSelfTest.java
@@ -477,7 +477,7 @@ public class IgniteDynamicCacheStartSelfTest extends GridCommonAbstractTest {
             for (int g = 0; g < nodeCount() + 1; g++) {
                 assertEquals("1", grid(g).cache(DYNAMIC_CACHE_NAME).get("1"));
 
-                Collection<ClusterNode> nodes = grid(g).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackups(0);
+                Collection<ClusterNode> nodes = grid(g).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackupsList(0);
 
                 assertEquals(nodeCount() + 1, nodes.size());
             }
@@ -531,14 +531,14 @@ public class IgniteDynamicCacheStartSelfTest extends GridCommonAbstractTest {
             for (int i = 0; i < 100; i++)
                 assertEquals(i, grid(1).cache(DYNAMIC_CACHE_NAME).get(i));
 
-            info("Affinity nodes: " + grid(0).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackups(0));
+            info("Affinity nodes: " + grid(0).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackupsList(0));
 
             for (int g = 0; g < nodeCount(); g++) {
                 for (int i = 0; i < 100; i++) {
-                    assertFalse(grid(g).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackups(i)
+                    assertFalse(grid(g).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackupsList(i)
                         .contains(grid(nodeCount()).cluster().localNode()));
 
-                    assertFalse(grid(g).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackups(i)
+                    assertFalse(grid(g).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackupsList(i)
                         .contains(grid(nodeCount() + 1).cluster().localNode()));
                 }
             }
@@ -1234,7 +1234,7 @@ public class IgniteDynamicCacheStartSelfTest extends GridCommonAbstractTest {
 
             try {
                 for (int i = 0; i < 100; i++) {
-                    assertFalse(ignite(0).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackups(i)
+                    assertFalse(ignite(0).affinity(DYNAMIC_CACHE_NAME).mapKeyToPrimaryAndBackupsList(i)
                         .contains(dNode.cluster().localNode()));
 
                     cache.put(i, i);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteSystemCacheOnClientTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteSystemCacheOnClientTest.java
@@ -52,7 +52,7 @@ public class IgniteSystemCacheOnClientTest extends GridCommonAbstractTest {
 
         GridCacheAdapter utilityCache = ((IgniteKernal)ignite(0)).internalCache(CU.UTILITY_CACHE_NAME);
 
-        Collection<ClusterNode> affNodes = utilityCache.affinity().mapKeyToPrimaryAndBackups(1);
+        Collection<ClusterNode> affNodes = utilityCache.affinity().mapKeyToPrimaryAndBackupsList(1);
 
         assertEquals(1, affNodes.size());
         assertTrue(affNodes.contains(ignite(0).cluster().localNode()));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteTxAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteTxAbstractTest.java
@@ -159,7 +159,7 @@ abstract class IgniteTxAbstractTest extends GridCommonAbstractTest {
                         int part = aff.partition(key);
 
                         debug("Key affinity [key=" + key + ", partition=" + part + ", affinity=" +
-                            U.toShortString(ignite(gridIdx).affinity(DEFAULT_CACHE_NAME).mapPartitionToPrimaryAndBackups(part)) + ']');
+                            U.toShortString(ignite(gridIdx).affinity(DEFAULT_CACHE_NAME).mapPartitionToPrimaryAndBackupsList(part)) + ']');
                     }
 
                     String val = Integer.toString(key);
@@ -270,7 +270,7 @@ abstract class IgniteTxAbstractTest extends GridCommonAbstractTest {
                         int part = aff.partition(key);
 
                         debug("Key affinity [key=" + key + ", partition=" + part + ", affinity=" +
-                            U.toShortString(ignite(gridIdx).affinity(DEFAULT_CACHE_NAME).mapPartitionToPrimaryAndBackups(part)) + ']');
+                            U.toShortString(ignite(gridIdx).affinity(DEFAULT_CACHE_NAME).mapPartitionToPrimaryAndBackupsList(part)) + ']');
                     }
 
                     String val = Integer.toString(key);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteTxMultiNodeAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteTxMultiNodeAbstractTest.java
@@ -100,7 +100,7 @@ public abstract class IgniteTxMultiNodeAbstractTest extends GridCommonAbstractTe
     private static UUID primaryId(Ignite ignite, Object key) {
         Affinity aff = ignite.affinity(DEFAULT_CACHE_NAME);
 
-        Collection<ClusterNode> affNodes = aff.mapPartitionToPrimaryAndBackups(aff.partition(key));
+        Collection<ClusterNode> affNodes = aff.mapPartitionToPrimaryAndBackupsList(aff.partition(key));
 
         ClusterNode first = F.first(affNodes);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/binary/GridCacheClientNodeBinaryObjectMetadataTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/binary/GridCacheClientNodeBinaryObjectMetadataTest.java
@@ -111,13 +111,13 @@ public class GridCacheClientNodeBinaryObjectMetadataTest extends GridCacheAbstra
         for (int i = 0 ; i < 100; i++) {
             TestObject1 obj1 = new TestObject1(i, i + 1);
 
-            assertEquals(aff1.mapKeyToPrimaryAndBackups(obj1),
-                aff0.mapKeyToPrimaryAndBackups(obj1));
+            assertEquals(aff1.mapKeyToPrimaryAndBackupsList(obj1),
+                aff0.mapKeyToPrimaryAndBackupsList(obj1));
 
             TestObject2 obj2 = new TestObject2(i, i + 1);
 
-            assertEquals(aff1.mapKeyToPrimaryAndBackups(obj2),
-                aff0.mapKeyToPrimaryAndBackups(obj2));
+            assertEquals(aff1.mapKeyToPrimaryAndBackupsList(obj2),
+                aff0.mapKeyToPrimaryAndBackupsList(obj2));
         }
 
         Collection<BinaryType> meta1 = ignite1.binary().types();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/partitioned/GridCachePartitionedQueueEntryMoveSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/partitioned/GridCachePartitionedQueueEntryMoveSelfTest.java
@@ -182,14 +182,14 @@ public class GridCachePartitionedQueueEntryMoveSelfTest extends IgniteCollection
 
         CacheConfiguration cCfg = getQueueCache(queue);
 
-        Collection<ClusterNode> aff1 = ignite(0).affinity(cCfg.getName()).mapKeyToPrimaryAndBackups(queueName);
+        Collection<ClusterNode> aff1 = ignite(0).affinity(cCfg.getName()).mapKeyToPrimaryAndBackupsList(queueName);
 
         for (int i = 0, id = GRID_CNT; i < cnt; i++) {
             startGrid(id++);
 
             awaitPartitionMapExchange();
 
-            Collection<ClusterNode> aff2 = ignite(0).affinity(cCfg.getName()).mapKeyToPrimaryAndBackups(queueName);
+            Collection<ClusterNode> aff2 = ignite(0).affinity(cCfg.getName()).mapKeyToPrimaryAndBackupsList(queueName);
 
             if (!aff1.iterator().next().equals(aff2.iterator().next())) {
                 info("Moved queue to new primary node [oldAff=" + aff1 + ", newAff=" + aff2 + ']');

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheLateAffinityAssignmentTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheLateAffinityAssignmentTest.java
@@ -2515,7 +2515,7 @@ public class CacheLateAffinityAssignmentTest extends GridCommonAbstractTest {
                     assert aff.partitions() > 0;
 
                     for (int p = 0; p > aff.partitions(); p++) {
-                        Collection<ClusterNode> partNodes = aff.mapPartitionToPrimaryAndBackups(p);
+                        Collection<ClusterNode> partNodes = aff.mapPartitionToPrimaryAndBackupsList(p);
 
                         assertTrue(partNodes.isEmpty());
                     }
@@ -2656,7 +2656,7 @@ public class CacheLateAffinityAssignmentTest extends GridCommonAbstractTest {
 
                         for (int p = 0; p < ideal.size(); p++) {
                             List<ClusterNode> exp = ideal.get(p);
-                            Collection<ClusterNode> partNodes = cacheAff.mapPartitionToPrimaryAndBackups(p);
+                            Collection<ClusterNode> partNodes = cacheAff.mapPartitionToPrimaryAndBackupsList(p);
 
                             assertEqualsCollections(exp, partNodes);
                         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCacheClientModesAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCacheClientModesAbstractSelfTest.java
@@ -224,7 +224,7 @@ public abstract class GridCacheClientModesAbstractSelfTest extends GridCacheAbst
                     if (cacheMode() == PARTITIONED)
                         assertFalse(affinity(cache).isPrimaryOrBackup(g.cluster().localNode(), key));
 
-                    assertFalse(affinity(cache).mapKeyToPrimaryAndBackups(key).contains(g.cluster().localNode()));
+                    assertFalse(affinity(cache).mapKeyToPrimaryAndBackupsList(key).contains(g.cluster().localNode()));
                 }
             }
             else {
@@ -237,7 +237,7 @@ public abstract class GridCacheClientModesAbstractSelfTest extends GridCacheAbst
                     if (g.affinity(DEFAULT_CACHE_NAME).isPrimaryOrBackup(g.cluster().localNode(), key))
                         foundEntry = true;
 
-                    if (g.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key).contains(g.cluster().localNode()))
+                    if (g.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key).contains(g.cluster().localNode()))
                         foundAffinityNode = true;
                 }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCacheNodeFailureAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCacheNodeFailureAbstractTest.java
@@ -237,7 +237,7 @@ public abstract class GridCacheNodeFailureAbstractTest extends GridCommonAbstrac
 
         info("Grid will be stopped: " + idx);
 
-        info("Nodes for key [id=" + grid(idx).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(KEY) +
+        info("Nodes for key [id=" + grid(idx).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(KEY) +
             ", key=" + KEY + ']');
 
         IgniteCache<Integer, String> cache = jcache(idx);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCachePreloadRestartAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/GridCachePreloadRestartAbstractSelfTest.java
@@ -211,7 +211,7 @@ public abstract class GridCachePreloadRestartAbstractSelfTest extends GridCommon
                 int part = affinity(c).partition(key);
 
                 info("Affinity nodes before stop [key=" + key + ", partition" + part + ", nodes=" +
-                    U.nodeIds(affinity(c).mapPartitionToPrimaryAndBackups(part)) + ']');
+                    U.nodeIds(affinity(c).mapPartitionToPrimaryAndBackupsList(part)) + ']');
             }
         }
     }
@@ -225,7 +225,7 @@ public abstract class GridCachePreloadRestartAbstractSelfTest extends GridCommon
                 int part = affinity(c).partition(key);
 
                 info("Affinity nodes after start [key=" + key + ", partition" + part + ", nodes=" +
-                    U.nodeIds(affinity(c).mapPartitionToPrimaryAndBackups(part)) + ']');
+                    U.nodeIds(affinity(c).mapPartitionToPrimaryAndBackupsList(part)) + ']');
             }
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteCacheClientNodePartitionsExchangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteCacheClientNodePartitionsExchangeTest.java
@@ -451,7 +451,7 @@ public class IgniteCacheClientNodePartitionsExchangeTest extends GridCommonAbstr
             assertEquals(aff0.partitions(), aff.partitions());
 
             for (int part = 0; part < aff.partitions(); part++)
-                assertEquals(aff0.mapPartitionToPrimaryAndBackups(part), aff.mapPartitionToPrimaryAndBackups(part));
+                assertEquals(aff0.mapPartitionToPrimaryAndBackupsList(part), aff.mapPartitionToPrimaryAndBackupsList(part));
         }
 
         for (Ignite ignite : nodes) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxCachePrimarySyncTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxCachePrimarySyncTest.java
@@ -881,7 +881,7 @@ public class IgniteTxCachePrimarySyncTest extends GridCommonAbstractTest {
         final Object key) throws Exception {
         Affinity<Object> aff = ignite.affinity(cacheName);
 
-        final Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackups(key);
+        final Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackupsList(key);
 
         assertEquals(expNodes, nodes.size());
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxOriginatingNodeFailureAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxOriginatingNodeFailureAbstractSelfTest.java
@@ -148,7 +148,7 @@ public abstract class IgniteTxOriginatingNodeFailureAbstractSelfTest extends Gri
         for (Integer key : keys) {
             Collection<ClusterNode> nodes = new ArrayList<>();
 
-            nodes.addAll(grid(1).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key));
+            nodes.addAll(grid(1).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key));
 
             nodes.remove(txNode);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxPessimisticOriginatingNodeFailureAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxPessimisticOriginatingNodeFailureAbstractSelfTest.java
@@ -183,7 +183,7 @@ public abstract class IgniteTxPessimisticOriginatingNodeFailureAbstractSelfTest 
         for (Integer key : keys) {
             Collection<ClusterNode> nodes = new ArrayList<>();
 
-            nodes.addAll(grid(1).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key));
+            nodes.addAll(grid(1).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key));
 
             nodes.remove(txNode);
 
@@ -353,7 +353,7 @@ public abstract class IgniteTxPessimisticOriginatingNodeFailureAbstractSelfTest 
         for (Integer key : keys) {
             Collection<ClusterNode> nodes = new ArrayList<>();
 
-            nodes.addAll(affinity(cache).mapKeyToPrimaryAndBackups(key));
+            nodes.addAll(affinity(cache).mapKeyToPrimaryAndBackupsList(key));
 
             nodes.remove(primaryNode);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtEvictionNearReadersSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtEvictionNearReadersSelfTest.java
@@ -149,7 +149,7 @@ public class GridCacheDhtEvictionNearReadersSelfTest extends GridCommonAbstractT
      * @return Primary node for the given key.
      */
     private Collection<ClusterNode> keyNodes(Object key) {
-        return grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key);
+        return grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtPreloadDelayedSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtPreloadDelayedSelfTest.java
@@ -407,7 +407,7 @@ public class GridCacheDhtPreloadDelayedSelfTest extends GridCommonAbstractTest {
      * @return Affinity nodes.
      */
     private Collection<ClusterNode> affinityNodes(Ignite g, int p) {
-        return affinity(g).mapPartitionToPrimaryAndBackups(p);
+        return affinity(g).mapPartitionToPrimaryAndBackupsList(p);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtPreloadSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtPreloadSelfTest.java
@@ -285,7 +285,7 @@ public class GridCacheDhtPreloadSelfTest extends GridCommonAbstractTest {
             info("Finished waiting for all exchange futures...");
 
             for (int i = 0; i < keyCnt; i++) {
-                if (aff.mapPartitionToPrimaryAndBackups(aff.partition(i)).contains(last.cluster().localNode())) {
+                if (aff.mapPartitionToPrimaryAndBackupsList(aff.partition(i)).contains(last.cluster().localNode())) {
                     GridDhtPartitionTopology top = dht.topology();
 
                     for (GridDhtLocalPartition p : top.localPartitions()) {
@@ -536,7 +536,7 @@ public class GridCacheDhtPreloadSelfTest extends GridCommonAbstractTest {
             Affinity<Integer> aff = affinity(lastCache);
 
             for (int i = 0; i < keyCnt; i++) {
-                if (aff.mapPartitionToPrimaryAndBackups(aff.partition(i)).contains(last.cluster().localNode())) {
+                if (aff.mapPartitionToPrimaryAndBackupsList(aff.partition(i)).contains(last.cluster().localNode())) {
                     GridDhtPartitionTopology top = dht.topology();
 
                     for (GridDhtLocalPartition p : top.localPartitions()) {
@@ -587,7 +587,7 @@ public class GridCacheDhtPreloadSelfTest extends GridCommonAbstractTest {
         for (int i = 0; i < cnt; i++) {
             Collection<ClusterNode> nodes = ignite.cluster().nodes();
 
-            Collection<ClusterNode> affNodes = aff.mapPartitionToPrimaryAndBackups(aff.partition(i));
+            Collection<ClusterNode> affNodes = aff.mapPartitionToPrimaryAndBackupsList(aff.partition(i));
 
             assert !affNodes.isEmpty();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtPreloadStartStopSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridCacheDhtPreloadStartStopSelfTest.java
@@ -212,7 +212,7 @@ public class GridCacheDhtPreloadStartStopSelfTest extends GridCommonAbstractTest
             Affinity<Integer> aff = affinity(c1);
 
             for (int i = 0; i < keyCnt; i++) {
-                if (aff.mapPartitionToPrimaryAndBackups(aff.partition(i)).contains(g1.cluster().localNode())) {
+                if (aff.mapPartitionToPrimaryAndBackupsList(aff.partition(i)).contains(g1.cluster().localNode())) {
                     GridDhtPartitionTopology top = dht.topology();
 
                     for (GridDhtLocalPartition p : top.localPartitions())
@@ -246,7 +246,7 @@ public class GridCacheDhtPreloadStartStopSelfTest extends GridCommonAbstractTest
         Ignite ignite = c.unwrap(Ignite.class);
 
         for (int i = 0; i < cnt; i++) {
-            if (aff.mapPartitionToPrimaryAndBackups(aff.partition(i)).contains(ignite.cluster().localNode())) {
+            if (aff.mapPartitionToPrimaryAndBackupsList(aff.partition(i)).contains(ignite.cluster().localNode())) {
                 String val = sync ? c.localPeek(i, CachePeekMode.ONHEAP) : c.get(i);
 
                 assertEquals("Key check failed [igniteInstanceName=" + ignite.name() + ", cache=" + c.getName() +

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/IgniteCacheConcurrentPutGetRemove.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/IgniteCacheConcurrentPutGetRemove.java
@@ -124,7 +124,7 @@ public class IgniteCacheConcurrentPutGetRemove extends GridCommonAbstractTest {
                 Affinity aff = ignite(0).affinity(ccfg.getName());
 
                 for (int k = 0; k < KEYS; k++) {
-                    Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackups(k);
+                    Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackupsList(k);
 
                     Object expVal = grid(nodes.iterator().next()).cache(ccfg.getName()).get(k);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/IgniteCachePrimaryNodeFailureRecoveryAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/IgniteCachePrimaryNodeFailureRecoveryAbstractTest.java
@@ -219,8 +219,8 @@ public abstract class IgniteCachePrimaryNodeFailureRecoveryAbstractTest extends 
         final Integer key1 = key0;
         final Integer key2 = primaryKey(cache2);
 
-        final Collection<ClusterNode> key1Nodes = aff.mapKeyToPrimaryAndBackups(key1);
-        final Collection<ClusterNode> key2Nodes = aff.mapKeyToPrimaryAndBackups(key2);
+        final Collection<ClusterNode> key1Nodes = aff.mapKeyToPrimaryAndBackupsList(key1);
+        final Collection<ClusterNode> key2Nodes = aff.mapKeyToPrimaryAndBackupsList(key2);
 
         TestCommunicationSpi commSpi = (TestCommunicationSpi)ignite(0).configuration().getCommunicationSpi();
 
@@ -399,8 +399,8 @@ public abstract class IgniteCachePrimaryNodeFailureRecoveryAbstractTest extends 
             int backups = origCache.getConfiguration(CacheConfiguration.class).getBackups();
 
             final Collection<ClusterNode> key1Nodes =
-                (locBackupKey && backups < 2) ? Collections.emptyList() : aff.mapKeyToPrimaryAndBackups(key1);
-            final Collection<ClusterNode> key2Nodes = aff.mapKeyToPrimaryAndBackups(key2);
+                (locBackupKey && backups < 2) ? Collections.emptyList() : aff.mapKeyToPrimaryAndBackupsList(key1);
+            final Collection<ClusterNode> key2Nodes = aff.mapKeyToPrimaryAndBackupsList(key2);
 
             TestCommunicationSpi commSpi = (TestCommunicationSpi)ignite(orig).configuration().getCommunicationSpi();
 
@@ -408,11 +408,11 @@ public abstract class IgniteCachePrimaryNodeFailureRecoveryAbstractTest extends 
 
             Transaction tx = txs.txStart(optimistic ? OPTIMISTIC : PESSIMISTIC, REPEATABLE_READ);
 
-            log.info("Put key1 [key1=" + key1 + ", nodes=" + U.nodeIds(aff.mapKeyToPrimaryAndBackups(key1)) + ']');
+            log.info("Put key1 [key1=" + key1 + ", nodes=" + U.nodeIds(aff.mapKeyToPrimaryAndBackupsList(key1)) + ']');
 
             origCache.put(key1, key1);
 
-            log.info("Put key2 [key2=" + key2 + ", nodes=" + U.nodeIds(aff.mapKeyToPrimaryAndBackups(key2)) + ']');
+            log.info("Put key2 [key2=" + key2 + ", nodes=" + U.nodeIds(aff.mapKeyToPrimaryAndBackupsList(key2)) + ']');
 
             origCache.put(key2, key2);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/IgniteTxReentryColocatedSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/IgniteTxReentryColocatedSelfTest.java
@@ -46,7 +46,7 @@ public class IgniteTxReentryColocatedSelfTest extends IgniteTxReentryAbstractSel
         IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
 
         while (true) {
-            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackups(key);
+            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackupsList(key);
 
             if (nodes.contains(grid(0).localNode()))
                 key++;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridCacheAtomicInvalidPartitionHandlingSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridCacheAtomicInvalidPartitionHandlingSelfTest.java
@@ -17,16 +17,6 @@
 
 package org.apache.ignite.internal.processors.cache.distributed.dht.atomic;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteDataStreamer;
 import org.apache.ignite.cache.CachePartialUpdateException;
@@ -52,11 +42,13 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.cache.CacheRebalanceMode.SYNC;
-import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_ASYNC;
-import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
-import static org.apache.ignite.cache.CacheWriteSynchronizationMode.PRIMARY_SYNC;
+import static org.apache.ignite.cache.CacheWriteSynchronizationMode.*;
 
 /**
  * Test GridDhtInvalidPartitionException handling in ATOMIC cache during restarts.
@@ -193,7 +185,7 @@ public class GridCacheAtomicInvalidPartitionHandlingSelfTest extends GridCommonA
                     while (it.hasNext()) {
                         Integer key = it.next();
 
-                        Collection<ClusterNode> affNodes = aff.mapKeyToPrimaryAndBackups(key);
+                        Collection<ClusterNode> affNodes = aff.mapKeyToPrimaryAndBackupsList(key);
 
                         for (int i = 0; i < gridCnt; i++) {
                             ClusterNode locNode = grid(i).localNode();
@@ -280,7 +272,7 @@ public class GridCacheAtomicInvalidPartitionHandlingSelfTest extends GridCommonA
             fut.get();
 
             for (int k = 0; k < range; k++) {
-                Collection<ClusterNode> affNodes = affinity(cache).mapKeyToPrimaryAndBackups(k);
+                Collection<ClusterNode> affNodes = affinity(cache).mapKeyToPrimaryAndBackupsList(k);
 
                 // Test is valid with at least one backup.
                 assert affNodes.size() >= 2;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearMetricsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearMetricsSelfTest.java
@@ -156,7 +156,7 @@ public class GridCacheNearMetricsSelfTest extends GridCacheAbstractSelfTest {
 
                 info("Puts: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 break;
             }
@@ -212,7 +212,7 @@ public class GridCacheNearMetricsSelfTest extends GridCacheAbstractSelfTest {
 
                 info("Puts: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 break;
             }
@@ -267,7 +267,7 @@ public class GridCacheNearMetricsSelfTest extends GridCacheAbstractSelfTest {
 
                 info("Writes: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 break;
             }
@@ -318,13 +318,13 @@ public class GridCacheNearMetricsSelfTest extends GridCacheAbstractSelfTest {
 
                 info("Writes: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 cache0.get(i); // +1 read.
 
                 info("Writes: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 break;
             }
@@ -375,13 +375,13 @@ public class GridCacheNearMetricsSelfTest extends GridCacheAbstractSelfTest {
 
                 info("Writes: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 cache0.get(i); // +1 read.
 
                 info("Writes: " + cache0.localMetrics().getCachePuts());
                 info("Reads: " + cache0.localMetrics().getCacheGets());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 break;
             }
@@ -430,7 +430,7 @@ public class GridCacheNearMetricsSelfTest extends GridCacheAbstractSelfTest {
                 info("Reads: " + cache0.localMetrics().getCacheGets());
                 info("Hits: " + cache0.localMetrics().getCacheHits());
                 info("Misses: " + cache0.localMetrics().getCacheMisses());
-                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackups(i)));
+                info("Affinity nodes: " + U.nodes2names(affinity(cache0).mapKeyToPrimaryAndBackupsList(i)));
 
                 break;
             }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearMultiGetSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearMultiGetSelfTest.java
@@ -268,7 +268,7 @@ public class GridCacheNearMultiGetSelfTest extends GridCommonAbstractTest {
 
                 if (isTestDebug())
                     info("Key affinity [key=" + key + ", partition=" + part + ", affinity=" +
-                        U.toShortString(aff.mapKeyToPrimaryAndBackups(key)) + ']');
+                        U.toShortString(aff.mapKeyToPrimaryAndBackupsList(key)) + ']');
             }
 
             for (int i = 0; i < GET_CNT; i++) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearMultiNodeSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearMultiNodeSelfTest.java
@@ -226,7 +226,7 @@ public class GridCacheNearMultiNodeSelfTest extends GridCommonAbstractTest {
 
             assert part != null;
 
-            Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackups(part);
+            Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackupsList(part);
 
             ClusterNode primary = F.first(nodes);
 
@@ -297,7 +297,7 @@ public class GridCacheNearMultiNodeSelfTest extends GridCommonAbstractTest {
      * @return Primary node for the key.
      */
     @Nullable private Collection<Ignite> backupGrids(Integer key) {
-        Collection<ClusterNode> nodes = affinity(0).mapKeyToPrimaryAndBackups(key);
+        Collection<ClusterNode> nodes = affinity(0).mapKeyToPrimaryAndBackupsList(key);
 
         Collection<ClusterNode> backups = CU.backups(nodes);
 
@@ -662,7 +662,7 @@ public class GridCacheNearMultiNodeSelfTest extends GridCommonAbstractTest {
 
         String val = Integer.toString(key);
 
-        Collection<ClusterNode> affNodes = grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(key);
+        Collection<ClusterNode> affNodes = grid(0).affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(key);
 
         info("Affinity for key [nodeId=" + U.nodeIds(affNodes) + ", key=" + key + ']');
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearReaderPreloadSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearReaderPreloadSelfTest.java
@@ -163,7 +163,7 @@ public class GridCacheNearReaderPreloadSelfTest extends GridCommonAbstractTest {
         int key = 0;
 
         while (true) {
-            Collection<ClusterNode> affNodes = affinity(cache1).mapKeyToPrimaryAndBackups(key);
+            Collection<ClusterNode> affNodes = affinity(cache1).mapKeyToPrimaryAndBackupsList(key);
 
             assert !F.isEmpty(affNodes);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearTxMultiNodeSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheNearTxMultiNodeSelfTest.java
@@ -17,10 +17,6 @@
 
 package org.apache.ignite.internal.processors.cache.distributed.near;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.affinity.AffinityKey;
@@ -38,6 +34,11 @@ import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionConcurrency;
 import org.apache.ignite.transactions.TransactionIsolation;
 import org.junit.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
@@ -95,7 +96,7 @@ public class GridCacheNearTxMultiNodeSelfTest extends GridCommonAbstractTest {
             Integer mainKey = 0;
 
             ClusterNode priNode = ignite.affinity(DEFAULT_CACHE_NAME).mapKeyToNode(mainKey);
-            ClusterNode backupNode = F.first(F.view(ignite.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(mainKey),
+            ClusterNode backupNode = F.first(F.view(ignite.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(mainKey),
                 F.notIn(F.asList(priNode))));
             ClusterNode otherNode = F.first(ignite.cluster().forPredicate(F.notIn(F.asList(priNode, backupNode))).nodes());
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedAffinityExcludeNeighborsPerformanceTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedAffinityExcludeNeighborsPerformanceTest.java
@@ -90,7 +90,7 @@ public class GridCachePartitionedAffinityExcludeNeighborsPerformanceTest extends
      * @return Nodes.
      */
     private static Collection<? extends ClusterNode> nodes(Affinity<Object> aff, Object key) {
-        return aff.mapKeyToPrimaryAndBackups(key);
+        return aff.mapKeyToPrimaryAndBackupsList(key);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedAffinitySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedAffinitySelfTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.ignite.internal.processors.cache.distributed.near;
 
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteLogger;
@@ -41,12 +38,14 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.cache.CacheRebalanceMode.SYNC;
-import static org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_PUT;
-import static org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_READ;
-import static org.apache.ignite.events.EventType.EVT_CACHE_OBJECT_REMOVED;
+import static org.apache.ignite.events.EventType.*;
 
 /**
  * Partitioned affinity test.
@@ -97,7 +96,7 @@ public class GridCachePartitionedAffinitySelfTest extends GridCommonAbstractTest
      * @return Nodes.
      */
     private static Collection<? extends ClusterNode> nodes(Affinity<Object> aff, Object key) {
-        return aff.mapKeyToPrimaryAndBackups(key);
+        return aff.mapKeyToPrimaryAndBackupsList(key);
     }
 
     /** @throws Exception If failed. */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedMultiNodeCounterSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedMultiNodeCounterSelfTest.java
@@ -238,7 +238,7 @@ public class GridCachePartitionedMultiNodeCounterSelfTest extends GridCommonAbst
 
         Affinity<String> aff = affinity(grid(0).<String, Integer>cache(DEFAULT_CACHE_NAME));
 
-        Collection<ClusterNode> affNodes = aff.mapKeyToPrimaryAndBackups(CNTR_KEY);
+        Collection<ClusterNode> affNodes = aff.mapKeyToPrimaryAndBackupsList(CNTR_KEY);
 
         X.println("*** Affinity nodes [key=" + CNTR_KEY + ", nodes=" + U.nodeIds(affNodes) + ", igniteInstanceNames=" +
             igniteInstanceNames(U.nodeIds(affNodes)) + ']');
@@ -536,7 +536,7 @@ public class GridCachePartitionedMultiNodeCounterSelfTest extends GridCommonAbst
     private void checkNearAndPrimaryMultiNode(int gridCnt) throws Exception {
         Affinity<String> aff = affinity(grid(0).<String, Integer>cache(DEFAULT_CACHE_NAME));
 
-        Collection<ClusterNode> affNodes = aff.mapKeyToPrimaryAndBackups(CNTR_KEY);
+        Collection<ClusterNode> affNodes = aff.mapKeyToPrimaryAndBackupsList(CNTR_KEY);
 
         assertEquals(1 + backups, affNodes.size());
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedMultiNodeFullApiSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePartitionedMultiNodeFullApiSelfTest.java
@@ -17,12 +17,6 @@
 
 package org.apache.ignite.internal.processors.cache.distributed.near;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.CachePeekMode;
 import org.apache.ignite.cache.affinity.Affinity;
@@ -34,11 +28,11 @@ import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.util.typedef.F;
 import org.junit.Test;
 
+import java.util.*;
+
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.cache.CacheMode.REPLICATED;
-import static org.apache.ignite.cache.CachePeekMode.BACKUP;
-import static org.apache.ignite.cache.CachePeekMode.NEAR;
-import static org.apache.ignite.cache.CachePeekMode.PRIMARY;
+import static org.apache.ignite.cache.CachePeekMode.*;
 import static org.apache.ignite.cache.CacheRebalanceMode.SYNC;
 
 /**
@@ -190,7 +184,7 @@ public class GridCachePartitionedMultiNodeFullApiSelfTest extends GridCacheParti
 
             Affinity<Object> aff = ignite(i).affinity(DEFAULT_CACHE_NAME);
 
-            info("Affinity nodes [nodes=" + F.nodeIds(aff.mapKeyToPrimaryAndBackups("key")) +
+            info("Affinity nodes [nodes=" + F.nodeIds(aff.mapKeyToPrimaryAndBackupsList("key")) +
                 ", locNode=" + ignite(i).cluster().localNode().id() + ']');
 
             if (aff.isBackup(grid(i).localNode(), "key")) {
@@ -353,11 +347,11 @@ public class GridCachePartitionedMultiNodeFullApiSelfTest extends GridCacheParti
 
         IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
 
-        info("Cache affinity nodes: " + affinity(cache).mapKeyToPrimaryAndBackups(key));
+        info("Cache affinity nodes: " + affinity(cache).mapKeyToPrimaryAndBackupsList(key));
 
         Affinity<Object> aff = affinity(cache);
 
-        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackups(key);
+        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackupsList(key);
 
         info("Got nodes from affinity: " + nodes);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePutArrayValueSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCachePutArrayValueSelfTest.java
@@ -70,7 +70,7 @@ public class GridCachePutArrayValueSelfTest extends GridCacheAbstractSelfTest {
         final InternalKey key = new InternalKey(0); // Hangs on the first remote put.
 
         // Make key belongs to remote node.
-        while (affinity(jcache).mapKeyToPrimaryAndBackups(key).iterator().next().isLocal())
+        while (affinity(jcache).mapKeyToPrimaryAndBackupsList(key).iterator().next().isLocal())
             key.key++;
 
         // Put bytes array(!), for integer numbers it works correctly.

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheRendezvousAffinityClientSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/GridCacheRendezvousAffinityClientSelfTest.java
@@ -89,7 +89,7 @@ public class GridCacheRendezvousAffinityClientSelfTest extends GridCommonAbstrac
                 int parts = aff.partitions();
 
                 for (int p = 0; p < parts; p++) {
-                    Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackups(p);
+                    Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackupsList(p);
 
                     assertEquals(2, nodes.size());
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/IgniteTxReentryNearSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/near/IgniteTxReentryNearSelfTest.java
@@ -46,7 +46,7 @@ public class IgniteTxReentryNearSelfTest extends IgniteTxReentryAbstractSelfTest
         IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
 
         while (true) {
-            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackups(key);
+            Collection<ClusterNode> nodes = affinity(cache).mapKeyToPrimaryAndBackupsList(key);
 
             if (nodes.contains(grid(0).localNode()))
                 key++;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/rebalancing/CacheNodeSafeAssertion.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/rebalancing/CacheNodeSafeAssertion.java
@@ -68,7 +68,7 @@ public class CacheNodeSafeAssertion implements Assertion {
         for (int x = 0; x < partCnt; ++x) {
             // Results are returned with the primary node first and backups after. We want to ensure that there is at
             // least one backup on a different host.
-            Collection<ClusterNode> results = affinity.mapPartitionToPrimaryAndBackups(x);
+            Collection<ClusterNode> results = affinity.mapPartitionToPrimaryAndBackupsList(x);
 
             Iterator<ClusterNode> nodes = results.iterator();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/rebalancing/GridCacheRebalancingSyncSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/rebalancing/GridCacheRebalancingSyncSelfTest.java
@@ -431,7 +431,7 @@ public class GridCacheRebalancingSyncSelfTest extends GridCommonAbstractTest {
                             "], node=" + g0.name() + " cache=" + c.getName(), res);
 
                         Collection<ClusterNode> affNodes =
-                            g0.affinity(cfg.getName()).mapPartitionToPrimaryAndBackups(loc.id());
+                            g0.affinity(cfg.getName()).mapPartitionToPrimaryAndBackupsList(loc.id());
 
                         assertTrue(affNodes.contains(g0.localNode()));
                     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgnitePdsWholeClusterRestartTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgnitePdsWholeClusterRestartTest.java
@@ -130,7 +130,7 @@ public class IgnitePdsWholeClusterRestartTest extends GridCommonAbstractTest {
 
                     for (int k = 0; k < ENTRIES_COUNT; k++)
                         assertEquals("Failed to read [g=" + g + ", part=" + ig.affinity(DEFAULT_CACHE_NAME).partition(k) +
-                                ", nodes=" + ig.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackups(k) + ']',
+                                ", nodes=" + ig.affinity(DEFAULT_CACHE_NAME).mapKeyToPrimaryAndBackupsList(k) + ']',
                             k, ig.cache(DEFAULT_CACHE_NAME).get(k));
                 }
             }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryFailoverAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryFailoverAbstractSelfTest.java
@@ -530,7 +530,7 @@ public abstract class CacheContinuousQueryFailoverAbstractSelfTest extends GridC
                 .localUpdateCounters(false);
 
             for (Map.Entry<Integer, Long> e : updCntrs.entrySet()) {
-                if (aff.mapPartitionToPrimaryAndBackups(e.getKey()).contains(grid(i).localNode())) {
+                if (aff.mapPartitionToPrimaryAndBackupsList(e.getKey()).contains(grid(i).localNode())) {
                     int partIdx = act.partitionIndex(e.getKey());
 
                     assertEquals(e.getValue(), (Long)act.updateCounterAt(partIdx));
@@ -684,7 +684,7 @@ public abstract class CacheContinuousQueryFailoverAbstractSelfTest extends GridC
 
         List<Integer> keys = testKeys(srvCache, 1);
 
-        Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackups(keys.get(0));
+        Collection<ClusterNode> nodes = aff.mapPartitionToPrimaryAndBackupsList(keys.get(0));
 
         Collection<UUID> ids = F.transform(nodes, new C1<ClusterNode, UUID>() {
             @Override public UUID apply(ClusterNode node) {

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
@@ -1659,7 +1659,7 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
 
         Affinity<Integer> aff = allGrids.get(0).affinity(DEFAULT_CACHE_NAME);
 
-        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackups(key);
+        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackupsList(key);
 
         for (Ignite ignite : allGrids) {
             if (!nodes.contains(ignite.cluster().localNode()))
@@ -1724,7 +1724,7 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
 
         Affinity<Object> aff = ignite.affinity(cacheName);
 
-        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackups(key);
+        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackupsList(key);
 
         assertTrue("Expected more than one node for key [key=" + key + ", nodes=" + nodes + ']', nodes.size() > 1);
 
@@ -1749,7 +1749,7 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
 
         Affinity<Object> aff = ignite.affinity(cacheName);
 
-        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackups(key);
+        Collection<ClusterNode> nodes = aff.mapKeyToPrimaryAndBackupsList(key);
 
         assertTrue("Expected more than one node for key [key=" + key + ", nodes=" + nodes + ']', nodes.size() > 1);
 


### PR DESCRIPTION
Deprecated methods:
Affinity::mapPartitionToPrimaryAndBackups
Affinity::mapKeyToPrimaryAndBackups
New methods are introduced:
Affinity::mapPartitionToPrimaryAndBackupsList
Affinity::mapKeyToPrimaryAndBackupsList