### PR TITLE
IGNITE-13373

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
@@ -117,6 +117,7 @@ import org.apache.ignite.internal.processors.cache.mvcc.txlog.TxState;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointEntry;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointEntryType;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointHistory;
+import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointHistoryResult;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointProgress;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.Checkpointer;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.ReservationReason;
@@ -301,9 +302,8 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
     /** This is the earliest WAL pointer that was reserved during exchange and would release after exchange completed. */
     private WALPointer reservedForExchange;
 
-    /** */
-    private final ConcurrentMap<T2</*grpId*/Integer, /*partId*/Integer>, T2</*updCntr*/Long, WALPointer>>
-        reservedForPreloading = new ConcurrentHashMap<>();
+    /** This is the earliest WAL pointer that was reserved during preloading. */
+    private volatile WALPointer reservedForPreloading;
 
     /** Snapshot manager. */
     private IgniteCacheSnapshotManager snapshotMgr;
@@ -378,8 +378,8 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
             cfgCheckpointReadLockTimeout != null
                 ? cfgCheckpointReadLockTimeout
                 : (ctx.workersRegistry() != null
-                    ? ctx.workersRegistry().getSystemWorkerBlockedTimeout()
-                    : ctx.config().getFailureDetectionTimeout()));
+                ? ctx.workersRegistry().getSystemWorkerBlockedTimeout()
+                : ctx.config().getFailureDetectionTimeout()));
     }
 
     /**
@@ -532,8 +532,8 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
             );
 
             final FileLockHolder preLocked = kernalCtx.pdsFolderResolver()
-                    .resolveFolders()
-                    .getLockedFileLockHolder();
+                .resolveFolders()
+                .getLockedFileLockHolder();
 
             acquireFileLock(preLocked);
 
@@ -1214,8 +1214,8 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
      * @return Wrapped memory provider.
      */
     @Override protected DirectMemoryProvider wrapMetricsMemoryProvider(
-            final DirectMemoryProvider memoryProvider0,
-            final DataRegionMetricsImpl memMetrics
+        final DirectMemoryProvider memoryProvider0,
+        final DataRegionMetricsImpl memMetrics
     ) {
         return new DirectMemoryProvider() {
             private AtomicInteger checkPointBufferIdxCnt = new AtomicInteger();
@@ -1651,7 +1651,12 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
         checkpointReadLock();
 
         try {
-            earliestValidCheckpoints = cpHistory.searchAndReserveCheckpoints(applicableGroupsAndPartitions);
+            CheckpointHistoryResult checkpointHistoryResult = cpHist.searchAndReserveCheckpoints(applicableGroupsAndPartitions);
+
+            earliestValidCheckpoints = checkpointHistoryResult.earliestValidCheckpoints();
+
+            if (checkpointHistoryResult.reservedCheckoint() != null)
+                reservedForExchange = checkpointHistoryResult.reservedCheckoint().checkpointMark();
         }
         finally {
             checkpointReadUnlock();
@@ -1675,12 +1680,8 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
 
                 Long updCntr = cpEntry.partitionCounter(cctx, grpId, partId);
 
-                if (updCntr != null) {
-                    if (reservedForExchange == null || ((FileWALPointer)cpEntry.checkpointMark()).index() < ((FileWALPointer)reservedForExchange).index())
-                        reservedForExchange = cpEntry.checkpointMark();
-
+                if (updCntr != null)
                     grpPartsWithCnts.computeIfAbsent(grpId, k -> new HashMap<>()).put(partId, updCntr);
-                }
             }
         }
 
@@ -1786,14 +1787,26 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
         if (F.isEmpty(entries))
             return false;
 
+        WALPointer oldestWALPointerToReserve = null;
+
         for (GroupPartitionId key : entries.keySet()) {
             WALPointer ptr = entries.get(key).checkpointMark();
 
-            if (ptr == null || !cctx.wal().reserve(ptr))
+            if (ptr == null)
                 return false;
+
+            if (oldestWALPointerToReserve == null ||
+                ((FileWALPointer)ptr).index() < ((FileWALPointer)oldestWALPointerToReserve).index())
+                oldestWALPointerToReserve = ptr;
         }
 
-        return true;
+        if (cctx.wal().reserve(oldestWALPointerToReserve)) {
+            reservedForPreloading = oldestWALPointerToReserve;
+
+            return true;
+        }
+        else
+            return false;
     }
 
     /** {@inheritDoc} */
@@ -1801,18 +1814,16 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
         releaseHistForPreloadingLock.lock();
 
         try {
-            for (Map.Entry<T2<Integer, Integer>, T2<Long, WALPointer>> e : reservedForPreloading.entrySet()) {
-                try {
-                    cctx.wal().release(e.getValue().get2());
-                }
-                catch (IgniteCheckedException ex) {
-                    U.error(log, "Could not release WAL reservation", ex);
+            if (reservedForPreloading != null) {
+                cctx.wal().release(reservedForPreloading);
 
-                    throw new IgniteException(ex);
-                }
+                reservedForPreloading = null;
             }
+        }
+        catch (IgniteCheckedException ex) {
+            U.error(log, "Could not release WAL reservation", ex);
 
-            reservedForPreloading.clear();
+            throw new IgniteException(ex);
         }
         finally {
             releaseHistForPreloadingLock.unlock();
@@ -2146,24 +2157,24 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
                     U.quietAndWarn(log, "Ignite node stopped in the middle of checkpoint. Will restore memory state and " +
                         "finish checkpoint on node start.");
 
-            cctx.cache().cacheGroupDescriptors().forEach((grpId, desc) -> {
-                if (!cacheGroupsPredicate.apply(grpId))
-                    return;
-
-                try {
-                    DataRegion region = cctx.database().dataRegion(desc.config().getDataRegionName());
-
-                    if (region == null || !cctx.isLazyMemoryAllocation(region))
+                cctx.cache().cacheGroupDescriptors().forEach((grpId, desc) -> {
+                    if (!cacheGroupsPredicate.apply(grpId))
                         return;
 
-                    region.pageMemory().start();
-                }
-                catch (IgniteCheckedException e) {
-                    throw new IgniteException(e);
-                }
-            });
+                    try {
+                        DataRegion region = cctx.database().dataRegion(desc.config().getDataRegionName());
 
-            cctx.pageStore().beginRecover();
+                        if (region == null || !cctx.isLazyMemoryAllocation(region))
+                            return;
+
+                        region.pageMemory().start();
+                    }
+                    catch (IgniteCheckedException e) {
+                        throw new IgniteException(e);
+                    }
+                });
+
+                cctx.pageStore().beginRecover();
 
                 if (!(startRec instanceof CheckpointRecord))
                     throw new StorageException("Checkpoint marker doesn't point to checkpoint record " +
@@ -3522,10 +3533,10 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
 
                     if (log.isInfoEnabled())
                         log.info("Partition [grp=" + grp.cacheOrGroupName()
-                                + ", id=" + p
-                                + ", state=" + state
-                                + ", counter=" + updateCntr
-                                + ", size=" + size + "]");
+                            + ", id=" + p
+                            + ", state=" + state
+                            + ", counter=" + updateCntr
+                            + ", size=" + size + "]");
                 }
                 finally {
                     pageMem.readUnlock(grp.groupId(), partMetaId, partMetaPage);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistory.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistory.java
@@ -549,21 +549,21 @@ public class CheckpointHistory {
      *
      * @param groupsAndPartitions Groups and partitions to find and reserve earliest valid checkpoint.
      *
-     * @return Map (groupId, Reason (the reason why reservation cannot be made deeper): Map
-     * (partitionId, earliest valid checkpoint to history search)).
+     * @return Checkpoint history reult: Map (groupId, Reason (the reason why reservation cannot be made deeper): Map
+     * (partitionId, earliest valid checkpoint to history search)) and reserved checkpoint.
      */
-    public Map<Integer, T2<ReservationReason, Map<Integer, CheckpointEntry>>> searchAndReserveCheckpoints(
+    public CheckpointHistoryResult searchAndReserveCheckpoints(
         final Map<Integer, Set<Integer>> groupsAndPartitions
     ) {
         if (F.isEmpty(groupsAndPartitions))
-            return Collections.emptyMap();
+            return new CheckpointHistoryResult(Collections.emptyMap(), null);
 
         final Map<Integer, T2<ReservationReason, Map<Integer, CheckpointEntry>>> res = new HashMap<>();
 
         CheckpointEntry oldestCpForReservation = null;
 
         synchronized (earliestCp) {
-            CheckpointEntry oldestHistoryCpEntry = firstCheckpoint();
+            CheckpointEntry oldestHistCpEntry = firstCheckpoint();
 
             for (Integer grpId : groupsAndPartitions.keySet()) {
                 CheckpointEntry oldestGrpCpEntry = null;
@@ -585,7 +585,7 @@ public class CheckpointHistory {
                         .get2().put(part, cpEntry);
                 }
 
-                if (oldestGrpCpEntry == null || oldestGrpCpEntry != oldestHistoryCpEntry)
+                if (oldestGrpCpEntry == null || oldestGrpCpEntry != oldestHistCpEntry)
                     res.computeIfAbsent(grpId, (partCpMap) ->
                         new T2<>(ReservationReason.CHECKPOINT_NOT_APPLICABLE, null))
                         .set1(ReservationReason.CHECKPOINT_NOT_APPLICABLE);
@@ -601,7 +601,7 @@ public class CheckpointHistory {
             }
         }
 
-        return res;
+        return new CheckpointHistoryResult(res, oldestCpForReservation);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistoryResult.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistoryResult.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +15,14 @@
  * limitations under the License.
  */
 
+
 package org.apache.ignite.internal.processors.cache.persistence.checkpoint;
 
+import java.util.Map;
 import org.apache.ignite.internal.util.typedef.T2;
 
-import java.util.Map;
-
 /**
- * Result of a checkpint search and reservation.
+ * Result of a checkpoint search and reservation.
  */
 public class CheckpointHistoryResult {
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistoryResult.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointHistoryResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.checkpoint;
+
+import org.apache.ignite.internal.util.typedef.T2;
+
+import java.util.Map;
+
+/**
+ * Result of a checkpint search and reservation.
+ */
+public class CheckpointHistoryResult {
+
+    /**
+     * Map (groupId, Reason why reservation cannot be made deeper): Map (partitionId, earliest valid checkpoint to
+     * history search)).
+     */
+    private final Map<Integer, T2<ReservationReason, Map<Integer, CheckpointEntry>>> earliestValidCheckpoints;
+
+    /** Reserved checkpoint. */
+    private final CheckpointEntry reservedCheckoint;
+
+    /**
+     * Constructor.
+     *
+     * @param earliestValidCheckpoints Map (groupId, Reason why reservation cannot be made deeper):
+     * Map (partitionId, earliest valid checkpoint to history search)).
+     * @param reservedCheckoint Reserved checkpoint.
+     */
+    public CheckpointHistoryResult(
+        Map<Integer, T2<ReservationReason, Map<Integer, CheckpointEntry>>> earliestValidCheckpoints,
+        CheckpointEntry reservedCheckoint) {
+        this.earliestValidCheckpoints = earliestValidCheckpoints;
+        this.reservedCheckoint = reservedCheckoint;
+    }
+
+    /**
+     * @return Map (groupId, Reason why reservation cannot be made deeper):  Map (partitionId, earliest valid checkpoint
+     * to history search)).
+     */
+    public Map<Integer, T2<ReservationReason, Map<Integer, CheckpointEntry>>> earliestValidCheckpoints() {
+        return earliestValidCheckpoints;
+    }
+
+    /**
+     * @return Reserved checkpoint.
+     */
+    public CheckpointEntry reservedCheckoint() {
+        return reservedCheckoint;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/WALPreloadingWithCompactionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/WALPreloadingWithCompactionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence;
+
+import java.io.File;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.configuration.WALMode;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.cache.persistence.wal.FileDescriptor;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Test for checking preloading within context of wall reservation and release.
+ */
+public class WALPreloadingWithCompactionTest extends GridCommonAbstractTest {
+    /** Partitions count. */
+    private static final int PARTITIONS_COUNT = 16;
+
+    /** WAL segment size. */
+    private static final int WAL_SEGMENT_SIZE = 1024 * 1024;
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        cleanPersistenceDir();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        DataStorageConfiguration storageCfg = new DataStorageConfiguration()
+            .setDefaultDataRegionConfiguration(
+                new DataRegionConfiguration().setPersistenceEnabled(true))
+            .setWalSegmentSize(WAL_SEGMENT_SIZE)
+            .setWalMode(WALMode.LOG_ONLY)
+            .setWalCompactionEnabled(true);
+
+        storageCfg.setWalCompactionLevel(6);
+
+        cfg.setDataStorageConfiguration(storageCfg);
+
+        return cfg;
+    }
+
+    /**
+     *
+     * @throws Exception if failed.
+     */
+    @Test
+    public void test() throws Exception {
+        System.setProperty(IgniteSystemProperties.IGNITE_PDS_WAL_REBALANCE_THRESHOLD, "1");
+
+        startGridsMultiThreaded(2).cluster().state(ClusterState.ACTIVE);
+
+        ignite(0).createCache(new CacheConfiguration<>(DEFAULT_CACHE_NAME).
+            setAffinity(new RendezvousAffinityFunction(false, PARTITIONS_COUNT)).setBackups(1));
+
+        forceCheckpoint();
+
+        for (int i = 0; i < PARTITIONS_COUNT; i++)
+            ignite(0).cache(DEFAULT_CACHE_NAME).put(i, i);
+
+        stopGrid(1);
+
+        for (int i = PARTITIONS_COUNT; i < 2 * PARTITIONS_COUNT; i++)
+            ignite(0).cache(DEFAULT_CACHE_NAME).put(i, i);
+
+        startGrid(1);
+
+        awaitPartitionMapExchange(true, true, null);
+
+        for (int i = 2 * PARTITIONS_COUNT; i < 500 * PARTITIONS_COUNT; i++)
+            ignite(0).cache(DEFAULT_CACHE_NAME).put(i, i);
+
+        forceCheckpoint();
+
+        for (int i = 500 * PARTITIONS_COUNT; i < 1000 * PARTITIONS_COUNT; i++)
+            ignite(0).cache(DEFAULT_CACHE_NAME).put(i, i);
+
+        checkThatOnlyZipSegmentExists(ignite(0), 0);
+        checkThatOnlyZipSegmentExists(ignite(1), 0);
+    }
+
+    /**
+     * Check that there's only compacted version of given segment.
+     * @param ignite Ignite instance.
+     * @param segment Segment index.
+     * @throws IgniteCheckedException If failed.
+     */
+    private void checkThatOnlyZipSegmentExists(IgniteEx ignite, int segment) throws IgniteCheckedException {
+        String nodeFolderName = ignite.context().pdsFolderResolver().resolveFolders().folderName();
+
+        File dbDir = U.resolveWorkDirectory(U.defaultWorkDirectory(), "db", false);
+        File walDir = new File(dbDir, "wal");
+        File archiveDir = new File(walDir, "archive");
+        File nodeArchiveDir = new File(archiveDir, nodeFolderName);
+        File walZipSegment = new File(nodeArchiveDir, FileDescriptor.fileName(segment) + ".zip");
+        File walRawSegment = new File(nodeArchiveDir, FileDescriptor.fileName(segment));
+
+        assertTrue(walZipSegment.exists());
+        assertFalse(walRawSegment.exists());
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/WALPreloadingWithCompactionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/WALPreloadingWithCompactionTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package org.apache.ignite.internal.processors.cache.persistence;
 

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgnitePdsTestSuite2.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgnitePdsTestSuite2.java
@@ -32,6 +32,7 @@ import org.apache.ignite.internal.processors.cache.persistence.IgnitePersistentS
 import org.apache.ignite.internal.processors.cache.persistence.IgniteRebalanceScheduleResendPartitionsTest;
 import org.apache.ignite.internal.processors.cache.persistence.LocalWalModeChangeDuringRebalancingSelfTest;
 import org.apache.ignite.internal.processors.cache.persistence.LocalWalModeNoChangeDuringRebalanceOnNonNodeAssignTest;
+import org.apache.ignite.internal.processors.cache.persistence.WALPreloadingWithCompactionTest;
 import org.apache.ignite.internal.processors.cache.persistence.WalPreloadingConcurrentTest;
 import org.apache.ignite.internal.processors.cache.persistence.baseline.ClientAffinityAssignmentWithBaselineTest;
 import org.apache.ignite.internal.processors.cache.persistence.baseline.ClusterActivationEventTest;
@@ -258,6 +259,8 @@ public class IgnitePdsTestSuite2 {
         GridTestUtils.addTestIfNeeded(suite, IgnitePdsPartitionsStateRecoveryTest.class, ignoredTests);
 
         GridTestUtils.addTestIfNeeded(suite, WalPreloadingConcurrentTest.class, ignoredTests);
+
+        GridTestUtils.addTestIfNeeded(suite, WALPreloadingWithCompactionTest.class, ignoredTests);
 
         GridTestUtils.addTestIfNeeded(suite, IgniteWalRebalanceLoggingTest.class, ignoredTests);
 


### PR DESCRIPTION
 - Reserve/releaseHistoryForPreloading() was reworked, now we store oldest WALPointer that was reserved during reserveHistoryForPreloading in reservedForPreloading field. As a result it's possible to release wall reservation on releaseHIstoryForPreloading().

- searchAndReserveCheckpoints() was slightly refactored: now it returns not only an earliestValidCheckpoints but also an oldest reservedCheckpoint, so that there’s no need to recalculate it within reserveHistoryForExchange().
