### PR TITLE
IGNITE-12642 Fix a typo in the log message about the topology version context.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPreloader.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPreloader.java
@@ -158,7 +158,7 @@ public class GridDhtPreloader extends GridCachePreloaderAdapter {
 
         if (!grp.affinity().cachedVersions().contains(rebTopVer)) {
             assert rebTopVer.compareTo(grp.localStartVersion()) <= 0 :
-                "Empty hisroty allowed only for newly started cache group [rebTopVer=" + rebTopVer +
+                "Empty history allowed only for newly started cache group [rebTopVer=" + rebTopVer +
                     ", localStartTopVer=" + grp.localStartVersion() + ']';
 
             return true; // Required, since no history info available.


### PR DESCRIPTION
Fix a typo in the log message about the topology version context
when check if rebalance should be started