### PR TITLE
IGNITE-12387 .NET Thin Client: Handle unsupported features gracefully

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.AspNet.Tests/IgniteSessionStateStoreProviderTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.AspNet.Tests/IgniteSessionStateStoreProviderTest.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.AspNet.Tests
     using System;
     using System.Collections.Specialized;
     using System.Configuration;
+    using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
     using System.Threading;
@@ -417,8 +418,12 @@ namespace Apache.Ignite.AspNet.Tests
             var statics = data.StaticObjects;
 
             // Modification method is internal.
-            statics.GetType().GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic)
-                .Invoke(statics, new object[] {"int", typeof(int), false});
+            var method = statics.GetType()
+                .GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic);
+            
+            Debug.Assert(method != null);
+            
+            method.Invoke(statics, new object[] {"int", typeof(int), false});
 
             CheckStoreData(data);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -127,12 +127,24 @@
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\Cache\TestKeyWithAffinity.cs">
       <Link>ThinClient\Cache\TestKeyWithAffinity.cs</Link>
     </Compile>
+    <Compile Include="..\Apache.Ignite.Core.Tests\Client\ClientProtocolCompatibilityTest.cs">
+      <Link>ThinClient\ClientProtocolCompatibilityTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\ClientConnectionTest.cs" Link="ThinClient\ClientConnectionTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Client\ClientOpExtensionsTest.cs">
+      <Link>ThinClient\ClientOpExtensionsTest.cs</Link>
+    </Compile>
+    <Compile Include="..\Apache.Ignite.Core.Tests\Client\ClientProtocolVersionTest.cs">
+      <Link>ThinClient\ClientProtocolVersionTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\ClientTestBase.cs" Link="ThinClient\ClientTestBase.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\Cluster\ClientClusterTests.cs" Link="ThinClient\Cluster\ClientClusterTests.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\EndpointTest.cs" Link="ThinClient\EndpointTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\IgniteClientConfigurationTest.cs" Link="ThinClient\IgniteClientConfigurationTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Client\RawSecureSocketTest.cs" Link="ThinClient\RawSecureSocketTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Client\RawSocketTest.cs">
+      <Link>ThinClient\RawSocketTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Common\IgniteProductVersionTests.cs" Link="Common\IgniteProductVersionTests.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Compute\ComputeApiTest.cs" Link="Compute\ComputeApiTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Compute\ComputeApiTest.JavaTask.cs" Link="Compute\ComputeApiTest.JavaTask.cs" />
@@ -145,8 +157,17 @@
     </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\EventsTestLocalListeners.cs" Link="Common\EventsTestLocalListeners.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\IgniteConfigurationTest.cs" Link="Common\IgniteConfigurationTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Log\ConsoleLoggerTest.cs">
+      <Link>Log\ConsoleLoggerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\Apache.Ignite.Core.Tests\Log\FixedDateTimeProvider.cs">
+      <Link>Log\FixedDateTimeProvider.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\PathUtils.cs">
       <Link>PathUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\Apache.Ignite.Core.Tests\ProjectFilesTest.cs">
+      <Link>Common\ProjectFilesTest.cs</Link>
     </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\TestBase.cs" Link="Common\TestBase.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\SpringTestBase.cs" Link="Common\SpringTestBase.cs" />
@@ -222,7 +243,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -151,6 +151,11 @@
     <Compile Include="Client\Cache\SqlQueryTestBase.cs" />
     <Compile Include="Client\Cache\TestKey.cs" />
     <Compile Include="Client\Cache\TestKeyWithAffinity.cs" />
+    <Compile Include="Client\ClientProtocolCompatibilityTest.cs" />
+    <Compile Include="Client\ClientOpExtensionsTest.cs" />
+    <Compile Include="Client\ClientProtocolVersionTest.cs" />
+    <Compile Include="Client\ClientReconnectCompatibilityTest.cs" />
+    <Compile Include="Client\ClientServerCompatibilityTest.cs" />
     <Compile Include="Client\ClientTestBase.cs" />
     <Compile Include="Client\Cluster\ClientClusterTests.cs" />
     <Compile Include="Client\EndpointTest.cs" />
@@ -212,7 +217,11 @@
     <Compile Include="EventsTestLocalListeners.cs" />
     <Compile Include="FailureHandlerTest.cs" />
     <Compile Include="Impl\Compute\ComputeImplTest.cs" />
+    <Compile Include="JavaServer.cs" />
+    <Compile Include="Log\ConsoleLoggerTest.cs" />
+    <Compile Include="Log\FixedDateTimeProvider.cs" />
     <Compile Include="PathUtils.cs" />
+    <Compile Include="Process\IgniteProcessCompositeOutputReader.cs" />
     <Compile Include="Process\ListDataReader.cs" />
     <Compile Include="Log\ConcurrentMemoryTarget.cs" />
     <Compile Include="Log\DefaultLoggerTest.cs" />
@@ -495,6 +504,8 @@
     <Content Include="Config\ssl.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="JavaServer\pom.xml" />
+    <Content Include="JavaServer\src\main\java\Runner.java" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Config\Apache.Ignite.exe.config.test">

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/AffinityAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/AffinityAwarenessTest.cs
@@ -483,8 +483,8 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                 @"Client request received \[reqId=\d+, addr=/127.0.0.1:\d+, " +
                 @"req=org.apache.ignite.internal.processors.platform.client.cache.ClientCache(\w+)Request@");
 
-            return logger.Messages
-                .Select(m => messageRegex.Match(m))
+            return logger.Entries
+                .Select(m => messageRegex.Match(m.Message))
                 .Where(m => m.Success)
                 .Select(m => m.Groups[1].Value);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ListLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ListLogger.cs
@@ -21,46 +21,132 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Collections.Generic;
     using System.Linq;
     using Apache.Ignite.Core.Log;
+    using NUnit.Framework;
 
+    /// <summary>
+    /// Stores log entries in a list.
+    /// </summary>
     public class ListLogger : ILogger
     {
         /** */
-        private readonly List<string> _messages = new List<string>();
+        private readonly List<Entry> _entries = new List<Entry>();
 
         /** */
         private readonly object _lock = new object();
 
-        public List<string> Messages
+        /** */
+        private readonly ILogger _wrappedLogger;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ListLogger"/> class.
+        /// </summary>
+        public ListLogger(ILogger wrappedLogger = null)
+        {
+            _wrappedLogger = wrappedLogger;
+        }
+
+        /// <summary>
+        /// Gets the entries.
+        /// </summary>
+        public List<Entry> Entries
         {
             get
             {
                 lock (_lock)
                 {
-                    return _messages.ToList();
+                    return _entries.ToList();
                 }
             }
         }
 
+        /// <summary>
+        /// Clears the entries.
+        /// </summary>
         public void Clear()
         {
             lock (_lock)
             {
-                _messages.Clear();
+                _entries.Clear();
             }
         }
 
+        /** <inheritdoc /> */
         public void Log(LogLevel level, string message, object[] args, IFormatProvider formatProvider, string category,
             string nativeErrorInfo, Exception ex)
         {
+            Assert.NotNull(message);
+            
+            if (_wrappedLogger != null)
+            {
+                _wrappedLogger.Log(level, message, args, formatProvider, category, nativeErrorInfo, ex);
+            }
+            
             lock (_lock)
             {
-                _messages.Add(message);
+                if (args != null)
+                {
+                    message = string.Format(formatProvider, message, args);
+                }
+                
+                _entries.Add(new Entry(message, level, category));
             }
         }
 
+        /** <inheritdoc /> */
         public bool IsEnabled(LogLevel level)
         {
             return level == LogLevel.Debug;
+        }
+
+        /// <summary>
+        /// Log entry.
+        /// </summary>
+        public class Entry
+        {
+            /** */
+            private readonly string _message;
+            
+            /** */
+            private readonly LogLevel _level;
+            
+            /** */
+            private readonly string _category;
+
+            /// <summary>
+            /// Initializes a new instance of <see cref="Entry"/> class.
+            /// </summary>
+            public Entry(string message, LogLevel level, string category)
+            {
+                Assert.NotNull(message);
+                
+                _message = message;
+                _level = level;
+                _category = category;
+            }
+
+            /// <summary>
+            /// Gets the message.
+            /// </summary>
+            public string Message
+            {
+                get { return _message; }
+            }
+            
+            /// <summary>
+            /// Gets the level.
+            /// </summary>
+            public LogLevel Level
+            {
+                get { return _level; }
+            }
+
+            /// <summary>
+            /// Gets the category.
+            /// </summary>
+            public string Category
+            {
+                get { return _category; }
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -22,7 +22,6 @@ namespace Apache.Ignite.Core.Tests.Client
     using System.Linq;
     using System.Net;
     using System.Net.Sockets;
-    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Configuration;
@@ -30,8 +29,8 @@ namespace Apache.Ignite.Core.Tests.Client
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Configuration;
-    using Apache.Ignite.Core.Impl.Client;
     using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Log;
     using NUnit.Framework;
 
     /// <summary>
@@ -191,7 +190,8 @@ namespace Apache.Ignite.Core.Tests.Client
 
             var clientCfg = new IgniteClientConfiguration
             {
-                Endpoints = new[] {"localhost:2000"}
+                Endpoints = new[] {"localhost:2000"},
+                Logger = new ConsoleLogger()
             };
 
             using (Ignition.Start(servCfg))
@@ -246,32 +246,6 @@ namespace Apache.Ignite.Core.Tests.Client
         public void TestDefaultConfigThrows()
         {
             Assert.Throws<IgniteClientException>(() => Ignition.StartClient(new IgniteClientConfiguration()));
-        }
-
-        /// <summary>
-        /// Tests the incorrect protocol version error.
-        /// </summary>
-        [Test]
-        [Category(TestUtils.CategoryIntensive)]
-        public void TestIncorrectProtocolVersionError()
-        {
-            using (Ignition.Start(TestUtils.GetTestConfiguration()))
-            {
-                // ReSharper disable once ObjectCreationAsStatement
-                var ex = Assert.Throws<IgniteClientException>(() =>
-                    new ClientSocket(GetClientConfiguration(),
-                        new DnsEndPoint(
-                            "localhost",
-                            ClientConnectorConfiguration.DefaultPort,
-                            AddressFamily.InterNetwork),
-                        null,
-                        new ClientProtocolVersion(-1, -1, -1)));
-
-                Assert.AreEqual(ClientStatusCode.Fail, ex.StatusCode);
-
-                Assert.IsTrue(Regex.IsMatch(ex.Message, "Client handshake failed: 'Unsupported version.'. " +
-                                "Client version: -1.-1.-1. Server version: [0-9]+.[0-9]+.[0-9]+"));
-            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientOpExtensionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientOpExtensionsTest.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientOpExtensionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientOpExtensionsTest.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using Apache.Ignite.Core.Impl.Client;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for <see cref="ClientOpExtensions"/> class.
+    /// </summary>
+    public class ClientOpExtensionsTest
+    {
+        /// <summary>
+        /// Tests that <see cref="ClientOpExtensions.GetMinVersion"/> returns a version
+        /// for every valid <see cref="ClientOp"/>.
+        /// </summary>
+        [Test]
+        public void TestGetMinVersionReturnsValueForEveryValidOp()
+        {
+            foreach (ClientOp clientOp in Enum.GetValues(typeof(ClientOp)))
+            {
+                var minVersion = clientOp.GetMinVersion();
+                
+                Assert.IsTrue(minVersion >= ClientSocket.Ver100);
+                Assert.IsTrue(minVersion <= ClientSocket.CurrentProtocolVersion);
+            }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ClientOpExtensions.GetMinVersion"/> returns a specific version for known new features.
+        /// </summary>
+        [Test]
+        public void TestGetMinVersionReturnsSpecificVersionForNewFeatures()
+        {
+            Assert.AreEqual(ClientSocket.Ver140, ClientOp.CachePartitions.GetMinVersion());
+
+            Assert.AreEqual(ClientSocket.Ver150, ClientOp.ClusterIsActive.GetMinVersion());
+            Assert.AreEqual(ClientSocket.Ver150, ClientOp.ClusterChangeState.GetMinVersion());
+            Assert.AreEqual(ClientSocket.Ver150, ClientOp.ClusterChangeWalState.GetMinVersion());
+            Assert.AreEqual(ClientSocket.Ver150, ClientOp.ClusterGetWalState.GetMinVersion());
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolCompatibilityTest.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolCompatibilityTest.cs
@@ -1,0 +1,188 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Apache.Ignite.Core.Cache.Query;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Impl.Client;
+    using Apache.Ignite.Core.Log;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests thin client with old protocol versions.
+    /// </summary>
+    public class ClientProtocolCompatibilityTest : ClientTestBase
+    {
+        /// <summary>
+        /// Tests that basic cache operations are supported on all protocols.
+        /// </summary>
+        [Test]
+        public void TestCacheOperationsAreSupportedOnAllProtocols(
+            [Values(0, 1, 2, 3, 4, 5)] short minor)
+        {
+            var version = new ClientProtocolVersion(1, minor, 0);
+            
+            using (var client = GetClient(version, true))
+            {
+                var cache = client.GetOrCreateCache<int, int>(TestContext.CurrentContext.Test.Name);
+                cache.Put(1, -1);
+                cache.PutAll(Enumerable.Range(2, 10).ToDictionary(x => x, x => x));
+                
+                Assert.AreEqual(-1, cache.Get(1));
+                Assert.AreEqual(11, cache.Query(new ScanQuery<int, int>()).GetAll().Count);
+            }
+        }
+
+        /// <summary>
+        /// Tests that cluster operations throw proper exception on older server versions.
+        /// </summary>
+        [Test]
+        public void TestClusterOperationsThrowCorrectExceptionOnVersionsOlderThan150(
+            [Values(0, 1, 2, 3, 4)] short minor)
+        {
+            var version = new ClientProtocolVersion(1, minor, 0);
+            
+            using (var client = GetClient(version))
+            {
+                TestClusterOperationsThrowCorrectExceptionOnVersionsOlderThan150(client, version.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Tests that partition awareness disables automatically on older server versions.
+        /// </summary>
+        [Test]
+        public void TestPartitionAwarenessDisablesAutomaticallyOnVersionsOlderThan140(
+            [Values(0, 1, 2, 3)] short minor)
+        {
+            var version = new ClientProtocolVersion(1, minor, 0);
+            
+            using (var client = GetClient(version, true))
+            {
+                Assert.IsFalse(client.GetConfiguration().EnableAffinityAwareness);
+                
+                var cache = client.GetOrCreateCache<int, int>(TestContext.CurrentContext.Test.Name);
+                cache.Put(1, 2);
+                Assert.AreEqual(2, cache.Get(1));
+
+                var log = GetLogs(client).Last();
+                var expectedMessage = string.Format("Partition awareness has been disabled: server protocol version " +
+                                                    "{0} is lower than required 1.4.0", version);
+                
+                Assert.AreEqual(expectedMessage, log.Message);
+                Assert.AreEqual(LogLevel.Warn, log.Level);
+                Assert.AreEqual(typeof(ClientFailoverSocket).Name, log.Category);
+            }
+        }
+
+        /// <summary>
+        /// Tests that client can connect to old server nodes and negotiate common protocol version. 
+        /// </summary>
+        [Test]
+        public void TestClientNewerThanServerReconnectsOnServerVersion()
+        {
+            // Use a non-existent version that is not supported by the server
+            var version = new ClientProtocolVersion(short.MaxValue, short.MaxValue, short.MaxValue);
+            
+            using (var client = GetClient(version))
+            {
+                Assert.AreEqual(ClientSocket.CurrentProtocolVersion, client.ServerVersion);
+
+                var logs = GetLogs(client);
+                
+                var expectedMessage = "Handshake failed on 127.0.0.1:10800, " +
+                                      "requested protocol version = 32767.32767.32767, server protocol version = , " +
+                                      "status = Fail, message = Unsupported version.";
+
+                var message = Regex.Replace(
+                    logs[2].Message, @"server protocol version = \d\.\d\.\d", "server protocol version = ");
+                
+                Assert.AreEqual(expectedMessage, message);
+            }
+        }
+
+        /// <summary>
+        /// Tests that old client with new server can negotiate a protocol version.
+        /// </summary>
+        [Test]
+        public void TestClientOlderThanServerConnectsOnClientVersion([Values(0, 1, 2, 3, 4, 5)] short minor)
+        {
+            var version = new ClientProtocolVersion(1, minor, 0);
+
+            using (var client = GetClient(version))
+            {
+                Assert.AreEqual(version, client.ServerVersion);
+
+                var lastLog = GetLogs(client).Last();
+                var expectedLog = string.Format(
+                    "Handshake completed on 127.0.0.1:10800, protocol version = {0}", version);
+                
+                Assert.AreEqual(expectedLog, lastLog.Message);
+                Assert.AreEqual(LogLevel.Debug, lastLog.Level);
+                Assert.AreEqual(typeof(ClientSocket).Name, lastLog.Category);
+            }
+        }
+        
+        /// <summary>
+        /// Asserts correct exception for cluster operations.
+        /// </summary>
+        public static void TestClusterOperationsThrowCorrectExceptionOnVersionsOlderThan150(IIgniteClient client,
+            string version)
+        {
+            var cluster = client.GetCluster();
+
+            AssertNotSupportedOperation(() => cluster.IsActive(), version, "ClusterIsActive");
+            AssertNotSupportedOperation(() => cluster.SetActive(true), version, "ClusterChangeState");
+            AssertNotSupportedOperation(() => cluster.IsWalEnabled("c"), version, "ClusterGetWalState");
+            AssertNotSupportedOperation(() => cluster.EnableWal("c"), version, "ClusterChangeWalState");
+            AssertNotSupportedOperation(() => cluster.DisableWal("c"), version, "ClusterChangeWalState");
+        }
+        
+        /// <summary>
+        /// Asserts proper exception for non-supported operation.
+        /// </summary>
+        private static void AssertNotSupportedOperation(Action action, string version,
+            string expectedOperationName)
+        {
+            var ex = Assert.Throws<IgniteClientException>(() => action());
+            
+            var expectedMessage = string.Format(
+                "Operation {0} is not supported by protocol version {1}. " +
+                "Minimum protocol version required is 1.5.0.",
+                expectedOperationName, version);
+
+            Assert.AreEqual(expectedMessage, ex.Message);
+        }
+
+        /// <summary>
+        /// Gets the client with specified protocol version.
+        /// </summary>
+        private IgniteClient GetClient(ClientProtocolVersion version, bool EnableAffinityAwareness = false)
+        {
+            var cfg = new IgniteClientConfiguration(GetClientConfiguration())
+            {
+                ProtocolVersion = version,
+                EnableAffinityAwareness = EnableAffinityAwareness
+            };
+
+            return (IgniteClient) Ignition.StartClient(cfg);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolVersionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolVersionTest.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolVersionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientProtocolVersionTest.cs
@@ -1,0 +1,160 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ReSharper disable EqualExpressionComparison
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using Apache.Ignite.Core.Impl.Client;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for <see cref="ClientProtocolVersion"/>.
+    /// </summary>
+    public class ClientProtocolVersionTest
+    {
+        /// <summary>
+        /// Tests constructors.
+        /// </summary>
+        [Test]
+        public void TestConstructor()
+        {
+            var v0 = new ClientProtocolVersion();
+            Assert.AreEqual(0, v0.Major);
+            Assert.AreEqual(0, v0.Minor);
+            Assert.AreEqual(0, v0.Maintenance);
+            
+            var v1 = new ClientProtocolVersion(2, 4, 8);
+            Assert.AreEqual(2, v1.Major);
+            Assert.AreEqual(4, v1.Minor);
+            Assert.AreEqual(8, v1.Maintenance);
+        }
+        
+        /// <summary>
+        /// Tests comparison for equality.
+        /// </summary>
+        [Test]
+        public void TestEqualityComparison()
+        {
+            Assert.AreEqual(
+                new ClientProtocolVersion(), 
+                new ClientProtocolVersion());
+            
+            Assert.IsTrue(new ClientProtocolVersion() == new ClientProtocolVersion());
+            
+            Assert.AreEqual(
+                new ClientProtocolVersion(1, 2, 3), 
+                new ClientProtocolVersion(1, 2, 3));
+            
+            Assert.IsTrue(
+                new ClientProtocolVersion(1, 2, 3) ==  
+                new ClientProtocolVersion(1, 2, 3));
+
+            Assert.IsTrue(
+                new ClientProtocolVersion(1, 2, 3).Equals(
+                    new ClientProtocolVersion(1, 2, 3)));
+
+            Assert.IsTrue(
+                new ClientProtocolVersion(1, 2, 3).Equals(
+                    (object) new ClientProtocolVersion(1, 2, 3)));
+            
+            Assert.IsFalse(
+                new ClientProtocolVersion(1, 2, 3).Equals(null));
+            
+            Assert.IsFalse(
+                new ClientProtocolVersion(1, 2, 3) !=  
+                new ClientProtocolVersion(1, 2, 3));
+            
+            Assert.IsFalse(
+                new ClientProtocolVersion(1, 2, 3) ==  
+                new ClientProtocolVersion(1, 2, 4));
+            
+            Assert.AreNotEqual(
+                new ClientProtocolVersion(1, 2, 3), 
+                new ClientProtocolVersion(1, 2, 4));
+            
+            Assert.AreNotEqual(
+                new ClientProtocolVersion(1, 2, 3), 
+                new ClientProtocolVersion(1, 3, 3));
+            
+            Assert.AreNotEqual(
+                new ClientProtocolVersion(1, 2, 3), 
+                new ClientProtocolVersion(0, 2, 3));
+        }
+
+        /// <summary>
+        /// Test relational comparison.
+        /// </summary>
+        [Test]
+        public void TestRelationalComparison()
+        {
+            Assert.AreEqual(0, new ClientProtocolVersion(1, 2, 3)
+                .CompareTo(new ClientProtocolVersion(1, 2, 3)));
+            
+            Assert.AreEqual(1, new ClientProtocolVersion(1, 2, 3)
+                .CompareTo(new ClientProtocolVersion(1, 1, 1)));
+            
+            Assert.AreEqual(1, new ClientProtocolVersion(1, 2, 3)
+                .CompareTo(new ClientProtocolVersion(0, 100, 200)));
+            
+            Assert.AreEqual(-1, new ClientProtocolVersion(1, 2, 3)
+                .CompareTo(new ClientProtocolVersion(2, 0, 0)));
+            
+            Assert.AreEqual(-1, new ClientProtocolVersion(1, 2, 3)
+                .CompareTo(new ClientProtocolVersion(1, 2, 4)));
+        }
+
+        /// <summary>
+        /// Test relational comparison operators.
+        /// </summary>
+        [Test]
+        public void TestRelationalComparisonOperators()
+        {
+            var v1 = new ClientProtocolVersion(1, 1, 1);
+            var v2 = new ClientProtocolVersion(1, 1, 2);
+            
+            Assert.IsTrue(v1 < v2);
+            Assert.IsTrue(v1 <= v2);
+            Assert.IsTrue(v2 > v1);
+            Assert.IsTrue(v2 >= v1);
+        }
+
+        /// <summary>
+        /// Tests GetHashCode method.
+        /// </summary>
+        [Test]
+        public void TestGetHashCode()
+        {
+            Assert.AreEqual(
+                new ClientProtocolVersion(1, 2, 3).GetHashCode(), 
+                new ClientProtocolVersion(1, 2, 3).GetHashCode());
+
+            Assert.AreNotEqual(
+                new ClientProtocolVersion(1, 2, 3).GetHashCode(), 
+                new ClientProtocolVersion(1, 2, 5).GetHashCode());
+        }
+
+        /// <summary>
+        /// Tests ToString method.
+        /// </summary>
+        [Test]
+        public void TestToString()
+        {
+            Assert.AreEqual(
+                "16.42.128", 
+                new ClientProtocolVersion(16, 42, 128).ToString());
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientReconnectCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientReconnectCompatibilityTest.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientReconnectCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientReconnectCompatibilityTest.cs
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using System.Linq;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Configuration;
+    using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests thin client compatibility with reconnect.
+    /// </summary>
+    [Category(TestUtils.CategoryIntensive)]    
+    public class ClientReconnectCompatibilityTest
+    {
+        /// <summary>
+        /// Tests that client reconnect to an old server node disables affinity awareness.
+        /// </summary>
+        [Test]
+        public void TestReconnectToOldNodeDisablesPartitionAwareness()
+        {
+            IIgniteClient client = null;
+            var clientConfiguration = new IgniteClientConfiguration(JavaServer.GetClientConfiguration())
+            {
+                EnableAffinityAwareness = true,
+                Logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace})
+            };
+            
+            try
+            {
+                using (StartNewServer())
+                {
+                    client = Ignition.StartClient(clientConfiguration);
+                    var cache = client.GetOrCreateCache<int, int>(TestContext.CurrentContext.Test.Name);
+                    cache.Put(1, 42);
+                    Assert.AreEqual(42, cache.Get(1));
+                    Assert.IsTrue(client.GetConfiguration().EnableAffinityAwareness);
+                }
+
+                Assert.Catch(() => client.GetCacheNames());
+
+                using (StartOldServer())
+                {
+                    var cache = client.GetOrCreateCache<int, int>(TestContext.CurrentContext.Test.Name);
+                    cache.Put(1, 42);
+                    Assert.AreEqual(42, cache.Get(1));
+                    Assert.IsFalse(client.GetConfiguration().EnableAffinityAwareness);
+
+                    var log = ((ListLogger) client.GetConfiguration().Logger).Entries.Last();
+                    Assert.AreEqual("Partition awareness has been disabled: " +
+                                    "server protocol version 1.0.0 is lower than required 1.4.0", log.Message);
+                }
+            }
+            finally
+            {
+                if (client != null)
+                {
+                    client.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Starts new server node (partition awareness is supported).
+        /// </summary>
+        private static IDisposable StartNewServer()
+        {
+            var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                ClientConnectorConfiguration = new ClientConnectorConfiguration
+                {
+                    Port = JavaServer.ClientPort
+                }
+            };
+
+            return Ignition.Start(cfg);
+        }
+
+        /// <summary>
+        /// Starts old server node (partition awareness is not supported).
+        /// </summary>
+        private static IDisposable StartOldServer()
+        {
+            return JavaServer.Start("2.4.0");
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCompatibilityTest.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCompatibilityTest.cs
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests thin client with old server versions.
+    /// Differs from <see cref="ClientProtocolCompatibilityTest"/>:
+    /// here we actually download and run old Ignite versions instead of changing the protocol version in handshake.
+    /// </summary>
+    [TestFixture("2.4.0", "1.0.0")]
+    [TestFixture("2.5.0", "1.1.0")]
+    [TestFixture("2.6.0", "1.1.0")]
+    [TestFixture("2.7.0", "1.2.0")]
+    [TestFixture("2.7.5", "1.2.0")]
+    [TestFixture("2.7.6", "1.2.0")]
+    [Category(TestUtils.CategoryIntensive)]
+    public class ClientServerCompatibilityTest
+    {
+        /** */
+        private readonly string _igniteVersion;
+        
+        /** */
+        private readonly string _clientProtocolVersion;
+
+        /** Server node holder. */
+        private IDisposable _server;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ClientServerCompatibilityTest"/>.
+        /// </summary>
+        public ClientServerCompatibilityTest(string igniteVersion, string clientProtocolVersion)
+        {
+            _igniteVersion = igniteVersion;
+            _clientProtocolVersion = clientProtocolVersion;
+        }
+
+        /// <summary>
+        /// Sets up the test fixture.
+        /// </summary>
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            _server = JavaServer.Start(_igniteVersion);
+        }
+
+        /// <summary>
+        /// Tears down the test fixture.
+        /// </summary>
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            _server.Dispose();
+        }
+
+        /// <summary>
+        /// Tests that basic cache operations work on all versions.
+        /// </summary>
+        [Test]
+        public void TestCacheOperationsAreSupportedOnAllVersions()
+        {
+            using (var client = StartClient())
+            {
+                var cache = client.GetOrCreateCache<int, int>(TestContext.CurrentContext.Test.Name);
+                cache.Put(1, 10);
+                Assert.AreEqual(10, cache.Get(1));
+            }
+        }
+
+        /// <summary>
+        /// Tests that cluster operations throw proper exception on older server versions.
+        /// </summary>
+        [Test]
+        public void TestClusterOperationsThrowCorrectExceptionOnVersionsOlderThan150()
+        {
+            using (var client = StartClient())
+            {
+                ClientProtocolCompatibilityTest.TestClusterOperationsThrowCorrectExceptionOnVersionsOlderThan150(
+                    client, _clientProtocolVersion);
+            }
+        }
+        
+        /// <summary>
+        /// Tests that partition awareness disables automatically on older server versions.
+        /// </summary>
+        [Test]
+        public void TestPartitionAwarenessDisablesAutomaticallyOnVersionsOlderThan140()
+        {
+            using (var client = StartClient())
+            {
+                Assert.IsFalse(client.GetConfiguration().EnableAffinityAwareness);
+                var cache = client.GetOrCreateCache<int, int>(TestContext.CurrentContext.Test.Name);
+                cache.Put(1, 2);
+                Assert.AreEqual(2, cache.Get(1));
+            }
+        }
+
+        /// <summary>
+        /// Starts the client.
+        /// </summary>
+        private static IIgniteClient StartClient()
+        {
+            var cfg = new IgniteClientConfiguration(JavaServer.GetClientConfiguration())
+            {
+                Logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace}),
+                EnableAffinityAwareness = true
+            };
+            
+            return Ignition.StartClient(cfg);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientTestBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientTestBase.cs
@@ -25,6 +25,8 @@ namespace Apache.Ignite.Core.Tests.Client
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Cache;
+    using Apache.Ignite.Core.Impl.Client;
+    using Apache.Ignite.Core.Log;
     using Apache.Ignite.Core.Tests.Client.Cache;
     using NUnit.Framework;
 
@@ -82,6 +84,7 @@ namespace Apache.Ignite.Core.Tests.Client
         public void FixtureTearDown()
         {
             Ignition.StopAll(true);
+            Client.Dispose();
         }
 
         /// <summary>
@@ -142,8 +145,9 @@ namespace Apache.Ignite.Core.Tests.Client
         {
             return new IgniteClientConfiguration
             {
-                Endpoints = new List<string> { IPAddress.Loopback.ToString() },
-                SocketTimeout = TimeSpan.FromSeconds(15)
+                Endpoints = new List<string> {IPAddress.Loopback.ToString()},
+                SocketTimeout = TimeSpan.FromSeconds(15),
+                Logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace})
             };
         }
 
@@ -195,6 +199,17 @@ namespace Apache.Ignite.Core.Tests.Client
             return ToBinary(new Person(id) { DateTime = DateTime.MinValue.ToUniversalTime() });
         }
 
+        /// <summary>
+        /// Gets the logs.
+        /// </summary>
+        protected List<ListLogger.Entry> GetLogs(IIgniteClient client)
+        {
+            var igniteClient = (IgniteClient) client;
+            var logger = igniteClient.GetConfiguration().Logger;
+            var listLogger = (ListLogger) logger;
+            return listLogger.Entries;
+        }
+        
         /// <summary>
         /// Asserts the client configs are equal.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
@@ -26,6 +26,8 @@ namespace Apache.Ignite.Core.Tests.Client
     using System.Xml;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Impl.Client;
+    using Apache.Ignite.Core.Log;
     using NUnit.Framework;
 
     /// <summary>
@@ -57,11 +59,13 @@ namespace Apache.Ignite.Core.Tests.Client
             // Empty (root element name does not matter).
             var cfg = IgniteClientConfiguration.FromXml("<foo />");
             Assert.AreEqual(new IgniteClientConfiguration().ToXml(), cfg.ToXml());
+            Assert.IsInstanceOf<ConsoleLogger>(cfg.Logger);
 
             // Properties.
-            cfg = IgniteClientConfiguration.FromXml("<a host='h' port='123' />");
+            cfg = IgniteClientConfiguration.FromXml("<a host='h' port='123'><logger type='null' /></a>");
             Assert.AreEqual("h", cfg.Host);
             Assert.AreEqual(123, cfg.Port);
+            Assert.IsNull(cfg.Logger);
 
             // Full config.
             var fullCfg = new IgniteClientConfiguration
@@ -92,7 +96,11 @@ namespace Apache.Ignite.Core.Tests.Client
                     "bar:123",
                     "baz:100..103"
                 },
-                EnableAffinityAwareness = true
+                EnableAffinityAwareness = true,
+                Logger = new ConsoleLogger
+                {
+                    MinLevel = LogLevel.Debug
+                }
             };
 
             using (var xmlReader = XmlReader.Create(Path.Combine("Config", "Client", "IgniteClientConfiguration.xml")))
@@ -102,7 +110,21 @@ namespace Apache.Ignite.Core.Tests.Client
                 cfg = IgniteClientConfiguration.FromXml(xmlReader);
 
                 Assert.AreEqual(cfg.ToXml(), fullCfg.ToXml());
+                Assert.AreEqual(cfg.ToXml(), IgniteClientConfiguration.FromXml(cfg.ToXml()).ToXml());
             }
+        }
+
+        /// <summary>
+        /// Tests ToXml and back.
+        /// </summary>
+        [Test]
+        public void TestFromXmlRoundtrip()
+        {
+            var cfg = new IgniteClientConfiguration();
+            Assert.AreEqual(cfg.ToXml(), IgniteClientConfiguration.FromXml(cfg.ToXml()).ToXml());
+
+            cfg.Logger = null;
+            Assert.AreEqual(cfg.ToXml(), IgniteClientConfiguration.FromXml(cfg.ToXml()).ToXml());
         }
 
         /// <summary>
@@ -112,28 +134,35 @@ namespace Apache.Ignite.Core.Tests.Client
         public void TestToXml()
         {
             // Empty config.
+            var emptyConfig = new IgniteClientConfiguration {Logger = null};
             Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>" + Environment.NewLine +
                             "<igniteClientConfiguration " +
-                            "xmlns=\"http://ignite.apache.org/schema/dotnet/IgniteClientConfigurationSection\" />",
-                new IgniteClientConfiguration().ToXml());
+                            "xmlns=\"http://ignite.apache.org/schema/dotnet/IgniteClientConfigurationSection\">" +
+                            Environment.NewLine + "  <logger type=\"null\" />" + Environment.NewLine + 
+                            "</igniteClientConfiguration>",
+                emptyConfig.ToXml());
 
             // Some properties.
             var cfg = new IgniteClientConfiguration
             {
                 Host = "myHost",
-                Port = 123
+                Port = 123,
+                Logger = null
             };
 
             Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>" + Environment.NewLine +
                             "<igniteClientConfiguration host=\"myHost\" port=\"123\" " +
-                            "xmlns=\"http://ignite.apache.org/schema/dotnet/IgniteClientConfigurationSection\" />",
+                            "xmlns=\"http://ignite.apache.org/schema/dotnet/IgniteClientConfigurationSection\">" +
+                            Environment.NewLine + "  <logger type=\"null\" />" + Environment.NewLine + 
+                            "</igniteClientConfiguration>",
                 cfg.ToXml());
 
             // Nested objects.
             cfg = new IgniteClientConfiguration
             {
                 SocketSendBufferSize = 2,
-                BinaryConfiguration = new BinaryConfiguration {CompactFooter = false}
+                BinaryConfiguration = new BinaryConfiguration {CompactFooter = false},
+                Logger = null
             };
 
             Assert.IsTrue(cfg.ToXml().Contains("<binaryConfiguration compactFooter=\"false\" />"), cfg.ToXml());
@@ -143,12 +172,77 @@ namespace Apache.Ignite.Core.Tests.Client
 
             using (var xmlWriter = XmlWriter.Create(sb))
             {
-                new IgniteClientConfiguration().ToXml(xmlWriter, "fooBar");
+                new IgniteClientConfiguration {Logger = null}.ToXml(xmlWriter, "fooBar");
             }
 
             Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?><fooBar " +
-                            "xmlns=\"http://ignite.apache.org/schema/dotnet/IgniteClientConfigurationSection\" />",
+                            "xmlns=\"http://ignite.apache.org/schema/dotnet/IgniteClientConfigurationSection\">" +
+                            "<logger type=\"null\" /></fooBar>",
                 sb.ToString());
+        }
+
+        /// <summary>
+        /// Tests that logger is used by default.
+        /// </summary>
+        [Test]
+        public void TestDefaultLoggerWritesToConsole()
+        {
+            IgniteClientConfiguration cfg = null;
+            
+            TestConsoleLogging(c => { cfg = c;}, (client, log) =>
+            {
+                Assert.AreSame(cfg.Logger, client.GetConfiguration().Logger);
+                StringAssert.Contains("Partition awareness has been disabled", log);
+            });
+        }
+
+        /// <summary>
+        /// Tests that logger is used by default.
+        /// </summary>
+        [Test]
+        public void TestNullLoggerDisablesLogging()
+        {
+            TestConsoleLogging(cfg => cfg.Logger = null, (client, log) =>
+            {
+                Assert.IsNull(client.GetConfiguration().Logger);
+                Assert.IsTrue(string.IsNullOrEmpty(log));
+            });
+        }
+
+        /// <summary>
+        /// Tests console logging.
+        /// </summary>
+        private static void TestConsoleLogging(Action<IgniteClientConfiguration> configAction,
+            Action<IIgniteClient, string> assertAction)
+        {
+            using (Ignition.Start(TestUtils.GetTestConfiguration()))
+            {
+                var cfg = new IgniteClientConfiguration("127.0.0.1")
+                {
+                    ProtocolVersion = new ClientProtocolVersion(1, 0, 0),
+                    EnableAffinityAwareness = true,
+                };
+
+                configAction(cfg);
+
+                var oldWriter = Console.Out;
+                var writer = new StringWriter();
+
+                try
+                {
+                    Console.SetOut(writer);
+
+                    using (var client = Ignition.StartClient(cfg))
+                    {
+                        assertAction(client, writer.ToString());
+                    }
+                }
+                finally
+                {
+                    Console.SetOut(oldWriter);
+                }
+
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/IgniteClientConfiguration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/IgniteClientConfiguration.xml
@@ -38,4 +38,6 @@
         <string>bar:123</string>
         <string>baz:100..103</string>
     </endpoints>
+
+    <logger type="Apache.Ignite.Core.Log.ConsoleLogger" minLevel="Debug"  />
 </igniteClientConfiguration>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Deployment/PeerAssemblyLoadingVersioningTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Deployment/PeerAssemblyLoadingVersioningTest.cs
@@ -24,7 +24,6 @@ namespace Apache.Ignite.Core.Tests.Deployment
     using Apache.Ignite.Core.Deployment;
     using Apache.Ignite.Core.Discovery.Tcp;
     using Apache.Ignite.Core.Discovery.Tcp.Static;
-    using Apache.Ignite.Core.Tests.Process;
     using NUnit.Framework;
 
     /// <summary>
@@ -97,7 +96,7 @@ namespace Apache.Ignite.Core.Tests.Deployment
             var proc = Process.Start(procStart);
             Assert.IsNotNull(proc);
 
-            IgniteProcess.AttachProcessConsoleReader(proc);
+            proc.AttachProcessConsoleReader();
 
             Assert.IsTrue(proc.WaitForExit(30000));
             Assert.AreEqual(0, proc.ExitCode);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -661,7 +661,8 @@ namespace Apache.Ignite.Core.Tests
 
             foreach (var prop in props.Where(p => p.Name != "SelectorsCount" && p.Name != "ReadStripesNumber" &&
                                                   !p.Name.Contains("ThreadPoolSize") && p.Name != "MaxSize" &&
-                                                  p.Name != "HandshakeTimeout" && p.Name != "ConcurrencyLevel"))
+                                                  p.Name != "HandshakeTimeout" && p.Name != "ConcurrencyLevel" &&
+                                                  p.Name != "Logger"))
             {
                 var attr = prop.GetCustomAttributes(true).OfType<DefaultValueAttribute>().FirstOrDefault();
                 var propValue = prop.GetValue(obj, null);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Impl.Unmanaged;
+    using Apache.Ignite.Core.Tests.Process;
+
+    /// <summary>
+    /// Starts Java server nodes.
+    /// Uses Maven project in JavaServer folder to download and run arbitrary release
+    /// (Maven is the fastest way to download a release (we only need the core jar, bare minimum).
+    /// Server node sets thin client port to 10890.
+    /// </summary>
+    public static class JavaServer
+    {
+        /** Client port. */
+        public const int ClientPort = 10890;
+        
+        /** Maven command to execute the main class. */
+        private const string MavenCommandExec = "compile exec:java -D\"exec.mainClass\"=\"Runner\"";
+
+        /** Java server sources path. */
+        private static readonly string JavaServerSourcePath = Path.Combine(
+            TestUtils.GetDotNetSourceDir().FullName,
+            "Apache.Ignite.Core.Tests",
+            "JavaServer");
+
+        /** Full path to Maven binary. */
+        private static readonly string MavenPath = GetMaven();
+
+        /// <summary>
+        /// Starts a server node with a given version.
+        /// </summary>
+        /// <param name="version">Product version.</param>
+        /// <returns>Disposable object to stop the server.</returns>
+        public static IDisposable Start(string version)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(version, "version");
+
+            ReplaceIgniteVersionInPomFile(version, Path.Combine(JavaServerSourcePath, "pom.xml"));
+            
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = Os.IsWindows ? "cmd.exe" : "/bin/bash",
+                    Arguments = Os.IsWindows 
+                        ? string.Format("/c \"{0} {1}\"", MavenPath, MavenCommandExec)
+                        : string.Format("-c \"{0} {1}\"", MavenPath, MavenCommandExec.Replace("\"", "\\\"")),
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WorkingDirectory = JavaServerSourcePath,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                }
+            };
+
+            process.Start();
+            
+            var listDataReader = new ListDataReader();
+            process.AttachProcessConsoleReader(listDataReader, new IgniteProcessConsoleOutputReader());
+            
+            var processWrapper = new DisposeAction(() => process.KillProcessTree());
+
+            // Wait for node to come up with a thin client connection.
+            if (WaitForStart())
+            {
+                return processWrapper;
+            }
+
+            if (!process.HasExited)
+            {
+                processWrapper.Dispose();
+            }
+            
+            throw new Exception("Failed to start Java node: " + string.Join(",", listDataReader.GetOutput()));
+        }
+
+        /// <summary>
+        /// Updates pom.xml with given Ignite version.
+        /// </summary>
+        private static void ReplaceIgniteVersionInPomFile(string version, string pomFile)
+        {
+            var pomContent = File.ReadAllText(pomFile);
+            pomContent = Regex.Replace(pomContent,
+                @"<version>\d+\.\d+\.\d+</version>",
+                string.Format("<version>{0}</version>", version));
+            File.WriteAllText(pomFile, pomContent);
+        }
+
+        /// <summary>
+        /// Gets client configuration to connect to the Java server.
+        /// </summary>
+        public static IgniteClientConfiguration GetClientConfiguration()
+        {
+            return new IgniteClientConfiguration("127.0.0.1:" + ClientPort);
+        }
+
+        /// <summary>
+        /// Waits for server node to fully start.
+        /// </summary>
+        private static bool WaitForStart()
+        {
+            return TestUtils.WaitForCondition(() =>
+            {
+                try
+                {
+                    // Port 10890 is set in Runner.java
+                    using (var client = Ignition.StartClient(GetClientConfiguration()))
+                    {
+                        // Create cache to ensure valid grid state.
+                        client.GetOrCreateCache<int, int>(typeof(JavaServer).FullName);
+                        return true;
+                    }
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            }, 60000);
+        }
+
+        /// <summary>
+        /// Gets maven path. 
+        /// </summary>
+        private static string GetMaven()
+        {
+            var extensions = Os.IsWindows ? new[] {".cmd", ".bat"} : new[] {string.Empty};
+            
+            return new[] {"MAVEN_HOME", "M2_HOME", "M3_HOME", "MVN_HOME"}
+                .Select(Environment.GetEnvironmentVariable)
+                .Where(x => !string.IsNullOrEmpty(x))
+                .Select(x => Path.Combine(x, "bin", "mvn"))
+                .SelectMany(x => extensions.Select(ext => x + ext))
+                .Where(File.Exists)
+                .FirstOrDefault() ?? "mvn";
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/pom.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>ignite-maven-server</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>2.7.6</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/pom.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/pom.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright 2019 GridGain Systems, Inc. and Contributors.
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
- Licensed under the GridGain Community Edition License (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
 
-     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/src/main/java/Runner.java
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/src/main/java/Runner.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/src/main/java/Runner.java
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/src/main/java/Runner.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.ClientConnectorConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+
+import java.util.Collections;
+
+public class Runner {
+    public static void main(String[] args) {
+        ClientConnectorConfiguration connectorConfiguration = new ClientConnectorConfiguration().setPort(10890);
+
+        TcpDiscoveryVmIpFinder ipFinder = new TcpDiscoveryVmIpFinder()
+                .setAddresses(Collections.singleton("127.0.0.1:47500..47501"));
+
+        TcpDiscoverySpi discoSpi = new TcpDiscoverySpi().setIpFinder(ipFinder).setSocketTimeout(300);
+
+        IgniteConfiguration cfg = new IgniteConfiguration()
+                .setClientConnectorConfiguration(connectorConfiguration)
+                .setDiscoverySpi(discoSpi);
+
+        Ignition.start(cfg);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/ConsoleLoggerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/ConsoleLoggerTest.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/ConsoleLoggerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/ConsoleLoggerTest.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Log
+{
+    using System;
+    using System.IO;
+    using Apache.Ignite.Core.Common;
+    using Apache.Ignite.Core.Log;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for <see cref="ConsoleLogger"/>.
+    /// </summary>
+    public class ConsoleLoggerTest
+    {
+        /// <summary>
+        /// Tests that default constructor sets log level to Warn.
+        /// </summary>
+        [Test]
+        public void TestDefaultConstructorSetsWarnMinLevel()
+        {
+            Assert.AreEqual(LogLevel.Warn, new ConsoleLogger().MinLevel);
+        }
+        
+        /// <summary>
+        /// Tests that IsEnabled returns false when specified level is less that MinLevel.
+        /// </summary>
+        [Test]
+        [TestCase(LogLevel.Error, LogLevel.Error, true)]
+        [TestCase(LogLevel.Error, LogLevel.Warn, false)]
+        [TestCase(LogLevel.Error, LogLevel.Info, false)]
+        [TestCase(LogLevel.Error, LogLevel.Debug, false)]
+        [TestCase(LogLevel.Error, LogLevel.Trace, false)]
+        [TestCase(LogLevel.Warn, LogLevel.Error, true)]
+        [TestCase(LogLevel.Warn, LogLevel.Warn, true)]
+        [TestCase(LogLevel.Warn, LogLevel.Info, false)]
+        [TestCase(LogLevel.Warn, LogLevel.Trace, false)]
+        public void TestIsEnabled(LogLevel loggerLevel, LogLevel level, bool expectedResult)
+        {
+            var logger = new ConsoleLogger {MinLevel = loggerLevel};
+            Assert.AreEqual(loggerLevel, logger.MinLevel);
+            Assert.AreEqual(expectedResult, logger.IsEnabled(level));
+        }
+
+        /// <summary>
+        /// Tests that logger writes to console.
+        /// </summary>
+        [Test]
+        public void TestLogWritesToConsole()
+        {
+            var oldWriter = Console.Out;
+            var writer = new StringWriter();
+
+            try
+            {
+                Console.SetOut(writer);
+                
+                var logger = new ConsoleLogger
+                {
+                    MinLevel = LogLevel.Debug,
+                    DateTimeProvider = new FixedDateTimeProvider()
+                }.GetLogger("my-cat");
+                logger.Warn("warn!");
+                logger.Error(new IgniteException("ex!"), "err!");
+                logger.Trace("trace (ignored)");
+
+                var expectedLog = string.Format("[04:05:06] [Warn] [my-cat] warn!{0}[04:05:06] [Error] [my-cat] err! " +
+                                                "(exception: Apache.Ignite.Core.Common.IgniteException: ex!){0}",
+                    Environment.NewLine);
+                Assert.AreEqual(expectedLog, writer.ToString());
+            }
+            finally
+            {
+                Console.SetOut(oldWriter);
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/FixedDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/FixedDateTimeProvider.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/FixedDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/FixedDateTimeProvider.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Log
+{
+    using System;
+    using Apache.Ignite.Core.Log;
+
+    /// <summary>
+    /// Provides fixed DateTime for tests.
+    /// </summary>
+    public class FixedDateTimeProvider : IDateTimeProvider
+    {
+        /** Fixed DateTime. */
+        public static DateTime DateTime = new DateTime(2001, 2, 3, 4, 5, 6);
+        
+        /** <inheritDoc /> */
+        public DateTime Now()
+        {
+            return DateTime;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcess.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcess.cs
@@ -22,7 +22,6 @@ namespace Apache.Ignite.Core.Tests.Process
     using System.IO;
     using System.Linq;
     using System.Text;
-    using System.Threading;
     using Apache.Ignite.Core.Impl.Common;
 
     /// <summary>
@@ -197,20 +196,9 @@ namespace Apache.Ignite.Core.Tests.Process
             Debug.Assert(proc != null);
 
             // 3. Attach output readers to avoid hangs.
-            AttachProcessConsoleReader(proc, outReader);
+            proc.AttachProcessConsoleReader(outReader ?? DfltOutReader);
 
             return proc;
-        }
-
-        /// <summary>
-        /// Attaches the process console reader.
-        /// </summary>
-        public static void AttachProcessConsoleReader(Process proc, IIgniteProcessOutputReader outReader = null)
-        {
-            outReader = outReader ?? DfltOutReader;
-
-            Attach(proc, proc.StandardOutput, outReader, false);
-            Attach(proc, proc.StandardError, outReader, true);
         }
 
         /// <summary>
@@ -284,22 +272,6 @@ namespace Apache.Ignite.Core.Tests.Process
             exitCode = 0;
 
             return false;
-        }
-
-        /// <summary>
-        /// Attach output reader to the process.
-        /// </summary>
-        /// <param name="proc">Process.</param>
-        /// <param name="reader">Process stream reader.</param>
-        /// <param name="outReader">Output reader.</param>
-        /// <param name="err">Whether this is error stream.</param>
-        private static void Attach(Process proc, StreamReader reader, IIgniteProcessOutputReader outReader, bool err)
-        {
-            new Thread(() =>
-            {
-                while (!proc.HasExited)
-                    outReader.OnOutput(proc, reader.ReadLine(), err);
-            }) {IsBackground = true}.Start();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcessCompositeOutputReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcessCompositeOutputReader.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcessCompositeOutputReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcessCompositeOutputReader.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Process
+{
+    using System.Diagnostics;
+    using Apache.Ignite.Core.Impl.Common;
+
+    /// <summary>
+    /// Combines multiple readers.
+    /// </summary>
+    public class IgniteProcessCompositeOutputReader : IIgniteProcessOutputReader
+    {
+        /** */
+        private readonly IIgniteProcessOutputReader[] _readers;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="IgniteProcessCompositeOutputReader" /> class.
+        /// </summary>
+        /// <param name="readers">Nested readers.</param>
+        public IgniteProcessCompositeOutputReader(params IIgniteProcessOutputReader[] readers)
+        {
+            IgniteArgumentCheck.NotNull(readers, "readers");
+            _readers = readers;
+        }
+
+        public void OnOutput(Process proc, string data, bool err)
+        {
+            foreach (var reader in _readers)
+            {
+                reader.OnOutput(proc, data, err);
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProcessExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProcessExtensions.cs
@@ -18,9 +18,14 @@
 namespace Apache.Ignite.Core.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
     using System.Runtime.InteropServices;
+    using System.Threading;
+    using Apache.Ignite.Core.Impl.Unmanaged;
+    using Apache.Ignite.Core.Tests.Process;
 
     /// <summary>
     /// Process extensions.
@@ -73,6 +78,121 @@ namespace Apache.Ignite.Core.Tests
 
                 ResumeThread(pOpenThread);
             }
+        }
+        
+        /// <summary>
+        /// Attaches the process console reader.
+        /// </summary>
+        public static void AttachProcessConsoleReader(this System.Diagnostics.Process proc, 
+            params IIgniteProcessOutputReader[] outReaders)
+        {
+            var outReader = outReaders == null || outReaders.Length == 0
+                ? (IIgniteProcessOutputReader) new IgniteProcessConsoleOutputReader()
+                : new IgniteProcessCompositeOutputReader(outReaders);
+
+            Attach(proc, proc.StandardOutput, outReader, false);
+            Attach(proc, proc.StandardError, outReader, true);
+        }
+        
+        
+        /// <summary>
+        /// Attach output reader to the process.
+        /// </summary>
+        /// <param name="proc">Process.</param>
+        /// <param name="reader">Process stream reader.</param>
+        /// <param name="outReader">Output reader.</param>
+        /// <param name="err">Whether this is error stream.</param>
+        private static void Attach(System.Diagnostics.Process proc, StreamReader reader, 
+            IIgniteProcessOutputReader outReader, bool err)
+        {
+            new Thread(() =>
+            {
+                while (!proc.HasExited)
+                    outReader.OnOutput(proc, reader.ReadLine(), err);
+            }) {IsBackground = true}.Start();
+        }
+               
+        /// <summary>
+        /// Kills process tree.
+        /// </summary>
+        public static void KillProcessTree(this System.Diagnostics.Process process)
+        {
+            process.EnableRaisingEvents = true;
+            
+            if (Os.IsWindows)
+            {
+                Execute("taskkill", string.Format("/T /F /PID {0}", process.Id));
+            }
+            else
+            {
+                var children = new HashSet<int>();
+                GetProcessChildIdsUnix(process.Id, children);
+                
+                foreach (var childId in children)
+                {
+                    KillProcessUnix(childId);
+                }
+                
+                KillProcessUnix(process.Id);
+            }
+            
+            // NOTE: This can hang on Linux if being ran after anything that uses Ignite Persistence.
+            // Process becomes a zombie for some reason (Java meddling with SIGCHLD?)
+            if (!process.WaitForExit(10000))
+            {
+                throw new Exception("Failed to kill process: " + process.Id);
+            }
+        }
+
+        /// <summary>
+        /// Runs a process and waits for exit.
+        /// </summary>
+        private static void Execute(string file, string args, params IIgniteProcessOutputReader[] readers)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = file,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            var process = new System.Diagnostics.Process {StartInfo = startInfo};
+            process.Start();
+
+            process.AttachProcessConsoleReader(readers);
+            if (!process.WaitForExit(1000))
+            {
+                process.Kill();
+            }
+        }
+
+        /// <summary>
+        /// Gets process child ids.
+        /// </summary>
+        private static void GetProcessChildIdsUnix(int parentId, ISet<int> children)
+        {
+            var reader = new ListDataReader();
+            Execute("pgrep", string.Format("-P {0}", parentId), reader);
+
+            foreach (var line in reader.GetOutput())
+            {
+                int id;
+                if (int.TryParse(line, out id))
+                {
+                    children.Add(id);
+                    GetProcessChildIdsUnix(id, children);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Kills Unix process.
+        /// </summary>
+        private static void KillProcessUnix(int processId)
+        {
+            Execute("kill", string.Format("-KILL {0}", processId));
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
@@ -21,7 +21,6 @@ namespace Apache.Ignite.Core.Tests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Text.RegularExpressions;
     using NUnit.Framework;
 
@@ -36,7 +35,7 @@ namespace Apache.Ignite.Core.Tests
         [Test]
         public void TestCsprojToolsVersion()
         {
-            var projFiles = GetDotNetSourceDir().GetFiles("*.csproj", SearchOption.AllDirectories)
+            var projFiles = TestUtils.GetDotNetSourceDir().GetFiles("*.csproj", SearchOption.AllDirectories)
                 .Where(x => !x.FullName.ToLower().Contains("dotnetcore")).ToArray();
             
             Assert.GreaterOrEqual(projFiles.Length, 7);
@@ -88,7 +87,7 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         private static IEnumerable<FileInfo> GetReleaseCsprojFiles()
         {
-            return GetDotNetSourceDir().GetFiles("*.csproj", SearchOption.AllDirectories)
+            return TestUtils.GetDotNetSourceDir().GetFiles("*.csproj", SearchOption.AllDirectories)
                 .Where(x => x.Name != "Apache.Ignite.csproj" &&
                             !x.Name.Contains("Test") &&
                             !x.Name.Contains("Example") &&
@@ -111,7 +110,7 @@ namespace Apache.Ignite.Core.Tests
         [Test]
         public void TestSlnToolsVersion()
         {
-            var slnFiles = GetDotNetSourceDir().GetFiles("*.sln", SearchOption.AllDirectories)
+            var slnFiles = TestUtils.GetDotNetSourceDir().GetFiles("*.sln", SearchOption.AllDirectories)
                 .Where(x => !x.Name.Contains("DotNetCore")).ToArray();
 
             Assert.GreaterOrEqual(slnFiles.Length, 2);
@@ -134,7 +133,7 @@ namespace Apache.Ignite.Core.Tests
                 "CacheTest.cs"
             };
 
-            var srcFiles = GetDotNetSourceDir()
+            var srcFiles = TestUtils.GetDotNetSourceDir()
                 .GetFiles("*.cs", SearchOption.AllDirectories)
                 .Where(x => !allowedFiles.Contains(x.Name));
 
@@ -150,25 +149,6 @@ namespace Apache.Ignite.Core.Tests
 
             Assert.AreEqual(0, invalidFiles.Length,
                 errorText + string.Join("\n ", invalidFiles.Select(x => x.FullName)));
-        }
-
-        /// <summary>
-        /// Gets the dot net source dir.
-        /// </summary>
-        private static DirectoryInfo GetDotNetSourceDir()
-        {
-            // ReSharper disable once AssignNullToNotNullAttribute
-            var dir = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
-
-            while (dir != null)
-            {
-                if (dir.GetFiles().Any(x => x.Name == "Apache.Ignite.sln"))
-                    return dir;
-
-                dir = dir.Parent;
-            }
-
-            throw new InvalidOperationException("Could not resolve Ignite.NET source directory.");
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.Common.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.Common.cs
@@ -389,5 +389,24 @@ namespace Apache.Ignite.Core.Tests
                 }
             }
         }
+        
+        /// <summary>
+        /// Gets the dot net source dir.
+        /// </summary>
+        public static DirectoryInfo GetDotNetSourceDir()
+        {
+            // ReSharper disable once AssignNullToNotNullAttribute
+            var dir = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+            while (dir != null)
+            {
+                if (dir.GetFiles().Any(x => x.Name == "Apache.Ignite.sln"))
+                    return dir;
+
+                dir = dir.Parent;
+            }
+
+            throw new InvalidOperationException("Could not resolve Ignite.NET source directory.");
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.Windows.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.Windows.cs
@@ -98,7 +98,7 @@ namespace Apache.Ignite.Core.Tests
 
             try
             {
-                IgniteProcess.AttachProcessConsoleReader(proc);
+                proc.AttachProcessConsoleReader();
 
                 Assert.IsTrue(proc.WaitForExit(30000));
                 Assert.AreEqual(0, proc.ExitCode);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Failure\StopNodeOrHaltFailureHandler.cs" />
     <Compile Include="Impl\Binary\BinaryHashCodeUtils.cs" />
     <Compile Include="Impl\Cache\QueryMetricsImpl.cs" />
+    <Compile Include="Impl\Client\ClientOpExtensions.cs" />
     <Compile Include="Impl\Client\Cluster\ClientCluster.cs" />
     <Compile Include="Impl\Client\Cache\ClientCacheAffinityAwarenessGroup.cs" />
     <Compile Include="Impl\Client\Cache\ClientCachePartitionMap.cs" />
@@ -90,10 +91,15 @@
     <Compile Include="Impl\Client\Cache\ClientRendezvousAffinityFunction.cs" />
     <Compile Include="Impl\Client\ClientFlags.cs" />
     <Compile Include="Impl\Client\Endpoint.cs" />
+    <Compile Include="Impl\Client\MinVersionAttribute.cs" />
     <Compile Include="Impl\Client\SocketEndpoint.cs" />
     <Compile Include="Impl\Common\TaskRunner.cs" />
+    <Compile Include="Impl\Log\NoopLogger.cs" />
     <Compile Include="Impl\Transactions\TransactionCollectionImpl.cs" />
     <Compile Include="Impl\Unmanaged\UnmanagedThread.cs" />
+    <Compile Include="Log\ConsoleLogger.cs" />
+    <Compile Include="Log\IDateTimeProvider.cs" />
+    <Compile Include="Log\LocalDateTimeProvider.cs" />
     <Compile Include="Ssl\ISslContextFactory.cs" />
     <Compile Include="Configuration\ClientConnectorConfiguration.cs" />
     <Compile Include="Configuration\ThinClientConfiguration.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -25,7 +25,9 @@ namespace Apache.Ignite.Core.Client
     using System.Xml;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Impl.Binary;
+    using Apache.Ignite.Core.Impl.Client;
     using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Log;
 
     /// <summary>
     /// Ignite thin client configuration.
@@ -68,6 +70,7 @@ namespace Apache.Ignite.Core.Client
             SocketReceiveBufferSize = DefaultSocketBufferSize;
             TcpNoDelay = DefaultTcpNoDelay;
             SocketTimeout = DefaultSocketTimeout;
+            Logger = new ConsoleLogger();
         }
 
         /// <summary>
@@ -114,6 +117,8 @@ namespace Apache.Ignite.Core.Client
             Endpoints = cfg.Endpoints == null ? null : cfg.Endpoints.ToList();
             ReconnectDisabled = cfg.ReconnectDisabled;
             EnableAffinityAwareness = cfg.EnableAffinityAwareness;
+            Logger = cfg.Logger;
+            ProtocolVersion = cfg.ProtocolVersion;
         }
 
         /// <summary>
@@ -212,11 +217,22 @@ namespace Apache.Ignite.Core.Client
         /// To do so, connection is established to every known server node at all times.
         /// </summary>
         public bool EnableAffinityAwareness { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the logger.
+        /// Default is <see cref="ConsoleLogger"/>. Set to <c>null</c> to disable logging.
+        /// </summary>
+        public ILogger Logger { get; set; }
 
         /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.
         /// </summary>
         internal IBinaryProcessor BinaryProcessor { get; set; }
+
+        /// <summary>
+        /// Gets or sets protocol version. Internal property for tests.
+        /// </summary>
+        internal ClientProtocolVersion? ProtocolVersion { get; set; }
 
         /// <summary>
         /// Serializes this instance to the specified XML writer.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Common/IFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Common/IFactory.cs
@@ -26,9 +26,9 @@ namespace Apache.Ignite.Core.Common
     public interface IFactory<out T>
     {
         /// <summary>
-        /// Creates an instance of the cache store.
+        /// Creates an instance of type <typeparamref name="T" />.
         /// </summary>
-        /// <returns>New instance of the cache store.</returns>
+        /// <returns>New instance of type <typeparamref name="T" />.</returns>
         T CreateInstance();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -216,6 +216,18 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="logger" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>The logger. Default is ConsoleLogger. Set to null to disable logging.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:attribute name="type" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation>Assembly-qualified type name.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
             </xs:all>
             <xs:attribute name="host" type="xs:string" use="required">
                 <xs:annotation>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -31,6 +31,8 @@ namespace Apache.Ignite.Core.Impl.Client
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
     using Apache.Ignite.Core.Impl.Client.Cache;
+    using Apache.Ignite.Core.Impl.Log;
+    using Apache.Ignite.Core.Log;
 
     /// <summary>
     /// Socket wrapper with reconnect/failover functionality: reconnects on failure.
@@ -70,6 +72,9 @@ namespace Apache.Ignite.Core.Impl.Client
         /** Distribution map locker. */
         private readonly object _distributionMapSyncRoot = new object();
 
+        /** Logger. */
+        private readonly ILogger _logger;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientFailoverSocket"/> class.
         /// </summary>
@@ -98,8 +103,10 @@ namespace Apache.Ignite.Core.Impl.Client
                 throw new IgniteClientException("Failed to resolve all specified hosts.");
             }
 
+            _logger = (_config.Logger ?? NoopLogger.Instance).GetLogger(GetType());
+            
             Connect();
-        }
+       }
 
         /** <inheritdoc /> */
         public T DoOutInOp<T>(ClientOp opId, Action<IBinaryStream> writeAction, Func<IBinaryStream, T> readFunc,
@@ -290,8 +297,8 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 try
                 {
-                    _socket = new ClientSocket(_config, endPoint.EndPoint, endPoint.Host, null,
-                        OnAffinityTopologyVersionChange);
+                    _socket = new ClientSocket(_config, endPoint.EndPoint, endPoint.Host, 
+                        _config.ProtocolVersion, OnAffinityTopologyVersionChange);
 
                     endPoint.Socket = _socket;
 
@@ -314,9 +321,17 @@ namespace Apache.Ignite.Core.Impl.Client
                                              "examine inner exceptions for details.", errors);
             }
 
-            if (_config.EnableAffinityAwareness)
+            if (_socket != null &&
+                _config.EnableAffinityAwareness &&
+                _socket.ServerVersion < ClientOp.CachePartitions.GetMinVersion())
             {
-                InitSocketMap();
+                _config.EnableAffinityAwareness = false;
+
+                _logger.Warn("Partition awareness has been disabled: server protocol version {0} " +
+                             "is lower than required {1}",
+                    _socket.ServerVersion,
+                    ClientOp.CachePartitions.GetMinVersion()
+                );
             }
         }
 
@@ -500,8 +515,8 @@ namespace Apache.Ignite.Core.Impl.Client
                 {
                     try
                     {
-                        var socket = new ClientSocket(_config, endPoint.EndPoint, endPoint.Host, null,
-                            OnAffinityTopologyVersionChange);
+                        var socket = new ClientSocket(_config, endPoint.EndPoint, endPoint.Host, 
+                            _config.ProtocolVersion, OnAffinityTopologyVersionChange);
 
                         endPoint.Socket = socket;
                     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -341,6 +341,11 @@ namespace Apache.Ignite.Core.Impl.Client
         private void OnAffinityTopologyVersionChange(AffinityTopologyVersion affinityTopologyVersion)
         {
             _affinityTopologyVersion = affinityTopologyVersion;
+
+            if (_config.EnableAffinityAwareness)
+            {
+                InitSocketMap();
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
@@ -54,6 +54,8 @@ namespace Apache.Ignite.Core.Impl.Client
         CacheGetOrCreateWithConfiguration = 1054,
         CacheGetConfiguration = 1055,
         CacheDestroy = 1056,
+        
+        [MinVersion(1, 4, 0)]
         CachePartitions = 1101,
         
         // Queries.
@@ -71,9 +73,16 @@ namespace Apache.Ignite.Core.Impl.Client
         BinaryTypePut = 3003,
 
         // Cluster.
+        [MinVersion(1, 5, 0)]
         ClusterIsActive = 5000,
+        
+        [MinVersion(1, 5, 0)]
         ClusterChangeState = 5001,
+        
+        [MinVersion(1, 5, 0)]
         ClusterChangeWalState = 5002,
+        
+        [MinVersion(1, 5, 0)]
         ClusterGetWalState = 5003
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOpExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOpExtensions.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOpExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOpExtensions.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Extension methods for <see cref="ClientOp"/>.
+    /// </summary>
+    internal static class ClientOpExtensions
+    {
+        /** */
+        private static readonly Dictionary<ClientOp, ClientProtocolVersion> VersionMap = GetVersionMap();
+
+        /// <summary>
+        /// Gets minimum protocol version that is required to perform specified operation.
+        /// </summary>
+        /// <param name="op">Operation.</param>
+        /// <returns>Minimum protocol version.</returns>
+        public static ClientProtocolVersion GetMinVersion(this ClientOp op)
+        {
+            ClientProtocolVersion minVersion;
+            
+            return VersionMap.TryGetValue(op, out minVersion) 
+                ? minVersion 
+                : ClientSocket.Ver100;
+        }
+        
+        /// <summary>
+        /// Gets the version map.
+        /// </summary>
+        private static Dictionary<ClientOp, ClientProtocolVersion> GetVersionMap()
+        {
+            var res = new Dictionary<ClientOp, ClientProtocolVersion>();
+            
+            foreach (var memberInfo in typeof(ClientOp).GetMembers())
+            {
+                var attr = memberInfo.GetCustomAttributes(false)
+                    .OfType<MinVersionAttribute>()
+                    .SingleOrDefault();
+
+                if (attr == null)
+                {
+                    continue;
+                }
+
+                var clientOp = (ClientOp) Enum.Parse(typeof(ClientOp), memberInfo.Name);
+                res[clientOp] = attr.Version;
+            }
+
+            return res;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientProtocolVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientProtocolVersion.cs
@@ -119,6 +119,30 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritdoc /> */
+        public static bool operator <(ClientProtocolVersion left, ClientProtocolVersion right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        /** <inheritdoc /> */
+        public static bool operator <=(ClientProtocolVersion left, ClientProtocolVersion right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+
+        /** <inheritdoc /> */
+        public static bool operator >(ClientProtocolVersion left, ClientProtocolVersion right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        /** <inheritdoc /> */
+        public static bool operator >=(ClientProtocolVersion left, ClientProtocolVersion right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
+
+        /** <inheritdoc /> */
         public override int GetHashCode()
         {
             unchecked

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -32,6 +32,8 @@ namespace Apache.Ignite.Core.Impl.Client
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
     using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Impl.Log;
+    using Apache.Ignite.Core.Log;
 
     /// <summary>
     /// Wrapper over framework socket for Ignite thin client operations.
@@ -39,10 +41,10 @@ namespace Apache.Ignite.Core.Impl.Client
     internal sealed class ClientSocket : IClientSocket
     {
         /** Version 1.0.0. */
-        private static readonly ClientProtocolVersion Ver100 = new ClientProtocolVersion(1, 0, 0);
+        public static readonly ClientProtocolVersion Ver100 = new ClientProtocolVersion(1, 0, 0);
 
         /** Version 1.1.0. */
-        private static readonly ClientProtocolVersion Ver110 = new ClientProtocolVersion(1, 1, 0);
+        public static readonly ClientProtocolVersion Ver110 = new ClientProtocolVersion(1, 1, 0);
 
         /** Version 1.2.0. */
         public static readonly ClientProtocolVersion Ver120 = new ClientProtocolVersion(1, 2, 0);
@@ -113,6 +115,9 @@ namespace Apache.Ignite.Core.Impl.Client
         /** Topology version update callback. */
         private readonly Action<AffinityTopologyVersion> _topVerCallback;
 
+        /** Logger. */
+        private readonly ILogger _logger;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientSocket" /> class.
         /// </summary>
@@ -129,8 +134,9 @@ namespace Apache.Ignite.Core.Impl.Client
 
             _topVerCallback = topVerCallback;
             _timeout = clientConfiguration.SocketTimeout;
+            _logger = (clientConfiguration.Logger ?? NoopLogger.Instance).GetLogger(GetType());
 
-            _socket = Connect(clientConfiguration, endPoint);
+            _socket = Connect(clientConfiguration, endPoint, _logger);
             _stream = GetSocketStream(_socket, clientConfiguration, host);
 
             ServerVersion = version ?? CurrentProtocolVersion;
@@ -307,7 +313,7 @@ namespace Apache.Ignite.Core.Impl.Client
         {
             ClientStatusCode statusCode;
 
-            if (ServerVersion.CompareTo(Ver140) >= 0)
+            if (ServerVersion >= Ver140)
             {
                 var flags = (ClientFlags) stream.ReadShort();
 
@@ -349,7 +355,7 @@ namespace Apache.Ignite.Core.Impl.Client
         /// </summary>
         private void Handshake(IgniteClientConfiguration clientConfiguration, ClientProtocolVersion version)
         {
-            bool auth = version.CompareTo(Ver110) >= 0 && clientConfiguration.UserName != null;
+            bool auth = version >= Ver110 && clientConfiguration.UserName != null;
 
             // Send request.
             int messageLen;
@@ -390,12 +396,15 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 if (success)
                 {
-                    if (version.CompareTo(Ver140) >= 0)
+                    if (version >= Ver140)
                     {
                         ServerNodeId = BinaryUtils.Marshaller.Unmarshal<Guid>(stream);
                     }
 
                     ServerVersion = version;
+                    
+                    _logger.Debug("Handshake completed on {0}, protocol version = {1}", 
+                        _socket.RemoteEndPoint, version);
 
                     return;
                 }
@@ -412,17 +421,26 @@ namespace Apache.Ignite.Core.Impl.Client
                     errCode = (ClientStatusCode) stream.ReadInt();
                 }
 
+                _logger.Debug("Handshake failed on {0}, requested protocol version = {1}, " +
+                              "server protocol version = {2}, status = {3}, message = {4}",
+                    _socket.RemoteEndPoint, version, ServerVersion, errCode, errMsg);
+
                 // Authentication error is handled immediately.
                 if (errCode == ClientStatusCode.AuthenticationFailed)
                 {
                     throw new IgniteClientException(errMsg, null, ClientStatusCode.AuthenticationFailed);
                 }
 
-                // Re-try if possible.
-                bool retry = ServerVersion.CompareTo(version) < 0 && ServerVersion.Equals(Ver100);
+                // Retry if server version is different and falls within supported version range.
+                var retry = ServerVersion != version &&
+                            ServerVersion >= Ver100 &&
+                            ServerVersion <= CurrentProtocolVersion;
 
                 if (retry)
                 {
+                    _logger.Debug("Retrying handshake on {0} with protocol version {1}", 
+                        _socket.RemoteEndPoint, ServerVersion);
+                    
                     Handshake(clientConfiguration, ServerVersion);
                 }
                 else
@@ -463,6 +481,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 if (res == 0)
                 {
                     // Disconnected.
+                    _logger.Debug("Connection lost on {0} (failed to read data from socket)", _socket.RemoteEndPoint);
                     _exception = _exception ?? new SocketException((int) SocketError.ConnectionAborted);
                     Dispose();
                     CheckException();
@@ -561,7 +580,13 @@ namespace Apache.Ignite.Core.Impl.Client
         /// </summary>
         private RequestMessage WriteMessage(Action<IBinaryStream> writeAction, ClientOp opId)
         {
+            ValidateOp(opId);
+            
             var requestId = Interlocked.Increment(ref _requestId);
+            
+            // Potential perf improvements:
+            // * ArrayPool<T>
+            // * Write to socket stream directly (not trivial because of unknown size) 
             var stream = new BinaryHeapStream(256);
 
             stream.WriteInt(0); // Reserve message size.
@@ -612,7 +637,7 @@ namespace Apache.Ignite.Core.Impl.Client
         /// </summary>
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "Socket is returned from this method.")]
-        private static Socket Connect(IgniteClientConfiguration cfg, EndPoint endPoint)
+        private static Socket Connect(IgniteClientConfiguration cfg, EndPoint endPoint, ILogger logger)
         {
             var socket = new Socket(endPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
@@ -632,7 +657,11 @@ namespace Apache.Ignite.Core.Impl.Client
                 socket.ReceiveBufferSize = cfg.SocketReceiveBufferSize;
             }
 
+            logger.Debug("Socket connection attempt: {0}", endPoint);
+
             socket.Connect(endPoint);
+            
+            logger.Debug("Socket connection established: {0} -> {1}", socket.LocalEndPoint, socket.RemoteEndPoint);
 
             return socket;
         }
@@ -736,6 +765,26 @@ namespace Apache.Ignite.Core.Impl.Client
                     }
                 }
             }
+        }
+        
+        /// <summary>
+        /// Validates op code against current protocol version.
+        /// </summary>
+        /// <param name="opId">Op code.</param>
+        private void ValidateOp(ClientOp opId)
+        {
+            var minVersion = opId.GetMinVersion();
+
+            if (ServerVersion >= minVersion)
+            {
+                return;
+            }
+
+            var message = string.Format("Operation {0} is not supported by protocol version {1}. " +
+                                        "Minimum protocol version required is {2}.", 
+                opId, ServerVersion, minVersion);
+                
+            throw new IgniteClientException(message);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
@@ -164,6 +164,7 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        [ExcludeFromCodeCoverage]
         public IIgnite GetIgnite()
         {
             throw GetClientNotSupportedException();
@@ -201,18 +202,21 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        [ExcludeFromCodeCoverage]
         public IgniteConfiguration Configuration
         {
             get { throw GetClientNotSupportedException(); }
         }
 
         /** <inheritDoc /> */
+        [ExcludeFromCodeCoverage]
         public HandleRegistry HandleRegistry
         {
             get { throw GetClientNotSupportedException(); }
         }
 
         /** <inheritDoc /> */
+        [ExcludeFromCodeCoverage]
         public ClusterNodeImpl GetNode(Guid? id)
         {
             throw GetClientNotSupportedException();
@@ -225,12 +229,14 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        [ExcludeFromCodeCoverage]
         public PluginProcessor PluginProcessor
         {
             get { throw GetClientNotSupportedException(); }
         }
 
         /** <inheritDoc /> */
+        [ExcludeFromCodeCoverage]
         public IDataStreamer<TK, TV> GetDataStreamer<TK, TV>(string cacheName, bool keepBinary)
         {
             throw GetClientNotSupportedException();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/MinVersionAttribute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/MinVersionAttribute.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/MinVersionAttribute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/MinVersionAttribute.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client
+{
+    using System;
+
+    /// <summary>
+    /// Version attribute for <see cref="ClientOp"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    internal sealed class MinVersionAttribute : Attribute
+    {
+        /** */
+        private readonly ClientProtocolVersion _version;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MinVersionAttribute"/> class.
+        /// </summary>
+        public MinVersionAttribute(short major, short minor, short maintenance)
+        {
+            _version = new ClientProtocolVersion(major, minor, maintenance);
+        }
+
+        /// <summary>
+        /// Gets the version.
+        /// </summary>
+        public ClientProtocolVersion Version
+        {
+            get { return _version; }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/IgniteConfigurationXmlSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/IgniteConfigurationXmlSerializer.cs
@@ -42,6 +42,9 @@ namespace Apache.Ignite.Core.Impl.Common
         /** Attribute that specifies a type for abstract properties, such as IpFinder. */
         private const string TypNameAttribute = "type";
 
+        /** Value for TypNameAttribute that denotes null. */
+        private const string TypNameNull = "null";
+
         /** Xmlns. */
         private const string XmlnsAttribute = "xmlns";
 
@@ -205,6 +208,14 @@ namespace Apache.Ignite.Core.Impl.Common
         /// </summary>
         private static void WriteComplexProperty(object obj, XmlWriter writer, Type valueType)
         {
+            if (obj == null)
+            {
+                // Happens with reference-type properties that have non-null default value.
+                // Example: IgniteClientConfiguration.Logger
+                writer.WriteAttributeString(TypNameAttribute, TypNameNull);
+                return;
+            }
+            
             var props = GetNonDefaultProperties(obj).OrderBy(x => x.Name).ToList();
 
             var realType = obj.GetType();
@@ -284,6 +295,11 @@ namespace Apache.Ignite.Core.Impl.Common
                 propType = ResolvePropertyType(reader, propType, prop.Name, targetType, resolver);
             }
 
+            if (propType == null)
+            {
+                return null;
+            }
+
             if (IsBasicType(propType))
             {
                 // Regular property in xmlElement form.
@@ -314,6 +330,11 @@ namespace Apache.Ignite.Core.Impl.Common
         {
             propType = ResolvePropertyType(reader, propType, propName, targetType, resolver);
 
+            if (propType == null)
+            {
+                return null;
+            }
+
             var nestedVal = Activator.CreateInstance(propType);
 
             using (var subReader = reader.ReadSubtree())
@@ -333,6 +354,9 @@ namespace Apache.Ignite.Core.Impl.Common
             TypeResolver resolver)
         {
             var typeName = reader.GetAttribute(TypNameAttribute);
+
+            if (typeName == TypNameNull)
+                return null;
 
             if (!propType.IsAbstract && typeName == null)
                 return propType;
@@ -574,7 +598,10 @@ namespace Apache.Ignite.Core.Impl.Common
         /// </summary>
         private static IEnumerable<PropertyInfo> GetNonDefaultProperties(object obj)
         {
-            Debug.Assert(obj != null);
+            if (obj == null)
+            {
+                Debug.Assert(obj != null);
+            }
 
             return obj.GetType().GetProperties()
                 .Where(p => p.GetIndexParameters().Length == 0 &&  // Skip indexed properties.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Log/NoopLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Log/NoopLogger.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Log/NoopLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Log/NoopLogger.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Log
+{
+    using System;
+    using Apache.Ignite.Core.Log;
+
+    /// <summary>
+    /// Logger that does not do anything - for convenience to avoid null checks.
+    /// </summary>
+    internal class NoopLogger : ILogger
+    {
+        /// <summary>
+        /// Singleton instance.
+        /// </summary>
+        public static readonly NoopLogger Instance = new NoopLogger();
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="NoopLogger"/> class.
+        /// </summary>
+        private NoopLogger()
+        {
+            // No-op.
+        }
+
+        /** <inheritdoc /> */
+        public void Log(LogLevel level, string message, object[] args, IFormatProvider formatProvider, string category,
+            string nativeErrorInfo, Exception ex)
+        {
+            // No-op.
+        }
+
+        /** <inheritdoc /> */
+        public bool IsEnabled(LogLevel level)
+        {
+            return false;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/ConsoleLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/ConsoleLogger.cs
@@ -1,11 +1,12 @@
 ﻿/*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/ConsoleLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/ConsoleLogger.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Log
+{
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Logs to Console.
+    /// <para />
+    /// Simple logger implementation without dependencies, provided out of the box for convenience.
+    /// For anything more complex please use NLog/log4net integrations.
+    /// </summary>
+    public class ConsoleLogger : ILogger
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="ConsoleLogger"/> class.
+        /// Uses <see cref="LogLevel.Warn"/> minimum level.
+        /// </summary>
+        public ConsoleLogger()
+        {
+            MinLevel = LogLevel.Warn;
+        }
+
+        /// <summary>
+        /// Gets the minimum level to be logged. Any levels lower than that are ignored.
+        /// Default is <see cref="LogLevel.Warn"/>.
+        /// </summary>
+        public LogLevel MinLevel { get; set; }
+        
+        /// <summary>
+        /// Gets or sets DateTime provider.
+        /// </summary>
+        public IDateTimeProvider DateTimeProvider { get; set; }
+
+        /// <summary>
+        /// Logs the specified message.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="args">The arguments to format <paramref name="message" />.
+        /// Can be null (formatting will not occur).</param>
+        /// <param name="formatProvider">The format provider. Can be null if <paramref name="args" /> is null.</param>
+        /// <param name="category">The logging category name.</param>
+        /// <param name="nativeErrorInfo">The native error information.</param>
+        /// <param name="ex">The exception. Can be null.</param>
+        public void Log(LogLevel level, string message, object[] args, IFormatProvider formatProvider, string category,
+            string nativeErrorInfo, Exception ex)
+        {
+            if (!IsEnabled(level))
+            {
+                return;
+            }
+
+            var dateTimeProvider = DateTimeProvider ?? LocalDateTimeProvider.Instance;
+
+            var sb = new StringBuilder().AppendFormat(
+                "[{0:HH:mm:ss}] [{1}] [{2}] ", dateTimeProvider.Now(), level, category);
+            
+            if (args != null)
+            {
+                sb.AppendFormat(formatProvider, message, args);
+            }
+            else
+            {
+                sb.Append(message);
+            }
+
+            if (ex != null)
+            {
+                sb.AppendFormat(" (exception: {0})", ex);
+            }
+            
+            Console.WriteLine(sb.ToString());
+        }
+
+        /// <summary>
+        /// Determines whether the specified log level is enabled.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        /// <returns>Value indicating whether the specified log level is enabled</returns>
+        public bool IsEnabled(LogLevel level)
+        {
+            return level >= MinLevel;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/IDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/IDateTimeProvider.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/IDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/IDateTimeProvider.cs
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Log
+{
+    using System;
+
+    /// <summary>
+    /// <see cref="DateTime"/> abstraction for logging. 
+    /// </summary>
+    public interface IDateTimeProvider
+    {
+        /// <summary>
+        /// Gets current <see cref="DateTime"/>.
+        /// </summary>
+        DateTime Now();
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/LocalDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/LocalDateTimeProvider.cs
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/LocalDateTimeProvider.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/LocalDateTimeProvider.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Log
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Returns <see cref="DateTime.Now"/>.
+    /// </summary>
+    public class LocalDateTimeProvider : IDateTimeProvider
+    {
+        /// <summary>
+        /// Default instance.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", 
+            Justification = "Type is immutable.")]
+        public static readonly LocalDateTimeProvider Instance = new LocalDateTimeProvider();
+        
+        /// <summary>
+        /// Gets current <see cref="DateTime"/>.
+        /// </summary>
+        public DateTime Now()
+        {
+            return DateTime.Now;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/LoggerExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/LoggerExtensions.cs
@@ -309,12 +309,26 @@ namespace Apache.Ignite.Core.Log
         /// </summary>
         /// <param name="logger">The logger.</param>
         /// <param name="category">The category.</param>
-        /// <returns>Logger that always uses specified category.</returns>
+        /// <returns>Logger that uses specified category when no other category is provided.</returns>
         public static ILogger GetLogger(this ILogger logger, string category)
         {
             IgniteArgumentCheck.NotNull(logger, "logger");
 
             return new CategoryLogger(logger, category);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="CategoryLogger"/> with a specified category that wraps provided logger.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="category">The category as a type.</param>
+        /// <returns>Logger that uses specified category when no other category is provided.</returns>
+        public static ILogger GetLogger(this ILogger logger, Type category)
+        {
+            IgniteArgumentCheck.NotNull(logger, "logger");
+            IgniteArgumentCheck.NotNull(category, "category");
+
+            return new CategoryLogger(logger, category.Name);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.sln.DotSettings
+++ b/modules/platforms/dotnet/Apache.Ignite.sln.DotSettings
@@ -12,4 +12,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dataload/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Failover/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=preloads/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=versioning/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>


### PR DESCRIPTION
* Fix Thin Client version handling bug (could not connect to older nodes)
* Disable Partition Awareness when connected to older servers
* Throw descriptive exception when doing unsupported operations on older server nodes (cluster API)
* Add Thin Client logging (defaults to console)
* Add compatibility tests