### PR TITLE
IGNITE-11312: Fix JDBC Driver properties in UI tools like DBeaver

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesImpl.java
@@ -941,7 +941,7 @@ public class ConnectionPropertiesImpl implements ConnectionProperties, Serializa
          * @return JDBC property info object.
          */
         DriverPropertyInfo getDriverPropertyInfo() {
-            DriverPropertyInfo dpi = new DriverPropertyInfo(name, valueObject());
+            DriverPropertyInfo dpi = new DriverPropertyInfo(PROP_PREFIX + name, valueObject());
 
             dpi.choices = choices();
             dpi.required = required;

--- a/modules/core/src/test/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.internal.jdbc.thin;
 
 import java.sql.DriverPropertyInfo;

--- a/modules/core/src/test/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesTest.java
@@ -1,0 +1,50 @@
+package org.apache.ignite.internal.jdbc.thin;
+
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link ConnectionPropertiesImpl} unit tests.
+ */
+public class ConnectionPropertiesTest {
+
+    /**
+     * Test check the {@link ConnectionPropertiesImpl#getDriverPropertyInfo()} return properties with prefix {@link
+     * ConnectionPropertiesImpl#PROP_PREFIX}
+     */
+    @Test
+    public void testNamePrefixDriverPropertyInfo() {
+        ConnectionPropertiesImpl connProps = new ConnectionPropertiesImpl();
+        DriverPropertyInfo[] propsInfo = connProps.getDriverPropertyInfo();
+
+        String propName = propsInfo[0].name;
+
+        assertTrue(propName.startsWith(ConnectionPropertiesImpl.PROP_PREFIX));
+    }
+
+    /**
+     * Test check the {@link ConnectionPropertiesImpl#init(String, Properties)} requires property names
+     * with prefix {@link ConnectionPropertiesImpl#PROP_PREFIX}
+     */
+    @Test
+    public void testPrefixedPropertiesApplicable() throws SQLException {
+        final String TEST_PROP_NAME = ConnectionPropertiesImpl.PROP_PREFIX + "enforceJoinOrder";
+        final Properties props = new Properties();
+
+        props.setProperty(TEST_PROP_NAME, Boolean.TRUE.toString());
+        ConnectionPropertiesImpl connPropsTrue = new ConnectionPropertiesImpl();
+        connPropsTrue.init("", props);
+
+        props.setProperty(TEST_PROP_NAME, Boolean.FALSE.toString());
+        ConnectionPropertiesImpl connPropsFalse = new ConnectionPropertiesImpl();
+        connPropsFalse.init("", props);
+
+        assertTrue(connPropsTrue.isEnforceJoinOrder());
+        assertFalse(connPropsFalse.isEnforceJoinOrder());
+    }
+}


### PR DESCRIPTION
Issue: 
JDBC driver properties in UI tools like DBeaver doesn't work.

Root cause: 
JDBC driver connect method requires prefixed property names, like _ignite.jdbc.enforceJoinOrder_, but  _getPropertyInfo()_ method (which is used by UI tools for getting available properties) returns property names without prefix, like _enforceJoinOrder_.

Solution:
Add prefix _ignite.jdbc_ to property names, returned by _getPropertyInfo()_ method.