### PR TITLE
IGNITE-12032 Improved warn message on abruptly closed client connection

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
@@ -2708,7 +2708,8 @@ public class GridNioServer<T> {
             if (e != null) {
                 // Print stack trace only if has runtime exception in it's cause.
                 if (e.hasCause(IOException.class))
-                    U.warn(log, "Closing NIO session because of unhandled exception [cls=" + e.getClass() +
+                    U.warn(log, "Client disconnected abruptly due to network connection loss or because " +
+                        "the connection was left open on application shutdown. [cls=" + e.getClass() +
                         ", msg=" + e.getMessage() + ']');
                 else
                     U.error(log, "Closing NIO session because of unhandled exception.", e);


### PR DESCRIPTION
Issue:
The exception is thrown on Ignite server side when user application closes thread with client database connection.

Root cause:
Closed network connection from user application side, using thin client (ODBC or JDBC) without notifying server about closing database connection itself. Server doesn't expect that network connection is closed and we got WARN message from Ignite on server side: "Closing NIO session because of unhandled exception" and the IOException from Java itself.

Solution: 
Make WARN message (in class GridNioServer) more user-friendly, giving a clue for user, that connection.close() should be called before closing connection thread.