### PR TITLE
IGNITE-12999: Fix ZookeeperDiscoverySpiSslTest.testIgniteSslWrongPort

### DIFF
--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoverySpiSslTestBase.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoverySpiSslTestBase.java
@@ -76,9 +76,10 @@ class ZookeeperDiscoverySpiSslTestBase extends ZookeeperDiscoverySpiTestBase {
     @Override protected DiscoverySpi cloneDiscoverySpi(DiscoverySpi discoverySpi) throws Exception {
         ZookeeperDiscoverySpi clone = (ZookeeperDiscoverySpi) super.cloneDiscoverySpi(discoverySpi);
 
-        String connStr = ((ZookeeperDiscoverySpi) discoverySpi).getZkConnectionString();
-
-        clone.setZkConnectionString(connStr);
+        if (USE_TEST_CLUSTER)
+            clone.setZkConnectionString(getTestClusterZkConnectionString());
+        else
+            clone.setZkConnectionString(getRealClusterZkConnectionString());
 
         return clone;
     }


### PR DESCRIPTION
After merging IGNITE-110947, in `cloneDiscoverySpi` input parameter was obtained every time from `getConfiguration()`, but not from first node, as it should be. This behaviour leads to instant failure of multijvm tests `GridCacheAtomicMultiJvmFullApiSelfTest` and   `GridCachePartitionedMultiJvmFullApiSelfTest`. After merging IGNITE-12992, this twist doesn't work and configuration cloned from first node, as it should. So we must set zk connection string explicitly. 