### PR TITLE
IGNITE-12208 Fix silent ignitevisorcmd.sh fail when JAVA_HOME is empty

### DIFF
--- a/bin/ignitevisorcmd.sh
+++ b/bin/ignitevisorcmd.sh
@@ -114,7 +114,7 @@ trap restoreSttySettings INT
 #
 # Final JVM_OPTS for Java 9+ compatibility
 #
-javaMajorVersion "${JAVA_HOME}/bin/java"
+javaMajorVersion "${JAVA}"
 
 if [ $version -eq 8 ] ; then
     JVM_OPTS="\


### PR DESCRIPTION
IGNITE-12208 Fix silent ignitevisorcmd.sh fail when JAVA_HOME is empty