### PR TITLE
IGNITE-13485 Java thin: increase test coverage for transactions and partition awareness

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -93,8 +93,10 @@ import static org.junit.Assert.fail;
 /**
  * Thin client functional tests.
  */
+@SuppressWarnings("unused")
 public class FunctionalTest {
     /** Per test timeout */
+    @SuppressWarnings("deprecation")
     @Rule
     public Timeout globalTimeout = new Timeout((int) GridTestUtils.DFLT_TEST_TIMEOUT);
 
@@ -186,7 +188,7 @@ public class FunctionalTest {
                 .setEagerTtl(false)
                 .setGroupName("FunctionalTest")
                 .setDefaultLockTimeout(12345)
-                .setPartitionLossPolicy(PartitionLossPolicy.READ_WRITE_ALL)
+                .setPartitionLossPolicy(PartitionLossPolicy.READ_WRITE_SAFE)
                 .setReadFromBackup(true)
                 .setRebalanceBatchSize(67890)
                 .setRebalanceBatchesPrefetchCount(102938)
@@ -217,7 +219,7 @@ public class FunctionalTest {
                 )
                 .setExpiryPolicy(new PlatformExpiryPolicy(10, 20, 30));
 
-            ClientCache cache = client.createCache(cacheCfg);
+            ClientCache<Object, Object> cache = client.createCache(cacheCfg);
 
             assertEquals(CACHE_NAME, cache.getName());
 
@@ -556,6 +558,7 @@ public class FunctionalTest {
     public void testClientFailsOnStart() {
         ClientConnectionException expEx = null;
 
+        //noinspection EmptyTryBlock
         try (IgniteClient ignored = Ignition.startClient(getClientConfiguration())) {
             // No-op.
         }

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -1056,7 +1056,7 @@ public class FunctionalTest {
                 // Start implicit transaction after explicit transaction has been closed by another thread.
                 cache.put(0, "value22");
 
-                ForkJoinPool.commonPool().submit(() -> assertEquals("value24", cache.get(0))).get();
+                ForkJoinPool.commonPool().submit(() -> assertEquals("value22", cache.get(0))).get();
 
                 // New explicit transaction can be started after current transaction has been closed by another thread.
                 try (ClientTransaction tx1 = client.transactions().txStart(PESSIMISTIC, READ_COMMITTED)) {

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -962,7 +962,7 @@ public class FunctionalTest {
 
                 cache.put(0, "value18");
 
-                Thread t = new Thread(() -> {
+                Future<?> fut = ForkJoinPool.commonPool().submit(() -> {
                     try (ClientTransaction tx1 = client.transactions().txStart(PESSIMISTIC, READ_COMMITTED)) {
                         cache.put(1, "value19");
 
@@ -983,8 +983,6 @@ public class FunctionalTest {
                     }
                 });
 
-                t.start();
-
                 barrier.await();
 
                 assertEquals("value9", cache.get(1));
@@ -997,7 +995,7 @@ public class FunctionalTest {
 
                 assertEquals("value19", cache.get(1));
 
-                t.join();
+                fut.get();
             }
 
             // Test transaction usage by different threads.

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractPartitionAwarenessTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractPartitionAwarenessTest.java
@@ -60,6 +60,15 @@ public abstract class ThinClientAbstractPartitionAwarenessTest extends GridCommo
 
     /** Partitioned with custom affinity cache name. */
     protected static final String PART_CUSTOM_AFFINITY_CACHE_NAME = "partitioned_custom_affinity_cache";
+    /**
+     * Name of a partitioned cache with 0 backups. */
+    protected static final String PART_CACHE_0_BACKUPS_NAME = "partitioned_0_backup_cache";
+
+    /** Name of a partitioned cache with 1 backups. */
+    protected static final String PART_CACHE_1_BACKUPS_NAME = "partitioned_1_backup_cache";
+
+    /** Name of a partitioned cache with 3 backups. */
+    protected static final String PART_CACHE_3_BACKUPS_NAME = "partitioned_3_backup_cache";
 
     /** Keys count. */
     protected static final int KEY_CNT = 30;
@@ -101,7 +110,22 @@ public abstract class ThinClientAbstractPartitionAwarenessTest extends GridCommo
                 new CacheKeyConfiguration(TestNotAnnotatedAffinityKey.class.getName(), "affinityKey"),
                 new CacheKeyConfiguration(TestAnnotatedAffinityKey.class));
 
-        return cfg.setCacheConfiguration(ccfg0, ccfg1, ccfg2);
+        CacheConfiguration ccfg3 = new CacheConfiguration()
+                .setName(PART_CACHE_0_BACKUPS_NAME)
+                .setCacheMode(CacheMode.PARTITIONED)
+                .setBackups(0);
+
+        CacheConfiguration ccfg4 = new CacheConfiguration()
+                .setName(PART_CACHE_1_BACKUPS_NAME)
+                .setCacheMode(CacheMode.PARTITIONED)
+                .setBackups(1);
+
+        CacheConfiguration ccfg5 = new CacheConfiguration()
+                .setName(PART_CACHE_3_BACKUPS_NAME)
+                .setCacheMode(CacheMode.PARTITIONED)
+                .setBackups(3);
+
+        return cfg.setCacheConfiguration(ccfg0, ccfg1, ccfg2, ccfg3, ccfg4, ccfg5);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractPartitionAwarenessTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractPartitionAwarenessTest.java
@@ -60,8 +60,8 @@ public abstract class ThinClientAbstractPartitionAwarenessTest extends GridCommo
 
     /** Partitioned with custom affinity cache name. */
     protected static final String PART_CUSTOM_AFFINITY_CACHE_NAME = "partitioned_custom_affinity_cache";
-    /**
-     * Name of a partitioned cache with 0 backups. */
+
+    /* Name of a partitioned cache with 0 backups. */
     protected static final String PART_CACHE_0_BACKUPS_NAME = "partitioned_0_backup_cache";
 
     /** Name of a partitioned cache with 1 backups. */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -115,6 +115,30 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
     }
 
     /**
+     * Test affinity awareness for all applicable operation types for partitioned cache with 0 backups.
+     */
+    @Test
+    public void testPartitionedCache0Backups() throws Exception {
+        testApplicableCache(PART_CACHE_0_BACKUPS_NAME, i -> i);
+    }
+
+    /**
+     * Test affinity awareness for all applicable operation types for partitioned cache with 1 backups.
+     */
+    @Test
+    public void testPartitionedCache1Backups() throws Exception {
+        testApplicableCache(PART_CACHE_1_BACKUPS_NAME, i -> i);
+    }
+
+    /**
+     * Test affinity awareness for all applicable operation types for partitioned cache with 3 backups.
+     */
+    @Test
+    public void testPartitionedCache3Backups() throws Exception {
+        testApplicableCache(PART_CACHE_3_BACKUPS_NAME, i -> i);
+    }
+
+    /**
      * @param cacheName Cache name.
      */
     private void testNotApplicableCache(String cacheName) {


### PR DESCRIPTION
* Add partition awareness tests for partitioned caches with backups
* Add transactions tests for pessimistic and optimistic modes
* Fix `new Thread()` usage in tests: assertion errors were ignored in some tests