### PR TITLE
IGNITE-7153: Fix parser to handle incomplete Redis packet

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/processors/rest/protocols/tcp/redis/RedisProtocolConnectSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/processors/rest/protocols/tcp/redis/RedisProtocolConnectSelfTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.rest.protocols.tcp.redis;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
@@ -72,6 +73,23 @@ public class RedisProtocolConnectSelfTest extends RedisCommonAbstractTest {
 
             jedis.select(0);
             Assert.assertEquals("v0", jedis.get("k0"));
+        }
+    }
+
+    //IGNITE-7153
+    public void testSetBigObject1() throws Exception {
+        String randomString1 = RandomStringUtils.random(8 << 10, true, true); //8192
+        String randomString2 = RandomStringUtils.random(10 << 10, true, true); //10240
+        String randomString3 = RandomStringUtils.random(8 << 11, true, true); //16384
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set("b1".getBytes(), randomString1.getBytes());
+            Assert.assertEquals(randomString1, jedis.get("b1"));
+
+            jedis.set("b2".getBytes(), randomString2.getBytes());
+            Assert.assertEquals(randomString2, jedis.get("b2"));
+
+            jedis.set("b3".getBytes(), randomString3.getBytes());
+            Assert.assertEquals(randomString3, jedis.get("b3"));
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/protocols/tcp/GridTcpRestParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/protocols/tcp/GridTcpRestParser.java
@@ -156,7 +156,7 @@ public class GridTcpRestParser implements GridNioParser {
                 break;
 
             case REDIS:
-                res = GridRedisProtocolParser.readArray(buf);
+                res = parseRedisPacket(ses, buf, state);
 
                 break;
 
@@ -243,6 +243,45 @@ public class GridTcpRestParser implements GridNioParser {
             slice.put(U.uuidToBytes(msg.destinationId()));
 
             return res;
+        }
+    }
+
+    /**
+     * Parses redis protocol message.
+     *
+     * @param ses Session.
+     * @param buf Buffer containing not parsed bytes.
+     * @param state Current parser state.
+     * @return Parsed packet.s
+     * @throws IOException If packet cannot be parsed.
+     * @throws IgniteCheckedException If deserialization error occurred.
+     */
+    private GridClientMessage parseRedisPacket(GridNioSession ses, ByteBuffer buf, ParserState state)
+            throws IOException, IgniteCheckedException {
+        assert state.packetType() == GridClientPacketType.REDIS;
+
+        ByteArrayOutputStream tmp = state.buffer();
+
+        if (GridRedisProtocolParser.validatePacket(buf)) {
+            //single parsable packet
+            return GridRedisProtocolParser.readArray(buf);
+        } else if (GridRedisProtocolParser.validatePacketFooter(buf)) { //Scenario 2
+
+            int fullLength = tmp.size() + buf.limit();
+            ByteBuffer fullPacket = ByteBuffer.allocate(fullLength);
+            fullPacket.put(tmp.toByteArray());
+            fullPacket = fullPacket.put(buf);
+            fullPacket.flip();
+
+            tmp.reset();
+            return GridRedisProtocolParser.readArray(fullPacket);
+        } else { //Scenario 1 or 3
+
+            byte[] data = new byte[buf.limit()];
+            buf.get(data);
+            tmp.write(data);
+
+            return null;
         }
     }
 


### PR DESCRIPTION
Add validation method to check packet completeness

Add logic to store incomplete packet temporarily and assemble them until
the final CRLF is seen.

Implement test cases for data = 8k, 10k and 16k

Ref: #5044 #7808

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-12407: Add Cluster API support to Java thin client`
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.