### PR TITLE
IGNITE-13392 [ML]: fix Incorrect Vector::kNorm evaluation for odd powers

### DIFF
--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/primitives/vector/AbstractVector.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/primitives/vector/AbstractVector.java
@@ -879,7 +879,8 @@ public abstract class AbstractVector implements Vector {
             return nonZeroElements();
         else
             // Default case.
-            return Math.pow(foldMap(Functions.PLUS, Functions.pow(power), 0d), 1.0 / power);
+            return Math.pow(foldMap(
+                Functions.PLUS, x -> Math.pow(Math.abs(x), power), 0d), 1.0 / power);
     }
 
     /** {@inheritDoc} */

--- a/modules/ml/src/test/java/org/apache/ignite/ml/math/primitives/vector/VectorNormCasesTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/math/primitives/vector/VectorNormCasesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.ml.math.primitives.vector;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.ignite.ml.math.primitives.vector.impl.DenseVector;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class VectorNormCasesTest {
+  /**
+   * Precision.
+   */
+  private static final double PRECISION = 0.01;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<TestData> data() {
+    return Arrays.asList(
+        new TestData(
+            new double[] {1.0, -1.0, 0.0},
+            1,
+            2.0
+        ),
+        new TestData(
+            new double[] {1.0, -1.0, 0.0},
+            2,
+            1.41
+        ),
+        new TestData(
+            new double[] {1.0, -1.0, 0.0},
+            3,
+            1.25
+        ),
+        new TestData(
+            new double[] {1.0, -1.0, 0.0},
+            4,
+            1.18
+        ),
+        new TestData(
+            new double[] {1.0, -1.0, 0.0},
+            5,
+            1.14
+        )
+    );
+  }
+
+  private final TestData testData;
+
+  public VectorNormCasesTest(TestData testData) {
+    this.testData = testData;
+  }
+
+  @Test
+  public void test() {
+    assertEquals(
+        testData.vector.kNorm(testData.p),
+        testData.expRes,
+        PRECISION
+    );
+  }
+
+  private static class TestData {
+    public final Vector vector;
+
+    public final Double p;
+
+    public final Double expRes;
+
+    private TestData(double[] vector, double p, double expRes) {
+      this.vector = new DenseVector(vector);
+      this.p = p;
+      this.expRes = expRes;
+    }
+
+    @Override public String toString() {
+      return String.format("norm(%s, %s) = %s",
+          Arrays.toString(vector.asArray()),
+          p,
+          expRes
+      );
+    }
+  }
+}

--- a/modules/ml/src/test/java/org/apache/ignite/ml/math/primitives/vector/VectorNormTest.java
+++ b/modules/ml/src/test/java/org/apache/ignite/ml/math/primitives/vector/VectorNormTest.java
@@ -203,7 +203,7 @@ public class VectorNormTest {
             double norm = 0;
 
             for (double val : arr)
-                norm += pow == 1 ? Math.abs(val) : Math.pow(val, pow);
+                norm += pow == 1 ? Math.abs(val) : Math.pow(Math.abs(val), pow);
 
             return norm;
         }


### PR DESCRIPTION
Current implementation of `Vector::kNorm` is incorrect. 

Current formula is (`org.apache.ignite.ml.math.primitives.vector.AbstractVector:882`):
```
(\sum_{i}{x^p})^{1/p}
```
But correct formula is:
```
(\sum_{i}{|x|^p})^{1/p}
```
We can verify this using lectures (https://www.math.usm.edu/lambers/mat610/sum10/lecture2.pdf) or using Wolfram Mathematica:
```
> Norm[{x, y, z}, p]
(Abs[x]^p+Abs[y]^p+Abs[z]^p)^(1/p)
```

Issue: https://issues.apache.org/jira/browse/IGNITE-13392