### PR TITLE
IGNITE-13563: Fix deserializing IBinaryObject containing an IBinaryObject field

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySelfTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySelfTest.cs
@@ -1635,6 +1635,28 @@ namespace Apache.Ignite.Core.Tests.Binary
             Assert.AreEqual(GetCompactFooter(), _marsh.CompactFooter);
         }
 
+        /// <summary>
+        /// Tests serializing/deserializing objects with IBinaryObject fields.
+        /// </summary>
+        [Test]
+        public void TestBinaryField()
+        {
+            byte[] dataInner = _marsh.Marshal(new BinaryObjectWrapper());
+
+            IBinaryObject innerObject = _marsh.Unmarshal<IBinaryObject>(dataInner, BinaryMode.ForceBinary);
+            BinaryObjectWrapper inner = innerObject.Deserialize<BinaryObjectWrapper>();
+            
+            Assert.NotNull(inner);
+
+            byte[] dataOuter = _marsh.Marshal(new BinaryObjectWrapper() { Val = innerObject });
+
+            IBinaryObject outerObject = _marsh.Unmarshal<IBinaryObject>(dataOuter, BinaryMode.ForceBinary);
+            BinaryObjectWrapper outer = outerObject.Deserialize<BinaryObjectWrapper>();
+            
+            Assert.NotNull(outer);
+            Assert.IsTrue(outer.Val.Equals(innerObject));
+        }
+
         private static void CheckKeepSerialized(BinaryConfiguration cfg, bool expKeep)
         {
             if (cfg.TypeConfigurations == null)
@@ -2745,6 +2767,11 @@ namespace Apache.Ignite.Core.Tests.Binary
             public byte* ByteP { get; set; }
             public int* IntP { get; set; }
             public void* VoidP { get; set; }
+        }
+
+        private class BinaryObjectWrapper
+        {
+            public IBinaryObject Val;
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
@@ -124,7 +124,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /** <inheritdoc /> */
         public T Deserialize<T>()
         {
-            return Deserialize<T>(BinaryMode.Deserialize);
+            return Deserialize<T>(BinaryMode.KeepBinary);
         }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -900,9 +900,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             var desc = _marsh.GetDescriptor(type);
 
-            _stream.WriteByte(BinaryTypeId.Enum);
-            _stream.WriteInt(desc.TypeId);
-            _stream.WriteInt(val);
+            WriteEnum(val, desc.TypeId);
 
             var binaryTypeHolder = Marshaller.GetCachedBinaryTypeHolder(desc.TypeId);
             if (binaryTypeHolder == null || !binaryTypeHolder.IsSaved)
@@ -913,6 +911,18 @@ namespace Apache.Ignite.Core.Impl.Binary
                 
                 SaveMetadata(desc, binaryFields);
             }
+        }
+
+        /// <summary>
+        /// Write enum value.
+        /// </summary>
+        /// <param name="val">Enum value.</param>
+        /// <param name="typeId">Enum type id.</param>
+        private void WriteEnum(int val, int typeId)
+        {
+            _stream.WriteByte(BinaryTypeId.Enum);
+            _stream.WriteInt(typeId);
+            _stream.WriteInt(val);
         }
 
         /// <summary>
@@ -1384,6 +1394,16 @@ namespace Apache.Ignite.Core.Impl.Binary
                 {
                     if (!WriteHandle(_stream.Position, portObj))
                         _builder.ProcessBinary(_stream, portObj);
+
+                    return true;
+                }
+
+                // Special case for binary enum during build.
+                BinaryEnum binEnum = obj as BinaryEnum;
+
+                if (binEnum != null)
+                {
+                    WriteEnum(binEnum.EnumValue, binEnum.TypeId);
 
                     return true;
                 }


### PR DESCRIPTION
After investigating the [issue](https://issues.apache.org/jira/browse/IGNITE-13563), it seems to occur because `BinaryObject.Deserialize<T>()` uses `BinaryMode.Deserialize`. This, in turn, causes `BinaryReader.ReadBinaryObject()` to call `BinaryReader.Deserialize()` for the first `BinaryTypeId.Binary` object found (while switching to `BinaryMode.KeepBinary` for nested objects). Then, `BinaryReader.ReadFullObject()` gets called, and not knowing better, tries to deserialize the object of a nonexistent type.

Now, `BinaryMode.Deserialize` is also used by `CacheClient`. However, upon further investigation of the values passed to `Marshaller.Unmarshall`, `CacheClient` unmarshalls values starting with `BinaryTypeId.Binary`, while `BinaryObject` unmarshalls values starting directly with `BinaryUtils.HdrFull`; thus, `BinaryReader` functions correctly for caches but fails with binary objects.

Due to the this, I think the proper fix is to change `BinaryObject.Deserialize<T>()` to use `BinaryMode.KeepBinary`.

Note: This change was initially submitted as a .patch file on the JIRA issue, following https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-2.CreateaPatch-file. As directed on the dev mailing list, I have made it into a PR instead.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
