### PR TITLE
IGNITE-12981: Fix pme-free snapshot exchange if coordinator left the cluster

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -4864,13 +4864,13 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
                                 final ClusterNode newCrd = crd0;
 
                                 // If coordinator changed during exchange free switch no need to send messages.
-                                if (!exchCtx.exchangeFreeSwitch()) {
+//                                if (!exchCtx.exchangeFreeSwitch()) {
                                     cctx.kernalContext().getSystemExecutorService().submit(new Runnable() {
                                         @Override public void run() {
                                             sendPartitions(newCrd);
                                         }
                                     });
-                                }
+//                                }
                             }
                         }
                     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -4874,7 +4874,6 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
 
                                 final ClusterNode newCrd = crd0;
 
-                                // If coordinator changed during exchange free switch no need to send messages.
                                 cctx.kernalContext().getSystemExecutorService().submit(new Runnable() {
                                     @Override public void run() {
                                         sendPartitions(newCrd);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -802,14 +802,14 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
 
             if (exchCtx.exchangeFreeSwitch()) {
                 if (isSnapshotOperation(firstDiscoEvt)) {
+                    // Keep if the cluster was rebalanced.
+                    if (wasRebalanced())
+                        markRebalanced();
+
                     if (!forceAffReassignment)
                         cctx.affinity().onCustomMessageNoAffinityChange(this, exchActions);
 
                     exchange = cctx.kernalContext().clientNode() ? ExchangeType.NONE : ExchangeType.ALL;
-
-                    // Keep if the cluster was rebalanced.
-                    if (wasRebalanced())
-                        markRebalanced();
                 }
                 else
                     exchange = onExchangeFreeSwitchNodeLeft();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -801,8 +801,18 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
             ExchangeType exchange;
 
             if (exchCtx.exchangeFreeSwitch()) {
-                exchange = isSnapshotOperation(firstDiscoEvt) ? onCustomMessageNoAffinityChange() :
-                    onExchangeFreeSwitchNodeLeft();
+                if (isSnapshotOperation(firstDiscoEvt)) {
+                    if (!forceAffReassignment)
+                        cctx.affinity().onCustomMessageNoAffinityChange(this, exchActions);
+
+                    exchange = cctx.kernalContext().clientNode() ? ExchangeType.NONE : ExchangeType.ALL;
+
+                    // Keep if the cluster was rebalanced.
+                    if (wasRebalanced())
+                        markRebalanced();
+                }
+                else
+                    exchange = onExchangeFreeSwitchNodeLeft();
 
                 initCoordinatorCaches(newCrd);
             }
@@ -1446,6 +1456,7 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
     private void clientOnlyExchange() throws IgniteCheckedException {
         if (crd != null) {
             assert !crd.isLocal() : crd;
+            assert !exchCtx.exchangeFreeSwitch() : this;
 
             cctx.exchange().exchangerBlockingSectionBegin();
 
@@ -4864,13 +4875,11 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
                                 final ClusterNode newCrd = crd0;
 
                                 // If coordinator changed during exchange free switch no need to send messages.
-//                                if (!exchCtx.exchangeFreeSwitch()) {
-                                    cctx.kernalContext().getSystemExecutorService().submit(new Runnable() {
-                                        @Override public void run() {
-                                            sendPartitions(newCrd);
-                                        }
-                                    });
-//                                }
+                                cctx.kernalContext().getSystemExecutorService().submit(new Runnable() {
+                                    @Override public void run() {
+                                        sendPartitions(newCrd);
+                                    }
+                                });
                             }
                         }
                     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteSnapshotManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteSnapshotManager.java
@@ -1171,7 +1171,7 @@ public class IgniteSnapshotManager extends GridCacheSharedManagerAdapter
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return S.toString(SnapshotStartDiscoveryMessage.class, this);
+            return S.toString(SnapshotStartDiscoveryMessage.class, this, super.toString());
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteClusterSnapshotSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteClusterSnapshotSelfTest.java
@@ -986,7 +986,6 @@ public class IgniteClusterSnapshotSelfTest extends AbstractSnapshotSelfTest {
 
         for (T2<GridDhtPartitionExchangeId, Boolean> exch : exchFuts)
             assertFalse("Snapshot `rebalanced` must be false with moving partitions: " + exch.get1(), exch.get2());
-
     }
 
     /** @throws Exception If fails. */
@@ -1001,25 +1000,20 @@ public class IgniteClusterSnapshotSelfTest extends AbstractSnapshotSelfTest {
 
             ((IgniteEx)ig).context().cache().context().exchange()
                 .registerExchangeAwareComponent(comp = new PartitionsExchangeAware() {
-                    /** Order of exchange calls. */
                     private final AtomicInteger order = new AtomicInteger();
 
-                    /** {@inheritDoc} */
                     @Override public void onInitBeforeTopologyLock(GridDhtPartitionsExchangeFuture fut) {
                         assertEquals("Exchange order violated: " + fut.firstEvent(), 0, order.getAndIncrement());
                     }
 
-                    /** {@inheritDoc} */
                     @Override public void onInitAfterTopologyLock(GridDhtPartitionsExchangeFuture fut) {
                         assertEquals("Exchange order violated: " + fut.firstEvent(), 1, order.getAndIncrement());
                     }
 
-                    /** {@inheritDoc} */
                     @Override public void onDoneBeforeTopologyUnlock(GridDhtPartitionsExchangeFuture fut) {
                         assertEquals("Exchange order violated: " + fut.firstEvent(), 2, order.getAndIncrement());
                     }
 
-                    /** {@inheritDoc} */
                     @Override public void onDoneAfterTopologyUnlock(GridDhtPartitionsExchangeFuture fut) {
                         assertEquals("Exchange order violated: " + fut.firstEvent(), 3, order.getAndSet(0));
                     }
@@ -1028,8 +1022,7 @@ public class IgniteClusterSnapshotSelfTest extends AbstractSnapshotSelfTest {
             comps.put(((IgniteEx)ig).localNode().id(), comp);
         }
 
-        ignite.snapshot().createSnapshot(SNAPSHOT_NAME)
-            .get();
+        ignite.snapshot().createSnapshot(SNAPSHOT_NAME).get();
 
         for (Ignite ig : G.allGrids()) {
             ((IgniteEx)ig).context().cache().context().exchange()

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteClusterSnapshotSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteClusterSnapshotSelfTest.java
@@ -854,6 +854,37 @@ public class IgniteClusterSnapshotSelfTest extends AbstractSnapshotSelfTest {
         assertSnapshotCacheKeys(snp.cache(ccfg2.getName()));
     }
 
+    /** @throws Exception If fails. */
+    @Test
+    public void testClusterSnapshotFromClientNodeStop() throws Exception {
+        startGridsWithCache(2, dfltCacheCfg, CACHE_KEYS_RANGE);
+
+        IgniteEx clnt = startClientGrid(2);
+
+        IgniteFuture<Void> fut = clnt.snapshot().createSnapshot(SNAPSHOT_NAME);
+
+        stopGrid(0);
+
+        System.out.println("@@@ fut=" + fut.get());
+
+        startGrid(0);
+
+        stopAllGrids();
+
+        IgniteEx snp = startGridsFromSnapshot(2, SNAPSHOT_NAME);
+
+        awaitPartitionMapExchange();
+
+        assertSnapshotCacheKeys(snp.cache(dfltCacheCfg.getName()));
+    }
+
+    // todo On cluster without clients start a snapshot and fail coordinator
+    //  (no errors must happen due to single messages resend)
+    // todo add test coordinator left during snapshot exchange (future inited, but not started)
+    // todo should client send its partitions in case of pme-free? #clientOnlyExchange
+    // todo "Wrap exception Topology projection" is empty with the user one.
+    // todo add test for PartitionExchangeAware execution order during snapshot
+
     /**
      * @param ignite Ignite instance.
      * @param started Latch will be released when delta partition processing starts.


### PR DESCRIPTION
Fixed:
- `wasRebalanced` flag doesn't keep after snapshot
- `ExchangeType` must be `NONE` for the snapshot on a client node
- exchange aware component is not covered by test for a snapshot operation