### PR TITLE
IGNITE-13303 Mockito updated to latest version.

### DIFF
--- a/modules/aws/pom.xml
+++ b/modules/aws/pom.xml
@@ -157,7 +157,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/modules/benchmarks/pom.xml
+++ b/modules/benchmarks/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
         </dependency>
         <dependency>

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/CassandraSessionImplTest.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/CassandraSessionImplTest.java
@@ -41,22 +41,27 @@ import org.apache.ignite.cache.store.cassandra.session.WrappedPreparedStatement;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/** */
 public class CassandraSessionImplTest {
-
+    /** */
     private PreparedStatement preparedStatement1 = mockPreparedStatement();
 
+    /** */
     private PreparedStatement preparedStatement2 = mockPreparedStatement();
 
+    /** */
     private MyBoundStatement1 boundStatement1 = new MyBoundStatement1(preparedStatement1);
 
+    /** */
     private MyBoundStatement2 boundStatement2 = new MyBoundStatement2(preparedStatement2);
 
+    /** */
     @SuppressWarnings("unchecked")
     @Test
     public void executeFailureTest() {
@@ -94,9 +99,10 @@ public class CassandraSessionImplTest {
 
         BatchExecutionAssistant<String, String> batchExecutionAssistant = new MyBatchExecutionAssistant();
         ArrayList<String> data = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
+
+        for (int i = 0; i < 10; i++)
             data.add(String.valueOf(i));
-        }
+
         cassandraSession.execute(batchExecutionAssistant, data);
 
         verify(cluster, times(2)).connect();
@@ -105,6 +111,7 @@ public class CassandraSessionImplTest {
         assertEquals(10, batchExecutionAssistant.processedCount());
     }
 
+    /** */
     private static PreparedStatement mockPreparedStatement() {
         PreparedStatement ps = mock(PreparedStatement.class);
         when(ps.getVariables()).thenReturn(mock(ColumnDefinitions.class));
@@ -113,10 +120,12 @@ public class CassandraSessionImplTest {
         return ps;
     }
 
+    /** */
     private class MyBatchExecutionAssistant implements BatchExecutionAssistant {
+        /** */
+        private final Set<Integer> processed = new HashSet<>();
 
-        private Set<Integer> processed = new HashSet<>();
-
+        /** {@inheritDoc} */
         @Override public void process(Row row, int seqNum) {
             if (processed.contains(seqNum))
                 return;
@@ -124,64 +133,78 @@ public class CassandraSessionImplTest {
             processed.add(seqNum);
         }
 
+        /** {@inheritDoc} */
         @Override public boolean alreadyProcessed(int seqNum) {
             return processed.contains(seqNum);
         }
 
+        /** {@inheritDoc} */
         @Override public int processedCount() {
             return processed.size();
         }
 
+        /** {@inheritDoc} */
         @Override public boolean tableExistenceRequired() {
             return false;
         }
 
+        /** {@inheritDoc} */
         @Override public String getTable() {
             return null;
         }
 
+        /** {@inheritDoc} */
         @Override public String getStatement() {
             return null;
         }
 
+        /** {@inheritDoc} */
         @Override public BoundStatement bindStatement(PreparedStatement statement, Object obj) {
             if (statement instanceof WrappedPreparedStatement)
                 statement = ((WrappedPreparedStatement)statement).getWrappedStatement();
 
-            if (statement == preparedStatement1) {
+            if (statement == preparedStatement1)
                 return boundStatement1;
-            }
-            else if (statement == preparedStatement2) {
+
+            if (statement == preparedStatement2)
                 return boundStatement2;
-            }
 
             throw new RuntimeException("unexpected");
         }
 
+        /** {@inheritDoc} */
         @Override public KeyValuePersistenceSettings getPersistenceSettings() {
             return null;
         }
 
+        /** {@inheritDoc} */
         @Override public String operationName() {
             return null;
         }
 
+        /** {@inheritDoc} */
         @Override public Object processedData() {
             return null;
         }
 
     }
 
+    /** */
     private static class MyBoundStatement1 extends BoundStatement {
-
+        /**
+         * @param ps Prepared statement.
+         */
         MyBoundStatement1(PreparedStatement ps) {
             super(ps);
         }
 
     }
 
+    /** */
     private static class MyBoundStatement2 extends BoundStatement {
-
+        /**
+         * @param ps Prepared statement.
+         */
         MyBoundStatement2(PreparedStatement ps) {
             super(ps);
         }

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/CassandraSessionImplTest.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/CassandraSessionImplTest.java
@@ -42,33 +42,29 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/** */
 public class CassandraSessionImplTest {
-    /** */
+
     private PreparedStatement preparedStatement1 = mockPreparedStatement();
 
-    /** */
     private PreparedStatement preparedStatement2 = mockPreparedStatement();
 
-    /** */
     private MyBoundStatement1 boundStatement1 = new MyBoundStatement1(preparedStatement1);
 
-    /** */
     private MyBoundStatement2 boundStatement2 = new MyBoundStatement2(preparedStatement2);
 
-    /** */
     @SuppressWarnings("unchecked")
     @Test
     public void executeFailureTest() {
         Session session1 = mock(Session.class);
         Session session2 = mock(Session.class);
-        when(session1.prepare(any(String.class))).thenReturn(preparedStatement1);
-        when(session2.prepare(any(String.class))).thenReturn(preparedStatement2);
+        when(session1.prepare(nullable(String.class))).thenReturn(preparedStatement1);
+        when(session2.prepare(nullable(String.class))).thenReturn(preparedStatement2);
 
         ResultSetFuture rsFuture = mock(ResultSetFuture.class);
         ResultSet rs = mock(ResultSet.class);
@@ -99,19 +95,17 @@ public class CassandraSessionImplTest {
 
         BatchExecutionAssistant<String, String> batchExecutionAssistant = new MyBatchExecutionAssistant();
         ArrayList<String> data = new ArrayList<>();
-
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < 10; i++) {
             data.add(String.valueOf(i));
-
+        }
         cassandraSession.execute(batchExecutionAssistant, data);
 
         verify(cluster, times(2)).connect();
-        verify(session1, times(1)).prepare(any(String.class));
-        verify(session2, times(1)).prepare(any(String.class));
+        verify(session1, times(1)).prepare(nullable(String.class));
+        verify(session2, times(1)).prepare(nullable(String.class));
         assertEquals(10, batchExecutionAssistant.processedCount());
     }
 
-    /** */
     private static PreparedStatement mockPreparedStatement() {
         PreparedStatement ps = mock(PreparedStatement.class);
         when(ps.getVariables()).thenReturn(mock(ColumnDefinitions.class));
@@ -120,12 +114,10 @@ public class CassandraSessionImplTest {
         return ps;
     }
 
-    /** */
     private class MyBatchExecutionAssistant implements BatchExecutionAssistant {
-        /** */
-        private final Set<Integer> processed = new HashSet<>();
 
-        /** {@inheritDoc} */
+        private Set<Integer> processed = new HashSet<>();
+
         @Override public void process(Row row, int seqNum) {
             if (processed.contains(seqNum))
                 return;
@@ -133,78 +125,64 @@ public class CassandraSessionImplTest {
             processed.add(seqNum);
         }
 
-        /** {@inheritDoc} */
         @Override public boolean alreadyProcessed(int seqNum) {
             return processed.contains(seqNum);
         }
 
-        /** {@inheritDoc} */
         @Override public int processedCount() {
             return processed.size();
         }
 
-        /** {@inheritDoc} */
         @Override public boolean tableExistenceRequired() {
             return false;
         }
 
-        /** {@inheritDoc} */
         @Override public String getTable() {
             return null;
         }
 
-        /** {@inheritDoc} */
         @Override public String getStatement() {
             return null;
         }
 
-        /** {@inheritDoc} */
         @Override public BoundStatement bindStatement(PreparedStatement statement, Object obj) {
             if (statement instanceof WrappedPreparedStatement)
                 statement = ((WrappedPreparedStatement)statement).getWrappedStatement();
 
-            if (statement == preparedStatement1)
+            if (statement == preparedStatement1) {
                 return boundStatement1;
-
-            if (statement == preparedStatement2)
+            }
+            else if (statement == preparedStatement2) {
                 return boundStatement2;
+            }
 
             throw new RuntimeException("unexpected");
         }
 
-        /** {@inheritDoc} */
         @Override public KeyValuePersistenceSettings getPersistenceSettings() {
             return null;
         }
 
-        /** {@inheritDoc} */
         @Override public String operationName() {
             return null;
         }
 
-        /** {@inheritDoc} */
         @Override public Object processedData() {
             return null;
         }
 
     }
 
-    /** */
     private static class MyBoundStatement1 extends BoundStatement {
-        /**
-         * @param ps Prepared statement.
-         */
+
         MyBoundStatement1(PreparedStatement ps) {
             super(ps);
         }
 
     }
 
-    /** */
     private static class MyBoundStatement2 extends BoundStatement {
-        /**
-         * @param ps Prepared statement.
-         */
+
         MyBoundStatement2(PreparedStatement ps) {
             super(ps);
         }

--- a/modules/compress/pom.xml
+++ b/modules/compress/pom.xml
@@ -118,7 +118,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -132,7 +132,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/GridIoManagerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/GridIoManagerSelfTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;

--- a/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/GridIoManagerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/GridIoManagerSelfTest.java
@@ -201,7 +201,7 @@ public class GridIoManagerSelfTest extends GridCommonAbstractTest {
     /**
      * Mockito argument matcher to compare collections produced by {@code F.view()} methods.
      */
-    private static class IsEqualCollection extends ArgumentMatcher<Collection<? extends ClusterNode>> {
+    private static class IsEqualCollection implements ArgumentMatcher<Collection<? extends ClusterNode>> {
         /** Expected collection. */
         private final Collection<? extends ClusterNode> expCol;
 
@@ -221,8 +221,8 @@ public class GridIoManagerSelfTest extends GridCommonAbstractTest {
          * @param colToCheck Collection to be matched against the expected one.
          * @return True if collections matches.
          */
-        @Override public boolean matches(Object colToCheck) {
-            return CollectionUtils.isEqualCollection(expCol, (Collection)colToCheck);
+        @Override public boolean matches(Collection<? extends ClusterNode> colToCheck) {
+            return CollectionUtils.isEqualCollection(expCol, colToCheck);
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/affinity/GridAffinityAssignmentV2Test.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/affinity/GridAffinityAssignmentV2Test.java
@@ -30,11 +30,11 @@ import java.util.Set;
 import java.util.UUID;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.internal.util.collection.BitSetIntSet;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteProductVersion;
 import org.apache.ignite.spi.discovery.DiscoveryMetricsProvider;
 import org.apache.ignite.spi.discovery.tcp.internal.TcpDiscoveryNode;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -152,7 +152,7 @@ public class GridAffinityAssignmentV2Test {
             // Ignored.
         }
 
-        Set<Integer> unwrapped = (Set<Integer>)Whitebox.getInternalState(
+        Set<Integer> unwrapped = U.field(
             gridAffinityAssignment2.primaryPartitions(clusterNode1.id()),
             "delegate"
         );

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/reader/MockWalIteratorFactory.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/reader/MockWalIteratorFactory.java
@@ -36,7 +36,7 @@ import org.apache.ignite.internal.processors.cache.persistence.wal.FileWriteAhea
 import org.jetbrains.annotations.Nullable;
 import org.mockito.Mockito;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgnitePageMemReplaceDelayedWriteUnitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgnitePageMemReplaceDelayedWriteUnitTest.java
@@ -64,7 +64,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.apache.ignite.internal.processors.database.DataRegionMetricsSelfTest.NO_OP_METRICS;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgniteThrottlingUnitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgniteThrottlingUnitTest.java
@@ -49,7 +49,7 @@ import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/wal/scanner/WalScannerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/wal/scanner/WalScannerTest.java
@@ -68,7 +68,7 @@ public class WalScannerTest {
     private static final String TEST_DUMP_FILE = "output.txt";
 
     /** **/
-    private static final FileWALPointer ZERO_POINTER = new FileWALPointer(0, 0, 0);
+    private static FileWALPointer ZERO_POINTER = new FileWALPointer(0, 0, 0);
 
     /**
      * @throws Exception If failed.

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/wal/scanner/WalScannerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/wal/scanner/WalScannerTest.java
@@ -55,7 +55,7 @@ import static org.apache.ignite.internal.processors.cache.persistence.wal.scanne
 import static org.apache.ignite.internal.processors.cache.persistence.wal.scanner.ScannerHandlers.printToLog;
 import static org.apache.ignite.internal.processors.cache.persistence.wal.scanner.WalScanner.buildWalScanner;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,7 +68,7 @@ public class WalScannerTest {
     private static final String TEST_DUMP_FILE = "output.txt";
 
     /** **/
-    private static FileWALPointer ZERO_POINTER = new FileWALPointer(0, 0, 0);
+    private static final FileWALPointer ZERO_POINTER = new FileWALPointer(0, 0, 0);
 
     /**
      * @throws Exception If failed.

--- a/modules/direct-io/pom.xml
+++ b/modules/direct-io/pom.xml
@@ -122,8 +122,8 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/ml/pom.xml
+++ b/modules/ml/pom.xml
@@ -144,7 +144,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/modules/ml/src/test/java/org/apache/ignite/ml/dataset/impl/cache/util/DatasetAffinityFunctionWrapperTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/dataset/impl/cache/util/DatasetAffinityFunctionWrapperTest.java
@@ -27,11 +27,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/modules/ml/src/test/java/org/apache/ignite/ml/dataset/primitive/DatasetWrapperTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/dataset/primitive/DatasetWrapperTest.java
@@ -27,11 +27,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,7 +108,7 @@
         <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <checkstyle.puppycrawl.version>8.21</checkstyle.puppycrawl.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>3.4.6</mockito.version>
         <mysql.connector.version>8.0.13</mysql.connector.version>
         <netlibjava.version>1.1.2</netlibjava.version>
         <oro.bundle.version>2.0.8_6</oro.bundle.version>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-13303

Updated Mockito library from 1.x to latest 3.x as suggested by Mockito itself.

> https://github.com/mockito/mockito
> Still on Mockito 1.x? See what's new in Mockito 2!
> Mockito 3 does not introduce any breaking API changes, but now requires Java 8 over Java 6 for Mockito 2.