### PR TITLE
IGNITE-13218 fixed. importComparator added to TreeSet to provide core…

### DIFF
--- a/modules/codegen/src/main/java/org/apache/ignite/codegen/SystemViewRowAttributeWalkerGenerator.java
+++ b/modules/codegen/src/main/java/org/apache/ignite/codegen/SystemViewRowAttributeWalkerGenerator.java
@@ -148,8 +148,7 @@ public class SystemViewRowAttributeWalkerGenerator {
      */
     private <T> Collection<String> generate(Class<T> clazz) {
         final List<String> code = new ArrayList<>();
-        Comparator<String> importComparatror = (s1, s2) -> s1.replace(";","").compareTo(s2.replace(";",""));
-        final Set<String> imports = new TreeSet<>(importComparatror);
+        final Set<String> imports = new TreeSet<>(Comparator.comparing(s -> s.replace(";", "")));
 
         addImport(imports, SystemViewRowAttributeWalker.class);
         addImport(imports, clazz);

--- a/modules/codegen/src/main/java/org/apache/ignite/codegen/SystemViewRowAttributeWalkerGenerator.java
+++ b/modules/codegen/src/main/java/org/apache/ignite/codegen/SystemViewRowAttributeWalkerGenerator.java
@@ -151,7 +151,6 @@ public class SystemViewRowAttributeWalkerGenerator {
         Comparator<String> importComparatror = (s1, s2) -> s1.replace(";","").compareTo(s2.replace(";",""));
         final Set<String> imports = new TreeSet<>(importComparatror);
 
-
         addImport(imports, SystemViewRowAttributeWalker.class);
         addImport(imports, clazz);
 

--- a/modules/codegen/src/main/java/org/apache/ignite/codegen/SystemViewRowAttributeWalkerGenerator.java
+++ b/modules/codegen/src/main/java/org/apache/ignite/codegen/SystemViewRowAttributeWalkerGenerator.java
@@ -148,7 +148,9 @@ public class SystemViewRowAttributeWalkerGenerator {
      */
     private <T> Collection<String> generate(Class<T> clazz) {
         final List<String> code = new ArrayList<>();
-        final Set<String> imports = new TreeSet<>();
+        Comparator<String> importComparatror = (s1, s2) -> s1.replace(";","").compareTo(s2.replace(";",""));
+        final Set<String> imports = new TreeSet<>(importComparatror);
+
 
         addImport(imports, SystemViewRowAttributeWalker.class);
         addImport(imports, clazz);


### PR DESCRIPTION
imports order was incorrect because if default lexicographical comparator
"import org.apache.ignite.spi.systemview.view.ComputeJobView.ComputeJobState;" is less "import org.apache.ignite.spi.systemview.view.ComputeJobView;"
however if we remove semicolom uring comparing the problem is fixed
so to fix the problem I've added custom comparator to "imports" TreeSet
