### PR TITLE
IGNITE-13369 .NET: Clear cached node data on client disconnect

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
@@ -190,6 +190,7 @@ namespace Apache.Ignite.Core.Tests
             var client = Ignition.Start(clientCfg);
 
             Assert.AreEqual(2, client.GetCluster().GetNodes().Count);
+            var localNode = client.GetCluster().GetLocalNode();
 
             var evt = new ManualResetEventSlim(false);
             client.ClientReconnected += (sender, args) => evt.Set();
@@ -221,6 +222,11 @@ namespace Apache.Ignite.Core.Tests
 
             var serverCache = server2.GetCache<int, Person>(CacheName);
             Assert.AreEqual(2, serverCache[2].Id);
+            
+            // Verify that local node info is updated on the client.
+            var localNodeNew = client.GetCluster().GetLocalNode();
+            Assert.AreNotSame(localNode, localNodeNew);
+            Assert.AreNotEqual(localNode.Id, localNodeNew.Id);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
@@ -231,6 +231,8 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreNotEqual(localNode.Id, localNodeNew.Id);
 
             var nodesNew = client.GetCluster().GetNodes();
+            Assert.AreEqual(2, nodesNew.Count);
+            
             foreach (var node in nodesNew)
             {
                 Assert.IsFalse(nodes.Any(n => n.Id == node.Id));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
@@ -129,7 +129,7 @@ namespace Apache.Ignite.Core.Tests
             using (var ignite = Ignition.Start(cfg))
             {
                 var localNode = ignite.GetCluster().GetLocalNode();
-                var nodes = ignite.GetCluster().GetNodes();
+                var remoteNode = ignite.GetCluster().ForRemotes().GetNode();
 
                 var reconnected = 0;
                 var disconnected = 0;
@@ -172,7 +172,12 @@ namespace Apache.Ignite.Core.Tests
                 Thread.Sleep(100);  // Wait for event handler
                 Assert.AreEqual(1, reconnected);
                 
-                CheckUpdatedNodes(ignite, localNode, nodes);
+                var localNodeNew = ignite.GetCluster().GetLocalNode();
+                Assert.AreNotSame(localNode, localNodeNew);
+                Assert.AreNotEqual(localNode.Id, localNodeNew.Id);
+
+                var remoteNodeNew = ignite.GetCluster().ForRemotes().GetNode();
+                Assert.AreEqual(remoteNode.Id, remoteNodeNew.Id);
             }
         }
 #endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Core.Tests
 {
     using System;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache;
@@ -191,6 +192,7 @@ namespace Apache.Ignite.Core.Tests
 
             Assert.AreEqual(2, client.GetCluster().GetNodes().Count);
             var localNode = client.GetCluster().GetLocalNode();
+            var nodes = client.GetCluster().GetNodes();
 
             var evt = new ManualResetEventSlim(false);
             client.ClientReconnected += (sender, args) => evt.Set();
@@ -223,10 +225,16 @@ namespace Apache.Ignite.Core.Tests
             var serverCache = server2.GetCache<int, Person>(CacheName);
             Assert.AreEqual(2, serverCache[2].Id);
             
-            // Verify that local node info is updated on the client.
+            // Verify that cached node info is updated on the client.
             var localNodeNew = client.GetCluster().GetLocalNode();
             Assert.AreNotSame(localNode, localNodeNew);
             Assert.AreNotEqual(localNode.Id, localNodeNew.Id);
+
+            var nodesNew = client.GetCluster().GetNodes();
+            foreach (var node in nodesNew)
+            {
+                Assert.IsFalse(nodes.Any(n => n.Id == node.Id));
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cluster/ClusterGroupImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cluster/ClusterGroupImpl.cs
@@ -721,6 +721,15 @@ namespace Apache.Ignite.Core.Impl.Cluster
 #pragma warning restore 618
 
         /// <summary>
+        /// Clears cached node data.
+        /// </summary>
+        internal void ClearCachedNodeData()
+        {
+            _topVer = TopVerInit;
+            _nodes = null;
+        }
+
+        /// <summary>
         /// Creates new Cluster Group from given native projection.
         /// </summary>
         /// <param name="prj">Native projection.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -1156,8 +1156,7 @@ namespace Apache.Ignite.Core.Impl
         /// </summary>
         internal void OnClientDisconnected()
         {
-            // TODO:
-            // _locNode = null;
+            _locNode = null;
 
             _clientReconnectTaskCompletionSource = new TaskCompletionSource<bool>();
             

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -129,7 +129,7 @@ namespace Apache.Ignite.Core.Impl
         private readonly IList<LifecycleHandlerHolder> _lifecycleHandlers;
 
         /** Local node. */
-        private IClusterNode _locNode;
+        private volatile IClusterNode _locNode;
 
         /** Callbacks */
         private readonly UnmanagedCallbacks _cbs;
@@ -1156,6 +1156,9 @@ namespace Apache.Ignite.Core.Impl
         /// </summary>
         internal void OnClientDisconnected()
         {
+            // TODO:
+            // _locNode = null;
+
             _clientReconnectTaskCompletionSource = new TaskCompletionSource<bool>();
             
             var handler = ClientDisconnected;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -1156,9 +1156,12 @@ namespace Apache.Ignite.Core.Impl
         /// </summary>
         internal void OnClientDisconnected()
         {
+            // Clear cached node data.
+            // Do not clear _nodes - it is in sync with PlatformContextImpl.sentNodes.
             _locNode = null;
             _prj.ClearCachedNodeData();
 
+            // Raise events.
             _clientReconnectTaskCompletionSource = new TaskCompletionSource<bool>();
             
             var handler = ClientDisconnected;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -1156,7 +1156,9 @@ namespace Apache.Ignite.Core.Impl
         /// </summary>
         internal void OnClientDisconnected()
         {
+            // TODO: _nodes gets out of date while we are disconnected.
             _locNode = null;
+            _prj.ClearCachedNodeData();
 
             _clientReconnectTaskCompletionSource = new TaskCompletionSource<bool>();
             

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -1156,7 +1156,6 @@ namespace Apache.Ignite.Core.Impl
         /// </summary>
         internal void OnClientDisconnected()
         {
-            // TODO: _nodes gets out of date while we are disconnected.
             _locNode = null;
             _prj.ClearCachedNodeData();
 


### PR DESCRIPTION
Client reconnect causes local node ID to change, so we should reset cached node data on disconnect.