### PR TITLE
IGNITE-12120 Changing the warning levels in GridCacheWriteBehindStore

### DIFF
--- a/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/session/CassandraSessionImpl.java
+++ b/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/session/CassandraSessionImpl.java
@@ -365,7 +365,7 @@ public class CassandraSessionImpl implements CassandraSession {
             " of " + dataSize + " elements, during " + assistant.operationName() +
             " operation with Cassandra";
 
-        log.error(errorMsg, error);
+        log.warning(errorMsg, error);
 
         throw new IgniteException(errorMsg, error);
     }
@@ -528,7 +528,7 @@ public class CassandraSessionImpl implements CassandraSession {
             decrementSessionRefs();
         }
 
-        log.error(errorMsg, error);
+        log.warning(errorMsg, error);
         throw new IgniteException(errorMsg, error);
     }
 

--- a/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/session/CassandraSessionImpl.java
+++ b/modules/cassandra/store/src/main/java/org/apache/ignite/cache/store/cassandra/session/CassandraSessionImpl.java
@@ -528,7 +528,7 @@ public class CassandraSessionImpl implements CassandraSession {
             decrementSessionRefs();
         }
 
-        log.warning(errorMsg, error);
+        log.error(errorMsg, error);
         throw new IgniteException(errorMsg, error);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/store/GridCacheWriteBehindStore.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/store/GridCacheWriteBehindStore.java
@@ -890,7 +890,7 @@ public class GridCacheWriteBehindStore<K, V> implements CacheStore<K, V>, Lifecy
             }
         }
         catch (Exception e) {
-            LT.error(log, e, "Unable to update underlying store: " + store);
+            LT.warn(log, e, "Unable to update underlying store: " + store, false, false);
 
             boolean overflow;
 
@@ -903,7 +903,7 @@ public class GridCacheWriteBehindStore<K, V> implements CacheStore<K, V>, Lifecy
                 for (Map.Entry<K, Entry<? extends K, ? extends  V>> entry : vals.entrySet()) {
                     Object val = entry.getValue() != null ? entry.getValue().getValue() : null;
 
-                    log.warning("Failed to update store (value will be lost as current buffer size is greater " +
+                    log.error("Failed to update store (value will be lost as current buffer size is greater " +
                         "than 'cacheCriticalSize' or node has been stopped before store was repaired) [key=" +
                         entry.getKey() + ", val=" + val + ", op=" + operation + "]");
                 }


### PR DESCRIPTION
In the GridCacheWriteBehindStore, when the updateStore failed to write to underlying store, it logs this as error:

LT.error(log, e, "Unable to update underlying store: " + store);

After this line logged the error, it would return false so that it would retry the store (by returning false).  

While later on in the updatStore function, when the writeCache overflows, it would log this:

log.warning("Failed to update store (value will be lost as current buffer size is greater " + …

then it will remove the failed entry.

I think the severity of the log messages is not right, as the fail update would still be retried.

So I propose to change the log severity level so that the first one would be a warn, and second one would be error