### PR TITLE
Only check for transaction if we're creating a cache

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -3438,11 +3438,6 @@ public class GridCacheProcessor extends GridProcessorAdapter {
     ) {
         assert cacheName != null;
 
-        if (checkThreadTx) {
-            checkEmptyTransactionsEx(() -> String.format(CACHE_NAME_AND_OPERATION_FORMAT, cacheName,
-                "dynamicStartCache"));
-        }
-
         GridPlainClosure<Collection<byte[]>, IgniteInternalFuture<Boolean>> startCacheClsr = (grpKeys) -> {
             assert ccfg == null || !ccfg.isEncryptionEnabled() || !grpKeys.isEmpty();
 
@@ -3460,6 +3455,11 @@ public class GridCacheProcessor extends GridProcessorAdapter {
                 ccfg != null && ccfg.isEncryptionEnabled() ? grpKeys.iterator().next() : null);
 
             if (req != null) {
+                if (checkThreadTx) {
+                    checkEmptyTransactionsEx(() -> String.format(CACHE_NAME_AND_OPERATION_FORMAT, cacheName,
+                            "dynamicStartCache"));
+                }
+
                 if (req.clientStartOnly())
                     return startClientCacheChange(F.asMap(req.cacheName(), req), null);
 


### PR DESCRIPTION
This is kind of related to https://issues.apache.org/jira/browse/IGNITE-6380 (Exception should be thrown on cache creation attempt inside transaction).

Ignite now _does_ raise an exception if you call `getOrCreateCache` inside a transaction, but it _always_ checks, even if the cache already exists.

This moves the check later in the process.