### PR TITLE
Ignite 12088

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -3201,7 +3201,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
     /** {@inheritDoc} */
     @Override public <K, V> IgniteCache<K, V> createCache(CacheConfiguration<K, V> cacheCfg) {
         A.notNull(cacheCfg, "cacheCfg");
-        CU.validateNewCacheName(cacheCfg.getName());
+        CU.validateConfigurationCacheNames(Arrays.asList(cacheCfg));
 
         guard();
 
@@ -3287,7 +3287,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         A.notNull(cacheCfg, "cacheCfg");
         String cacheName = cacheCfg.getName();
 
-        CU.validateNewCacheName(cacheName);
+        CU.validateConfigurationCacheNames(Arrays.asList(cacheCfg));
 
         guard();
 
@@ -3357,7 +3357,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
         NearCacheConfiguration<K, V> nearCfg
     ) {
         A.notNull(cacheCfg, "cacheCfg");
-        CU.validateNewCacheName(cacheCfg.getName());
+        CU.validateConfigurationCacheNames(Arrays.asList(cacheCfg));
         A.notNull(nearCfg, "nearCfg");
 
         guard();
@@ -3386,7 +3386,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
     @Override public <K, V> IgniteCache<K, V> getOrCreateCache(CacheConfiguration<K, V> cacheCfg,
         NearCacheConfiguration<K, V> nearCfg) {
         A.notNull(cacheCfg, "cacheCfg");
-        CU.validateNewCacheName(cacheCfg.getName());
+        CU.validateConfigurationCacheNames(Arrays.asList(cacheCfg));
         A.notNull(nearCfg, "nearCfg");
 
         guard();
@@ -3642,7 +3642,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
     /** {@inheritDoc} */
     @Override public <K, V> void addCacheConfiguration(CacheConfiguration<K, V> cacheCfg) {
         A.notNull(cacheCfg, "cacheCfg");
-        CU.validateNewCacheName(cacheCfg.getName());
+        CU.validateConfigurationCacheNames(Arrays.asList(cacheCfg));
 
         guard();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
@@ -140,7 +140,7 @@ public class GridCacheUtils {
     public static final int UNDEFINED_CACHE_ID = 0;
 
     /** */
-    public static final int MAX_CACHE_NAME_LENGTH = 235;
+    public static final int MAX_FILE_NAME_LENGTH = 235;
 
     /*
      *
@@ -1581,7 +1581,17 @@ public class GridCacheUtils {
      */
     public static void validateCacheName(String name) throws IllegalArgumentException {
         A.ensure(name != null && !name.isEmpty(), "Cache name must not be null or empty.");
-        A.ensure(name.length() <= MAX_CACHE_NAME_LENGTH, "Length of cache name can not exceed "+ MAX_CACHE_NAME_LENGTH+".");
+        A.ensure(name.length() <= MAX_FILE_NAME_LENGTH, "Length of cache name can not exceed "+ MAX_FILE_NAME_LENGTH +".");
+    }
+
+    /**
+     *
+     * @param name
+     * @throws IllegalArgumentException In case group name is not valid
+     */
+    public static void validateCacheGroupName(String name) throws IllegalArgumentException {
+        if (name != null)
+            A.ensure(name.length() <= MAX_FILE_NAME_LENGTH, "Length of cache group name can not exceed "+ MAX_FILE_NAME_LENGTH +".");
     }
 
     /**
@@ -1610,8 +1620,10 @@ public class GridCacheUtils {
      */
     public static void validateConfigurationCacheNames(Collection<CacheConfiguration> ccfgs)
         throws IllegalArgumentException {
-        for (CacheConfiguration ccfg : ccfgs)
+        for (CacheConfiguration ccfg : ccfgs) {
             validateNewCacheName(ccfg.getName());
+            validateCacheGroupName(ccfg.getGroupName());
+        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheUtils.java
@@ -139,6 +139,9 @@ public class GridCacheUtils {
     /** */
     public static final int UNDEFINED_CACHE_ID = 0;
 
+    /** */
+    public static final int MAX_CACHE_NAME_LENGTH = 235;
+
     /*
      *
      */
@@ -1578,6 +1581,7 @@ public class GridCacheUtils {
      */
     public static void validateCacheName(String name) throws IllegalArgumentException {
         A.ensure(name != null && !name.isEmpty(), "Cache name must not be null or empty.");
+        A.ensure(name.length() <= MAX_CACHE_NAME_LENGTH, "Length of cache name can not exceed "+ MAX_CACHE_NAME_LENGTH+".");
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/failure/FailureHandlingConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/failure/FailureHandlingConfigurationTest.java
@@ -132,6 +132,25 @@ public class FailureHandlingConfigurationTest extends GridCommonAbstractTest {
      * @throws Exception If failed
      */
     @Test
+    public void testGetorCreateLongCacheGroupNameExceed235() throws Exception{
+        IgniteEx ignite = startGrid(0);
+        ignite.cluster().active(true);
+        final CacheConfiguration cfg = new CacheConfiguration(DEFAULT_CACHE_NAME);
+        String cacheName = GridTestUtils.randomString(30);
+        cfg.setName(cacheName);
+        cfg.setGroupName(GridTestUtils.randomString(236));
+        GridTestUtils.assertThrows(log, new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return ignite.getOrCreateCache(cfg);
+            }
+        }, IllegalArgumentException.class, "Ouch! Argument is invalid: Length of cache group name can not exceed 235.");
+    }
+
+    /**
+     * @throws Exception If failed
+     */
+    @Test
     public void testGetorCreateLongCacheNameLessThan235() throws Exception{
         IgniteEx ignite = startGrid(0);
         ignite.cluster().active(true);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteDynamicCacheStartSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteDynamicCacheStartSelfTest.java
@@ -56,6 +56,7 @@ import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -870,6 +871,43 @@ public class IgniteDynamicCacheStartSelfTest extends GridCommonAbstractTest {
         }
         finally {
             stopGrid(nodeCount());
+        }
+    }
+
+    /** */
+    @Test
+    public void testGetorCreateLongCacheNameExceed235() throws Exception {
+        try {
+            final CacheConfiguration cfg = new CacheConfiguration(DEFAULT_CACHE_NAME);
+            String cacheName = GridTestUtils.randomString(250);
+            cfg.setName(cacheName);
+            cfg.setNodeFilter(NODE_FILTER);
+
+            GridTestUtils.assertThrows(log, new Callable<Object>() {
+                @Override public Object call() throws Exception {
+                    return grid(0).getOrCreateCache(cfg);
+                }
+            }, IllegalArgumentException.class, "Ouch! Argument is invalid: Length of cache name can not exceed 235.");
+        } finally {
+            grid(0).destroyCache(DYNAMIC_CACHE_NAME);
+        }
+    }
+
+    /** */
+    @Test
+    public void testGetorCreateLongCacheNameLessThan236() throws Exception {
+        try {
+            final CacheConfiguration cfg = new CacheConfiguration(DEFAULT_CACHE_NAME);
+            String cacheName = GridTestUtils.randomString(235);
+            cfg.setName(cacheName);
+            cfg.setNodeFilter(NODE_FILTER);
+            IgniteCache<String,String> cache = grid(0).getOrCreateCache(cfg);
+            String randomKey = GridTestUtils.randomString(30);
+            String randomValue = GridTestUtils.randomString(30);
+            cache.put(randomKey, randomValue);
+            Assert.assertEquals(randomValue, cache.get(randomKey));
+        } finally {
+            grid(0).destroyCache(DYNAMIC_CACHE_NAME);
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/testframework/GridTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/GridTestUtils.java
@@ -2092,6 +2092,16 @@ public final class GridTestUtils {
         return b.toString();
     }
 
+    /** */
+    public static String randomString(int len) {
+        StringBuilder builder = new StringBuilder(len);
+        Random random = new Random(System.currentTimeMillis());
+        for (int i = 0; i < len; i++)
+            builder.append(ALPHABETH.charAt(random.nextInt(ALPHABETH.length())));
+
+        return builder.toString();
+    }
+
     /**
      * @param node Node.
      * @param topVer Ready exchange version to wait for before trying to merge exchanges.


### PR DESCRIPTION
Cache or template name should be validated before attempt to start,  max valid name length is 235 characters (20 is reserved for internal prefixes, suffixes or extensions).