### PR TITLE
IGNITE-13531 [ML]: Code cleanup in Util classes

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/metastorage/persistence/DistributedMetaStorageUtil.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/metastorage/persistence/DistributedMetaStorageUtil.java
@@ -24,7 +24,14 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.marshaller.jdk.JdkMarshaller;
 
 /** */
-class DistributedMetaStorageUtil {
+final class DistributedMetaStorageUtil {
+    /**
+     *
+     */
+    private DistributedMetaStorageUtil() {
+        // No-op.
+    }
+
     /**
      * Common prefix for everything that is going to be written into {@link MetaStorage}. Something that has minimal
      * chance of collision with the existing keys.

--- a/modules/ml/src/main/java/org/apache/ignite/ml/clustering/kmeans/KMeansTrainer.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/clustering/kmeans/KMeansTrainer.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -114,13 +115,13 @@ public class KMeansTrainer extends SingleLabelDatasetTrainer<KMeansModel> {
 
                 converged = true;
 
-                for (Integer ind : totalRes.sums.keySet()) {
-                    Vector massCenter = totalRes.sums.get(ind).times(1.0 / totalRes.counts.get(ind));
+                for (Map.Entry<Integer, Vector> entry : totalRes.sums.entrySet()) {
+                    Vector massCenter = entry.getValue().times(1.0 / totalRes.counts.get(entry.getKey()));
 
-                    if (converged && distance.compute(massCenter, centers[ind]) > epsilon * epsilon)
+                    if (converged && distance.compute(massCenter, centers[entry.getKey()]) > epsilon * epsilon)
                         converged = false;
 
-                    newCentroids[ind] = massCenter;
+                    newCentroids[entry.getKey()] = massCenter;
                 }
 
                 iteration++;

--- a/modules/ml/src/main/java/org/apache/ignite/ml/dataset/feature/ObjectHistogram.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/dataset/feature/ObjectHistogram.java
@@ -60,9 +60,9 @@ public abstract class ObjectHistogram<T> implements Histogram<T, ObjectHistogram
         TreeMap<Integer, Double> res = new TreeMap<>();
 
         double accum = 0.0;
-        for (Integer bucket : hist.keySet()) {
-            accum += hist.get(bucket);
-            res.put(bucket, accum);
+        for (Map.Entry<Integer, Double> entry : hist.entrySet()) {
+            accum += entry.getValue();
+            res.put(entry.getKey(), accum);
         }
 
         return res;
@@ -71,7 +71,7 @@ public abstract class ObjectHistogram<T> implements Histogram<T, ObjectHistogram
     /** {@inheritDoc} */
     @Override public ObjectHistogram<T> plus(ObjectHistogram<T> other) {
         ObjectHistogram<T> res = newInstance();
-        addTo(this.hist, res.hist);
+        addTo(hist, res.hist);
         addTo(other.hist, res.hist);
         return res;
     }

--- a/modules/ml/src/main/java/org/apache/ignite/ml/dataset/impl/cache/util/ComputeUtils.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/dataset/impl/cache/util/ComputeUtils.java
@@ -56,7 +56,14 @@ import org.apache.ignite.ml.util.Utils;
 /**
  * Util class that provides common methods to perform computations on top of the Ignite Compute Grid.
  */
-public class ComputeUtils {
+public final class ComputeUtils {
+    /**
+     *
+     */
+    private ComputeUtils() {
+        // No-op.
+    }
+
     /** Template of the key used to store partition {@code data} in local storage. */
     private static final String DATA_STORAGE_KEY_TEMPLATE = "part_data_storage_%s";
 
@@ -110,11 +117,11 @@ public class ComputeUtils {
                 }
 
             // Collects results.
-            for (int part : futures.keySet())
+            for (Map.Entry<Integer, IgniteFuture<R>> entry : futures.entrySet())
                 try {
-                    R res = futures.get(part).get();
+                    R res = entry.getValue().get();
                     results.add(res);
-                    completionFlags.set(part);
+                    completionFlags.set(entry.getKey());
                 }
                 catch (IgniteException ignore) {
                 }

--- a/modules/ml/src/main/java/org/apache/ignite/ml/inference/IgniteModelStorageUtil.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/inference/IgniteModelStorageUtil.java
@@ -42,7 +42,14 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Utils class that helps to operate with model storage and Ignite models.
  */
-public class IgniteModelStorageUtil {
+public final class IgniteModelStorageUtil {
+    /**
+     *
+     */
+    private IgniteModelStorageUtil(){
+        // No-op.
+    }
+
     /** Folder to be used to store Ignite models. */
     private static final String IGNITE_MDL_FOLDER = "/ignite_models";
 

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/Blas.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/Blas.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.ml.math;
 
+import java.io.Serializable;
 import java.util.Set;
 import com.github.fommil.netlib.BLAS;
 import com.github.fommil.netlib.F2jBLAS;
@@ -35,7 +36,10 @@ import org.apache.ignite.ml.math.util.MatrixUtil;
  * Useful subset of BLAS operations.
  * This class is based on 'BLAS' class from Apache Spark MLlib.
  */
-public class Blas {
+public class Blas implements Serializable {
+    /** */
+    private static final long serialVersionUID = 124309657712638021L;
+
     /** F2J implementation of BLAS. */
     private static transient BLAS f2jBlas = new F2jBLAS();
 

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/util/MapUtil.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/util/MapUtil.java
@@ -27,7 +27,14 @@ import java.util.stream.Stream;
 /**
  * Some {@link Map} related utils.
  */
-public class MapUtil {
+public final class MapUtil {
+    /**
+     *
+     */
+    private MapUtil(){
+        // No-op.
+    }
+
     /** */
     public static <K, V, M extends Map<K, V>> M mergeMaps(M m1, M m2, BinaryOperator<V> op, Supplier<M> mapSupplier) {
         return Stream.of(m1, m2)

--- a/modules/ml/src/main/java/org/apache/ignite/ml/math/util/MatrixUtil.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/math/util/MatrixUtil.java
@@ -32,7 +32,14 @@ import org.apache.ignite.ml.math.primitives.vector.impl.DenseVector;
 /**
  * Utility class for various matrix operations.
  */
-public class MatrixUtil {
+public final class MatrixUtil {
+    /**
+     *
+     */
+    private MatrixUtil() {
+        // No-op.
+    }
+
     /**
      * Create the like matrix with read-only matrices support.
      *

--- a/modules/ml/src/main/java/org/apache/ignite/ml/nn/Activators.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/nn/Activators.java
@@ -26,7 +26,7 @@ public class Activators {
     /**
      * Sigmoid activation function.
      */
-    public static IgniteDifferentiableDoubleToDoubleFunction SIGMOID = new IgniteDifferentiableDoubleToDoubleFunction() {
+    public static final IgniteDifferentiableDoubleToDoubleFunction SIGMOID = new IgniteDifferentiableDoubleToDoubleFunction() {
         /** {@inheritDoc} */
         @Override public double differential(double pnt) {
             double v = apply(pnt);
@@ -42,7 +42,7 @@ public class Activators {
     /**
      * Rectified linear unit (ReLU) activation function.
      */
-    public static IgniteDifferentiableDoubleToDoubleFunction RELU = new IgniteDifferentiableDoubleToDoubleFunction() {
+    public static final IgniteDifferentiableDoubleToDoubleFunction RELU = new IgniteDifferentiableDoubleToDoubleFunction() {
         /**
          * Differential of ReLU at pnt. Formally, function is not differentiable at 0, but we let differential at 0 be 0.
          *
@@ -62,7 +62,7 @@ public class Activators {
     /**
      * Linear unit activation function.
      */
-    public static IgniteDifferentiableDoubleToDoubleFunction LINEAR = new IgniteDifferentiableDoubleToDoubleFunction() {
+    public static final IgniteDifferentiableDoubleToDoubleFunction LINEAR = new IgniteDifferentiableDoubleToDoubleFunction() {
         /** {@inheritDoc} */
         @Override public double differential(double pnt) {
             return 1.0;

--- a/modules/ml/src/main/java/org/apache/ignite/ml/preprocessing/imputing/ImputerTrainer.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/preprocessing/imputing/ImputerTrainer.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.ml.preprocessing.imputing;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -442,8 +443,7 @@ public class ImputerTrainer<K, V> implements PreprocessingTrainer<K, V> {
     private double[] updateTheMins(LabeledVector row, double[] mins) {
         if (mins == null) {
             mins = new double[row.size()];
-            for (int i = 0; i < mins.length; i++)
-                mins[i] = Double.POSITIVE_INFINITY;
+            Arrays.fill(mins, Double.POSITIVE_INFINITY);
         }
 
         else
@@ -468,8 +468,7 @@ public class ImputerTrainer<K, V> implements PreprocessingTrainer<K, V> {
     private double[] updateTheMaxs(LabeledVector row, double[] maxs) {
         if (maxs == null) {
             maxs = new double[row.size()];
-            for (int i = 0; i < maxs.length; i++)
-                maxs[i] = Double.NEGATIVE_INFINITY;
+            Arrays.fill(maxs, Double.NEGATIVE_INFINITY);
         }
 
         else

--- a/modules/ml/src/main/java/org/apache/ignite/ml/preprocessing/maxabsscaling/MaxAbsScalerTrainer.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/preprocessing/maxabsscaling/MaxAbsScalerTrainer.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.ml.preprocessing.maxabsscaling;
 
+import java.util.Arrays;
 import org.apache.ignite.ml.dataset.Dataset;
 import org.apache.ignite.ml.dataset.DatasetBuilder;
 import org.apache.ignite.ml.dataset.UpstreamEntry;
@@ -50,8 +51,7 @@ public class MaxAbsScalerTrainer<K, V> implements PreprocessingTrainer<K, V> {
 
                     if (maxAbs == null) {
                         maxAbs = new double[row.size()];
-                        for (int i = 0; i < maxAbs.length; i++)
-                            maxAbs[i] = .0;
+                        Arrays.fill(maxAbs, .0);
                     }
                     else
                         assert maxAbs.length == row.size() : "Base preprocessor must return exactly " + maxAbs.length

--- a/modules/ml/src/main/java/org/apache/ignite/ml/preprocessing/minmaxscaling/MinMaxScalerTrainer.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/preprocessing/minmaxscaling/MinMaxScalerTrainer.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.ml.preprocessing.minmaxscaling;
 
+import java.util.Arrays;
 import org.apache.ignite.ml.dataset.Dataset;
 import org.apache.ignite.ml.dataset.DatasetBuilder;
 import org.apache.ignite.ml.dataset.PartitionContextBuilder;
@@ -53,8 +54,7 @@ public class MinMaxScalerTrainer<K, V> implements PreprocessingTrainer<K, V> {
 
                     if (min == null) {
                         min = new double[row.size()];
-                        for (int i = 0; i < min.length; i++)
-                            min[i] = Double.MAX_VALUE;
+                        Arrays.fill(min, Double.MAX_VALUE);
                     }
                     else
                         assert min.length == row.size() : "Base preprocessor must return exactly " + min.length
@@ -62,8 +62,7 @@ public class MinMaxScalerTrainer<K, V> implements PreprocessingTrainer<K, V> {
 
                     if (max == null) {
                         max = new double[row.size()];
-                        for (int i = 0; i < max.length; i++)
-                            max[i] = -Double.MAX_VALUE;
+                        Arrays.fill(max, -Double.MAX_VALUE);
                     }
                     else
                         assert max.length == row.size() : "Base preprocessor must return exactly " + min.length

--- a/modules/ml/src/main/java/org/apache/ignite/ml/util/Utils.java
+++ b/modules/ml/src/main/java/org/apache/ignite/ml/util/Utils.java
@@ -34,7 +34,14 @@ import org.apache.ignite.IgniteException;
 /**
  * Class with various utility methods.
  */
-public class Utils {
+public final class Utils {
+    /**
+     *
+     */
+    private Utils(){
+        // No-op.
+    }
+
     /**
      * Perform deep copy of an object.
      *


### PR DESCRIPTION
- add a private constructorto Util classes in ignite ml.
- add Serializable to Blas class
- add final modifier to static inner fields in utils class
- inefficient use of keySet iterator instead of entrySet
- can be replaced with single Arrays.fill method call

Issue: https://issues.apache.org/jira/browse/IGNITE-13531