### PR TITLE
IGNITE-13293 .NET: Fix enum serialization performance

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/BenchmarkEnum.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/BenchmarkEnum.cs
@@ -1,0 +1,9 @@
+namespace Apache.Ignite.BenchmarkDotNet.Models
+{
+    public enum BenchmarkEnum
+    {
+        Foo,
+        Bar,
+        Baz
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/BenchmarkEnum.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/BenchmarkEnum.cs
@@ -1,5 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Apache.Ignite.BenchmarkDotNet.Models
 {
+    /// <summary>
+    /// Benchmark model: custom enum.
+    /// </summary>
     public enum BenchmarkEnum
     {
         Foo,

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithEnumField.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithEnumField.cs
@@ -1,5 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Apache.Ignite.BenchmarkDotNet.Models
 {
+    /// <summary>
+    /// Benchmark model: class with a custom enum field.
+    /// </summary>
     public class ClassWithEnumField
     {
         public BenchmarkEnum BenchmarkEnum { get; set; } 

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithEnumField.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithEnumField.cs
@@ -1,0 +1,7 @@
+namespace Apache.Ignite.BenchmarkDotNet.Models
+{
+    public class ClassWithEnumField
+    {
+        public BenchmarkEnum BenchmarkEnum { get; set; } 
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithIntField.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithIntField.cs
@@ -1,0 +1,7 @@
+namespace Apache.Ignite.BenchmarkDotNet.Models
+{
+    public class ClassWithIntField
+    {
+        public int Foo { get; set; }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithIntField.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Models/ClassWithIntField.cs
@@ -1,5 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace Apache.Ignite.BenchmarkDotNet.Models
 {
+    /// <summary>
+    /// Benchmark model: class with an int field.
+    /// </summary>
     public class ClassWithIntField
     {
         public int Foo { get; set; }

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Program.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Program.cs
@@ -30,7 +30,7 @@ namespace Apache.Ignite.BenchmarkDotNet
         /// </summary>
         public static void Main()
         {
-            BenchmarkRunner.Run<ThinClientCacheGetBenchmark>();
+            BenchmarkRunner.Run<ThinClientCachePutBenchmark>();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
@@ -67,7 +67,7 @@ namespace Apache.Ignite.BenchmarkDotNet.ThinClient
         /// Class with int field benchmark.
         /// </summary>
         [Benchmark]
-        public void PutClassWithEnumFieldBenchmark()
+        public void PutClassWithEnumField()
         {
             var obj = new ClassWithEnumField
             {

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
@@ -8,12 +8,12 @@ namespace Apache.Ignite.BenchmarkDotNet.ThinClient
     /// <summary>
     /// Cache put benchmarks.
     /// <para />
-    /// |                         Method |      Mean |    Error |   StdDev | Ratio | RatioSD |
-    /// |------------------------------- |----------:|---------:|---------:|------:|--------:|
-    /// |                   PutPrimitive |  44.54 us | 0.886 us | 1.551 us |  1.00 |    0.00 |
-    /// |              PutPrimitiveAsync |  65.24 us | 1.290 us | 1.434 us |  1.45 |    0.05 |
-    /// |           PutClassWithIntField |  67.21 us | 1.275 us | 1.518 us |  1.50 |    0.05 |
-    /// | PutClassWithEnumFieldBenchmark | 130.13 us | 2.472 us | 2.428 us |  2.88 |    0.08 |
+    /// |                Method |     Mean |    Error |   StdDev | Ratio | RatioSD |
+    /// |---------------------- |---------:|---------:|---------:|------:|--------:|
+    /// |          PutPrimitive | 45.47 us | 0.907 us | 1.330 us |  1.00 |    0.00 |
+    /// |     PutPrimitiveAsync | 66.28 us | 1.317 us | 1.617 us |  1.45 |    0.05 |
+    /// |  PutClassWithIntField | 68.34 us | 1.275 us | 1.130 us |  1.49 |    0.05 |
+    /// | PutClassWithEnumField | 71.13 us | 1.419 us | 2.734 us |  1.57 |    0.08 |
     /// </summary>
     public class ThinClientCachePutBenchmark : ThinClientBenchmarkBase
     {

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
@@ -7,6 +7,13 @@ namespace Apache.Ignite.BenchmarkDotNet.ThinClient
 
     /// <summary>
     /// Cache put benchmarks.
+    /// <para />
+    /// |                         Method |      Mean |    Error |   StdDev | Ratio | RatioSD |
+    /// |------------------------------- |----------:|---------:|---------:|------:|--------:|
+    /// |                   PutPrimitive |  44.54 us | 0.886 us | 1.551 us |  1.00 |    0.00 |
+    /// |              PutPrimitiveAsync |  65.24 us | 1.290 us | 1.434 us |  1.45 |    0.05 |
+    /// |           PutClassWithIntField |  67.21 us | 1.275 us | 1.518 us |  1.50 |    0.05 |
+    /// | PutClassWithEnumFieldBenchmark | 130.13 us | 2.472 us | 2.428 us |  2.88 |    0.08 |
     /// </summary>
     public class ThinClientCachePutBenchmark : ThinClientBenchmarkBase
     {

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Apache.Ignite.BenchmarkDotNet.ThinClient
 {
     using System.Threading;

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientCachePutBenchmark.cs
@@ -1,0 +1,81 @@
+namespace Apache.Ignite.BenchmarkDotNet.ThinClient
+{
+    using System.Threading;
+    using Apache.Ignite.BenchmarkDotNet.Models;
+    using Apache.Ignite.Core.Client.Cache;
+    using global::BenchmarkDotNet.Attributes;
+
+    /// <summary>
+    /// Cache put benchmarks.
+    /// </summary>
+    public class ThinClientCachePutBenchmark : ThinClientBenchmarkBase
+    {
+        /** */
+        private ICacheClient<int, object> _cache;
+
+        /** */
+        private static int _counter;
+        
+        /** <inheritdoc /> */
+        public override void GlobalSetup()
+        {
+            base.GlobalSetup();
+
+            _cache = Client.GetOrCreateCache<int, object>("c");
+        }
+
+        /// <summary>
+        /// Put primitive benchmark.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public void PutPrimitive()
+        {
+            _cache.Put(1, 1);
+        }
+
+        /// <summary>
+        /// PutAsync benchmark.
+        /// </summary>
+        [Benchmark]
+        public void PutPrimitiveAsync()
+        {
+            _cache.PutAsync(1, GetNextInt()).Wait();
+        }
+
+        /// <summary>
+        /// Class with int field benchmark.
+        /// </summary>
+        [Benchmark]
+        public void PutClassWithIntField()
+        {
+            var obj = new ClassWithIntField
+            {
+                Foo = GetNextInt()
+            };
+            
+            _cache.PutAsync(1, obj).Wait();
+        }
+
+        /// <summary>
+        /// Class with int field benchmark.
+        /// </summary>
+        [Benchmark]
+        public void PutClassWithEnumFieldBenchmark()
+        {
+            var obj = new ClassWithEnumField
+            {
+                BenchmarkEnum = (BenchmarkEnum)(GetNextInt() % 3)
+            };
+            
+            _cache.PutAsync(1, obj).Wait();
+        }
+
+        /// <summary>
+        /// Gets the next integer.
+        /// </summary>
+        private static int GetNextInt()
+        {
+            return Interlocked.Increment(ref _counter);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/EnumsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/EnumsTest.cs
@@ -19,6 +19,7 @@
 namespace Apache.Ignite.Core.Tests.Binary
 {
     using System;
+    using System.Linq;
     using System.Runtime.Serialization;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Impl;
@@ -85,6 +86,11 @@ namespace Apache.Ignite.Core.Tests.Binary
                 {
                     Assert.AreEqual(string.Format("{0} [typeId={1}, enumValue={2}, enumValueName={3}]",
                         typeof(T).FullName, binRes.GetBinaryType().TypeId, binRes.EnumValue, val), binRes.ToString());
+
+                    var expectedEnumNames = Enum.GetValues(typeof(T)).OfType<T>().Select(x => x.ToString()).ToList();
+                    var actualEnumNames = binRes.GetBinaryType().GetEnumValues().Select(v => v.EnumName).ToList();
+                    
+                    CollectionAssert.AreEquivalent(expectedEnumNames, actualEnumNames);
                 }
                 else
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -112,7 +112,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             (Environment.GetEnvironmentVariable(IgniteBinaryMarshallerUseStringSerializationVer2) ?? "false") == "true";
         
         /** Cached maps of enum members per type. */
-        public static readonly CopyOnWriteConcurrentDictionary<Type, Dictionary<string, int>> EnumValues = 
+        private static readonly CopyOnWriteConcurrentDictionary<Type, Dictionary<string, int>> EnumValues = 
             new CopyOnWriteConcurrentDictionary<Type, Dictionary<string, int>>();
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -110,6 +110,10 @@ namespace Apache.Ignite.Core.Impl.Binary
         /** String mode. */
         public static readonly bool UseStringSerializationVer2 =
             (Environment.GetEnvironmentVariable(IgniteBinaryMarshallerUseStringSerializationVer2) ?? "false") == "true";
+        
+        /** Cached maps of enum members per type. */
+        public static readonly CopyOnWriteConcurrentDictionary<Type, Dictionary<string, int>> EnumValues = 
+            new CopyOnWriteConcurrentDictionary<Type, Dictionary<string, int>>();
 
         /// <summary>
         /// Default marshaller.
@@ -1748,6 +1752,76 @@ namespace Apache.Ignite.Core.Impl.Binary
                 return TimeSpan.MinValue;
 
             return TimeSpan.FromMilliseconds(ms);
+        }
+        
+        /// <summary>
+        /// Gets the enum values.
+        /// </summary>
+        public static IDictionary<string, int> GetEnumValues(Type enumType)
+        {
+            Debug.Assert(enumType != null);
+            Debug.Assert(enumType.IsEnum);
+            
+            Dictionary<string,int> res;
+            if (EnumValues.TryGetValue(enumType, out res))
+            {
+                return res;
+            }
+
+            var values = Enum.GetValues(enumType);
+            res = new Dictionary<string, int>(values.Length);
+
+            var underlyingType = Enum.GetUnderlyingType(enumType);
+
+            foreach (var value in values)
+            {
+                var name = Enum.GetName(enumType, value);
+                Debug.Assert(name != null);
+
+                res[name] = GetEnumValueAsInt(underlyingType, value);
+            }
+
+            EnumValues.Set(enumType, res);
+            
+            return res;
+        }
+        
+        /// <summary>
+        /// Gets the enum value as int.
+        /// </summary>
+        private static int GetEnumValueAsInt(Type underlyingType, object value)
+        {
+            if (underlyingType == typeof(int))
+            {
+                return (int) value;
+            }
+
+            if (underlyingType == typeof(byte))
+            {
+                return (byte) value;
+            }
+
+            if (underlyingType == typeof(sbyte))
+            {
+                return (sbyte) value;
+            }
+
+            if (underlyingType == typeof(short))
+            {
+                return (short) value;
+            }
+
+            if (underlyingType == typeof(ushort))
+            {
+                return (ushort) value;
+            }
+
+            if (underlyingType == typeof(uint))
+            {
+                return unchecked((int) (uint) value);
+            }
+
+            throw new BinaryObjectException("Unexpected enum underlying type: " + underlyingType);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -904,10 +904,12 @@ namespace Apache.Ignite.Core.Impl.Binary
             _stream.WriteInt(desc.TypeId);
             _stream.WriteInt(val);
 
-            var metaHnd = _marsh.GetBinaryTypeHandler(desc);
-            
             // TODO: This happens on every write - bottleneck. We only need to send a given enum once.
-            SaveMetadata(desc, metaHnd.OnObjectWriteFinished());
+            // Cache this somehow in Marshaller.
+            {
+                // TODO: Fields are always empty for enums, why can't we pass null?
+                SaveMetadata(desc, null);
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -905,6 +905,8 @@ namespace Apache.Ignite.Core.Impl.Binary
             _stream.WriteInt(val);
 
             var metaHnd = _marsh.GetBinaryTypeHandler(desc);
+            
+            // TODO: This happens on every write - bottleneck. We only need to send a given enum once.
             SaveMetadata(desc, metaHnd.OnObjectWriteFinished());
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Metadata/BinaryType.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Metadata/BinaryType.cs
@@ -407,60 +407,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Metadata
                 return null;
             }
 
-            var enumType = desc.Type;
-
-            var values = Enum.GetValues(enumType);
-            var res = new Dictionary<string, int>(values.Length);
-
-            var underlyingType = Enum.GetUnderlyingType(enumType);
-
-            foreach (var value in values)
-            {
-                var name = Enum.GetName(enumType, value);
-                Debug.Assert(name != null);
-
-                res[name] = GetEnumValueAsInt(underlyingType, value);
-            }
-
-            return res;
-        }
-
-        /// <summary>
-        /// Gets the enum value as int.
-        /// </summary>
-        private static int GetEnumValueAsInt(Type underlyingType, object value)
-        {
-            if (underlyingType == typeof(int))
-            {
-                return (int) value;
-            }
-
-            if (underlyingType == typeof(byte))
-            {
-                return (byte) value;
-            }
-
-            if (underlyingType == typeof(sbyte))
-            {
-                return (sbyte) value;
-            }
-
-            if (underlyingType == typeof(short))
-            {
-                return (short) value;
-            }
-
-            if (underlyingType == typeof(ushort))
-            {
-                return (ushort) value;
-            }
-
-            if (underlyingType == typeof(uint))
-            {
-                return unchecked((int) (uint) value);
-            }
-
-            throw new BinaryObjectException("Unexpected enum underlying type: " + underlyingType);
+            return BinaryUtils.GetEnumValues(desc.Type);
         }
     }
 }


### PR DESCRIPTION
* Don't send enum metadata more than once (main part of this fix - see `BinaryWriter` changes)
* Cache name-value map per enum type
* Add benchmark

As a result, enum field serialization is on par with int field:

```
|                Method |     Mean |    Error |   StdDev | Ratio | RatioSD |
|---------------------- |---------:|---------:|---------:|------:|--------:|
|          PutPrimitive | 45.47 us | 0.907 us | 1.330 us |  1.00 |    0.00 |
|     PutPrimitiveAsync | 66.28 us | 1.317 us | 1.617 us |  1.45 |    0.05 |
|  PutClassWithIntField | 68.34 us | 1.275 us | 1.130 us |  1.49 |    0.05 |
| PutClassWithEnumField | 71.13 us | 1.419 us | 2.734 us |  1.57 |    0.08 |
```