### PR TITLE
Make tox external dependency.

### DIFF
--- a/modules/ducktests/tests/README.md
+++ b/modules/ducktests/tests/README.md
@@ -7,7 +7,16 @@ the `ducktape` test framework, for information about it check the links:
 
 Structure of the `ignitetest` directory is:
 - `./ignitetest/services` contains basic services functionality;
-- `./ignitetest/tests/utils` contains utils for testing.  
+- `./ignitetest/utils` contains utils for testing;
+- `./ignitetest/tests` contains tests.
 
-## Review Checklist
-1. All tests must be parameterized with `version`.
+Docker is used to emulate distributed environment. Single container represents 
+a running node.
+
+## Requirements
+To just start tests locally the only requirement is preinstalled `docker`. 
+
+For development process requirements are:
+1. `python` >= 3.6;
+2. `tox` (check python codestyle);
+3. `docker`.

--- a/modules/ducktests/tests/setup.py
+++ b/modules/ducktests/tests/setup.py
@@ -30,7 +30,7 @@ setup(name="ignitetest",
       license="apache2.0",
       packages=find_packages(exclude=["ignitetest.tests", "ignitetest.tests.*"]),
       include_package_data=True,
-      install_requires=["ducktape==0.8.0", "tox==3.15.2"],
+      install_requires=["ducktape==0.8.0"],
       dependency_links=[
           'https://github.com/confluentinc/ducktape/tarball/master#egg=ducktape-0.8.0'
       ])


### PR DESCRIPTION
Remove tox from ignitetest setup.py due to version conflict with ducktape