### PR TITLE
IGNITE-12302 Test ZookeeperDiscoveryTopologyChangeAndReconnectTest.testDuplicatedNodeId is broken.

### DIFF
--- a/modules/indexing/src/main/java/org/apache/ignite/spi/systemview/SqlViewExporterSpi.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/spi/systemview/SqlViewExporterSpi.java
@@ -52,10 +52,12 @@ public class SqlViewExporterSpi extends IgniteSpiAdapter implements SystemViewEx
     @Override protected void onContextInitialized0(IgniteSpiContext spiCtx) throws IgniteSpiException {
         GridKernalContext ctx = ((IgniteEx)ignite()).context();
 
-        this.mgr = ((IgniteH2Indexing)ctx.query().getIndexing()).schemaManager();
+        if (ctx.query().getIndexing() instanceof IgniteH2Indexing) {
+            mgr = ((IgniteH2Indexing)ctx.query().getIndexing()).schemaManager();
 
-        sysViewReg.forEach(this::register);
-        sysViewReg.addSystemViewCreationListener(this::register);
+            sysViewReg.forEach(this::register);
+            sysViewReg.addSystemViewCreationListener(this::register);
+        }
     }
 
     /**

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryTopologyChangeAndReconnectTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryTopologyChangeAndReconnectTest.java
@@ -75,15 +75,8 @@ public class ZookeeperDiscoveryTopologyChangeAndReconnectTest extends ZookeeperD
 
         cfg.setIncludeEventTypes(EventType.EVTS_ALL);
 
-        if (indexingDisabled) {
+        if (indexingDisabled)
             GridQueryProcessor.idxCls = DummyQueryIndexing.class;
-
-            cfg.setSystemViewExporterSpi(new JmxSystemViewExporterSpi() {
-                @Override protected void register(SystemView<?> sysView) {
-                    // No-op.
-                }
-            });
-        }
 
         return cfg;
     }
@@ -93,6 +86,8 @@ public class ZookeeperDiscoveryTopologyChangeAndReconnectTest extends ZookeeperD
         super.afterTest();
 
         indexingDisabled = false;
+
+        GridQueryProcessor.idxCls = null;
     }
 
     /**

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryTopologyChangeAndReconnectTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryTopologyChangeAndReconnectTest.java
@@ -48,8 +48,6 @@ import org.apache.ignite.lang.IgniteInClosure;
 import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.discovery.zk.ZookeeperDiscoverySpi;
-import org.apache.ignite.spi.systemview.jmx.JmxSystemViewExporterSpi;
-import org.apache.ignite.spi.systemview.view.SystemView;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZKUtil;

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryTopologyChangeAndReconnectTest.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryTopologyChangeAndReconnectTest.java
@@ -89,7 +89,9 @@ public class ZookeeperDiscoveryTopologyChangeAndReconnectTest extends ZookeeperD
     }
 
     /** {@inheritDoc} */
-    @Override protected void afterTest() {
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
         indexingDisabled = false;
     }
 


### PR DESCRIPTION
Fixed test by disabling registering system views.
Optimized test speed by decreasing server join tries counts.
Added correct SPI exception check. 