### PR TITLE
IGNITE-12085: Fix the late registration of the thread pools metrics.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -1361,6 +1361,19 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
             startTimer.finishGlobalStage("Await transition");
 
+            ctx.metric().registerThreadPools(utilityCachePool, execSvc, svcExecSvc, sysExecSvc, stripedExecSvc,
+                p2pExecSvc, mgmtExecSvc, igfsExecSvc, dataStreamExecSvc, restExecSvc, affExecSvc, idxExecSvc,
+                callbackExecSvc, qryExecSvc, schemaExecSvc, rebalanceExecSvc, rebalanceStripedExecSvc, customExecSvcs);
+
+            registerMetrics();
+
+            // Register MBeans.
+            mBeansMgr.registerAllMBeans(utilityCachePool, execSvc, svcExecSvc, sysExecSvc, stripedExecSvc, p2pExecSvc,
+                mgmtExecSvc, igfsExecSvc, dataStreamExecSvc, restExecSvc, affExecSvc, idxExecSvc, callbackExecSvc,
+                qryExecSvc, schemaExecSvc, rebalanceExecSvc, rebalanceStripedExecSvc, customExecSvcs, ctx.workersRegistry());
+
+            ctx.systemView().registerThreadPools(stripedExecSvc, dataStreamExecSvc);
+
             boolean recon = false;
 
             // Callbacks.
@@ -1403,19 +1416,6 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
 
             if (recon)
                 reconnectState.waitFirstReconnect();
-
-            ctx.metric().registerThreadPools(utilityCachePool, execSvc, svcExecSvc, sysExecSvc, stripedExecSvc,
-                p2pExecSvc, mgmtExecSvc, igfsExecSvc, dataStreamExecSvc, restExecSvc, affExecSvc, idxExecSvc,
-                callbackExecSvc, qryExecSvc, schemaExecSvc, rebalanceExecSvc, rebalanceStripedExecSvc, customExecSvcs);
-
-            registerMetrics();
-
-            // Register MBeans.
-            mBeansMgr.registerAllMBeans(utilityCachePool, execSvc, svcExecSvc, sysExecSvc, stripedExecSvc, p2pExecSvc,
-                mgmtExecSvc, igfsExecSvc, dataStreamExecSvc, restExecSvc, affExecSvc, idxExecSvc, callbackExecSvc,
-                qryExecSvc, schemaExecSvc, rebalanceExecSvc, rebalanceStripedExecSvc, customExecSvcs, ctx.workersRegistry());
-
-            ctx.systemView().registerThreadPools(stripedExecSvc, dataStreamExecSvc);
 
             // Lifecycle bean notifications.
             notifyLifecycleBeans(AFTER_NODE_START);

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteUtilSelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteUtilSelfTestSuite.java
@@ -49,6 +49,7 @@ import org.apache.ignite.spi.discovery.ClusterRebalancedMetricTest;
 import org.apache.ignite.thread.GridThreadPoolExecutorServiceSelfTest;
 import org.apache.ignite.thread.GridThreadTest;
 import org.apache.ignite.thread.IgniteThreadPoolSizeTest;
+import org.apache.ignite.thread.ThreadPoolMetricsTest;
 import org.apache.ignite.util.GridConcurrentLinkedDequeMultiThreadedTest;
 import org.apache.ignite.util.GridIntListSelfTest;
 import org.apache.ignite.util.GridLogThrottleTest;
@@ -114,6 +115,7 @@ import org.junit.runners.Suite;
     ClusterMetricsSnapshotSerializeCompatibilityTest.class,
     ClusterMetricsSelfTest.class,
     ClusterRebalancedMetricTest.class,
+    ThreadPoolMetricsTest.class,
 
     // Unsafe.
     GridUnsafeMemorySelfTest.class,

--- a/modules/core/src/test/java/org/apache/ignite/thread/ThreadPoolMetricsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/thread/ThreadPoolMetricsTest.java
@@ -27,7 +27,6 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.processors.metric.GridMetricManager;
-import org.apache.ignite.mxbean.ThreadPoolMXBean;
 import org.apache.ignite.plugin.AbstractTestPluginProvider;
 import org.apache.ignite.spi.metric.log.LogExporterSpi;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
@@ -104,7 +103,7 @@ public class ThreadPoolMetricsTest extends GridCommonAbstractTest {
      * @throws Exception If failed.
      */
     @Test
-    @SuppressWarnings({"Convert2MethodRef", "deprecation"})
+    @SuppressWarnings("Convert2MethodRef")
     public void testThreadPoolMetrics() throws Exception {
         try {
             runAsync(() -> startGrid());
@@ -123,13 +122,6 @@ public class ThreadPoolMetricsTest extends GridCommonAbstractTest {
             );
 
             assertTrue(metrics.contains(GridMetricManager.IGNITE_METRICS));
-
-            THREAD_POOL_NAMES.forEach(name -> getMxBean(
-                getTestIgniteInstanceName(),
-                "Thread Pools",
-                name,
-                ThreadPoolMXBean.class
-            ));
 
             List<String> views = new ArrayList<>();
 

--- a/modules/core/src/test/java/org/apache/ignite/thread/ThreadPoolMetricsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/thread/ThreadPoolMetricsTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.thread;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.processors.metric.GridMetricManager;
+import org.apache.ignite.mxbean.ThreadPoolMXBean;
+import org.apache.ignite.spi.IgniteSpiAdapter;
+import org.apache.ignite.spi.IgniteSpiContext;
+import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.spi.metric.MetricExporterSpi;
+import org.apache.ignite.spi.metric.ReadOnlyMetricManager;
+import org.apache.ignite.spi.metric.ReadOnlyMetricRegistry;
+import org.apache.ignite.spi.systemview.ReadOnlySystemViewRegistry;
+import org.apache.ignite.spi.systemview.SystemViewExporterSpi;
+import org.apache.ignite.spi.systemview.view.SystemView;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.ignite.internal.managers.systemview.GridSystemViewManager.STREAM_POOL_QUEUE_VIEW;
+import static org.apache.ignite.internal.managers.systemview.GridSystemViewManager.SYS_POOL_QUEUE_VIEW;
+import static org.apache.ignite.internal.processors.metric.impl.MetricUtils.metricName;
+import static org.apache.ignite.testframework.GridTestUtils.runAsync;
+
+/**
+ * Tests that thread pool metrics are registered before {@link GridMetricManager#onKernalStart} invocation.
+ */
+public class ThreadPoolMetricsTest extends GridCommonAbstractTest {
+    /** Names of the general thread pools. */
+    private static final Collection<String> THREAD_POOL_NAMES = Arrays.asList(
+        "GridUtilityCacheExecutor",
+        "GridExecutionExecutor",
+        "GridServicesExecutor",
+        "GridSystemExecutor",
+        "GridClassLoadingExecutor",
+        "GridManagementExecutor",
+        "GridIgfsExecutor",
+        "GridAffinityExecutor",
+        "GridCallbackExecutor",
+        "GridQueryExecutor",
+        "GridSchemaExecutor",
+        "GridRebalanceExecutor",
+        "GridRebalanceStripedExecutor",
+        "GridDataStreamExecutor"
+    );
+
+    /** Test instance of the {@link MetricExporterSpi}. */
+    private final TestMetricExporterSpi metricExporter = new TestMetricExporterSpi(getTestTimeout());
+
+    /** Test instance of the {@link SystemViewExporterSpi}. */
+    private final TestSystemViewExporterSpi sysViewExporter = new TestSystemViewExporterSpi();
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        return super.getConfiguration(igniteInstanceName)
+            .setMetricExporterSpi(metricExporter)
+            .setSystemViewExporterSpi(sysViewExporter);
+    }
+
+    /**
+     * Tests that thread pool metrics are registered before {@link GridMetricManager#onKernalStart} invocation.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    @SuppressWarnings({"Convert2MethodRef", "deprecation"})
+    public void testThreadPoolMetrics() throws Exception {
+        assertEquals(1, metricExporter.startInitLatch.getCount());
+
+        runAsync(() -> startGrid());
+
+        assertTrue(metricExporter.startInitLatch.await(getTestTimeout(), MILLISECONDS));
+
+        metricExporter.checkMetricsRegistered();
+
+        THREAD_POOL_NAMES.forEach(name -> getMxBean(
+            getTestIgniteInstanceName(),
+            "Thread Pools",
+            name,
+            ThreadPoolMXBean.class
+        ));
+
+        sysViewExporter.checkSystemViewsRegistered();
+
+        assertEquals(1, metricExporter.unblockInitLatch.getCount());
+
+        metricExporter.unblockInitLatch.countDown();
+    }
+
+    /** */
+    private static class TestSystemViewExporterSpi extends IgniteSpiAdapter implements SystemViewExporterSpi {
+        /** System view registry. */
+        private volatile ReadOnlySystemViewRegistry reg;
+
+        /** {@inheritDoc} */
+        @Override public void setSystemViewRegistry(ReadOnlySystemViewRegistry reg) {
+            this.reg = reg;
+        }
+
+        /**
+         * Checks that thread pool system views are registered.
+         */
+        public void checkSystemViewsRegistered() {
+            List<String> views = new ArrayList<>();
+
+            reg.forEach(view -> views.add(view.name()));
+
+            assertTrue(views.containsAll(Arrays.asList(SYS_POOL_QUEUE_VIEW, STREAM_POOL_QUEUE_VIEW)));
+        }
+
+        /** {@inheritDoc} */
+        @Override public void setExportFilter(Predicate<SystemView<?>> filter) {
+            // No-op.
+        }
+
+        /** {@inheritDoc} */
+        @Override public void spiStart(@Nullable String igniteInstanceName) throws IgniteSpiException {
+            // No-op.
+        }
+
+        /** {@inheritDoc} */
+        @Override public void spiStop() throws IgniteSpiException {
+            // No-op.
+        }
+    }
+
+    /** */
+    private static class TestMetricExporterSpi extends IgniteSpiAdapter implements MetricExporterSpi {
+        /** Latch that indicates whether {@link IgniteSpiAdapter#onContextInitialized0} was invoked. */
+        public final CountDownLatch startInitLatch = new CountDownLatch(1);
+
+        /** Latch that indicates whether {@link IgniteSpiAdapter#onContextInitialized0} execution was unblocked. */
+        public final CountDownLatch unblockInitLatch = new CountDownLatch(1);
+
+        /** Timeout of {@link IgniteSpiAdapter#onContextInitialized0} execution blocked state. */
+        public final long timeout;
+
+        /** Metric registry. */
+        private volatile ReadOnlyMetricManager reg;
+
+        /** */
+        private TestMetricExporterSpi(long timeout) {
+            this.timeout = timeout;
+        }
+
+        /** {@inheritDoc} */
+        @Override public void setMetricRegistry(ReadOnlyMetricManager reg) {
+            this.reg = reg;
+        }
+
+        /** {@inheritDoc} */
+        @Override protected void onContextInitialized0(IgniteSpiContext spiCtx) throws IgniteSpiException {
+            startInitLatch.countDown();
+
+            try {
+                unblockInitLatch.await(timeout, MILLISECONDS);
+            }
+            catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public void setExportFilter(Predicate<ReadOnlyMetricRegistry> filter) {
+            // No-op.
+        }
+
+        /** {@inheritDoc} */
+        @Override public void spiStart(@Nullable String igniteInstanceName) throws IgniteSpiException {
+            // No-op.
+        }
+
+        /** {@inheritDoc} */
+        @Override public void spiStop() throws IgniteSpiException {
+            // No-op.
+        }
+
+        /**
+         * Checks that thread pool metrics are registered.
+         */
+        public void checkMetricsRegistered() {
+            List<String> metrics = new ArrayList<>();
+
+            reg.forEach(metric -> metrics.add(metric.name()));
+
+            assertTrue(metrics.containsAll(THREAD_POOL_NAMES.stream()
+                .map(name -> metricName(GridMetricManager.THREAD_POOLS, name))
+                .collect(Collectors.toList()))
+            );
+
+            assertTrue(metrics.contains(GridMetricManager.IGNITE_METRICS));
+        }
+    }
+}


### PR DESCRIPTION
Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-12407: Add Cluster API support to Java thin client`
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.