### PR TITLE
IGNITE-12261 Issue with adding nested index dynamically

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -2719,17 +2719,19 @@ public class GridQueryProcessor extends GridProcessorAdapter {
 
         for (QueryField col : cols) {
             try {
-                props.add(new QueryBinaryProperty(
-                    ctx,
-                    col.name(),
-                    null,
-                    Class.forName(col.typeName()),
-                    false,
-                    null,
-                    !col.isNullable(),
-                    null,
-                    col.precision(),
-                    col.scale()));
+                QueryBinaryProperty queryBinaryProperty =
+                        QueryUtils.buildBinaryProperty(
+                                ctx,
+                                col.name(),
+                                Class.forName(col.typeName()),
+                                d.aliases(),
+                                false,
+                                !col.isNullable(),
+                                null,
+                                col.precision(),
+                                col.scale());
+
+                props.add(queryBinaryProperty);
             }
             catch (ClassNotFoundException e) {
                 throw new SchemaOperationException("Class not found for new property: " + col.typeName());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -837,6 +837,10 @@ public class QueryUtils {
 
             String alias = aliases.get(fullName.toString());
 
+            if (alias == null) {
+                alias = fullName.toString();
+            }
+
             // The key flag that we've found out is valid for the whole path.
             res = new QueryBinaryProperty(ctx, prop, res, resType, isKeyField, alias, notNull, dlftVal,
                 precision, scale);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/query/QueryUtilsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/query/QueryUtilsTest.java
@@ -1,0 +1,64 @@
+package org.apache.ignite.internal.processors.query;
+
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.processors.query.property.QueryBinaryProperty;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryUtilsTest {
+
+    @Test
+    public void testBuildBinaryProperty()
+    {
+        GridKernalContext ctx = null;
+        String pathStr = "user.address.streetName";
+        Class<?> resType = null;
+        Map<String, String> aliases = new HashMap<>();
+        boolean isKeyField = false;
+        boolean notNull = false;
+        Object dlftVal = "DEFAULT";
+        int precision = 10;
+        int scale = 5;
+
+        QueryBinaryProperty queryBinaryProperty = QueryUtils.buildBinaryProperty(ctx, pathStr, resType, aliases, isKeyField, notNull, dlftVal, precision, scale);
+
+        Assert.assertNotNull(queryBinaryProperty);
+        assertEquals(dlftVal, queryBinaryProperty.defaultValue());
+        assertEquals(precision, queryBinaryProperty.precision());
+        assertEquals(scale, queryBinaryProperty.scale());
+        assertEquals(pathStr, queryBinaryProperty.name());
+        assertEquals(notNull, queryBinaryProperty.notNull());
+        assertEquals(resType, queryBinaryProperty.type());
+    }
+
+    @Test
+    public void testBuildBinaryPropertyWithAlias()
+    {
+        GridKernalContext ctx = null;
+        String pathStr = "user.address.streetName";
+        String alias = "user_address_streetName";
+        Class<?> resType = null;
+        Map<String, String> aliases = new HashMap<>();
+        aliases.put(pathStr, alias);
+        boolean isKeyField = false;
+        boolean notNull = false;
+        Object dlftVal = "DEFAULT";
+        int precision = 10;
+        int scale = 5;
+
+        QueryBinaryProperty queryBinaryProperty = QueryUtils.buildBinaryProperty(ctx, pathStr, resType, aliases, isKeyField, notNull, dlftVal, precision, scale);
+
+        Assert.assertNotNull(queryBinaryProperty);
+        assertEquals(dlftVal, queryBinaryProperty.defaultValue());
+        assertEquals(precision, queryBinaryProperty.precision());
+        assertEquals(scale, queryBinaryProperty.scale());
+        assertEquals(alias, queryBinaryProperty.name());
+        assertEquals(notNull, queryBinaryProperty.notNull());
+        assertEquals(resType, queryBinaryProperty.type());
+    }
+}


### PR DESCRIPTION
This will ensure we are using fullName instead of lastAttribute in nested attribute
Ex: Address.street
With out this fix, field name will be street
with this fix, field name will be Address.street. It will help when we query from other node