### PR TITLE
IGNITE-12377 .NET: Add IBinaryObjectBuilder.SetField(name, val, type)

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryBuilderSelfTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryBuilderSelfTest.cs
@@ -660,7 +660,22 @@ namespace Apache.Ignite.Core.Tests.Binary
                 .Build();
 
             CheckPrimitiveFields1(binObj2);
+            
+            // Generic SetField with custom type and boxed values.
+            var binObj3 = _grid.GetBinary().GetBuilder(typeof(Primitives))
+                .SetField<object>("fByte", (byte) 1, typeof(byte))
+                .SetField<object>("fBool", true, typeof(bool))
+                .SetField<object>("fShort", (short) 2, typeof(short))
+                .SetField<object>("fChar", 'a', typeof(char))
+                .SetField<object>("fInt", 3, typeof(int))
+                .SetField<object>("fLong", 4L, typeof(long))
+                .SetField<object>("fFloat", 5f, typeof(float))
+                .SetField<object>("fDouble", 6d, typeof(double))
+                .SetField<object>("fDecimal", 7.7m, typeof(decimal))
+                .Build();
 
+            CheckPrimitiveFields1(binObj3);
+            
             // Check equality.
             Assert.AreEqual(binObj, binObj2);
             Assert.AreEqual(binObj.GetHashCode(), binObj2.GetHashCode());
@@ -695,9 +710,27 @@ namespace Apache.Ignite.Core.Tests.Binary
 
             CheckPrimitiveFields2(binObj);
 
+            // Overwrite with generic methods and type override.
+            binObj3 = binObj.ToBuilder()
+                .SetField<object>("fByte", (byte) 7)
+                .SetField<object>("fBool", false)
+                .SetField<object>("fShort", (short) 8)
+                .SetField<object>("fChar", 'b')
+                .SetField<object>("fInt", 9)
+                .SetField<object>("fLong", 10L)
+                .SetField<object>("fFloat", 11f)
+                .SetField<object>("fDouble", 12d)
+                .SetField<object>("fDecimal", 13.13m)
+                .Build();
+
+            CheckPrimitiveFields2(binObj);
+
             // Check equality.
             Assert.AreEqual(binObj, binObj2);
+            Assert.AreEqual(binObj, binObj3);
+            Assert.AreEqual(binObj2, binObj3);
             Assert.AreEqual(binObj.GetHashCode(), binObj2.GetHashCode());
+            Assert.AreEqual(binObj.GetHashCode(), binObj3.GetHashCode());
         }
 
         /// <summary>
@@ -813,9 +846,26 @@ namespace Apache.Ignite.Core.Tests.Binary
 
             CheckPrimitiveArrayFields1(binObj2);
 
+            // Generic SetField method with type override.
+            var binObj3 = _grid.GetBinary().GetBuilder(typeof(PrimitiveArrays))
+                .SetField<object>("fByte", new byte[] {1}, typeof(byte[]))
+                .SetField<Array>("fBool", new[] {true}, typeof(bool[]))
+                .SetField<object>("fShort", new short[] {2}, typeof(short[]))
+                .SetField<Array>("fChar", new[] {'a'}, typeof(char[]))
+                .SetField<object>("fInt", new[] {3}, typeof(int[]))
+                .SetField<Array>("fLong", new long[] {4}, typeof(long[]))
+                .SetField<object>("fFloat", new float[] {5}, typeof(float[]))
+                .SetField<Array>("fDouble", new double[] {6}, typeof(double[]))
+                .SetField<object>("fDecimal", new decimal?[] {7.7m}, typeof(decimal?[]))
+                .Build();
+
+            CheckPrimitiveArrayFields1(binObj);
+
             // Check equality.
             Assert.AreEqual(binObj, binObj2);
+            Assert.AreEqual(binObj, binObj3);
             Assert.AreEqual(binObj.GetHashCode(), binObj2.GetHashCode());
+            Assert.AreEqual(binObj.GetHashCode(), binObj3.GetHashCode());
 
             // Overwrite with generic setter.
             binObj = _grid.GetBinary().GetBuilder(binObj)
@@ -847,9 +897,26 @@ namespace Apache.Ignite.Core.Tests.Binary
 
             CheckPrimitiveArrayFields2(binObj);
 
+            // Overwrite with generic setter and type override.
+            binObj3 = _grid.GetBinary().GetBuilder(binObj)
+                .SetField<Array>("fByte", new byte[] { 7 }, typeof(byte[]))
+                .SetField<object>("fBool", new[] { false }, typeof(bool[]))
+                .SetField<Array>("fShort", new short[] { 8 }, typeof(short[]))
+                .SetField<object>("fChar", new[] { 'b' }, typeof(char[]))
+                .SetField<Array>("fInt", new[] { 9 }, typeof(int[]))
+                .SetField<object>("fLong", new long[] { 10 }, typeof(long[]))
+                .SetField<Array>("fFloat", new float[] { 11 }, typeof(float[]))
+                .SetField<object>("fDouble", new double[] { 12 }, typeof(double[]))
+                .SetField<Array>("fDecimal", new decimal?[] { 13.13m }, typeof(decimal?[]))
+                .Build();
+
+            CheckPrimitiveArrayFields2(binObj3);
+
             // Check equality.
             Assert.AreEqual(binObj, binObj2);
+            Assert.AreEqual(binObj, binObj3);
             Assert.AreEqual(binObj.GetHashCode(), binObj2.GetHashCode());
+            Assert.AreEqual(binObj.GetHashCode(), binObj3.GetHashCode());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Binary/IBinaryObjectBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Binary/IBinaryObjectBuilder.cs
@@ -46,11 +46,25 @@ namespace Apache.Ignite.Core.Binary
         /// <summary>
         /// Set object field value. Value can be of any type including other
         /// <see cref="IBinaryObject"/> and other builders.
+        /// <para />
+        /// Value type for metadata is determined as <c>typeof(T)</c>;
+        /// use <see cref="SetField{T}(string,T,Type)"/> overload to override.  
         /// </summary>
         /// <param name="fieldName">Field name.</param>
         /// <param name="val">Field value.</param>
         /// <returns>Current builder instance.</returns>
         IBinaryObjectBuilder SetField<T>(string fieldName, T val);
+
+        /// <summary>
+        /// Set object field value. Value can be of any type including other
+        /// <see cref="IBinaryObject"/> and other builders.
+        /// </summary>
+        /// <param name="fieldName">Field name.</param>
+        /// <param name="val">Field value.</param>
+        /// <param name="valType">Field value type for metadata
+        /// (see also <see cref="IBinaryType.GetFieldTypeName"/>).</param>
+        /// <returns>Current builder instance.</returns>
+        IBinaryObjectBuilder SetField<T>(string fieldName, T val, Type valType);
 
         /// <summary>
         /// Remove object field.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectBuilder.cs
@@ -26,6 +26,7 @@ namespace Apache.Ignite.Core.Impl.Binary
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Impl.Binary.IO;
     using Apache.Ignite.Core.Impl.Binary.Metadata;
+    using Apache.Ignite.Core.Impl.Common;
 
     /// <summary>
     /// Binary builder implementation.
@@ -123,8 +124,18 @@ namespace Apache.Ignite.Core.Impl.Binary
         /** <inheritDoc /> */
         public IBinaryObjectBuilder SetField<T>(string fieldName, T val)
         {
-            return SetField0(fieldName,
-                new BinaryBuilderField(typeof (T), val, BinaryTypeId.GetTypeId(typeof (T))));
+            // typeof(T) is used instead of val.GetType():
+            // it works for nulls, and generic parameter is supposed to clearly show the intent of the user.
+            // When boxed values are being passed, the overload below should be used.
+            return SetField(fieldName, val, typeof(T));
+        }
+
+        /** <inheritDoc /> */
+        public IBinaryObjectBuilder SetField<T>(string fieldName, T val, Type valType)
+        {
+            IgniteArgumentCheck.NotNull(valType, "valType");
+            
+            return SetField0(fieldName, new BinaryBuilderField(valType, val, BinaryTypeId.GetTypeId(valType)));
         }
 
         /** <inheritDoc /> */


### PR DESCRIPTION
Provide a way to set custom field type for metadata. Can be useful when passing values as `object` and calling `GetType()` on them (common use case is loading data in a generic way from another system):

```
foreach(IList<object> row in cursor)
  foreach(KeyValuePair<string, object> field in row)
    builder.SetField(field.Key, field.Value, field.Value.GetType())
```