### PR TITLE
IGNITE-12905 - QueryKeyValueIterable missing custom spliterator() implementation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxyImpl.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -724,6 +726,10 @@ public class IgniteCacheProxyImpl<K, V> extends AsyncSupportAdapter<IgniteCache<
 
                 @Override public List<Cache.Entry<K, V>> getAll() {
                     return cur != null ? cur.getAll() : Collections.<Cache.Entry<K, V>>emptyList();
+                }
+
+                @Override public Spliterator<Entry<K, V>> spliterator() {
+                    return cur != null ? cur.spliterator() : Spliterators.emptySpliterator();
                 }
 
                 @Override public void close() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/QueryCursorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/QueryCursorImpl.java
@@ -21,6 +21,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.cache.CacheException;
 import org.apache.ignite.IgniteCheckedException;
@@ -90,6 +91,11 @@ public class QueryCursorImpl<T> implements QueryCursorEx<T>, FieldsQueryCursor<T
     /** {@inheritDoc} */
     @Override public Iterator<T> iterator() {
         return new AutoClosableCursorIterator<>(this, iter());
+    }
+
+    /** {@inheritDoc} */
+    @Override public Spliterator<T> spliterator() {
+        return iterExec == null ? QueryCursorEx.super.spliterator() : iterExec.spliterator();
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryKeyValueIterable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryKeyValueIterable.java
@@ -22,6 +22,7 @@ import org.apache.ignite.cache.query.QueryCursor;
 import javax.cache.Cache;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 /**
  * SqlQuery key-value iterable.
@@ -42,6 +43,11 @@ public class QueryKeyValueIterable<K, V> implements Iterable<Cache.Entry<K, V>> 
     /** {@inheritDoc} */
     @Override public Iterator<Cache.Entry<K, V>> iterator() {
         return new QueryKeyValueIterator<>(cur.iterator());
+    }
+
+    /** {@inheritDoc} */
+    @Override public Spliterator<Cache.Entry<K, V>> spliterator() {
+        return new QueryKeyValueSpliterator<>(cur.spliterator());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryKeyValueSpliterator.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryKeyValueSpliterator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query;
+
+import org.apache.ignite.internal.processors.cache.CacheEntryImpl;
+
+import javax.cache.Cache;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * SqlQuery key-value spliterator.
+ */
+public class QueryKeyValueSpliterator<K, V> implements Spliterator<Cache.Entry<K, V>> {
+    /** Target spliterator. */
+    private final Spliterator<List<?>> spliterator;
+
+    /**
+     * Constructor.
+     *
+     * @param spliterator Target spliterator.
+     */
+    public QueryKeyValueSpliterator(Spliterator<List<?>> spliterator) {
+        this.spliterator = spliterator;
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean tryAdvance(Consumer<? super Cache.Entry<K, V>> action) {
+        return spliterator.tryAdvance(new Consumer<List<?>>() {
+            @Override public void accept(List<?> row) {
+                action.accept(new CacheEntryImpl<>((K)row.get(0), (V)row.get(1)));
+            }
+        });
+    }
+
+    /** {@inheritDoc} */
+    @Override public Spliterator<Cache.Entry<K, V>> trySplit() {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override public long estimateSize() {
+        return spliterator.estimateSize();
+    }
+
+    /** {@inheritDoc} */
+    @Override public int characteristics() {
+        return spliterator.characteristics();
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/QueryCursorSpliteratorCallsTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/QueryCursorSpliteratorCallsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.cache.query.ContinuousQuery;
+import org.apache.ignite.cache.query.Query;
+import org.apache.ignite.cache.query.QueryCursor;
+import org.apache.ignite.cache.query.ScanQuery;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.cache.query.SqlQuery;
+import org.apache.ignite.cache.query.TextQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Query cursor spliterator called multiple times without triggering IgniteException("Iterator is already fetched or
+ * query was cancelled.")
+ */
+public class QueryCursorSpliteratorCallsTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        return super.getConfiguration(igniteInstanceName)
+            .setCacheConfiguration(new CacheConfiguration<>(DEFAULT_CACHE_NAME)
+                .setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL)
+                .setIndexedTypes(Integer.class, String.class));
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        startGrids(1);
+    }
+
+    /**
+     * @throws IgniteException If failed.
+     */
+    @Test
+    public void testScanQueryCursorSpliteratorCalls() throws IgniteException {
+        doQueryCursorSpliteratorCalls(new ScanQuery<>((key, val) -> key != null));
+    }
+
+    /**
+     * @throws IgniteException If failed.
+     */
+    @Test
+    public void testContinuousQueryCursorSpliteratorCalls() throws IgniteException {
+        doQueryCursorSpliteratorCalls(new ContinuousQuery<>()
+            .setInitialQuery(new ScanQuery<>((key, val) -> key != null))
+            .setAutoUnsubscribe(true)
+            .setLocalListener(iterable -> {}));
+    }
+
+    /**
+     * @throws IgniteException If failed.
+     */
+    @Test
+    public void testSqlQueryCursorSpliteratorCalls() throws IgniteException {
+        doQueryCursorSpliteratorCalls(new SqlQuery<>("String", "from String"));
+    }
+
+    /**
+     * @throws IgniteException If failed.
+     */
+    @Test
+    public void testSqlFieldQueryCursorSpliteratorCalls() throws IgniteException {
+        doQueryCursorSpliteratorCalls(new SqlFieldsQuery("select _key from String"));
+    }
+
+    /**
+     * @throws IgniteException If failed.
+     */
+    @Test
+    public void testTextQueryCursorSpliteratorCalls() throws IgniteException {
+        doQueryCursorSpliteratorCalls(new TextQuery<>("String", "1"));
+    }
+
+    /**
+     * Executes query on cache then calls {@link QueryCursor#iterator()} and {@link QueryCursor#spliterator()}
+     * sequentially.
+     *
+     * @param qry Query.
+     */
+    private void doQueryCursorSpliteratorCalls(Query<?> qry) {
+        Ignite client = grid(0);
+
+        IgniteCache<Object, String> cache = client.getOrCreateCache(new CacheConfiguration<>(DEFAULT_CACHE_NAME));
+
+        try (QueryCursor<?> cur = cache.query(qry)) {
+            cur.iterator();
+            cur.spliterator();
+
+            GridTestUtils.assertThrows(log, IgniteException.class, "Iterator is already fetched or query was cancelled.",
+                cur, "iterator");
+        }
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
@@ -214,6 +214,7 @@ import org.apache.ignite.internal.processors.query.KillQueryFromNeighbourTest;
 import org.apache.ignite.internal.processors.query.KillQueryOnClientDisconnectTest;
 import org.apache.ignite.internal.processors.query.KillQueryTest;
 import org.apache.ignite.internal.processors.query.MultipleStatementsSqlQuerySelfTest;
+import org.apache.ignite.internal.processors.query.QueryCursorSpliteratorCallsTest;
 import org.apache.ignite.internal.processors.query.RunningQueriesTest;
 import org.apache.ignite.internal.processors.query.SqlIllegalSchemaSelfTest;
 import org.apache.ignite.internal.processors.query.SqlIncompatibleDataTypeExceptionTest;
@@ -392,6 +393,7 @@ import org.junit.runners.Suite;
     IgniteCacheMultipleIndexedTypesTest.class,
     CacheDataPageScanQueryTest.class,
     QueryDataPageScanTest.class,
+    QueryCursorSpliteratorCallsTest.class,
 
     // DML.
     IgniteCacheMergeSqlQuerySelfTest.class,


### PR DESCRIPTION
Because QueryKeyValueIterable does not implement spliterator, calling `spliterator().hasCharacteristics(Spliterator.SIZED)` will construct a new Spliterator with `java.util.Spliterators#spliteratorUnknownSize(java.util.Iterator<? extends T>, int)` and that will call `org.apache.ignite.internal.processors.cache.QueryCursorImpl#iter` again, thus throwing exception `throw new IgniteException("Iterator is already fetched or query was cancelled.")`