### PR TITLE
Fixed incorrect hostnameConstraint

### DIFF
--- a/modules/yarn/src/main/java/org/apache/ignite/yarn/ApplicationMaster.java
+++ b/modules/yarn/src/main/java/org/apache/ignite/yarn/ApplicationMaster.java
@@ -199,7 +199,7 @@ public class ApplicationMaster implements AMRMClientAsync.CallbackHandler {
 
         // Check host name
         if (props.hostnameConstraint() != null
-                && props.hostnameConstraint().matcher(cont.getNodeId().getHost()).matches()) {
+                && !props.hostnameConstraint().matcher(cont.getNodeId().getHost()).matches()) {
             log.log(Level.WARNING, "Wrong host name '{0}'. It didn't match to '{1}' pattern.",
                 new Object[] {cont.getNodeId().getHost(), props.hostnameConstraint().toString()});
 

--- a/modules/yarn/src/test/java/org/apache/ignite/yarn/IgniteApplicationMasterSelfTest.java
+++ b/modules/yarn/src/test/java/org/apache/ignite/yarn/IgniteApplicationMasterSelfTest.java
@@ -250,7 +250,6 @@ public class IgniteApplicationMasterSelfTest {
         assertEquals(1, nmClient.startedContainer().size());
     }
 
-
     /**
      * @throws Exception If failed.
      */
@@ -268,15 +267,45 @@ public class IgniteApplicationMasterSelfTest {
         props.cpusPerNode(8);
         props.memoryPerNode(5000);
         props.instances(3);
-        props.hostnameConstraint(Pattern.compile("ignoreHost"));
+        props.hostnameConstraint(Pattern.compile("constraintHost"));
 
         // Check that container resources
-        appMaster.onContainersAllocated(Collections.singletonList(createContainer("simple", 8, 5000)));
+        appMaster.onContainersAllocated(Collections.singletonList(createContainer("constraintHost", 8, 5000)));
         assertEquals(0, rmMock.releasedResources().size());
-        assertEquals(1, nmClient.startedContainer().size());
 
         appMaster.onContainersAllocated(Collections.singletonList(createContainer("ignoreHost", 8, 5000)));
         assertEquals(1, rmMock.releasedResources().size());
+        assertEquals(1, nmClient.startedContainer().size());
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testHostnameConstraintNegativeLookahead() throws Exception {
+        rmMock.availableRes(new MockResource(1024, 2));
+
+        NMMock nmClient = new NMMock();
+
+        appMaster.setRmClient(rmMock);
+        appMaster.setNmClient(nmClient);
+
+        appMaster.setFs(new MockFileSystem());
+
+        props.cpusPerNode(8);
+        props.memoryPerNode(5000);
+        props.instances(3);
+        props.hostnameConstraint(Pattern.compile("^(?!excludedPrefix).*"));
+
+        // Check that container resources
+        appMaster.onContainersAllocated(Collections.singletonList(createContainer("excludedPrefix", 8, 5000)));
+        assertEquals(1, rmMock.releasedResources().size());
+
+        appMaster.onContainersAllocated(Collections.singletonList(createContainer("excludedPrefixHost", 8, 5000)));
+        assertEquals(2, rmMock.releasedResources().size());
+
+        appMaster.onContainersAllocated(Collections.singletonList(createContainer("excluded", 8, 5000)));
+        assertEquals(2, rmMock.releasedResources().size());
         assertEquals(1, nmClient.startedContainer().size());
     }
 


### PR DESCRIPTION
Previously hostnameConstraint was excluded match, this patch fixed it. Please refer to the unittests.


### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
