### PR TITLE
Checkstyle expects OS specific line separator for NewlineAtEndOfFile rule.

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -30,7 +30,9 @@
     </module>
 
     <!-- Misc Checks. See: http://checkstyle.sourceforge.net/config_misc.html -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <module name="TreeWalker">
         <!-- Import Checks. See: http://checkstyle.sourceforge.net/config_imports.html -->


### PR DESCRIPTION
Windows users can have  problems with checkstyle plugin.