### PR TITLE
IGNITE-12994 Move binary metadata to PDS storage folder

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/jdbc2/JdbcAbstractDmlStatementSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/jdbc2/JdbcAbstractDmlStatementSelfTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import org.apache.ignite.cache.QueryEntity;
 import org.apache.ignite.cache.query.annotations.QuerySqlField;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -147,7 +148,7 @@ public abstract class JdbcAbstractDmlStatementSelfTest extends GridCommonAbstrac
     private void cleanUpWorkingDir() throws Exception {
         String workDir = U.defaultWorkDirectory();
 
-        U.delete(U.resolveWorkDirectory(workDir, "marshaller", false));
+        U.delete(U.resolveWorkDirectory(workDir, DataStorageConfiguration.DFLT_MARSHALLER_PATH, false));
     }
 
     /**

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/FoldersReuseCompatibilityTest.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/FoldersReuseCompatibilityTest.java
@@ -25,6 +25,7 @@ import java.util.TreeSet;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.MemoryConfiguration;
 import org.apache.ignite.configuration.MemoryPolicyConfiguration;
@@ -218,7 +219,7 @@ public class FoldersReuseCompatibilityTest extends IgnitePersistenceCompatibilit
      * @throws IgniteCheckedException if IO error occur
      */
     private void assertPdsDirsDefaultExist(String subDirName) throws IgniteCheckedException {
-        assertDirectoryExist("binary_meta", subDirName);
+        assertDirectoryExist(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, subDirName);
         assertDirectoryExist(PersistentStoreConfiguration.DFLT_WAL_STORE_PATH, subDirName);
         assertDirectoryExist(PersistentStoreConfiguration.DFLT_WAL_ARCHIVE_PATH, subDirName);
         assertDirectoryExist(PdsConsistentIdProcessor.DB_DEFAULT_FOLDER, subDirName);

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/IgnitePersistenceCompatibilityAbstractTest.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/IgnitePersistenceCompatibilityAbstractTest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.ignite.compatibility.testframework.junits.IgniteCompatibilityAbstractTest;
 import org.apache.ignite.compatibility.testframework.util.CompatibilityTestsUtils;
-import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.internal.util.typedef.internal.U;
 
 import static org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager.DFLT_STORE_DIR;

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/IgnitePersistenceCompatibilityAbstractTest.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/IgnitePersistenceCompatibilityAbstractTest.java
@@ -32,7 +32,7 @@ import static org.apache.ignite.internal.processors.cache.persistence.file.FileP
  */
 public abstract class IgnitePersistenceCompatibilityAbstractTest extends IgniteCompatibilityAbstractTest {
     /** Persistence directories. */
-    private static final List<String> PERSISTENCE_DIRS = Arrays.asList(DFLT_STORE_DIR, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, "cp", "marshaller");
+    private static final List<String> PERSISTENCE_DIRS = Arrays.asList(DFLT_STORE_DIR, "binary_meta", "cp", "marshaller");
 
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/IgnitePersistenceCompatibilityAbstractTest.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/IgnitePersistenceCompatibilityAbstractTest.java
@@ -22,9 +22,9 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.ignite.compatibility.testframework.junits.IgniteCompatibilityAbstractTest;
 import org.apache.ignite.compatibility.testframework.util.CompatibilityTestsUtils;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.internal.util.typedef.internal.U;
 
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
 import static org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager.DFLT_STORE_DIR;
 
 /**
@@ -32,7 +32,7 @@ import static org.apache.ignite.internal.processors.cache.persistence.file.FileP
  */
 public abstract class IgnitePersistenceCompatibilityAbstractTest extends IgniteCompatibilityAbstractTest {
     /** Persistence directories. */
-    private static final List<String> PERSISTENCE_DIRS = Arrays.asList(DFLT_STORE_DIR, BINARY_META_FOLDER, "cp", "marshaller");
+    private static final List<String> PERSISTENCE_DIRS = Arrays.asList(DFLT_STORE_DIR, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, "cp", "marshaller");
 
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/MoveBinaryMetadataCompatibility.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/MoveBinaryMetadataCompatibility.java
@@ -28,7 +28,7 @@ import org.apache.ignite.internal.IgnitionEx;
 import org.junit.Test;
 
 /**
- * Test for moving binary_meta and marshaller folders to PDS
+ * Test for moving binary_meta and marshaller folders to PDS.
  */
 public class MoveBinaryMetadataCompatibility extends IgnitePersistenceCompatibilityAbstractTest {
     /** Test Ignite version. */

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/MoveBinaryMetadataCompatibility.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/persistence/MoveBinaryMetadataCompatibility.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.compatibility.persistence;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteBinary;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgnitionEx;
+import org.junit.Test;
+
+/**
+ * Test for moving binary_meta and marshaller folders to PDS
+ */
+public class MoveBinaryMetadataCompatibility extends IgnitePersistenceCompatibilityAbstractTest {
+    /** Test Ignite version. */
+    private static final String IGNITE_VERSION = "2.8.0";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setDataStorageConfiguration(
+                new DataStorageConfiguration()
+                        .setDefaultDataRegionConfiguration(
+                                new DataRegionConfiguration()
+                                        .setPersistenceEnabled(true)
+                        ));
+
+        return cfg;
+    }
+
+    /**
+     * Test that folder migration is successfull
+     */
+    @Test
+    public void test() throws Exception {
+        String typeName = "TestBinaryType";
+
+        String fieldName = "testField";
+
+        String fieldVal = "testVal";
+
+        String cacheName = "testCache";
+
+        String objKey = "obj";
+
+        String consid = "node1";
+
+        // start old version and save some binary object to cache
+        startGrid(1, IGNITE_VERSION, configuration -> {
+            configuration.setConsistentId(consid);
+            configuration.setDataStorageConfiguration(
+                    new DataStorageConfiguration()
+                            .setDefaultDataRegionConfiguration(
+                                    new DataRegionConfiguration()
+                                            .setPersistenceEnabled(true)
+                            ));
+        }, (ignite) -> {
+            ignite.active(true);
+
+            IgniteBinary binary = ignite.binary();
+
+            BinaryObject test = binary.builder(typeName).setField(fieldName, fieldVal).build();
+
+            IgniteCache<Object, Object> cache = ignite.getOrCreateCache(cacheName).withKeepBinary();
+
+            cache.put(objKey, test);
+        });
+
+        stopAllGrids();
+
+        IgniteConfiguration configuration = getConfiguration();
+
+        configuration.setConsistentId(consid);
+
+        Ignite newGrid = IgnitionEx.start(configuration);
+
+        IgniteCache<Object, Object> cache = newGrid.getOrCreateCache(cacheName).withKeepBinary();
+
+        // check that binary object is still available in new version of grid
+        BinaryObject obj = (BinaryObject) cache.get(objKey);
+
+        assertTrue(obj.hasField(fieldName));
+
+        assertEquals(fieldVal, obj.field(fieldName));
+
+        newGrid.close();
+    }
+
+}

--- a/modules/compatibility/src/test/java/org/apache/ignite/compatibility/testsuites/IgniteCompatibilityBasicTestSuite.java
+++ b/modules/compatibility/src/test/java/org/apache/ignite/compatibility/testsuites/IgniteCompatibilityBasicTestSuite.java
@@ -21,6 +21,7 @@ import org.apache.ignite.compatibility.cache.LocalCacheTest;
 import org.apache.ignite.compatibility.persistence.FoldersReuseCompatibilityTest;
 import org.apache.ignite.compatibility.persistence.MetaStorageCompatibilityTest;
 import org.apache.ignite.compatibility.persistence.MigratingToWalV2SerializerWithCompactionTest;
+import org.apache.ignite.compatibility.persistence.MoveBinaryMetadataCompatibility;
 import org.apache.ignite.compatibility.persistence.PersistenceBasicCompatibilityTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -34,7 +35,8 @@ import org.junit.runners.Suite;
     FoldersReuseCompatibilityTest.class,
     MigratingToWalV2SerializerWithCompactionTest.class,
     MetaStorageCompatibilityTest.class,
-    LocalCacheTest.class
+    LocalCacheTest.class,
+    MoveBinaryMetadataCompatibility.class
 })
 public class IgniteCompatibilityBasicTestSuite {
 }

--- a/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
@@ -159,6 +159,12 @@ public class DataStorageConfiguration implements Serializable {
     /** Default wal archive directory. */
     public static final String DFLT_WAL_ARCHIVE_PATH = "db/wal/archive";
 
+    /** Default path (relative to working directory) of binary metadata folder */
+    public static final String DFLT_BINARY_METADATA_PATH = "db/binary_meta";
+
+    /** Default path (relative to working directory) of marshaller mappings folder */
+    public static final String DFLT_MARSHALLER_PATH = "db/marshaller";
+
     /** Default write throttling enabled. */
     public static final boolean DFLT_WRITE_THROTTLING_ENABLED = false;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/MarshallerContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/MarshallerContextImpl.java
@@ -37,6 +37,7 @@ import java.util.function.Function;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionFullMap;
 import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionMap;
@@ -189,7 +190,8 @@ public class MarshallerContextImpl implements MarshallerContext {
      * @param mappings Marshaller mappings to save.
      * @param dir Directory to save given mappings to.
      */
-    public static void saveMappings(GridKernalContext ctx, List<Map<Integer, MappedName>> mappings, File dir) {
+    public static void saveMappings(GridKernalContext ctx, List<Map<Integer, MappedName>> mappings, File dir)
+        throws IgniteCheckedException {
         MarshallerMappingFileStore writer = new MarshallerMappingFileStore(ctx,
             resolveMappingFileStoreWorkDir(dir.getAbsolutePath()));
 
@@ -594,7 +596,6 @@ public class MarshallerContextImpl implements MarshallerContext {
         fileStore = marshallerMappingFileStoreDir == null ?
             new MarshallerMappingFileStore(ctx, resolveMappingFileStoreWorkDir(workDir)) :
             new MarshallerMappingFileStore(ctx, marshallerMappingFileStoreDir);
-
         this.transport = transport;
         closProc = ctx.closure();
         clientNode = ctx.clientNode();
@@ -624,7 +625,7 @@ public class MarshallerContextImpl implements MarshallerContext {
         if (F.isEmpty(igniteWorkDir))
             throw new IgniteException("Work directory has not been set: " + igniteWorkDir);
 
-        return new File(igniteWorkDir, "marshaller");
+        return new File(igniteWorkDir, DataStorageConfiguration.DFLT_MARSHALLER_PATH);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryUtils.java
@@ -1045,7 +1045,7 @@ public class BinaryUtils {
                                 + " has a different/incorrect type for field '" + newField.getKey()
                                 + "'. Expected '" + oldFieldTypeName + "' but '" + newFieldTypeName
                                 + "' was provided. Field type's modification is unsupported, clean {root_path}/marshaller " +
-                                "and {root_path}/binary_meta directories if the type change is required."
+                                "and {root_path}/db/binary_meta directories if the type change is required."
                         );
                     }
                 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/BinaryMetadataFileStore.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/BinaryMetadataFileStore.java
@@ -115,6 +115,9 @@ class BinaryMetadataFileStore {
      * Starts worker thread for async writing of binary metadata.
      */
     void start() throws IgniteCheckedException {
+        if (!isPersistenceEnabled)
+            return;
+
         U.ensureDirectory(metadataDir, "directory for serialized binary metadata", log);
 
         writer = new BinaryMetadataAsyncWriter();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/CacheObjectBinaryProcessorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/binary/CacheObjectBinaryProcessorImpl.java
@@ -49,6 +49,7 @@ import org.apache.ignite.cache.affinity.AffinityKeyMapper;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.BinaryConfiguration;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteFutureTimeoutCheckedException;
@@ -126,9 +127,6 @@ import static org.apache.ignite.internal.binary.BinaryUtils.mergeMetadata;
  * Binary processor implementation.
  */
 public class CacheObjectBinaryProcessorImpl extends GridProcessorAdapter implements IgniteCacheObjectProcessor {
-    /** Binary metadata file store folder. */
-    public static final String BINARY_META_FOLDER = "binary_meta";
-
     /** Immutable classes. */
     private static final Collection<Class<?>> IMMUTABLE_CLS = new HashSet<>();
 
@@ -230,7 +228,7 @@ public class CacheObjectBinaryProcessorImpl extends GridProcessorAdapter impleme
                 "[igniteWorkDir=" + igniteWorkDir + ", consId=" + consId + ']');
         }
 
-        return Paths.get(igniteWorkDir, BINARY_META_FOLDER, consId).toFile();
+        return Paths.get(igniteWorkDir, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, consId).toFile();
     }
 
     /** {@inheritDoc} */
@@ -683,7 +681,7 @@ public class CacheObjectBinaryProcessorImpl extends GridProcessorAdapter impleme
         catch (BinaryObjectException e) {
             throw new BinaryObjectException("New binary metadata is incompatible with binary metadata" +
                 " persisted locally." +
-                " Consider cleaning up persisted metadata from <workDir>/binary_meta directory.", e);
+                " Consider cleaning up persisted metadata from <workDir>/db/binary_meta directory.", e);
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/filename/PdsConsistentIdProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/filename/PdsConsistentIdProcessor.java
@@ -78,8 +78,11 @@ public class PdsConsistentIdProcessor extends GridProcessorAdapter implements Pd
     /** Database subfolders for old style filter. */
     private static final FileFilter DB_SUBFOLDERS_OLD_STYLE_FILTER = new FileFilter() {
         @Override public boolean accept(File pathname) {
+            String path = pathname.toString();
             return pathname.isDirectory()
                 && !"wal".equals(pathname.getName())
+                && !path.contains(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH)
+                && !path.contains(DataStorageConfiguration.DFLT_MARSHALLER_PATH)
                 && !pathname.getName().matches(SUBDIR_PATTERN);
         }
     };

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteSnapshotManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteSnapshotManager.java
@@ -1092,7 +1092,12 @@ public class IgniteSnapshotManager extends GridCacheSharedManagerAdapter
             if (mappings == null)
                 return;
 
-            saveMappings(cctx.kernalContext(), mappings, snpLocDir);
+            try {
+                saveMappings(cctx.kernalContext(), mappings, snpLocDir);
+            }
+            catch (IgniteCheckedException e) {
+                throw new IgniteException(e);
+            }
         }
 
         /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteSnapshotManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteSnapshotManager.java
@@ -112,6 +112,8 @@ import org.jetbrains.annotations.Nullable;
 
 import static java.nio.file.StandardOpenOption.READ;
 import static org.apache.ignite.cluster.ClusterState.active;
+import static org.apache.ignite.configuration.DataStorageConfiguration.DFLT_BINARY_METADATA_PATH;
+import static org.apache.ignite.configuration.DataStorageConfiguration.DFLT_MARSHALLER_PATH;
 import static org.apache.ignite.events.EventType.EVT_NODE_FAILED;
 import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
 import static org.apache.ignite.internal.IgniteFeatures.PERSISTENCE_CACHE_SNAPSHOT;
@@ -429,6 +431,12 @@ public class IgniteSnapshotManager extends GridCacheSharedManagerAdapter
                     return FileVisitResult.CONTINUE;
                 }
             });
+
+            File binMetadataDfltDir = new File(snpDir, DFLT_BINARY_METADATA_PATH);
+            File marshallerDfltDir = new File(snpDir, DFLT_MARSHALLER_PATH);
+
+            U.delete(binMetadataDfltDir);
+            U.delete(marshallerDfltDir);
 
             File db = new File(snpDir, DB_DEFAULT_FOLDER);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/reader/StandaloneGridKernalContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/reader/StandaloneGridKernalContext.java
@@ -106,8 +106,6 @@ import org.apache.ignite.thread.IgniteStripedThreadPoolExecutor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
-
 /**
  * Dummy grid kernal context
  */
@@ -166,7 +164,7 @@ public class StandaloneGridKernalContext implements GridKernalContext {
 
         // Fake folder provided to perform processor startup on empty folder.
         if (binaryMetadataFileStoreDir == null)
-            binaryMetadataFileStoreDir = new File(BINARY_META_FOLDER).getAbsoluteFile();
+            binaryMetadataFileStoreDir = new File(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH).getAbsoluteFile();
 
         this.cacheObjProcessor = binaryProcessor(this, binaryMetadataFileStoreDir);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteMarshallerCacheClientRequestsMappingOnMissTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteMarshallerCacheClientRequestsMappingOnMissTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.GridComponent;
 import org.apache.ignite.internal.GridKernalContext;
@@ -99,7 +100,7 @@ public class IgniteMarshallerCacheClientRequestsMappingOnMissTest extends GridCo
      *
      */
     private void cleanupMarshallerFileStore() throws IOException {
-        Path marshCache = Paths.get(TMP_DIR, "marshaller");
+        Path marshCache = Paths.get(TMP_DIR, DataStorageConfiguration.DFLT_MARSHALLER_PATH);
 
         for (File file : marshCache.toFile().listFiles())
             Files.delete(file.toPath());
@@ -126,7 +127,7 @@ public class IgniteMarshallerCacheClientRequestsMappingOnMissTest extends GridCo
 
         stopGrid(1);
 
-        File[] files = Paths.get(TMP_DIR, "marshaller").toFile().listFiles();
+        File[] files = Paths.get(TMP_DIR, DataStorageConfiguration.DFLT_MARSHALLER_PATH).toFile().listFiles();
 
         assertNotNull(TMP_DIR + "/marshaller directory should contain at least one file", files);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteMarshallerCacheFSRestoreTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteMarshallerCacheFSRestoreTest.java
@@ -21,6 +21,8 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.ignite.Ignite;
@@ -31,6 +33,7 @@ import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.PersistentStoreConfiguration;
 import org.apache.ignite.internal.IgniteEx;
@@ -118,7 +121,7 @@ public class IgniteMarshallerCacheFSRestoreTest extends GridCommonAbstractTest {
     private void cleanUpWorkDir() throws Exception {
         String workDir = U.defaultWorkDirectory();
 
-        U.delete(U.resolveWorkDirectory(workDir, "marshaller", false));
+        U.delete(U.resolveWorkDirectory(workDir, DataStorageConfiguration.DFLT_MARSHALLER_PATH, false));
     }
 
     /**
@@ -174,7 +177,7 @@ public class IgniteMarshallerCacheFSRestoreTest extends GridCommonAbstractTest {
 
         String fileName = typeId + ".classname0";
 
-        File marshStoreDir = U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", false);
+        File marshStoreDir = U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH, false);
 
         try (FileOutputStream out = new FileOutputStream(new File(marshStoreDir, fileName))) {
             try (Writer writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
@@ -218,9 +221,9 @@ public class IgniteMarshallerCacheFSRestoreTest extends GridCommonAbstractTest {
      * Class name for CustomClass class mapping file gets cleaned up from file system.
      */
     private void corruptMarshallerStorage() throws Exception {
-        String marshallerDir = U.defaultWorkDirectory() + File.separator + "marshaller";
+        Path marshallerDir = Paths.get(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH);
 
-        File[] storedMappingsFiles = new File(marshallerDir).listFiles();
+        File[] storedMappingsFiles = marshallerDir.toFile().listFiles();
 
         assert storedMappingsFiles.length == 1;
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/MarshallerCacheJobRunNodeRestartTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/MarshallerCacheJobRunNodeRestartTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.processors.cache;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteCallable;
@@ -38,7 +39,7 @@ public class MarshallerCacheJobRunNodeRestartTest extends GridCommonAbstractTest
     @Test
     public void testJobRun() throws Exception {
         for (int i = 0; i < 5; i++) {
-            U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", true);
+            U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH, true);
 
             log.info("Iteration: " + i);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/binary/BinaryMetadataMoveLegacyFolderTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/binary/BinaryMetadataMoveLegacyFolderTest.java
@@ -38,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test for moving binary metadata folder to PDS
+ * Test for moving binary metadata and marshaller folders to PDS.
  */
 public class BinaryMetadataMoveLegacyFolderTest extends GridCommonAbstractTest {
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/binary/BinaryMetadataMoveLegacyFolderTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/binary/BinaryMetadataMoveLegacyFolderTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.internal.processors.cache.binary;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Collection;
+import java.util.UUID;
+import org.apache.ignite.IgniteBinary;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.binary.BinaryObjectBuilder;
+import org.apache.ignite.binary.BinaryType;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.binary.BinaryMetadata;
+import org.apache.ignite.internal.binary.BinaryTypeImpl;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test for moving binary metadata folder to PDS
+ */
+public class BinaryMetadataMoveLegacyFolderTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Before
+    @Override public void beforeTest() throws Exception {
+        super.beforeTest();
+
+        stopAllGrids();
+
+        cleanPersistenceDir();
+    }
+
+    /** {@inheritDoc} */
+    @After
+    @Override public void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids();
+
+        cleanPersistenceDir();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration configuration = super.getConfiguration(igniteInstanceName);
+
+        configuration.setConsistentId(UUID.randomUUID());
+
+        DataStorageConfiguration dsCfg = new DataStorageConfiguration();
+
+        configuration.setDataStorageConfiguration(dsCfg);
+
+        dsCfg.setDefaultDataRegionConfiguration(
+            new DataRegionConfiguration()
+                .setPersistenceEnabled(true));
+
+        return configuration;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteEx startGrid(IgniteConfiguration cfg) throws Exception {
+        IgniteEx grid = super.startGrid(cfg);
+        grid.active(true);
+        return grid;
+    }
+
+    /**
+     * Get byte representation of simple binary type with one field
+     *
+     * @param typeName  Type name.
+     * @param fieldName Field name.
+     */
+    private byte[] createBinaryType(String typeName, String fieldName) throws Exception {
+        IgniteConfiguration configuration = getConfiguration();
+
+        IgniteEx grid = startGrid(configuration);
+
+        IgniteBinary binary = grid.binary();
+
+        BinaryObjectBuilder builder = binary.builder("TestBinaryType");
+
+        builder.setField(fieldName, 1);
+
+        builder.build();
+
+        BinaryMetadata metadata = ((BinaryTypeImpl)binary.type(typeName)).metadata();
+
+        byte[] marshalled = U.marshal(grid.context(), metadata);
+
+        stopAllGrids();
+
+        cleanPersistenceDir();
+
+        return marshalled;
+    }
+
+    /**
+     * Test that binary_meta directory, that was previously located in workdir's root, is successfully moving to PDS
+     * folder.
+     */
+    @Test
+    public void testBinaryMetadataDirectoryMigration() throws Exception {
+        IgniteConfiguration configuration = getConfiguration();
+
+        String typeName = "TestBinaryType";
+
+        String fieldName = "testField";
+
+        // build binary type and get byte representation
+        byte[] testBinaryTypeDefinition = createBinaryType(typeName, fieldName);
+
+        File legacyDir = new File(U.resolveWorkDirectory(
+            U.defaultWorkDirectory(),
+            "binary_meta",
+            false
+        ), U.maskForFileName(configuration.getConsistentId().toString()));
+
+        legacyDir.mkdirs();
+
+        // just some random type id
+        File testBinaryTypeDefFile = new File(legacyDir, "708045005.bin");
+
+        // write binary type definition to legacy folder
+        Files.write(testBinaryTypeDefFile.toPath(), testBinaryTypeDefinition);
+
+        IgniteEx grid = startGrid(configuration);
+
+        // legacy metadata dir must be deleted at this moment
+        assertFalse(legacyDir.exists());
+
+        IgniteBinary binary = grid.binary();
+
+        // binary type must exist
+        BinaryType type = binary.type(typeName);
+
+        assertNotNull(type);
+
+        // it must be the type that we created in the beginning (1 field with specific name)
+        Collection<String> strings = type.fieldNames();
+
+        assertEquals(1, strings.size());
+
+        assertTrue(strings.contains(fieldName));
+
+        // try using this binary type to create, put and get object
+        BinaryObjectBuilder builder = binary.builder(typeName);
+
+        builder.setField(fieldName, 1);
+
+        IgniteCache<Object, Object> testCache = grid.getOrCreateCache("test").withKeepBinary();
+
+        testCache.put("some", builder.build());
+
+        BinaryObject some = (BinaryObject)testCache.get("some");
+
+        Integer test = some.<Integer>field(fieldName);
+
+        assertEquals(1, test.intValue());
+    }
+
+
+
+    /**
+     * Test that marshaller directory, that was previously located in workdir's root, is successfully moving to PDS
+     * folder.
+     */
+    @Test
+    public void testMarshallerMappingsDirectoryMigration() throws Exception {
+        IgniteConfiguration configuration = getConfiguration();
+
+        String typeName = "TestBinaryType";
+
+        File legacyDir = U.resolveWorkDirectory(
+            U.defaultWorkDirectory(),
+            "marshaller",
+            false
+        );
+
+        // just some random type id
+        String typeIdFile = "708045005.classname0";
+
+        File testBinaryTypeDefFile = new File(legacyDir, typeIdFile);
+
+        // write typename definition to legacy folder
+        Files.write(testBinaryTypeDefFile.toPath(), typeName.getBytes());
+
+        startGrid(configuration);
+
+        // legacy marshaller mappings dir must be deleted at this moment
+        assertFalse(legacyDir.exists());
+
+        File newDir = U.resolveWorkDirectory(
+            U.defaultWorkDirectory(),
+            DataStorageConfiguration.DFLT_MARSHALLER_PATH,
+            false
+        );
+
+        // assert folder and contents moved to new location
+        assertTrue(newDir.exists());
+
+        assertTrue(new File(newDir, typeIdFile).exists());
+    }
+
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsBinaryMetadataAsyncWritingTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsBinaryMetadataAsyncWritingTest.java
@@ -58,7 +58,6 @@ import org.junit.Test;
 
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.PRIMARY_SYNC;
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
 import static org.apache.ignite.testframework.GridTestUtils.suppressException;
 
 /**
@@ -555,7 +554,7 @@ public class IgnitePdsBinaryMetadataAsyncWritingTest extends GridCommonAbstractT
      */
     private void cleanBinaryMetaFolderForNode(String consId) throws IgniteCheckedException {
         String dfltWorkDir = U.defaultWorkDirectory();
-        File metaDir = U.resolveWorkDirectory(dfltWorkDir, BINARY_META_FOLDER, false);
+        File metaDir = U.resolveWorkDirectory(dfltWorkDir, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, false);
 
         for (File subDir : metaDir.listFiles()) {
             if (subDir.getName().contains(consId)) {
@@ -683,7 +682,7 @@ public class IgnitePdsBinaryMetadataAsyncWritingTest extends GridCommonAbstractT
 
     /** */
     private static boolean isBinaryMetaFile(File file) {
-        return file.getPath().contains(BINARY_META_FOLDER);
+        return file.getPath().contains(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH);
     }
 
     /** */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsBinaryMetadataOnClusterRestartTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsBinaryMetadataOnClusterRestartTest.java
@@ -45,8 +45,6 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
-
 /**
  *
  */
@@ -337,7 +335,7 @@ public class IgnitePdsBinaryMetadataOnClusterRestartTest extends GridCommonAbstr
         String expectedMsg = String.format(
             "Type '%s' with typeId %d has a different/incorrect type for field '%s'. Expected 'int' but 'long' was " +
                 "provided. Field type's modification is unsupported, clean {root_path}/marshaller and " +
-                "{root_path}/binary_meta directories if the type change is required.",
+                "{root_path}/db/binary_meta directories if the type change is required.",
             DYNAMIC_TYPE_NAME,
             createdTypeId,
             decimalFieldName);
@@ -366,8 +364,10 @@ public class IgnitePdsBinaryMetadataOnClusterRestartTest extends GridCommonAbstr
     ) throws Exception {
         String workDir = U.defaultWorkDirectory();
 
-        Path fromFile = Paths.get(workDir, fromWorkDir, BINARY_META_FOLDER, fromConsId, fileName);
-        Path toFile = Paths.get(workDir, toWorkDir, BINARY_META_FOLDER, toConsId, fileName);
+        Path fromFile = Paths.get(workDir, fromWorkDir, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH,
+            fromConsId, fileName);
+        Path toFile = Paths.get(workDir, toWorkDir, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH,
+            toConsId, fileName);
 
         Files.copy(fromFile, toFile, StandardCopyOption.REPLACE_EXISTING);
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsNoSpaceLeftOnDeviceTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsNoSpaceLeftOnDeviceTest.java
@@ -35,8 +35,6 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.transactions.Transaction;
 import org.junit.Test;
 
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
-
 /**
  *
  */
@@ -134,7 +132,7 @@ public class IgnitePdsNoSpaceLeftOnDeviceTest extends GridCommonAbstractTest {
         @Override public FileIO create(File file, OpenOption... modes) throws IOException {
             if (unluckyConsistentId.get() != null
                 && file.getAbsolutePath().contains(unluckyConsistentId.get())
-                && file.getAbsolutePath().contains(BINARY_META_FOLDER))
+                && file.getAbsolutePath().contains(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH))
                 throw new IOException("No space left on device");
 
             return delegateFactory.create(file, modes);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/filename/IgniteUidAsConsistentIdMigrationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/filename/IgniteUidAsConsistentIdMigrationTest.java
@@ -117,7 +117,7 @@ public class IgniteUidAsConsistentIdMigrationTest extends GridCommonAbstractTest
         if (pstWalStoreCustomPath != null)
             ok &= U.delete(pstWalStoreCustomPath);
 
-        ok &= U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "binary_meta", false));
+        ok &= U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, false));
 
         if (failIfDeleteNotCompleted)
             assertTrue(ok);
@@ -185,7 +185,7 @@ public class IgniteUidAsConsistentIdMigrationTest extends GridCommonAbstractTest
         UUID.fromString(ignite.cluster().localNode().consistentId().toString());
         final String subfolderName = genNewStyleSubfolderName(0, ignite);
 
-        assertDirectoryExist("binary_meta", subfolderName);
+        assertDirectoryExist(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, subfolderName);
 
         assertDirectoryExist(pstWalArchCustomPath, subfolderName);
         assertDirectoryExist(pstWalArchCustomPath, subfolderName);
@@ -676,7 +676,7 @@ public class IgniteUidAsConsistentIdMigrationTest extends GridCommonAbstractTest
      * @throws IgniteCheckedException if IO error occur
      */
     private void assertPdsDirsDefaultExist(String subDirName) throws IgniteCheckedException {
-        assertDirectoryExist("binary_meta", subDirName);
+        assertDirectoryExist(DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, subDirName);
         assertDirectoryExist(DataStorageConfiguration.DFLT_WAL_PATH, subDirName);
         assertDirectoryExist(DataStorageConfiguration.DFLT_WAL_ARCHIVE_PATH, subDirName);
         assertDirectoryExist(PdsConsistentIdProcessor.DB_DEFAULT_FOLDER, subDirName);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/reader/IgniteWalReaderTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/reader/IgniteWalReaderTest.java
@@ -1303,9 +1303,10 @@ public class IgniteWalReaderTest extends GridCommonAbstractTest {
         String workDir,
         String subfolderName
     ) throws IgniteCheckedException {
-        File binaryMeta = U.resolveWorkDirectory(workDir, "binary_meta", false);
+        File binaryMeta = U.resolveWorkDirectory(workDir, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH,
+            false);
         File binaryMetaWithConsId = new File(binaryMeta, subfolderName);
-        File marshallerMapping = U.resolveWorkDirectory(workDir, "marshaller", false);
+        File marshallerMapping = U.resolveWorkDirectory(workDir, DataStorageConfiguration.DFLT_MARSHALLER_PATH, false);
 
         return new IteratorParametersBuilder()
             .binaryMetadataFileStoreDir(binaryMetaWithConsId)

--- a/modules/core/src/test/java/org/apache/ignite/marshaller/MarshallerContextSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/marshaller/MarshallerContextSelfTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.MarshallerContextImpl;
 import org.apache.ignite.internal.processors.closure.GridClosureProcessor;
@@ -161,7 +162,7 @@ public class MarshallerContextSelfTest extends GridCommonAbstractTest {
      */
     @Test
     public void testOnUpdated() throws Exception {
-        File workDir = U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", false);
+        File workDir = U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH, false);
         MarshallerContextImpl ctx = new MarshallerContextImpl(null, null);
 
         ctx.onMarshallerProcessorStarted(this.ctx, null);

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -158,7 +158,6 @@ import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL_SNAPSHOT;
 import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
 import static org.apache.ignite.internal.GridKernalState.DISCONNECTED;
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
 import static org.apache.ignite.testframework.GridTestUtils.getFieldValue;
 import static org.apache.ignite.testframework.GridTestUtils.getFieldValueHierarchy;
 import static org.apache.ignite.testframework.GridTestUtils.setFieldValue;
@@ -664,8 +663,8 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
      * Will clean and re-create marshaller directory from scratch.
      */
     private void resolveWorkDirectory() throws Exception {
-        U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", true);
-        U.resolveWorkDirectory(U.defaultWorkDirectory(), BINARY_META_FOLDER, true);
+        U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH, true);
+        U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_BINARY_METADATA_PATH, true);
     }
 
     /** */

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
@@ -68,6 +68,7 @@ import org.apache.ignite.cluster.ClusterTopologyException;
 import org.apache.ignite.compute.ComputeTask;
 import org.apache.ignite.compute.ComputeTaskFuture;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.events.Event;
 import org.apache.ignite.events.EventType;
@@ -142,7 +143,6 @@ import static org.apache.ignite.cache.CacheMode.LOCAL;
 import static org.apache.ignite.cache.CacheRebalanceMode.NONE;
 import static org.apache.ignite.configuration.IgniteConfiguration.DFLT_SNAPSHOT_DIRECTORY;
 import static org.apache.ignite.internal.processors.cache.GridCacheUtils.isNearEnabled;
-import static org.apache.ignite.internal.processors.cache.binary.CacheObjectBinaryProcessorImpl.BINARY_META_FOLDER;
 import static org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtPartitionState.OWNING;
 import static org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager.DFLT_STORE_DIR;
 import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
@@ -1928,8 +1928,9 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
 
         U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "cp", false));
         U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DFLT_STORE_DIR, false));
-        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", false));
-        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), BINARY_META_FOLDER, false));
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH, false));
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_BINARY_METADATA_PATH,
+            false));
         U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DFLT_SNAPSHOT_DIRECTORY, false));
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBinaryObjectsTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBinaryObjectsTestSuite.java
@@ -56,6 +56,7 @@ import org.apache.ignite.internal.binary.streams.BinaryAbstractOutputStreamTest;
 import org.apache.ignite.internal.binary.streams.BinaryHeapStreamByteOrderSelfTest;
 import org.apache.ignite.internal.binary.streams.BinaryOffheapStreamByteOrderSelfTest;
 import org.apache.ignite.internal.processors.cache.binary.BinaryAtomicCacheLocalEntriesSelfTest;
+import org.apache.ignite.internal.processors.cache.binary.BinaryMetadataMoveLegacyFolderTest;
 import org.apache.ignite.internal.processors.cache.binary.BinaryMetadataRegistrationCacheApiTest;
 import org.apache.ignite.internal.processors.cache.binary.BinaryMetadataRegistrationCacheStoreTest;
 import org.apache.ignite.internal.processors.cache.binary.BinaryMetadataRegistrationEntryProcessorTest;
@@ -160,7 +161,9 @@ import org.junit.runners.Suite;
     BinaryAbstractOutputStreamTest.class,
     BinaryOffheapStreamByteOrderSelfTest.class,
 
-    GridCacheBinaryObjectUserClassloaderSelfTest.class
+    GridCacheBinaryObjectUserClassloaderSelfTest.class,
+
+    BinaryMetadataMoveLegacyFolderTest.class
 })
 public class IgniteBinaryObjectsTestSuite {
 }

--- a/modules/dev-utils/ignite-modules-test/src/test/java/org/apache/ignite/modulestest/IgniteLaunchInModularEnvTest.java
+++ b/modules/dev-utils/ignite-modules-test/src/test/java/org/apache/ignite/modulestest/IgniteLaunchInModularEnvTest.java
@@ -79,8 +79,9 @@ public class IgniteLaunchInModularEnvTest {
 
         U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "cp", false));
         U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DFLT_STORE_DIR, false));
-        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "marshaller", false));
-        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "binary_meta", false));
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.DFLT_MARSHALLER_PATH, false));
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), DataStorageConfiguration.BINARY_METADATA_DFLT_PATH,
+            false));
     }
 
     /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -428,7 +428,7 @@ namespace Apache.Ignite.Core.Tests
 
             using (Ignition.Start(cfg))
             {
-                var marshDir = Path.Combine(cfg.WorkDirectory, "marshaller");
+                var marshDir = Path.Combine(cfg.WorkDirectory, "db", "marshaller");
 
                 Assert.IsTrue(Directory.Exists(marshDir));
             }


### PR DESCRIPTION
Binary metadata and marshaller directories are now located inside /db directory.

If on a startup any of these folders are found in legacy location, they're moved safely to new location.
Motivation: For example, on K8s deployment disk that is attached to container can not be accessible from other containers or outside of K8s. In case if support will need to drop persistence except data, there will be no way to recover due to binary metadata is required to process PDS files.