### PR TITLE
IGNITE-9033 .NET: specify expiry policy when creating cache using thin client

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientConnectionContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientConnectionContext.java
@@ -59,11 +59,15 @@ public class ClientConnectionContext extends ClientListenerAbstractConnectionCon
     /** Version 1.5.0. Added: Transactions support, IEP-34. */
     public static final ClientListenerProtocolVersion VER_1_5_0 = ClientListenerProtocolVersion.create(1, 5, 0);
 
+    /** Version 1.6.0. Added: Expiration Policy configuration. */
+    public static final ClientListenerProtocolVersion VER_1_6_0 = ClientListenerProtocolVersion.create(1, 6, 0);
+
     /** Default version. */
-    public static final ClientListenerProtocolVersion DEFAULT_VER = VER_1_5_0;
+    public static final ClientListenerProtocolVersion DEFAULT_VER = VER_1_6_0;
 
     /** Supported versions. */
     private static final Collection<ClientListenerProtocolVersion> SUPPORTED_VERS = Arrays.asList(
+        VER_1_6_0,
         VER_1_5_0,
         VER_1_4_0,
         VER_1_3_0,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -31,7 +31,9 @@ import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProtocolVersion;
+import org.apache.ignite.internal.processors.platform.utils.PlatformConfigurationUtils;
 
+import static org.apache.ignite.internal.processors.platform.client.ClientConnectionContext.VER_1_6_0;
 import static org.apache.ignite.internal.processors.platform.utils.PlatformConfigurationUtils.readQueryEntity;
 import static org.apache.ignite.internal.processors.platform.utils.PlatformConfigurationUtils.writeEnumInt;
 import static org.apache.ignite.internal.processors.platform.utils.PlatformConfigurationUtils.writeQueryEntity;
@@ -130,6 +132,10 @@ public class ClientCacheConfigurationSerializer {
     /** */
     private static final short STATISTICS_ENABLED = 406;
 
+    /** */
+    private static final short EXPIRY_POLICY = 407;
+
+
     /**
      * Writes the cache configuration.
      * @param writer Writer.
@@ -196,6 +202,9 @@ public class ClientCacheConfigurationSerializer {
         } else
             writer.writeInt(0);
 
+        if (ver.compareTo(VER_1_6_0) >= 0)
+            PlatformConfigurationUtils.writeExpiryPolicyFactory(writer, cfg.getExpiryPolicyFactory());
+
         // Write length (so that part of the config can be skipped).
         writer.writeInt(pos, writer.out().position() - pos - 4);
     }
@@ -240,6 +249,10 @@ public class ClientCacheConfigurationSerializer {
 
                 case EAGER_TTL:
                     cfg.setEagerTtl(reader.readBoolean());
+                    break;
+
+                case EXPIRY_POLICY:
+                    cfg.setExpiryPolicyFactory(PlatformConfigurationUtils.readExpiryPolicyFactory(reader));
                     break;
 
                 case STATISTICS_ENABLED:

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -135,7 +135,6 @@ public class ClientCacheConfigurationSerializer {
     /** */
     private static final short EXPIRY_POLICY = 407;
 
-
     /**
      * Writes the cache configuration.
      * @param writer Writer.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheRequest.java
@@ -20,10 +20,13 @@ package org.apache.ignite.internal.processors.platform.client.cache;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.internal.processors.cache.DynamicCacheDescriptor;
+import org.apache.ignite.internal.processors.platform.cache.expiry.PlatformExpiryPolicy;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientRequest;
 import org.apache.ignite.internal.processors.platform.client.ClientStatus;
 import org.apache.ignite.internal.processors.platform.client.IgniteClientException;
+
+import javax.cache.expiry.ExpiryPolicy;
 
 /**
  * Cache request.
@@ -35,11 +38,17 @@ class ClientCacheRequest extends ClientRequest {
     /** "Under transaction" flag mask. */
     private static final byte TRANSACTIONAL_FLAG_MASK = 0x02;
 
+    /** "With expiry policy" flag mask. */
+    private static final byte FLAG_WITH_EXPIRY_POLICY = 0x04;
+
     /** Cache ID. */
     private final int cacheId;
 
     /** Flags. */
     private final byte flags;
+
+    /** Expiry policy. */
+    private final ExpiryPolicy expiryPolicy;
 
     /**
      * Constructor.
@@ -52,6 +61,10 @@ class ClientCacheRequest extends ClientRequest {
         cacheId = reader.readInt();
 
         flags = reader.readByte();
+
+        expiryPolicy = withExpiryPolicy()
+                ? new PlatformExpiryPolicy(reader.readLong(), reader.readLong(), reader.readLong())
+                : null;
     }
 
     /**
@@ -83,6 +96,15 @@ class ClientCacheRequest extends ClientRequest {
     }
 
     /**
+     *  Gets a value indicating whether expiry policy is set in this request.
+     *
+     * @return expiry policy flag value.
+     */
+    private boolean withExpiryPolicy() {
+        return (flags & FLAG_WITH_EXPIRY_POLICY) == FLAG_WITH_EXPIRY_POLICY;
+    }
+
+    /**
      * Gets the cache for current cache id, ignoring any flags.
      *
      * @param ctx Kernal context.
@@ -93,7 +115,11 @@ class ClientCacheRequest extends ClientRequest {
 
         String cacheName = cacheDesc.cacheName();
 
-        return ctx.kernalContext().grid().cache(cacheName);
+        IgniteCache<Object, Object> cache = ctx.kernalContext().grid().cache(cacheName);
+        if (withExpiryPolicy())
+            cache = cache.withExpiryPolicy(expiryPolicy);
+        
+        return cache;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
@@ -291,7 +291,7 @@ public class PlatformConfigurationUtils {
      * @param in Reader.
      * @return Expiry policy factory.
      */
-    private static Factory<? extends ExpiryPolicy> readExpiryPolicyFactory(BinaryRawReader in) {
+    public static Factory<? extends ExpiryPolicy> readExpiryPolicyFactory(BinaryRawReader in) {
         if (!in.readBoolean())
             return null;
 
@@ -303,7 +303,7 @@ public class PlatformConfigurationUtils {
      *
      * @param out Writer.
      */
-    private static void writeExpiryPolicyFactory(BinaryRawWriter out, Factory<? extends ExpiryPolicy> factory) {
+    public static void writeExpiryPolicyFactory(BinaryRawWriter out, Factory<? extends ExpiryPolicy> factory) {
         if (!(factory instanceof PlatformExpiryPolicyFactory)) {
             out.writeBoolean(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAsyncWrapper.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Client.Cache;
 
@@ -349,6 +350,12 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         public ICacheClient<TK1, TV1> WithKeepBinary<TK1, TV1>()
         {
             return _cache.WithKeepBinary<TK1, TV1>();
+        }
+
+        /** <inheritDoc /> */
+        public ICacheClient<TK, TV> WithExpiryPolicy(IExpiryPolicy plc)
+        {
+            return _cache.WithExpiryPolicy(plc);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTest.cs
@@ -25,6 +25,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Threading;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Client;
     using NUnit.Framework;
 
@@ -675,7 +676,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// Tests the RemoveAll with a set of keys.
         /// </summary>
         [Test]
-        public void TestRemoveReys()
+        public void TestRemoveKeys()
         {
             var cache = GetClientCache<int?, int?>();
             var keys = Enumerable.Range(1, 10).Cast<int?>().ToArray();
@@ -915,6 +916,169 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                     Assert.AreEqual(cacheName, cache[i]);
                 }
             }
+        }
+
+        /// <summary>
+        /// Test cache with expiry policy for Create action.
+        /// </summary>
+        [Test]
+        public void TestCacheWithExpiryPolicyOnCreate()
+        {
+            const int val = 3;
+            var expiryPolicy = new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null);
+            var cache = GetClientCache<int>();
+            var cacheWithExpiryPolicy = cache.WithExpiryPolicy(expiryPolicy);
+
+            cacheWithExpiryPolicy.Put(val, val);
+
+            // Initially added value is the same.
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            // Wait for an expiration.
+            Thread.Sleep(200);
+
+            // Expiry policies should be applied, no cache item exists.
+            Assert.IsFalse(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsFalse(cache.ContainsKey(val));
+        }
+
+        /// <summary>
+        /// Test cache with expiry policy for Update enabled.
+        /// </summary>
+        [Test]
+        public void TestCacheWithExpiryPolicyOnUpdate()
+        {
+            const int val = 4;
+            var expiryPolicy = new ExpiryPolicy(null, TimeSpan.FromMilliseconds(100), null);
+            var cache = GetClientCache<int>();
+            var cacheWithExpiryPolicy = cache.WithExpiryPolicy(expiryPolicy);
+
+            cacheWithExpiryPolicy.Put(val, val);
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            Thread.Sleep(50);
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            cacheWithExpiryPolicy.Put(val, val + 1);
+
+            Thread.Sleep(70);
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            Thread.Sleep(50);
+            
+            // Expiry policies should be applied, no cache item exists.
+            Assert.IsFalse(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsFalse(cache.ContainsKey(val));
+        }
+
+        /// <summary>
+        /// Test cache with expiry policy for Access enabled.
+        /// </summary>
+        [Test]
+        public void TestCacheWithExpiryPolicyOnAccess()
+        {
+            const int val = 6;
+            var expiryPolicy = new ExpiryPolicy(null, null, TimeSpan.FromMilliseconds(200));
+            var cache = GetClientCache<int>();
+            var cacheWithExpiryPolicy = cache.WithExpiryPolicy(expiryPolicy);
+
+            cacheWithExpiryPolicy.Put(val, val);
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            Thread.Sleep(100);
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            cacheWithExpiryPolicy.Get(val);
+
+            Thread.Sleep(150);
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsTrue(cache.ContainsKey(val));
+
+            Thread.Sleep(150);
+
+            // Expiry policies should be applied, no cache item exists.
+            Assert.IsFalse(cacheWithExpiryPolicy.ContainsKey(val));
+            Assert.IsFalse(cache.ContainsKey(val));
+        }
+
+        /// <summary>
+        /// Test cache with expiration does not affect original cache.
+        /// </summary>
+        [Test]
+        public void TestCacheWithExpirationHasIsolatedScope()
+        {
+            const int val = 7;
+            var expiryPolicy = new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null);
+            var cache = GetClientCache<int>();
+            var cacheWithExpiryPolicy = cache.WithExpiryPolicy(expiryPolicy);
+
+            cache.Put(val, val);
+            cacheWithExpiryPolicy.Put(val + 1, val);
+
+            Thread.Sleep(200);
+            
+            // Both caches contains the original value.
+            Assert.IsTrue(cache.ContainsKey(val));
+            Assert.IsTrue(cacheWithExpiryPolicy.ContainsKey(val));
+
+            // New value is being absent for both caches.
+            Assert.IsFalse(cache.ContainsKey(val + 1));
+            Assert.IsFalse(cacheWithExpiryPolicy.ContainsKey(val + 1));
+        }
+        
+        /// <summary>
+        /// Test cache with expiration does not modify keepBinary flag.
+        /// </summary>
+        [Test]
+        public void TestCacheWithExpirationDoesNotAffectKeepBinarySettings()
+        {
+            const int key = 10;
+            var person = new Person(1);
+
+            var cache = GetClientCache<Person>();
+            cache.Put(key, person);
+
+            var cacheWithKeepBinary = cache.WithKeepBinary<int, IBinaryObject>();
+            AssertExtensions.ReflectionEqual(person, cacheWithKeepBinary.Get(key).Deserialize<Person>());
+
+            var expiryPolicy = new ExpiryPolicy(null, null, TimeSpan.FromMilliseconds(100));
+            
+            var cacheWithExpiryPolicy = cacheWithKeepBinary.WithExpiryPolicy(expiryPolicy);
+            AssertExtensions.ReflectionEqual(person, cacheWithExpiryPolicy.Get(key).Deserialize<Person>());
+
+            Thread.Sleep(200);
+
+            Assert.IsFalse(cacheWithExpiryPolicy.ContainsKey(key));
+            Assert.IsFalse(cache.ContainsKey(key));
+        }
+
+        /// <summary>
+        /// Test cache with keepBinary does not modify expiry policy settings.
+        /// </summary>
+        [Test]
+        public void TestCacheWithKeepBinaryDoesNotAffectExpirationPolicy()
+        {
+            const int key = 11;
+            var person = new Person(1);
+
+            var expiryPolicy = new ExpiryPolicy(null, null, TimeSpan.FromMilliseconds(100));
+            var cacheWithExpiryPolicy = GetClientCache<Person>().WithExpiryPolicy(expiryPolicy);
+
+            cacheWithExpiryPolicy.Put(key, person);
+
+            var cacheWithKeepBinary = cacheWithExpiryPolicy.WithKeepBinary<int, IBinaryObject>();
+            AssertExtensions.ReflectionEqual(person, cacheWithKeepBinary.Get(key).Deserialize<Person>());
+
+            Thread.Sleep(200);
+
+            Assert.IsFalse(cacheWithKeepBinary.ContainsKey(key));
+            Assert.IsFalse(cacheWithExpiryPolicy.ContainsKey(key));
         }
 
         private class Container

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestKeepBinary.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestKeepBinary.cs
@@ -460,7 +460,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// Tests the RemoveAll with a set of keys.
         /// </summary>
         [Test]
-        public void TestRemoveReys()
+        public void TestRemoveKeys()
         {
             var cache = GetBinaryKeyCache();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientCacheConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientCacheConfigurationTest.cs
@@ -53,9 +53,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             TestSerializeDeserializeUnspported(cfg, "EvictionPolicy");
             cfg.EvictionPolicy = null;
 
-            TestSerializeDeserializeUnspported(cfg, "ExpiryPolicyFactory");
-            cfg.ExpiryPolicyFactory = null;
-
             TestSerializeDeserializeUnspported(cfg, "PluginConfigurations");
             cfg.PluginConfigurations = null;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientTestBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientTestBase.cs
@@ -209,7 +209,17 @@ namespace Apache.Ignite.Core.Tests.Client
                 }
             }
 
-            AssertExtensions.ReflectionEqual(cfg, cfg2);
+            HashSet<string> ignoredProps = null;
+
+            if (cfg.ExpiryPolicyFactory != null && cfg2.ExpiryPolicyFactory != null)
+            {
+                ignoredProps = new HashSet<string> {"ExpiryPolicyFactory"};
+
+                AssertExtensions.ReflectionEqual(cfg.ExpiryPolicyFactory.CreateInstance(),
+                    cfg2.ExpiryPolicyFactory.CreateInstance());
+            }
+
+            AssertExtensions.ReflectionEqual(cfg, cfg2, ignoredProperties : ignoredProps);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Expiry/ExpiryPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Expiry/ExpiryPolicy.cs
@@ -20,7 +20,7 @@ namespace Apache.Ignite.Core.Cache.Expiry
     using System;
 
     /// <summary>
-    /// Default expiry policy implementation with all durations deinfed explicitly.
+    /// Default expiry policy implementation with all durations defined explicitly.
     /// </summary>
     public class ExpiryPolicy : IExpiryPolicy
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/ICache.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/ICache.cs
@@ -105,7 +105,7 @@ namespace Apache.Ignite.Core.Cache
         /// invoked on the returned cache.
         /// <para />
         /// Expiry durations for each operation are calculated only once and then used as constants. Please
-        /// consider this when implementing customg expiry policy implementations.
+        /// consider this when implementing custom expiry policy implementations.
         /// </summary>
         /// <param name="plc">Expiry policy to use.</param>
         /// <returns>Cache instance with the specified expiry policy set.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/CacheClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/CacheClientConfiguration.cs
@@ -26,6 +26,8 @@ namespace Apache.Ignite.Core.Client.Cache
     using System.Linq;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Expiry;
+    using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Configuration;
     using Apache.Ignite.Core.Impl;
     using Apache.Ignite.Core.Impl.Binary.IO;
@@ -410,5 +412,13 @@ namespace Apache.Ignite.Core.Client.Cache
         /// </summary>
         [DefaultValue(CacheConfiguration.DefaultQueryParallelism)]
         public int QueryParallelism { get; set; }
+
+        /// <summary>
+        /// Gets or sets the factory for <see cref="IExpiryPolicy"/> to be used for all cache operations,
+        /// unless <see cref="ICacheClient{TK,TV}.WithExpiryPolicy"/> is called.
+        /// <para />
+        /// Default is null, which means no expiration.
+        /// </summary>
+        public IFactory<IExpiryPolicy> ExpiryPolicyFactory { get; set; }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/ICacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/ICacheClient.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Core.Client.Cache
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Cache.Query;
 
     /// <summary>
@@ -423,5 +424,16 @@ namespace Apache.Ignite.Core.Client.Cache
         /// <typeparam name="TV1">Value type in binary mode.</typeparam>
         /// <returns>Cache instance with binary mode enabled.</returns>
         ICacheClient<TK1, TV1> WithKeepBinary<TK1, TV1>();
+
+        /// <summary>
+        /// Returns cache with the specified expired policy set. This policy will be used for each operation
+        /// invoked on the returned cache.
+        /// <para />
+        /// Unlike the <see cref="ICache{TK,TV}.WithExpiryPolicy"/> method, expiry durations are retrieved
+        /// from specified <see cref="IExpiryPolicy"/> on every key-value API operation.
+        /// </summary>
+        /// <param name="plc">Expiry policy to use.</param>
+        /// <returns>Cache instance with the specified expiry policy set.</returns>
+        ICacheClient<TK, TV> WithExpiryPolicy(IExpiryPolicy plc);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -26,12 +26,14 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
     using Apache.Ignite.Core.Impl.Cache;
+    using Apache.Ignite.Core.Impl.Cache.Expiry;
     using Apache.Ignite.Core.Impl.Client;
     using Apache.Ignite.Core.Impl.Client.Cache.Query;
     using Apache.Ignite.Core.Impl.Common;
@@ -42,6 +44,38 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
     /// </summary>
     internal sealed class CacheClient<TK, TV> : ICacheClient<TK, TV>, ICacheInternal
     {
+        /// <summary>
+        /// Additional flag values for cache operations.
+        /// </summary>
+        private enum ClientCacheRequestFlag : byte
+        {
+            /// <summary>
+            /// No flags
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// With keep binary flag.
+            /// Reserved for other thin clients.
+            /// </summary>
+            // ReSharper disable once ShiftExpressionRealShiftCountIsZero
+            // ReSharper disable once UnusedMember.Local
+            WithKeepBinary = 1 << 0,
+
+            /// <summary>
+            /// With transactional binary flag.
+            /// Reserved for IEP-34 Thin client: transactions support.
+            /// </summary>
+            // ReSharper disable once ShiftExpressionRealShiftCountIsZero
+            // ReSharper disable once UnusedMember.Local
+            WithTransactional = 1 << 1,
+
+            /// <summary>
+            /// With expiration policy.
+            /// </summary>
+            WithExpiryPolicy = 1 << 2
+        }
+
         /** Scan query filter platform code: .NET filter. */
         private const byte FilterPlatformDotnet = 2;
 
@@ -60,13 +94,17 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         /** Keep binary flag. */
         private readonly bool _keepBinary;
 
+        /** Expiry policy. */
+        private readonly IExpiryPolicy _expiryPolicy;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CacheClient{TK, TV}" /> class.
         /// </summary>
         /// <param name="ignite">Ignite.</param>
         /// <param name="name">Cache name.</param>
         /// <param name="keepBinary">Binary mode flag.</param>
-        public CacheClient(IgniteClient ignite, string name, bool keepBinary = false)
+        /// /// <param name="expiryPolicy">Expire policy.</param>
+        public CacheClient(IgniteClient ignite, string name, bool keepBinary = false, IExpiryPolicy expiryPolicy = null)
         {
             Debug.Assert(ignite != null);
             Debug.Assert(name != null);
@@ -76,6 +114,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             _marsh = _ignite.Marshaller;
             _id = BinaryUtils.GetCacheId(name);
             _keepBinary = keepBinary;
+            _expiryPolicy = expiryPolicy;
         }
 
         /** <inheritDoc /> */
@@ -538,7 +577,15 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
                 return result;
             }
 
-            return new CacheClient<TK1, TV1>(_ignite, _name, true);
+            return new CacheClient<TK1, TV1>(_ignite, _name, true, _expiryPolicy);
+        }
+
+        /** <inheritDoc /> */
+        public ICacheClient<TK, TV> WithExpiryPolicy(IExpiryPolicy plc)
+        {
+            IgniteArgumentCheck.NotNull(plc, "plc");
+
+            return new CacheClient<TK, TV>(_ignite, _name, _keepBinary, plc);
         }
 
         /** <inheritDoc /> */
@@ -701,11 +748,18 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         private void WriteRequest(Action<BinaryWriter> writeAction, IBinaryStream stream)
         {
             stream.WriteInt(_id);
-            stream.WriteByte(0); // Flags (skipStore, etc).
+
+            var writer = _marsh.StartMarshal(stream);
+            if (_expiryPolicy != null)
+            {
+                stream.WriteByte((byte) ClientCacheRequestFlag.WithExpiryPolicy);
+                ExpiryPolicySerializer.WritePolicy(writer, _expiryPolicy);
+            }
+            else
+                stream.WriteByte((byte) ClientCacheRequestFlag.None); // Flags (skipStore, etc).
 
             if (writeAction != null)
             {
-                var writer = _marsh.StartMarshal(stream);
 
                 writeAction(writer);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -66,7 +66,6 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             /// With transactional binary flag.
             /// Reserved for IEP-34 Thin client: transactions support.
             /// </summary>
-            // ReSharper disable once ShiftExpressionRealShiftCountIsZero
             // ReSharper disable once UnusedMember.Local
             WithTransactional = 1 << 1,
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/ClientCacheConfigurationSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/ClientCacheConfigurationSerializer.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
+    using Apache.Ignite.Core.Impl.Cache.Expiry;
 
     /// <summary>
     /// Writes and reads <see cref="CacheConfiguration"/> for thin client mode.
@@ -75,7 +76,8 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             MaxConcurrentAsyncOperations = 403,
             PartitionLossPolicy = 404,
             EagerTtl = 405, 
-            StatisticsEnabled = 406
+            StatisticsEnabled = 406,
+            ExpiryPolicy = 407
         }
 
         /** Property count. */
@@ -95,6 +97,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             to.CopyOnRead = from.CopyOnRead;
             to.DataRegionName = from.DataRegionName;
             to.EagerTtl = from.EagerTtl;
+            to.ExpiryPolicyFactory = from.ExpiryPolicyFactory;
             to.EnableStatistics = from.EnableStatistics;
             to.GroupName = from.GroupName;
             to.LockTimeout = from.LockTimeout;
@@ -126,7 +129,6 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
                 // Unsupported complex properties.
                 ThrowUnsupportedIfNotDefault(from.AffinityFunction, "AffinityFunction");
                 ThrowUnsupportedIfNotDefault(from.EvictionPolicy, "EvictionPolicy");
-                ThrowUnsupportedIfNotDefault(from.ExpiryPolicyFactory, "ExpiryPolicyFactory");
                 ThrowUnsupportedIfNotDefault(from.PluginConfigurations, "PluginConfigurations");
                 ThrowUnsupportedIfNotDefault(from.CacheStoreFactory, "CacheStoreFactory");
                 ThrowUnsupportedIfNotDefault(from.NearConfiguration, "NearConfiguration");
@@ -165,6 +167,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             to.CopyOnRead = from.CopyOnRead;
             to.DataRegionName = from.DataRegionName;
             to.EagerTtl = from.EagerTtl;
+            to.ExpiryPolicyFactory = from.ExpiryPolicyFactory;
             to.EnableStatistics = from.EnableStatistics;
             to.GroupName = from.GroupName;
             to.LockTimeout = from.LockTimeout;
@@ -232,7 +235,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             
             code(Op.EagerTtl);
             writer.WriteBoolean(cfg.EagerTtl);
-            
+
             code(Op.StatisticsEnabled);
             writer.WriteBoolean(cfg.EnableStatistics);
             
@@ -305,6 +308,9 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             code(Op.QueryEntities);
             writer.WriteCollectionRaw(cfg.QueryEntities, srvVer);
 
+            code(Op.ExpiryPolicy);
+            ExpiryPolicySerializer.WritePolicyFactory(writer, cfg.ExpiryPolicyFactory);
+
             // Write length (so that part of the config can be skipped).
             var len = writer.Stream.Position - pos - 4;
             writer.Stream.WriteInt(pos, len);
@@ -353,6 +359,8 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             cfg.WriteSynchronizationMode = (CacheWriteSynchronizationMode)reader.ReadInt();
             cfg.KeyConfiguration = reader.ReadCollectionRaw(r => new CacheKeyConfiguration(r));
             cfg.QueryEntities = reader.ReadCollectionRaw(r => new QueryEntity(r, srvVer));
+            if (srvVer.CompareTo(ClientSocket.Ver160) >= 0)
+                cfg.ExpiryPolicyFactory = ExpiryPolicySerializer.ReadPolicyFactory(reader);
 
             Debug.Assert(len == reader.Stream.Position - pos);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -53,8 +53,16 @@ namespace Apache.Ignite.Core.Impl.Client
         /** Version 1.4.0. */
         public static readonly ClientProtocolVersion Ver140 = new ClientProtocolVersion(1, 4, 0);
 
+        /** Version 1.5.0. */
+        // This version is reserved for IEP-34 Thin client: transactions support
+        // ReSharper disable once UnusedMember.Global
+        public static readonly ClientProtocolVersion Ver150 = new ClientProtocolVersion(1, 5, 0);
+
+        /** Version 1.6.0. */
+        public static readonly ClientProtocolVersion Ver160 = new ClientProtocolVersion(1, 6, 0);
+
         /** Current version. */
-        public static readonly ClientProtocolVersion CurrentProtocolVersion = Ver140;
+        public static readonly ClientProtocolVersion CurrentProtocolVersion = Ver160;
 
         /** Handshake opcode. */
         private const byte OpHandshake = 1;


### PR DESCRIPTION
Added ability to create dynamic caches for thin clients with expiry policies.

- Added expiry policy property  to thin client cache configuration
- Added withExpiryPolicy method to the client cache interface

(cherry picked from commit b2b12eb31df3d240de8a657eec57cd6cbedb94fe)