### PR TITLE
IGNITE-13226 .NET: Fix ClientNotificationHandler leak in ClientSocket

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Common/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Common/TestRunner.cs
@@ -17,6 +17,8 @@
 
 namespace Apache.Ignite.Core.Tests.DotNetCore.Common
 {
+    using Apache.Ignite.Core.Tests.Client.Compute;
+
     /// <summary>
     /// Test runner.
     /// </summary>
@@ -27,7 +29,12 @@ namespace Apache.Ignite.Core.Tests.DotNetCore.Common
         /// </summary>
         private static void Main(string[] args)
         {
-            new IgnitionStartTest().TestIgniteStartsFromAppConfig();
+            var t = new ComputeClientTests();
+            t.FixtureSetUp();
+            t.TestSetUp();
+            t.TestExecuteJavaTaskAsyncMultithreaded();
+            t.TearDown();
+            t.FixtureTearDown();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Common/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.DotNetCore/Common/TestRunner.cs
@@ -17,8 +17,6 @@
 
 namespace Apache.Ignite.Core.Tests.DotNetCore.Common
 {
-    using Apache.Ignite.Core.Tests.Client.Compute;
-
     /// <summary>
     /// Test runner.
     /// </summary>
@@ -29,12 +27,7 @@ namespace Apache.Ignite.Core.Tests.DotNetCore.Common
         /// </summary>
         private static void Main(string[] args)
         {
-            var t = new ComputeClientTests();
-            t.FixtureSetUp();
-            t.TestSetUp();
-            t.TestExecuteJavaTaskAsyncMultithreaded();
-            t.TearDown();
-            t.FixtureTearDown();
+            new IgnitionStartTest().TestIgniteStartsFromAppConfig();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compute/ComputeClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compute/ComputeClientTests.cs
@@ -80,6 +80,8 @@ namespace Apache.Ignite.Core.Tests.Client.Compute
                     Assert.Fail(entry.Message);
                 }
             }
+
+            Assert.IsEmpty(Client.GetActiveNotificationListeners());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientNotificationHandler.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientNotificationHandler.cs
@@ -35,12 +35,12 @@ namespace Apache.Ignite.Core.Impl.Client
     {
         /** Handler delegate. */
         public delegate void Handler(IBinaryStream stream, Exception ex);
-        
+
         /** Logger. */
         private readonly ILogger _logger;
 
         /** Nested handler. */
-        private Handler _handler;
+        private volatile Handler _handler;
 
         /** Queue. */
         private List<KeyValuePair<IBinaryStream, Exception>> _queue;
@@ -51,9 +51,17 @@ namespace Apache.Ignite.Core.Impl.Client
         public ClientNotificationHandler(ILogger logger, Handler handler = null)
         {
             Debug.Assert(logger != null);
-            
+
             _logger = logger;
             _handler = handler;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether handler is set for this instance.
+        /// </summary>
+        public bool HasHandler
+        {
+            get { return _handler != null; }
         }
 
         /// <summary>
@@ -69,7 +77,7 @@ namespace Apache.Ignite.Core.Impl.Client
             {
                 // NOTE: Back pressure control should be added here when needed (e.g. for Continuous Queries).
                 var handler = _handler;
-                
+
                 if (handler != null)
                 {
                     ThreadPool.QueueUserWorkItem(_ => Handle(handler, stream, exception));
@@ -86,10 +94,11 @@ namespace Apache.Ignite.Core.Impl.Client
         /// Sets the handler.
         /// </summary>
         /// <param name="handler">Handler.</param>
-        public ClientNotificationHandler SetHandler(Handler handler)
+        public void SetHandler(Handler handler)
         {
             Debug.Assert(handler != null);
-            
+            Debug.Assert(_handler == null);
+
             lock (this)
             {
                 _handler = handler;
@@ -102,8 +111,6 @@ namespace Apache.Ignite.Core.Impl.Client
                     ThreadPool.QueueUserWorkItem(_ => Drain(handler, queue));
                 }
             }
-
-            return this;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -260,6 +260,8 @@ namespace Apache.Ignite.Core.Impl.Client
 
             if (!handler.HasHandler)
             {
+                // We could use AddOrUpdate, but SetHandler must be called outside of Update call,
+                // because it causes handler execution, which, in turn, may call RemoveNotificationHandler.
                 handler.SetHandler(handlerDelegate);
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Compute/ComputeClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Compute/ComputeClient.cs
@@ -191,13 +191,13 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
 
             ctx.Socket.AddNotificationHandler(taskId, (stream, ex) =>
             {
+                ctx.Socket.RemoveNotificationHandler(taskId);
+
                 if (ex != null)
                 {
                     tcs.TrySetException(ex);
                     return;
                 }
-
-                ctx.Socket.RemoveNotificationHandler(taskId);
 
                 var reader = ctx.Marshaller.StartUnmarshal(stream,
                     keepBinary ? BinaryMode.ForceBinary : BinaryMode.Deserialize);


### PR DESCRIPTION
Fix race condition in `ClientSocket.AddNotificationHandler`: `SetHandler` call was causing `RemoveNotificationHandler` call before `ConcurrentDictionary.AddOrUpdate` has finished, so `AddOrUpdate` added the handler back, causing the leak.