### PR TITLE
IGNITE-12324 improper message in BinaryObjectException is printed whe…

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryFieldImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryFieldImpl.java
@@ -286,12 +286,25 @@ public class BinaryFieldImpl implements BinaryFieldEx {
             BinaryType expType = ctx.metadata(typeId);
             BinaryType actualType = obj.type();
 
-            throw new BinaryObjectException("Failed to get field because type ID of passed object differs" +
-                " from type ID this " + BinaryField.class.getSimpleName() + " belongs to [expected=[typeId=" + typeId +
-                ", typeName=" + (nonNull(expType) ? expType.typeName() : null) + "], actual=[typeId=" +
-                actualType.typeId() + ", typeName=" + actualType.typeName() + "], fieldId=" + fieldId +
-                ", fieldName=" + fieldName + ", fieldType=" +
-                (nonNull(expType) ? expType.fieldTypeName(fieldName) : null) + ']');
+            String actualTypeName = null;
+
+            Exception actualTypeNameEx = null;
+
+            try {
+                actualTypeName = actualType.typeName();
+            }
+            catch (BinaryObjectException e) {
+                actualTypeNameEx = new BinaryObjectException("Failed to get actual binary type name.", e);
+            }
+
+            throw new BinaryObjectException(
+                "Failed to get field because type ID of passed object differs from type ID this " +
+                    BinaryField.class.getSimpleName() + " belongs to [expected=[typeId=" + typeId + ", typeName=" +
+                    (nonNull(expType) ? expType.typeName() : null) + "], actual=[typeId=" + actualType.typeId() +
+                    ", typeName=" + actualTypeName + "], fieldId=" + fieldId + ", fieldName=" + fieldName +
+                    ", fieldType=" + (nonNull(expType) ? expType.fieldTypeName(fieldName) : null) + ']',
+                actualTypeNameEx
+            );
         }
 
         int schemaId = obj.schemaId();


### PR DESCRIPTION
…n accessing fieldOrder method binary field with binary object of unregistered type