### PR TITLE
IGNITE-13043 C++: Fix compilation when boost 1.71 is used

### DIFF
--- a/modules/platforms/cpp/core-test/src/teamcity_boost.cpp
+++ b/modules/platforms/cpp/core-test/src/teamcity_boost.cpp
@@ -151,7 +151,7 @@ void TeamcityBoostLogFormatter::log_build_info(std::ostream& /*out*/)
 #if BOOST_VERSION >= 107000
  // Since v1.70.0 the second argument indicates whether build info should be logged or not
  // See boostorg/test.git:7e20f966dca4e4b49585bbe7654334f31b35b3db
-void log_build_info(std::ostream& os, bool log_build_info) override {
+void TeamcityBoostLogFormatter::log_build_info(std::ostream& os, bool log_build_info) {
     if (log_build_info) this->log_build_info(os);
 }
 #endif

--- a/modules/platforms/cpp/odbc-test/src/teamcity/teamcity_boost.cpp
+++ b/modules/platforms/cpp/odbc-test/src/teamcity/teamcity_boost.cpp
@@ -151,7 +151,7 @@ void TeamcityBoostLogFormatter::log_build_info(std::ostream& /*out*/)
 #if BOOST_VERSION >= 107000
  // Since v1.70.0 the second argument indicates whether build info should be logged or not
  // See boostorg/test.git:7e20f966dca4e4b49585bbe7654334f31b35b3db
-void log_build_info(std::ostream& os, bool log_build_info) override {
+void TeamcityBoostLogFormatter::log_build_info(std::ostream& os, bool log_build_info) {
     if (log_build_info) this->log_build_info(os);
 }
 #endif

--- a/modules/platforms/cpp/thin-client-test/src/teamcity/teamcity_boost.cpp
+++ b/modules/platforms/cpp/thin-client-test/src/teamcity/teamcity_boost.cpp
@@ -151,7 +151,7 @@ void TeamcityBoostLogFormatter::log_build_info(std::ostream& /*out*/)
 #if BOOST_VERSION >= 107000
  // Since v1.70.0 the second argument indicates whether build info should be logged or not
  // See boostorg/test.git:7e20f966dca4e4b49585bbe7654334f31b35b3db
-void log_build_info(std::ostream& os, bool log_build_info) override {
+void TeamcityBoostLogFormatter::log_build_info(std::ostream& os, bool log_build_info) {
     if (log_build_info) this->log_build_info(os);
 }
 #endif


### PR DESCRIPTION
Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-12407: Add Cluster API support to Java thin client`
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.