### PR TITLE
IGNITE-12860 .NET: Fix NRE in BinaryStructure.GetFieldId

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -53,10 +53,25 @@
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryBuilderSelfTest.cs" Link="Binary\BinaryBuilderSelfTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryBuilderSelfTestDynamicRegistration.cs" Link="Binary\BinaryBuilderSelfTestDynamicRegistration.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryDateTimeTest.cs" Link="Binary\BinaryDateTimeTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryEqualityComparerTest.cs">
+      <Link>Binary\BinaryEqualityComparerTest.cs</Link>
+    </Compile>
+    <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryNameMapperTest.cs">
+      <Link>Binary\BinaryNameMapperTest.cs</Link>
+    </Compile>
+    <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryReaderWriterTest.cs">
+      <Link>Binary\BinaryReaderWriterTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinarySelfTest.cs" Link="Binary\BinarySelfTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Binary\BinaryStructureTest.cs">
+      <Link>Binary\BinaryStructureTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\EnumsTest.cs" Link="Binary\EnumsTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\EnumsTestOnline.cs" Link="Binary\EnumsTestOnline.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\JavaBinaryInteropTest.cs" Link="Binary\JavaBinaryInteropTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Binary\JavaTypeMappingTest.cs">
+      <Link>Binary\JavaTypeMappingTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\Serializable\AdvancedSerializationTest.cs" Link="Binary\Serializable\AdvancedSerializationTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\Serializable\CallbacksTest.cs" Link="Binary\Serializable\CallbacksTest.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\Serializable\DynamicFieldSetSerializable.cs">
@@ -73,6 +88,9 @@
       <Link>Binary\Serializable\PrimitivesTest.cs</Link>
     </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Binary\Serializable\SqlDmlTest.cs" Link="Binary\Serializable\SqlDmlTest.cs" />
+    <Compile Include="..\Apache.Ignite.Core.Tests\Binary\TypeNameParserTest.cs">
+      <Link>Binary\TypeNameParserTest.cs</Link>
+    </Compile>
     <Compile Include="..\Apache.Ignite.Core.Tests\Cache\AddArgCacheEntryProcessor.cs" Link="Cache\AddArgCacheEntryProcessor.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Cache\BinarizableAddArgCacheEntryProcessor.cs" Link="Cache\BinarizableAddArgCacheEntryProcessor.cs" />
     <Compile Include="..\Apache.Ignite.Core.Tests\Cache\BinarizableTestException.cs" Link="Cache\BinarizableTestException.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryStructureTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryStructureTest.cs
@@ -146,6 +146,71 @@ namespace Apache.Ignite.Core.Tests.Binary
             Assert.AreEqual(3, res.Nested.Baz);
             Assert.AreEqual(5, res.Nested.Qux);
         }
+
+        /// <summary>
+        /// Tests a combination of changing field order and some fields being added or removed.
+        /// </summary>
+        [Test]
+        public void TestChangingFieldOrderAndPresence()
+        {
+            // Create two different binary structure paths, than make one of them longer to defeat the optimization. 
+            TestChangingFieldOrderAndPresence(new[] {1, 0}, new[] {0}, new[] {0, 1});
+
+            // Growing path.
+            TestChangingFieldOrderAndPresence(new[] {1}, new[] {1, 2, 3, 4}, new[] {1, 2, 3, 4, 5, 6});
+
+            // Shrinking path.
+            TestChangingFieldOrderAndPresence(new[] {1}, new[] {1, 2, 3, 4}, new[] {1, 2, 3}, new[] {1, 2});
+        }
+
+        /// <summary>
+        /// Tests specified field combination.
+        /// </summary>
+        private static void TestChangingFieldOrderAndPresence(params int[][] fieldSequences)
+        {
+            var marsh = new Marshaller(new BinaryConfiguration(typeof(CustomFieldOrder)));
+
+            foreach (var fields in fieldSequences)
+            {
+                CustomFieldOrder.Fields = fields;
+                marsh.Marshal(new CustomFieldOrder());
+            }
+        }
+
+        /// <summary>
+        /// Tests object with random order and presence of fields.
+        /// </summary>
+        [Test]
+        public void TestRandomFieldOrderAndPresence()
+        {
+            var marsh = new Marshaller(new BinaryConfiguration(typeof(RandomFieldOrder)));
+            var obj = new RandomFieldOrder();
+
+            for (var i = 0; i < 1000; i++)
+            {
+                var bytes = marsh.Marshal(obj);
+                
+                marsh.Unmarshal<RandomFieldOrder>(bytes);
+            }
+        }
+    
+        /// <summary>
+        /// Runs write/read test in multiple threads, using random field order to create lots of schemas.
+        /// </summary>
+        [Test]
+        public void TestMultithreadedRandomFields()
+        {
+            var marsh = new Marshaller(new BinaryConfiguration(typeof(RandomFieldOrder)));
+            var obj = new RandomFieldOrder();
+            
+            TestUtils.RunMultiThreaded(() =>
+            {
+                var bytes = marsh.Marshal(obj);
+                
+                marsh.Unmarshal<RandomFieldOrder>(bytes);
+
+            }, Environment.ProcessorCount, 5);
+        }
     }
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -383,6 +448,71 @@ namespace Apache.Ignite.Core.Tests.Binary
             // Read in reverse order to defeat structure optimization.
             Qux = reader.ReadInt("qux");
             Baz = reader.ReadInt("baz");
+        }
+    }
+
+    public class RandomFieldOrder : IBinarizable
+    {
+        public const int FieldCount = 5;
+
+        public void WriteBinary(IBinaryWriter writer)
+        {
+            var fieldNames = GetRandomOrderFieldNames().ToArray();
+            
+            foreach (var fieldName in fieldNames)
+            {
+                writer.WriteString(fieldName, fieldName);
+            }
+        }
+
+        public void ReadBinary(IBinaryReader reader)
+        {
+            var fieldNames = GetRandomOrderFieldNames().ToArray();
+            
+            foreach (var fieldName in fieldNames)
+            {
+                var fieldValue = reader.ReadString(fieldName);
+
+                if (fieldValue != null)
+                {
+                    Assert.AreEqual(fieldName, fieldValue);
+                }
+            }
+        }
+        
+        private static IEnumerable<string> GetRandomOrderFieldNames()
+        {
+            return Enumerable.Range(0, FieldCount).Select(x => "Field_" + x).OrderBy(_ => Guid.NewGuid())
+                .Skip(IgniteUtils.ThreadLocalRandom.Next(FieldCount));
+        }
+    }
+
+    public class CustomFieldOrder : IBinarizable
+    {
+        public static int[] Fields;
+
+        public void WriteBinary(IBinaryWriter writer)
+        {
+            foreach (var field in Fields)
+            {
+                var fieldName = "Field_" + field;
+                writer.WriteString(fieldName, fieldName);
+            }
+        }
+
+        public void ReadBinary(IBinaryReader reader)
+        {
+            foreach (var field in Fields)
+            {
+                var fieldName = "Field_" + field;
+                
+                var fieldValue = reader.ReadString(fieldName);
+                
+                if (fieldValue != null)
+                {
+                    Assert.AreEqual(fieldName, fieldValue);
+                }
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
@@ -82,6 +82,12 @@ namespace Apache.Ignite.Core.Tests.Binary
         [Test]
         public void TestGenericTypes()
         {
+#if NETCOREAPP
+            const string coreAsmNamePrefix = "System.Private.CoreLib,";
+#else
+            const string coreAsmNamePrefix = "mscorlib,";
+#endif
+            
             // Simple name.
             var res = TypeNameParser.Parse("List`1[[Int]]");
             Assert.AreEqual("List`1", res.GetName());
@@ -123,38 +129,38 @@ namespace Apache.Ignite.Core.Tests.Binary
             res = TypeNameParser.Parse(typeof(List<int>).AssemblyQualifiedName);
             Assert.AreEqual("List`1", res.GetName());
             Assert.AreEqual("System.Collections.Generic.List`1", res.GetNameWithNamespace());
-            Assert.IsTrue(res.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(res.GetAssemblyName().StartsWith(coreAsmNamePrefix));
 
             Assert.AreEqual(1, res.Generics.Count);
             var gen = res.Generics.Single();
             Assert.AreEqual("Int32", gen.GetName());
             Assert.AreEqual("System.Int32", gen.GetNameWithNamespace());
-            Assert.IsTrue(gen.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(gen.GetAssemblyName().StartsWith(coreAsmNamePrefix));
 
             // One arg open.
             res = TypeNameParser.Parse(typeof(List<>).AssemblyQualifiedName);
             Assert.AreEqual("List`1", res.GetName());
             Assert.AreEqual("System.Collections.Generic.List`1", res.GetNameWithNamespace());
-            Assert.IsTrue(res.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(res.GetAssemblyName().StartsWith(coreAsmNamePrefix));
             Assert.IsEmpty(res.Generics);
 
             // Two args.
             res = TypeNameParser.Parse(typeof(Dictionary<int, string>).AssemblyQualifiedName);
             Assert.AreEqual("Dictionary`2", res.GetName());
             Assert.AreEqual("System.Collections.Generic.Dictionary`2", res.GetNameWithNamespace());
-            Assert.IsTrue(res.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(res.GetAssemblyName().StartsWith(coreAsmNamePrefix));
 
             Assert.AreEqual(2, res.Generics.Count);
 
             gen = res.Generics.First();
             Assert.AreEqual("Int32", gen.GetName());
             Assert.AreEqual("System.Int32", gen.GetNameWithNamespace());
-            Assert.IsTrue(gen.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(gen.GetAssemblyName().StartsWith(coreAsmNamePrefix));
 
             gen = res.Generics.Last();
             Assert.AreEqual("String", gen.GetName());
             Assert.AreEqual("System.String", gen.GetNameWithNamespace());
-            Assert.IsTrue(gen.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(gen.GetAssemblyName().StartsWith(coreAsmNamePrefix));
 
             // Nested args.
             res = TypeNameParser.Parse(typeof(Dictionary<int, List<string>>).FullName);
@@ -168,13 +174,13 @@ namespace Apache.Ignite.Core.Tests.Binary
             gen = res.Generics.Last();
             Assert.AreEqual("List`1", gen.GetName());
             Assert.AreEqual("System.Collections.Generic.List`1", gen.GetNameWithNamespace());
-            Assert.IsTrue(gen.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(gen.GetAssemblyName().StartsWith(coreAsmNamePrefix));
             Assert.AreEqual(1, gen.Generics.Count);
 
             gen = gen.Generics.Single();
             Assert.AreEqual("String", gen.GetName());
             Assert.AreEqual("System.String", gen.GetNameWithNamespace());
-            Assert.IsTrue(gen.GetAssemblyName().StartsWith("mscorlib,"));
+            Assert.IsTrue(gen.GetAssemblyName().StartsWith(coreAsmNamePrefix));
 
             // Nested class.
             res = TypeNameParser.Parse(typeof(NestedGeneric<int>).FullName);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -344,7 +344,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
 
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
             var ex = Assert.Throws<CacheException>(() =>
-                persons.SelectMany(p => GetRoleCache().AsCacheQueryable()).ToArray());
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    persons.SelectMany(p => GetRoleCache().AsCacheQueryable()).ToArray();
+                }
+            });
 
             Assert.IsTrue(ex.ToString().Contains("QueryCancelledException: The query was cancelled while executing."));
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureEntry.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureEntry.cs
@@ -106,7 +106,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         /// </summary>
         public bool IsJumpTable
         {
-            get { return _name == null && _id >= 0; }
+            get { return _name == null && _id > 0; }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
+++ b/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
@@ -8,4 +8,5 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Multithreaded/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>


### PR DESCRIPTION
* Fix NullReferenceException in BinaryStructure.GetFieldId
* Remove dead code

NRE was caused by empty (default) BinaryStructureEntry caused by replacing longer structure path with shorter one, then again using a longer path. This can be caused by the following behavior of `IBinarizable.WriteBinary`:
* First write: fields "Bar", "Foo"
* Second write: fields "Foo"
* Third write: fields "Foo", "Bar"

Third write yields structure path from second write, but second entry there is empty.