### PR TITLE
IGNITE-13057: Fix tmp workdir message print condition

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/file/FilePageStoreManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/file/FilePageStoreManager.java
@@ -229,13 +229,13 @@ public class FilePageStoreManager extends GridCacheSharedManagerAdapter implemen
 
         String tmpDir = System.getProperty("java.io.tmpdir");
 
-        if (tmpDir != null && storeWorkDir.getAbsolutePath().contains(tmpDir)) {
+        if (tmpDir != null && storeWorkDir.getAbsolutePath().startsWith(tmpDir)) {
             log.warning("Persistence store directory is in the temp directory and may be cleaned." +
                 "To avoid this set \"IGNITE_HOME\" environment variable properly or " +
                 "change location of persistence directories in data storage configuration " +
                 "(see DataStorageConfiguration#walPath, DataStorageConfiguration#walArchivePath, " +
                 "DataStorageConfiguration#storagePath properties). " +
-                "Current persistence store directory is: [" + tmpDir + "]");
+                "Current persistence store directory is: [" + storeWorkDir.getAbsolutePath() + "]");
         }
 
         File[] files = storeWorkDir.listFiles();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/PersistenceDirectoryWarningLoggingTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/PersistenceDirectoryWarningLoggingTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.ignite.internal.processors.cache.persistence;
 
+import java.io.File;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.GridStringLogger;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
@@ -87,4 +89,27 @@ public class PersistenceDirectoryWarningLoggingTest extends GridCommonAbstractTe
 
         assertTrue(log0.toString().contains(WARN_MSG_PREFIX));
     }
+
+    /**
+     * Test that temporary work directory warning is not printed, if PDS is not actually in temporary directory
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testPdsDirWarningIsNotLogged() throws Exception {
+        IgniteConfiguration cfg = getConfiguration("0");
+
+        String tempDir = System.getProperty("java.io.tmpdir");
+
+        assertNotNull(tempDir);
+
+        File workDir = new File(U.defaultWorkDirectory(), tempDir);
+
+        // set working directory to file not in tmp directory, but with temp directory folder name in path
+        cfg.setWorkDirectory(workDir.getAbsolutePath());
+
+        startGrid(cfg);
+
+        assertFalse(log0.toString().contains(WARN_MSG_PREFIX));
+    }
+
 }


### PR DESCRIPTION
Warning about tmp workdir usage for PDS was printed in case if pds path contains system tmp folder name. E.g. /home/username/**tmp**/pds, warning will be printed even though it's not a real tmp folder.

Now this warning will be printed only in case if pds is really in tmp folder