### PR TITLE
IGNITE-12171 Remove the MetricRegistry.remove(String name) method.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/MetricRegistry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/MetricRegistry.java
@@ -26,6 +26,7 @@ import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.internal.processors.metric.impl.AtomicLongMetric;
 import org.apache.ignite.internal.processors.metric.impl.BooleanGauge;
 import org.apache.ignite.internal.processors.metric.impl.BooleanMetricImpl;
 import org.apache.ignite.internal.processors.metric.impl.DoubleGauge;
@@ -37,7 +38,6 @@ import org.apache.ignite.internal.processors.metric.impl.IntMetricImpl;
 import org.apache.ignite.internal.processors.metric.impl.LongAdderMetric;
 import org.apache.ignite.internal.processors.metric.impl.LongAdderWithDelegateMetric;
 import org.apache.ignite.internal.processors.metric.impl.LongGauge;
-import org.apache.ignite.internal.processors.metric.impl.AtomicLongMetric;
 import org.apache.ignite.internal.processors.metric.impl.ObjectGauge;
 import org.apache.ignite.internal.processors.metric.impl.ObjectMetricImpl;
 import org.apache.ignite.spi.metric.BooleanMetric;
@@ -111,15 +111,6 @@ public class MetricRegistry implements Iterable<Metric> {
      */
     public void register(Metric metric) {
         addMetric(metric.name(), metric);
-    }
-
-    /**
-     * Removes metrics with the {@code name}.
-     *
-     * @param name Metric name.
-     */
-    public void remove(String name) {
-        metrics.remove(name);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsSelfTest.java
@@ -286,30 +286,6 @@ public class MetricsSelfTest extends GridCommonAbstractTest {
 
     /** */
     @Test
-    public void testRemove() throws Exception {
-        MetricRegistry mreg = new MetricRegistry("group", null);
-
-        AtomicLongMetric cntr = mreg.longMetric("my.name", null);
-        AtomicLongMetric cntr2 = mreg.longMetric("my.name.x", null);
-
-        assertNotNull(cntr);
-        assertNotNull(cntr2);
-
-        assertNotNull(mreg.findMetric("my.name"));
-        assertNotNull(mreg.findMetric("my.name.x"));
-
-        mreg.remove("my.name");
-
-        assertNull(mreg.findMetric("my.name"));
-        assertNotNull(mreg.findMetric("my.name.x"));
-
-        cntr = mreg.longMetric("my.name", null);
-
-        assertNotNull(mreg.findMetric("my.name"));
-    }
-
-    /** */
-    @Test
     public void testHitRateMetric() throws Exception {
         long rateTimeInterval = 500;
 


### PR DESCRIPTION
Remove the MetricRegistry.remove(String name) method. See IGNITE-12171