### PR TITLE
IGNITE-12261 Issue with adding nested index dynamically

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -836,6 +836,10 @@ public class QueryUtils {
             fullName.append(prop);
 
             String alias = aliases.get(fullName.toString());
+            
+            if (alias == null) {
+                alias = fullName.toString();
+            }
 
             // The key flag that we've found out is valid for the whole path.
             res = new QueryBinaryProperty(ctx, prop, res, resType, isKeyField, alias, notNull, dlftVal,


### PR DESCRIPTION
This will ensure we are using fullName instead of lastAttribute in nested attribute
Ex: Address.street
With out this fix, field name will be street
with this fix, field name will be Address.street. It will help when we query from other node