### PR TITLE
IGNITE-12940 .NET: Use fixed NuGet version in build script

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.NuGet/install-package.ps1
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.NuGet/install-package.ps1
@@ -14,11 +14,11 @@ rmdir packages -Force -Recurse
 # Detect NuGet
 $ng = "nuget"
 if ((Get-Command $ng -ErrorAction SilentlyContinue) -eq $null) { 
-    $ng = ".\nuget.exe"
+    $ng = "$PSScriptRoot\..\nuget.exe"
 
     if (-not (Test-Path $ng)) {
         echo "Downloading NuGet..."
-        (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe", "nuget.exe");    
+        (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe", $ng)    
     }
 }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -30,7 +30,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
     using System.Linq;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
-    using Apache.Ignite.Core.Common;
     using Apache.Ignite.Linq;
     using NUnit.Framework;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/CustomLoggerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/CustomLoggerTest.cs
@@ -449,14 +449,5 @@ namespace Apache.Ignite.Core.Tests.Log
                 throw new ArithmeticException("Error in func.");
             }
         }
-
-        /// <summary>
-        /// Custom enum for testing.
-        /// </summary>
-        private struct CustomEnum
-        {
-            // ReSharper disable once UnusedMember.Local
-            public int Field { get; set; }
-        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/CacheConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/CacheConfiguration.cs
@@ -272,7 +272,6 @@ namespace Apache.Ignite.Core.Cache.Configuration
         /// Initializes a new instance of the <see cref="CacheConfiguration"/> class.
         /// </summary>
         /// <param name="reader">The reader.</param>
-        /// <param name="srvVer">Server version.</param>
         internal CacheConfiguration(BinaryReader reader)
         {
             Read(reader);
@@ -282,7 +281,6 @@ namespace Apache.Ignite.Core.Cache.Configuration
         /// Reads data into this instance from the specified reader.
         /// </summary>
         /// <param name="reader">The reader.</param>
-        /// <param name="srvVer">Server version.</param>
         private void Read(BinaryReader reader)
         {
             // Make sure system marshaller is used.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataRegionConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataRegionConfiguration.cs
@@ -120,7 +120,6 @@ namespace Apache.Ignite.Core.Configuration
         /// Writes this instance to a writer.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        /// <param name="srvVer">Server version.</param>
         internal void Write(IBinaryRawWriter writer)
         {
             writer.WriteString(Name);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataStorageConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataStorageConfiguration.cs
@@ -264,7 +264,6 @@ namespace Apache.Ignite.Core.Configuration
         /// Writes this instance to the specified writer.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        /// <param name="srvVer">Server version.</param>
         internal void Write(IBinaryRawWriter writer)
         {
             Debug.Assert(writer != null);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfiguration.cs
@@ -311,7 +311,6 @@ namespace Apache.Ignite.Core
         /// Writes this instance to a writer.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        /// <param name="srvVer">Server version.</param>
         internal void Write(BinaryWriter writer)
         {
             Debug.Assert(writer != null);
@@ -929,7 +928,6 @@ namespace Apache.Ignite.Core
         /// Reads data from specified reader into current instance.
         /// </summary>
         /// <param name="binaryReader">The binary reader.</param>
-        /// <param name="srvVer">Server version.</param>
         private void Read(BinaryReader binaryReader)
         {
             ReadCore(binaryReader);

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -179,7 +179,7 @@ if ((Get-Command $ng -ErrorAction SilentlyContinue) -eq $null) {
 
 	if (-not (Test-Path $ng)) {
 		echo "Downloading NuGet..."
-		(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v5.4.0/nuget.exe", "$PSScriptRoot/nuget.exe")    
+		(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe", "$PSScriptRoot/nuget.exe")    
 	}
 }
 

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -179,7 +179,7 @@ if ((Get-Command $ng -ErrorAction SilentlyContinue) -eq $null) {
 
 	if (-not (Test-Path $ng)) {
 		echo "Downloading NuGet..."
-		(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", "$PSScriptRoot/nuget.exe")    
+		(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v5.4.0/nuget.exe", "$PSScriptRoot/nuget.exe")    
 	}
 }
 


### PR DESCRIPTION
New NuGet release has a bug causing failing builds: https://github.com/NuGet/Home/issues/9458
To fix this and prevent future issues, use a fixed NuGet version instead of the latest.