### PR TITLE
IGNITE-13405 fix: invalid value type for PROP_PARTITION_LOSS_POLICY cache configuration value

### DIFF
--- a/modules/platforms/python/pyignite/datatypes/cache_properties.py
+++ b/modules/platforms/python/pyignite/datatypes/cache_properties.py
@@ -68,7 +68,7 @@ def prop_map(code: int):
         PROP_CACHE_KEY_CONFIGURATION: PropCacheKeyConfiguration,
         PROP_DEFAULT_LOCK_TIMEOUT: PropDefaultLockTimeout,
         PROP_MAX_CONCURRENT_ASYNC_OPERATIONS: PropMaxConcurrentAsyncOperation,
-        PROP_PARTITION_LOSS_POLICY: PartitionLossPolicy,
+        PROP_PARTITION_LOSS_POLICY: PropPartitionLossPolicy,
         PROP_EAGER_TTL: PropEagerTTL,
         PROP_STATISTICS_ENABLED: PropStatisticsEnabled,
     }[code]


### PR DESCRIPTION

Problem:
 invalid cache creation parameters which break cache creation process
Reason:
invalid object in map configuration

Implementation:
fix parametr in map configuration 
 