### PR TITLE
IGNITE-12405 .NET: Remove WithReadRepair, deprecate WithAllowAtomicOpsInTx

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheTestAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheTestAsyncWrapper.cs
@@ -78,14 +78,9 @@ namespace Apache.Ignite.Core.Tests.Cache
         }
 
         /** <inheritDoc /> */
-        public bool IsReadRepair
+        public bool IsAllowAtomicOpsInTx
         {
-            get { return _cache.IsReadRepair; }
-        }
-
-        /** <inheritDoc /> */
-        public bool IsAllowAtomicOpsInTx {
-            get { return _cache.IsAllowAtomicOpsInTx; }
+            get { return false; }
         }
 
         /** <inheritDoc /> */
@@ -110,12 +105,6 @@ namespace Apache.Ignite.Core.Tests.Cache
         public ICache<TK, TV> WithAllowAtomicOpsInTx()
         {
             return _cache.WithAllowAtomicOpsInTx().WrapAsync();
-        }
-
-        /** <inheritDoc /> */
-        public ICache<TK, TV> WithReadRepair()
-        {
-            return _cache.WithReadRepair().WrapAsync();
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheTestAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheTestAsyncWrapper.cs
@@ -104,7 +104,7 @@ namespace Apache.Ignite.Core.Tests.Cache
         /** <inheritDoc /> */
         public ICache<TK, TV> WithAllowAtomicOpsInTx()
         {
-            return _cache.WithAllowAtomicOpsInTx().WrapAsync();
+            return this;
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/ICache.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/ICache.cs
@@ -85,13 +85,9 @@ namespace Apache.Ignite.Core.Cache
         bool IsKeepBinary { get; }
 
         /// <summary>
-        /// Gets a value indicating whether to consistency should be checked and fixed if necessary.
-        /// </summary>
-        bool IsReadRepair { get; }
-
-        /// <summary>
         /// Gets a value indicating whether to allow use atomic operations in transactions.
         /// </summary>
+        [Obsolete("Not supported, will be removed in future releases.")]
         bool IsAllowAtomicOpsInTx { get; }
 
         /// <summary>
@@ -126,15 +122,8 @@ namespace Apache.Ignite.Core.Cache
         /// Only atomic caches need this. Transactional caches already available for transactions.
         /// </summary>
         /// <returns>Cache allowed to use in transactions.</returns>
+        [Obsolete("Not supported, will be removed in future releases.")]
         ICache<TK, TV> WithAllowAtomicOpsInTx();
-
-        /// <summary>
-        /// Gets cache with Consistency mode enabled.
-        /// Each explicit get operation will check data is consistent over the topology, each backup value
-        /// will be compared with primary and fixed in case consistency violation found.
-        /// </summary>
-        /// <returns>Cache instance with consistency mode enabled.</returns>
-        ICache<TK, TV> WithReadRepair();
 
         /// <summary>
         /// Executes <see cref="LocalLoadCache"/> on all cache nodes.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
@@ -254,7 +254,8 @@ namespace Apache.Ignite.Core.Impl.Cache
         }
 
         /** <inheritDoc /> */
-        public bool IsAllowAtomicOpsInTx {
+        public bool IsAllowAtomicOpsInTx
+        {
             get { return _flagAllowAtomicOpsInTx; }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
@@ -74,8 +74,6 @@ namespace Apache.Ignite.Core.Impl.Cache
         /// <param name="flagKeepBinary">Keep binary flag.</param>
         /// <param name="flagNoRetries">No-retries mode flag.</param>
         /// <param name="flagPartitionRecover">Partition recover mode flag.</param>
-        /// <param name="flagReadRepair">Read Repair mode flag.</param>
-        /// <param name="flagAllowAtomicOpsInTx">Allow atomic operations in transactions flag.</param>
         public CacheImpl(IPlatformTargetInternal target,
             bool flagSkipStore, bool flagKeepBinary, bool flagNoRetries, bool flagPartitionRecover
             ) : base(target)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
@@ -226,7 +226,7 @@ namespace Apache.Ignite.Core.Impl.Cache
             if (_flagReadRepair)
                 return this;
 
-            return new CacheImpl<TK, TV>(DoOutOpObject((int)CacheOp.WithReadRepair),
+            return new CacheImpl<TK, TV>(DoOutOpObject((int) CacheOp.WithReadRepair),
                 true, _flagKeepBinary, _flagSkipStore, _flagPartitionRecover, true, _flagAllowAtomicOpsInTx);
         }
 
@@ -248,7 +248,8 @@ namespace Apache.Ignite.Core.Impl.Cache
         }
 
         /** <inheritDoc /> */
-        public bool IsReadRepair {
+        public bool IsReadRepair
+        {
             get { return _flagReadRepair; }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheImpl.cs
@@ -54,17 +54,11 @@ namespace Apache.Ignite.Core.Impl.Cache
         /** Flag: keep binary. */
         private readonly bool _flagKeepBinary;
 
-        /** Flag: allow atomic operations in transactions. */
-        private readonly bool _flagAllowAtomicOpsInTx;
-
         /** Flag: no-retries.*/
         private readonly bool _flagNoRetries;
 
         /** Flag: partition recover.*/
         private readonly bool _flagPartitionRecover;
-
-        /** Flag: consistency.*/
-        private readonly bool _flagReadRepair;
 
         /** Transaction manager. */
         private readonly CacheTransactionManager _txManager;
@@ -83,16 +77,14 @@ namespace Apache.Ignite.Core.Impl.Cache
         /// <param name="flagReadRepair">Read Repair mode flag.</param>
         /// <param name="flagAllowAtomicOpsInTx">Allow atomic operations in transactions flag.</param>
         public CacheImpl(IPlatformTargetInternal target,
-            bool flagSkipStore, bool flagKeepBinary, bool flagNoRetries, bool flagPartitionRecover,
-            bool flagReadRepair, bool flagAllowAtomicOpsInTx) : base(target)
+            bool flagSkipStore, bool flagKeepBinary, bool flagNoRetries, bool flagPartitionRecover
+            ) : base(target)
         {
             _ignite = target.Marshaller.Ignite;
             _flagSkipStore = flagSkipStore;
             _flagKeepBinary = flagKeepBinary;
             _flagNoRetries = flagNoRetries;
             _flagPartitionRecover = flagPartitionRecover;
-            _flagReadRepair = flagReadRepair;
-            _flagAllowAtomicOpsInTx = flagAllowAtomicOpsInTx;
 
             _txManager = GetConfiguration().AtomicityMode == CacheAtomicityMode.Transactional
                 ? new CacheTransactionManager(_ignite.GetIgnite().GetTransactions())
@@ -183,7 +175,7 @@ namespace Apache.Ignite.Core.Impl.Cache
                 return this;
 
             return new CacheImpl<TK, TV>(DoOutOpObject((int) CacheOp.WithSkipStore),
-                true, _flagKeepBinary, true, _flagPartitionRecover, _flagReadRepair, _flagAllowAtomicOpsInTx);
+                true, _flagKeepBinary, true, _flagPartitionRecover);
         }
 
         /// <summary>
@@ -207,27 +199,13 @@ namespace Apache.Ignite.Core.Impl.Cache
             }
 
             return new CacheImpl<TK1, TV1>(DoOutOpObject((int) CacheOp.WithKeepBinary),
-                _flagSkipStore, true, _flagNoRetries, _flagPartitionRecover, _flagReadRepair, _flagAllowAtomicOpsInTx);
+                _flagSkipStore, true, _flagNoRetries, _flagPartitionRecover);
         }
 
         /** <inheritDoc /> */
         public ICache<TK, TV> WithAllowAtomicOpsInTx()
         {
-            if (_flagAllowAtomicOpsInTx)
-                return this;
-
-            return new CacheImpl<TK, TV>(DoOutOpObject((int)CacheOp.WithSkipStore),
-                true, _flagKeepBinary, _flagSkipStore, _flagPartitionRecover, _flagReadRepair, true);
-        }
-
-        /** <inheritDoc /> */
-        public ICache<TK, TV> WithReadRepair()
-        {
-            if (_flagReadRepair)
-                return this;
-
-            return new CacheImpl<TK, TV>(DoOutOpObject((int) CacheOp.WithReadRepair),
-                true, _flagKeepBinary, _flagSkipStore, _flagPartitionRecover, true, _flagAllowAtomicOpsInTx);
+            return this;
         }
 
         /** <inheritDoc /> */
@@ -237,8 +215,7 @@ namespace Apache.Ignite.Core.Impl.Cache
 
             var cache0 = DoOutOpObject((int)CacheOp.WithExpiryPolicy, w => ExpiryPolicySerializer.WritePolicy(w, plc));
 
-            return new CacheImpl<TK, TV>(cache0, _flagSkipStore, _flagKeepBinary, 
-                _flagNoRetries, _flagPartitionRecover, _flagReadRepair, _flagAllowAtomicOpsInTx);
+            return new CacheImpl<TK, TV>(cache0, _flagSkipStore, _flagKeepBinary, _flagNoRetries, _flagPartitionRecover);
         }
 
         /** <inheritDoc /> */
@@ -248,15 +225,9 @@ namespace Apache.Ignite.Core.Impl.Cache
         }
 
         /** <inheritDoc /> */
-        public bool IsReadRepair
-        {
-            get { return _flagReadRepair; }
-        }
-
-        /** <inheritDoc /> */
         public bool IsAllowAtomicOpsInTx
         {
-            get { return _flagAllowAtomicOpsInTx; }
+            get { return false; }
         }
 
         /** <inheritDoc /> */
@@ -1217,7 +1188,7 @@ namespace Apache.Ignite.Core.Impl.Cache
                 return this;
 
             return new CacheImpl<TK, TV>(DoOutOpObject((int) CacheOp.WithNoRetries),
-                _flagSkipStore, _flagKeepBinary, true, _flagPartitionRecover, _flagReadRepair, _flagAllowAtomicOpsInTx);
+                _flagSkipStore, _flagKeepBinary, true, _flagPartitionRecover);
         }
 
         /** <inheritDoc /> */
@@ -1227,7 +1198,7 @@ namespace Apache.Ignite.Core.Impl.Cache
                 return this;
 
             return new CacheImpl<TK, TV>(DoOutOpObject((int) CacheOp.WithPartitionRecover),
-                _flagSkipStore, _flagKeepBinary, _flagNoRetries, true, _flagReadRepair, _flagAllowAtomicOpsInTx);
+                _flagSkipStore, _flagKeepBinary, _flagNoRetries, true);
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheOp.cs
@@ -112,7 +112,6 @@ namespace Apache.Ignite.Core.Impl.Cache
         LocalPreloadPartition = 89,
         SizeLong = 90,
         SizeLongAsync = 91,
-        SizeLongLoc = 92,
-        WithReadRepair = 93
+        SizeLongLoc = 92
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -528,7 +528,7 @@ namespace Apache.Ignite.Core.Impl
         /// </returns>
         public static ICache<TK, TV> GetCache<TK, TV>(IPlatformTargetInternal nativeCache, bool keepBinary = false)
         {
-            return new CacheImpl<TK, TV>(nativeCache, false, keepBinary, false, false, false, false);
+            return new CacheImpl<TK, TV>(nativeCache, false, keepBinary, false, false);
         }
 
         /** <inheritdoc /> */


### PR DESCRIPTION
* `WithReadRepair` was added to public API, but not implemented internally (`PlatformCache`) and not covered with tests. The functionality is somewhat niche and confusing, so let's remove it for now (not included into any release so far).

* `WithAllowAtomicOpsInTx` has a similar problem: implementation in `PlatformCache` is missing, there are no tests, the purpose is not clear. However, this was added much earlier and is present in 2.7.x releases, so we can't remove the method. Therefore marking it `[Obsolete]`.