### PR TITLE
IGNITE-12527 repair Deployment Modes-Un-Deployment and User Versions function can not use

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -8841,8 +8841,13 @@ public abstract class IgniteUtils {
                 throw new RuntimeException("Deserialization of class " + clsName + " is disallowed.");
 
             // Avoid class caching inside Class.forName
-            if (ldr instanceof CacheClassLoaderMarker)
+            if (ldr instanceof CacheClassLoaderMarker){
                 cls = ldr.loadClass(clsName);
+                
+                // fixed Versions function bug
+                //if do not return , cls will add to ldrmap and User Versions function can not use
+                return cls ;
+            }
             else
                 cls = Class.forName(clsName, true, ldr);
 


### PR DESCRIPTION
When using continuous deployment mode, the custom entryprocessor works correctly the first time it is loaded; however, it does not work properly after that, because the custom entryprocessor is cached by igniteutils concurrentmap < classloader, concurrentmap < string, class > >.
When processing custom entryprocessor, it will directly return to class without adding cache