### PR TITLE
IGNITE-13160 .NET: Register binary metadata during cache start

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
@@ -585,6 +585,16 @@ public class BinaryContext {
     }
 
     /**
+     * Registers binary type.
+     *
+     * @param binaryType Binary type to register.
+     * @param failIfUnregistered Whether to fail when not registered.
+     */
+    public void registerClass(BinaryType binaryType, boolean failIfUnregistered) {
+        metaHnd.addMetaLocally(binaryType.typeId(), binaryType, failIfUnregistered);
+    }
+
+    /**
      * @param cls Class.
      * @return A descriptor for the given class. If the class hasn't been registered yet, then a new descriptor will be
      * created, but its {@link BinaryClassDescriptor#registered()} will be {@code false}.

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryObjectBuilderImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/builder/BinaryObjectBuilderImpl.java
@@ -46,6 +46,8 @@ import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.thread.IgniteThread;
 import org.jetbrains.annotations.Nullable;
 
+import static org.apache.ignite.internal.MarshallerPlatformIds.JAVA_ID;
+
 /**
  *
  */
@@ -360,7 +362,7 @@ public class BinaryObjectBuilderImpl implements BinaryObjectBuilder {
                 if (affFieldName0 == null)
                     affFieldName0 = ctx.affinityKeyFieldName(typeId);
 
-                ctx.registerUserClassName(typeId, typeName, writer.failIfUnregistered(), false);
+                ctx.registerUserClassName(typeId, typeName, writer.failIfUnregistered(), false, JAVA_ID);
 
                 ctx.updateMetadata(typeId, new BinaryMetadata(typeId, typeName, fieldsMeta, affFieldName0,
                     Collections.singleton(curSchema), false, null), writer.failIfUnregistered());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContext.java
@@ -326,4 +326,10 @@ public interface PlatformContext {
      * @return Metadata when type exists; null otherwise.
      */
     @Nullable BinaryMetadata getBinaryType(String typeName);
+
+    /**
+     * Gets marshaller platform id (see {@link org.apache.ignite.internal.MarshallerPlatformIds}).
+     * @return Marshaller platform id.
+     */
+    byte getMarshallerPlatformId();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContext.java
@@ -22,6 +22,7 @@ import org.apache.ignite.cluster.ClusterMetrics;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.events.Event;
 import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.binary.BinaryMetadata;
 import org.apache.ignite.internal.binary.BinaryRawReaderEx;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
@@ -317,4 +318,12 @@ public interface PlatformContext {
      * Disables thread-local optimization for platform cache update.
      */
     void disableThreadLocalForPlatformCacheUpdate();
+
+    /**
+     * Gets platform binary type metadata.
+     *
+     * @param typeName Type name.
+     * @return Metadata when type exists; null otherwise.
+     */
+    @Nullable BinaryMetadata getBinaryType(String typeName);
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContextImpl.java
@@ -40,6 +40,7 @@ import org.apache.ignite.events.EventType;
 import org.apache.ignite.events.JobEvent;
 import org.apache.ignite.events.TaskEvent;
 import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.MarshallerPlatformIds;
 import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.binary.BinaryMetadata;
 import org.apache.ignite.internal.binary.BinaryRawReaderEx;
@@ -669,6 +670,14 @@ public class PlatformContextImpl implements PlatformContext, PartitionsExchangeA
 
             return PlatformUtils.readBinaryMetadata(reader(in));
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override public byte getMarshallerPlatformId() {
+        // Only .NET has a specific marshaller ID, C++ does not have it.
+        return platform.equals(PlatformUtils.PLATFORM_DOTNET)
+                ? MarshallerPlatformIds.DOTNET_ID
+                : MarshallerPlatformIds.JAVA_ID;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContextImpl.java
@@ -661,13 +661,11 @@ public class PlatformContextImpl implements PlatformContext, PartitionsExchangeA
             writer.writeString(typeName);
             out.synchronize();
 
-            gateway().binaryTypeGet(mem0.pointer());
+            if (gateway().binaryTypeGet(mem0.pointer()) == 0)
+                return null;
 
             PlatformInputStream in = mem0.input();
             in.synchronize();
-
-            if (!in.readBoolean())
-                return null;
 
             return PlatformUtils.readBinaryMetadata(reader(in));
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackGateway.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackGateway.java
@@ -1303,11 +1303,11 @@ public class PlatformCallbackGateway {
      *
      * @param memPtr Ptr to a stream with serialized type name. Result is returned in the same stream.
      */
-    public void binaryTypeGet(long memPtr) {
+    public long binaryTypeGet(long memPtr) {
         enter();
 
         try {
-            PlatformCallbackUtils.inLongOutLong(envPtr, PlatformCallbackOp.BinaryTypeGet, memPtr);
+            return PlatformCallbackUtils.inLongOutLong(envPtr, PlatformCallbackOp.BinaryTypeGet, memPtr);
         }
         finally {
             leave();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackGateway.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackGateway.java
@@ -1301,7 +1301,7 @@ public class PlatformCallbackGateway {
     /**
      * Gets binary type by name.
      *
-     * @param memPtr Ptr to a stream with serialized data.
+     * @param memPtr Ptr to a stream with serialized type name. Result is returned in the same stream.
      */
     public void binaryTypeGet(long memPtr) {
         enter();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackGateway.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackGateway.java
@@ -1299,6 +1299,22 @@ public class PlatformCallbackGateway {
     }
 
     /**
+     * Gets binary type by name.
+     *
+     * @param memPtr Ptr to a stream with serialized data.
+     */
+    public void binaryTypeGet(long memPtr) {
+        enter();
+
+        try {
+            PlatformCallbackUtils.inLongOutLong(envPtr, PlatformCallbackOp.BinaryTypeGet, memPtr);
+        }
+        finally {
+            leave();
+        }
+    }
+
+    /**
      * Enter gateway.
      */
     protected void enter() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackOp.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/callback/PlatformCallbackOp.java
@@ -245,4 +245,7 @@ class PlatformCallbackOp {
 
     /** */
     public static final int ComputeActionExecute = 75;
+
+    /** */
+    public static final int BinaryTypeGet = 76;
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -288,13 +288,6 @@ public class GridQueryProcessor extends GridProcessorAdapter {
     }
 
     /** {@inheritDoc} */
-    @Override public void onKernalStart(boolean active) throws IgniteCheckedException {
-        super.onKernalStart(active);
-
-        registerMetadataForRegisteredCaches();
-    }
-
-    /** {@inheritDoc} */
     @Override public void onKernalStop(boolean cancel) {
         super.onKernalStop(cancel);
 
@@ -333,13 +326,9 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      * @throws IgniteCheckedException If failed.
      */
     public void onCacheKernalStart() throws IgniteCheckedException {
-        synchronized (stateMux) {
-            exchangeReady = true;
+        registerMetadataForRegisteredCaches();
 
-            // Re-run pending top-level proposals.
-            for (SchemaOperation schemaOp : schemaOps.values())
-                onSchemaPropose(schemaOp.proposeMessage());
-        }
+        rerunPendingSchemaProposals();
     }
 
     /**
@@ -353,7 +342,19 @@ public class GridQueryProcessor extends GridProcessorAdapter {
 
             disconnected = false;
 
-            onCacheKernalStart();
+            rerunPendingSchemaProposals();
+        }
+    }
+
+    /**
+     * Re-run pending top-level schema proposals.
+     */
+    private void rerunPendingSchemaProposals() {
+        synchronized (stateMux) {
+            exchangeReady = true;
+
+            for (SchemaOperation schemaOp : schemaOps.values())
+                onSchemaPropose(schemaOp.proposeMessage());
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -1295,6 +1295,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
     private void registerPlatformTypeLocally(String clsName, CacheObjectBinaryProcessorImpl binProc) {
         PlatformProcessor platformProc = ctx.platform();
 
+        assert platformProc != null : "Platform processor must be initialized";
+
         if (!platformProc.hasContext())
             return;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -285,6 +285,11 @@ public class GridQueryProcessor extends GridProcessorAdapter {
                     ctxs.queries().evictDetailMetrics();
             }
         }, QRY_DETAIL_METRICS_EVICTION_FREQ, QRY_DETAIL_METRICS_EVICTION_FREQ);
+    }
+
+    /** {@inheritDoc} */
+    @Override public void onKernalStart(boolean active) throws IgniteCheckedException {
+        super.onKernalStart(active);
 
         registerMetadataForRegisteredCaches();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -1283,7 +1283,7 @@ public class GridQueryProcessor extends GridProcessorAdapter {
             if (cls != null)
                 binProc.binaryContext().registerClass(cls, true, false, true);
             else {
-                registerPlatformTypeLocally(binProc);
+                registerPlatformTypeLocally(clsName, binProc);
             }
         }
     }
@@ -1291,18 +1291,19 @@ public class GridQueryProcessor extends GridProcessorAdapter {
     /**
      * Registers platform type locally.
      *
+     * @param clsName Class name.
      * @param binProc Binary processor.
      */
-    private void registerPlatformTypeLocally(CacheObjectBinaryProcessorImpl binProc) {
+    private void registerPlatformTypeLocally(String clsName, CacheObjectBinaryProcessorImpl binProc) {
         PlatformProcessor platformProc = ctx.platform();
 
         if (!platformProc.hasContext())
             return;
 
-        // TODO: Get meta from platforms
-        platformProc.context().gateway().binaryTypeGet(0);
-        BinaryMetadata meta = PlatformUtils.readBinaryMetadata(null);
-        binProc.binaryContext().registerClass(meta.wrap(binProc.binaryContext()), false);
+        BinaryMetadata meta = platformProc.context().getBinaryType(clsName);
+
+        if (meta != null)
+            binProc.binaryContext().registerClass(meta.wrap(binProc.binaryContext()), false);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -1289,7 +1289,7 @@ public class GridQueryProcessor extends GridProcessorAdapter {
                 PlatformProcessor platformProc = ctx.platform();
                 if (platformProc.hasContext()) {
                     // TODO: Get meta from platforms
-                    platformProc.context().gateway().computeTaskComplete(0, 0);
+                    platformProc.context().gateway().binaryTypeGet(0);
                     binProc.binaryContext().registerClass((BinaryType)null, false);
                 }
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -61,6 +61,7 @@ import org.apache.ignite.events.CacheQueryExecutedEvent;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.NodeStoppingException;
+import org.apache.ignite.internal.binary.BinaryMetadata;
 import org.apache.ignite.internal.managers.communication.GridMessageListener;
 import org.apache.ignite.internal.processors.GridProcessorAdapter;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
@@ -84,6 +85,7 @@ import org.apache.ignite.internal.processors.cache.query.GridCacheQueryType;
 import org.apache.ignite.internal.processors.cache.query.IgniteQueryErrorCode;
 import org.apache.ignite.internal.processors.cacheobject.IgniteCacheObjectProcessor;
 import org.apache.ignite.internal.processors.platform.PlatformProcessor;
+import org.apache.ignite.internal.processors.platform.utils.PlatformUtils;
 import org.apache.ignite.internal.processors.query.property.QueryBinaryProperty;
 import org.apache.ignite.internal.processors.query.schema.SchemaIndexCacheVisitor;
 import org.apache.ignite.internal.processors.query.schema.SchemaIndexCacheVisitorClosure;
@@ -1290,7 +1292,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
                 if (platformProc.hasContext()) {
                     // TODO: Get meta from platforms
                     platformProc.context().gateway().binaryTypeGet(0);
-                    binProc.binaryContext().registerClass((BinaryType)null, false);
+                    BinaryMetadata meta = PlatformUtils.readBinaryMetadata(null);
+                    binProc.binaryContext().registerClass(meta.wrap(binProc.binaryContext()), false);
                 }
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -84,6 +84,7 @@ import org.apache.ignite.internal.processors.cache.query.CacheQueryFuture;
 import org.apache.ignite.internal.processors.cache.query.GridCacheQueryType;
 import org.apache.ignite.internal.processors.cache.query.IgniteQueryErrorCode;
 import org.apache.ignite.internal.processors.cacheobject.IgniteCacheObjectProcessor;
+import org.apache.ignite.internal.processors.platform.PlatformContext;
 import org.apache.ignite.internal.processors.platform.PlatformProcessor;
 import org.apache.ignite.internal.processors.query.property.QueryBinaryProperty;
 import org.apache.ignite.internal.processors.query.schema.SchemaIndexCacheVisitor;
@@ -1300,10 +1301,14 @@ public class GridQueryProcessor extends GridProcessorAdapter {
         if (!platformProc.hasContext())
             return;
 
-        BinaryMetadata meta = platformProc.context().getBinaryType(clsName);
+        PlatformContext platformCtx = platformProc.context();
+        BinaryMetadata meta = platformCtx.getBinaryType(clsName);
 
         if (meta != null)
-            binProc.binaryContext().registerClass(meta.wrap(binProc.binaryContext()), false);
+            binProc.binaryContext().registerClassLocally(
+                    meta.wrap(binProc.binaryContext()),
+                    false,
+                    platformCtx.getMarshallerPlatformId());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -85,7 +85,6 @@ import org.apache.ignite.internal.processors.cache.query.GridCacheQueryType;
 import org.apache.ignite.internal.processors.cache.query.IgniteQueryErrorCode;
 import org.apache.ignite.internal.processors.cacheobject.IgniteCacheObjectProcessor;
 import org.apache.ignite.internal.processors.platform.PlatformProcessor;
-import org.apache.ignite.internal.processors.platform.utils.PlatformUtils;
 import org.apache.ignite.internal.processors.query.property.QueryBinaryProperty;
 import org.apache.ignite.internal.processors.query.schema.SchemaIndexCacheVisitor;
 import org.apache.ignite.internal.processors.query.schema.SchemaIndexCacheVisitorClosure;
@@ -1282,9 +1281,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
 
             if (cls != null)
                 binProc.binaryContext().registerClass(cls, true, false, true);
-            else {
+            else
                 registerPlatformTypeLocally(clsName, binProc);
-            }
         }
     }
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/SqlCacheStartStopTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/SqlCacheStartStopTest.java
@@ -24,8 +24,6 @@ import java.util.stream.IntStream;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.QueryEntity;
-import org.apache.ignite.cache.affinity.Affinity;
-import org.apache.ignite.cache.affinity.AffinityKeyMapped;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.apache.ignite.cache.query.annotations.QuerySqlField;
 import org.apache.ignite.configuration.CacheConfiguration;
@@ -60,33 +58,6 @@ public class SqlCacheStartStopTest extends GridCommonAbstractTest {
     /** {@inheritDoc} */
     @Override protected void afterTest() throws Exception {
         stopAllGrids();
-    }
-
-    /**
-     */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Test
-    public void testCustomAffinity() throws Exception {
-        IgniteConfiguration srvCfg = getConfiguration("server");
-
-        IgniteEx srv = startGrid(srvCfg);
-
-        CacheConfiguration cfg = new CacheConfiguration("mycache")
-                .setQueryEntities(Collections.singletonList(new QueryEntity(MyKey.class, String.class)));
-
-        IgniteCache cache = srv.getOrCreateCache(cfg);
-
-        MyKey key1 = new MyKey();
-        key1.Data = "data1";
-        key1.AffinityKey = 1;
-
-        MyKey key2 = new MyKey();
-        key2.Data = "data2";
-        key2.AffinityKey = 1;
-
-        Affinity<Object> aff = srv.affinity(cache.getName());
-
-        assertEquals(aff.partition(key1), aff.partition(key2));
     }
 
     /**
@@ -355,13 +326,5 @@ public class SqlCacheStartStopTest extends GridCommonAbstractTest {
         public Val(String s) {
             this.s = s;
         }
-    }
-
-    public static class MyKey {
-        @QuerySqlField
-        public String Data;
-
-        @AffinityKeyMapped
-        public long AffinityKey;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -93,6 +93,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Remove="Compute\Forked\**" />
+    <None Update="Config\query-entity-metadata-registration.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
 
   </ItemGroup>
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -147,6 +147,8 @@
     <Compile Include="Cache\Query\QueryEntityMetadataRegistrationTest.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestCodeConfig.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestSharedFactory.cs" />
+    <Compile Include="Client\Cache\ClientQueryEntityMetadataRegistrationTest.cs" />
+    <Compile Include="Client\Cache\ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs" />
     <Compile Include="Client\Cache\ContinuousQueryTest.cs" />
     <Compile Include="Client\Cache\CacheClientAbstractTxTest.cs" />
     <Compile Include="Client\Cache\CacheClientLocalTxTest.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Cache\Query\Linq\CacheLinqTest.Misc.cs" />
     <Compile Include="Cache\Query\Linq\CacheLinqTest.Custom.cs" />
     <Compile Include="Cache\Query\Linq\CacheLinqTest.Contains.cs" />
+    <Compile Include="Cache\Query\QueryEntityMetadataRegistrationTest.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestCodeConfig.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestSharedFactory.cs" />
     <Compile Include="Client\Cache\ContinuousQueryTest.cs" />
@@ -519,6 +520,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Config\Log\custom-log.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Config\query-entity-metadata-registration.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Config\spring-test.xml">

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -126,12 +126,18 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             };
 
             var cache = Ignition.GetIgnite("grid-0").GetOrCreateCache<QueryEntityKey, QueryEntityValue>(cacheCfg);
+            var cache2 = Ignition.GetIgnite("grid-1").GetOrCreateCache<QueryEntityKey, QueryEntityValue>(cacheCfg);
 
             TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-0"), cacheCfg.Name);
             TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-1"), cacheCfg.Name);
 
-            // TODO: Check put/get
-            cache[new QueryEntityKey {Data = "x", AffinityKey = 123}] = new QueryEntityValue {Name = "y", AffKey = 321};
+            // Check put/get.
+            var key = new QueryEntityKey {Data = "x", AffinityKey = 123};
+            cache[key] = new QueryEntityValue {Name = "y", AffKey = 321};
+
+            var val = cache2[key];
+            Assert.AreEqual("y", val.Name);
+            Assert.AreEqual(321, val.AffKey);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         [TestFixtureSetUp]
         public void StartGrids()
         {
-            for (int i = 0; i < 1; i++)
+            for (int i = 0; i < 3; i++)
             {
                 var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -128,7 +128,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             var key1 = new QueryEntityKey {Data = "data1", AffinityKey = 1};
             var key2 = new QueryEntityKey {Data = "data2", AffinityKey = 1};
 
+            var val1 = new QueryEntityValue {Name = "foo", AffKey = 100};
+            var val2 = new QueryEntityValue {Name = "bar", AffKey = 100};
+
             Assert.AreEqual(aff.GetPartition(key1), aff.GetPartition(key2));
+            Assert.AreEqual(aff.GetPartition(val1), aff.GetPartition(val2));
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -111,9 +111,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         [Test]
         public void TestAffinityKeyMappedWithQueryEntity()
         {
-            var cacheCfg = new CacheConfiguration("mycache")
+            var cacheCfg = new CacheConfiguration(TestUtils.TestName)
             {
-                // Without QueryEntities tests passes.
                 QueryEntities = new List<QueryEntity>
                 {
                     new QueryEntity(typeof(QueryEntityKey), typeof(QueryEntityValue))

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -125,10 +125,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
                 }
             };
 
-            Ignition.GetIgnite("grid-0").GetOrCreateCache<int, int>(cacheCfg);
-            
+            var cache = Ignition.GetIgnite("grid-0").GetOrCreateCache<QueryEntityKey, QueryEntityValue>(cacheCfg);
+
             TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-0"), cacheCfg.Name);
             TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-1"), cacheCfg.Name);
+
+            // TODO: Check put/get
+            cache[new QueryEntityKey {Data = "x", AffinityKey = 123}] = new QueryEntityValue {Name = "y", AffKey = 321};
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -98,10 +98,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             }
         }
 
+        /// <summary>
+        /// Tests that <see cref="AffinityKeyMappedAttribute"/> works when used on a property of a type that is
+        /// specified as <see cref="QueryEntity.KeyType"/> or <see cref="QueryEntity.ValueType"/> and
+        /// configured in a Spring XML file. 
+        /// </summary>
         [Test]
         public void TestAffinityKeyMappedWithQueryEntitySpringXml()
         {
-            // TODO
+            TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-0"), "cache1");
+            TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-1"), "cache1");
         }
 
         /// <summary>
@@ -118,11 +124,19 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
                     new QueryEntity(typeof(QueryEntityKey), typeof(QueryEntityValue))
                 }
             };
-            
-            var ignite = Ignition.GetIgnite("grid-0");
 
-            ignite.GetOrCreateCache<QueryEntityKey, int>(cacheCfg);
-            var aff = ignite.GetAffinity(cacheCfg.Name);
+            Ignition.GetIgnite("grid-0").GetOrCreateCache<QueryEntityKey, int>(cacheCfg);
+            
+            TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-0"), cacheCfg.Name);
+            TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-1"), cacheCfg.Name);
+        }
+
+        /// <summary>
+        /// Checks affinity mapping.
+        /// </summary>
+        private static void TestAffinityKeyMappedWithQueryEntity0(IIgnite ignite, string cacheName)
+        {
+            var aff = ignite.GetAffinity(cacheName);
 
             var key1 = new QueryEntityKey {Data = "data1", AffinityKey = 1};
             var key2 = new QueryEntityKey {Data = "data2", AffinityKey = 1};

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         [TestFixtureSetUp]
         public void StartGrids()
         {
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < 1; i++)
             {
                 var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -116,29 +116,19 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
                 // Without QueryEntities tests passes.
                 QueryEntities = new List<QueryEntity>
                 {
-                    new QueryEntity(typeof(MyKey), typeof(int))
+                    new QueryEntity(typeof(QueryEntityKey), typeof(QueryEntityValue))
                 }
             };
             
             var ignite = Ignition.GetIgnite("grid-0");
 
-            ignite.GetOrCreateCache<MyKey, int>(cacheCfg);
+            ignite.GetOrCreateCache<QueryEntityKey, int>(cacheCfg);
             var aff = ignite.GetAffinity(cacheCfg.Name);
 
-            var key1 = new MyKey {Data = "data1", AffinityKey = 1};
-            var key2 = new MyKey {Data = "data2", AffinityKey = 1};
+            var key1 = new QueryEntityKey {Data = "data1", AffinityKey = 1};
+            var key2 = new QueryEntityKey {Data = "data2", AffinityKey = 1};
 
             Assert.AreEqual(aff.GetPartition(key1), aff.GetPartition(key2));
-        }
-
-        [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
-        private class MyKey
-        {
-            [QuerySqlField]
-            public string Data { get; set; }
-            
-            [AffinityKeyMapped]
-            public long AffinityKey { get; set; }
         }
 
         /// <summary>
@@ -177,6 +167,36 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             {
                 return _id;
             }
+        }
+        
+        /// <summary>
+        /// Query entity key.
+        /// </summary>
+        [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
+        private class QueryEntityKey
+        {
+            /** */
+            [QuerySqlField]
+            public string Data { get; set; }
+            
+            /** */
+            [AffinityKeyMapped]
+            public long AffinityKey { get; set; }
+        }
+        
+        /// <summary>
+        /// Query entity key.
+        /// </summary>
+        [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]
+        private class QueryEntityValue
+        {
+            /** */
+            [QuerySqlField]
+            public string Name { get; set; }
+            
+            /** */
+            [AffinityKeyMapped]
+            public long AffKey { get; set; }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -125,7 +125,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
                 }
             };
 
-            Ignition.GetIgnite("grid-0").GetOrCreateCache<QueryEntityKey, int>(cacheCfg);
+            Ignition.GetIgnite("grid-0").GetOrCreateCache<int, int>(cacheCfg);
             
             TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-0"), cacheCfg.Name);
             TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-1"), cacheCfg.Name);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -105,8 +105,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         }
 
         /// <summary>
-        /// Tests AffinityKeyMapped attribute should map to the same partitions
-        /// for the same field value.
+        /// Tests that <see cref="AffinityKeyMappedAttribute"/> works when used on a property of a type that is
+        /// specified as <see cref="QueryEntity.KeyType"/> or <see cref="QueryEntity.ValueType"/>. 
         /// </summary>
         [Test]
         public void TestAffinityKeyMappedWithQueryEntity()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -201,6 +201,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         private class Key1
         {
             /** */
+            [QuerySqlField]
             public string Foo;
 
             /** */
@@ -212,9 +213,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         private class Value1
         {
             /** */
+            [QuerySqlField]
             public string Name { get; set; }
             
             /** */
+            [QuerySqlField]
             public long Value { get; set; }
         }
         

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -79,6 +79,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void TestCacheStartFromCodeRegistersMetaForQueryEntityTypes()
         {
+            // TODO: Test this for thin clients - it won't work?
+            // What about Java Thin?
             var cfg = new CacheConfiguration
             {
                 Name = TestUtils.TestName,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -78,7 +78,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void CacheStartFromCodeRegistersMetaForQueryEntityTypes()
         {
-            var cacheCfg = new CacheConfiguration
+            var cfg = new CacheConfiguration
             {
                 Name = TestUtils.TestName,
                 QueryEntities = new[]
@@ -91,14 +91,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 }
             };
 
-            Ignition.GetIgnite("0").CreateCache<object, object>(cacheCfg);
+            Ignition.GetIgnite("0").CreateCache<object, object>(cfg);
             
             foreach (var ignite in Ignition.GetAll())
             {
                 // Do not use GetBinaryType which always returns something.
                 // Use GetBinaryTypes to make sure that types are actually registered.
                 var types = ignite.GetBinary().GetBinaryTypes();
-                var qryEntity = ignite.GetCache<object, object>(CacheName).GetConfiguration().QueryEntities.Single();
+                var qryEntity = ignite.GetCache<object, object>(cfg.Name).GetConfiguration().QueryEntities.Single();
 
                 var keyType = types.Single(t => t.TypeName == qryEntity.KeyTypeName);
                 var valType = types.Single(t => t.TypeName == qryEntity.ValueTypeName);
@@ -107,12 +107,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 Assert.AreEqual(typeof(Value1).FullName, qryEntity.ValueTypeName);
 
                 Assert.AreEqual("Bar", keyType.AffinityKeyFieldName);
-                CollectionAssert.AreEquivalent(new[] {"Foo", "Bar"}, keyType.Fields);
-                Assert.AreEqual("Integer", keyType.GetFieldTypeName("Bar"));
+                Assert.IsEmpty(keyType.Fields);
 
                 Assert.IsNull(valType.AffinityKeyFieldName);
-                CollectionAssert.AreEquivalent(new[] {"Name", "Value"}, valType.Fields);
-                Assert.AreEqual("String", valType.GetFieldTypeName("Name"));
+                Assert.IsEmpty(valType.Fields);
             }
         }
 
@@ -141,12 +139,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 Assert.AreEqual(typeof(Value2).FullName, qryEntity.ValueTypeName);
 
                 Assert.AreEqual("AffKey", keyType.AffinityKeyFieldName);
-                CollectionAssert.AreEquivalent(new[] {"Baz", "AffKey"}, keyType.Fields);
-                Assert.AreEqual("String", keyType.GetFieldTypeName("Baz"));
+                Assert.IsEmpty(keyType.Fields);
 
                 Assert.IsNull(valType.AffinityKeyFieldName);
-                CollectionAssert.AreEquivalent(new[] {"Name", "Price"}, valType.Fields);
-                Assert.AreEqual("Double", valType.GetFieldTypeName("Price"));
+                Assert.IsEmpty(valType.Fields);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -45,7 +45,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [TestFixtureSetUp]
         public void StartGrids()
         {
-            // TODO: Test for KeyFieldName and ValueFieldName, and combined with QuerySqlField
             // TODO: Test with type names that can't be resolved
             for (int i = 0; i < 2; i++)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -45,6 +45,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [TestFixtureSetUp]
         public void StartGrids()
         {
+            // TODO: Test for KeyFieldName and ValueFieldName
             for (int i = 0; i < 2; i++)
             {
                 var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -76,7 +76,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// * Check that key and value types are registered in the cluster 
         /// </summary>
         [Test]
-        public void CacheStartFromCodeRegistersMetaForQueryEntityTypes()
+        public void TestCacheStartFromCodeRegistersMetaForQueryEntityTypes()
         {
             var cfg = new CacheConfiguration
             {
@@ -123,7 +123,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// * Check that key and value types are registered in the cluster 
         /// </summary>
         [Test]
-        public void CacheStartFromSpringRegistersMetaForQueryEntityTypes()
+        public void TestCacheStartFromSpringRegistersMetaForQueryEntityTypes()
         {
             foreach (var ignite in Ignition.GetAll())
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -16,6 +16,7 @@
  */
 
 // ReSharper disable UnusedMember.Local
+// ReSharper disable NotAccessedField.Local
 #pragma warning disable 649 // Unassigned field
 namespace Apache.Ignite.Core.Tests.Cache.Query
 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     using System.IO;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Configuration;
+    using NUnit.Framework;
 
     /// <summary>
     /// Tests that <see cref="QueryEntity.KeyTypeName"/> and <see cref="QueryEntity.ValueTypeName"/>
@@ -39,10 +40,29 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         // * Code config
         // * Spring config
         // * Local and remote node check
-        // * Java config with .NET types? 
+
+        /// <summary>
+        /// Tests that starting a cache from code with a <see cref="QueryEntity"/> causes binary type registration
+        /// for key and value types.
+        /// </summary>
+        [Test]
+        public void CacheStartFromCodeRegistersMetaForQueryEntityTypes()
+        {
+            // TODO
+        }
+
+        /// <summary>
+        /// Tests that starting a cache from Spring XML with a <see cref="QueryEntity"/> causes binary type registration
+        /// for key and value types.
+        /// </summary>
+        [Test]
+        public void CacheStartFromSpringRegistersMetaForQueryEntityTypes()
+        {
+            // TODO
+        }
 
         /** */
-        public class Key1
+        private class Key1
         {
             /** */
             public string Foo;
@@ -53,7 +73,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
         
         /** */
-        public class Value1
+        private class Value1
         {
             /** */
             public string Name { get; set; }
@@ -63,7 +83,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
         
         /** */
-        public class Key2
+        private class Key2
         {
             /** */
             public string Baz;
@@ -74,7 +94,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
         
         /** */
-        public class Value2
+        private class Value2
         {
             /** */
             public string Name { get; set; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 {
     using System.IO;
     using System.Linq;
+    using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Configuration;
     using NUnit.Framework;
@@ -88,12 +89,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         public void CacheStartFromSpringRegistersMetaForQueryEntityTypes()
         {
             var ignite = Ignition.GetIgnite();
-            var cache = ignite.GetCache<object, object>(CacheName);
-            var cfg = cache.GetConfiguration();
-            var qryEntity = cfg.QueryEntities.Single();
-            
-            var keyType = ignite.GetBinary().GetBinaryType(qryEntity.KeyTypeName);
-            var valType = ignite.GetBinary().GetBinaryType(qryEntity.ValueTypeName);
+            var qryEntity = ignite.GetCache<object, object>(CacheName).GetConfiguration().QueryEntities.Single();
+
+            // Do not use GetBinaryType which always returns something.
+            // Use GetBinaryTypes to make sure that types are actually registered.
+            var types = ignite.GetBinary().GetBinaryTypes();
+
+            var keyType = types.Single(t => t.TypeName == qryEntity.KeyTypeName);
+            var valType = types.Single(t => t.TypeName == qryEntity.ValueTypeName);
             
             Assert.AreEqual(typeof(Key2).FullName, qryEntity.KeyTypeName);
             Assert.AreEqual(typeof(Value2).FullName, qryEntity.ValueTypeName);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -82,7 +82,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void TestCacheStartFromCodeRegistersMetaForQueryEntityTypes()
         {
-            // TODO: Test scenario with missing class using a Java-only node
             var cfg = new CacheConfiguration
             {
                 Name = TestUtils.TestName,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -87,12 +87,24 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void CacheStartFromSpringRegistersMetaForQueryEntityTypes()
         {
-            var cache = Ignition.GetIgnite().GetCache<object, object>(CacheName);
+            var ignite = Ignition.GetIgnite();
+            var cache = ignite.GetCache<object, object>(CacheName);
             var cfg = cache.GetConfiguration();
             var qryEntity = cfg.QueryEntities.Single();
             
-            Assert.AreEqual(typeof(Key2), qryEntity.KeyType);
-            Assert.AreEqual(typeof(Value2), qryEntity.ValueType);
+            var keyType = ignite.GetBinary().GetBinaryType(qryEntity.KeyTypeName);
+            var valType = ignite.GetBinary().GetBinaryType(qryEntity.ValueTypeName);
+            
+            Assert.AreEqual(typeof(Key2).FullName, qryEntity.KeyTypeName);
+            Assert.AreEqual(typeof(Value2).FullName, qryEntity.ValueTypeName);
+            
+            Assert.AreEqual("AffKey", keyType.AffinityKeyFieldName);
+            CollectionAssert.AreEquivalent(new[] {"Baz", "AffKey"}, keyType.Fields);
+            Assert.AreEqual("String", keyType.GetFieldTypeName("Baz"));
+            
+            Assert.IsNull(valType.AffinityKeyFieldName);
+            CollectionAssert.AreEquivalent(new[] {"Name", "Price"}, valType.Fields);
+            Assert.AreEqual("Double", valType.GetFieldTypeName("Price"));
         }
 
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -46,6 +46,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         public void StartGrids()
         {
             // TODO: Test for KeyFieldName and ValueFieldName, and combined with QuerySqlField
+            // TODO: Test with type names that can't be resolved
             for (int i = 0; i < 2; i++)
             {
                 var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Core.Tests.Cache.Query
 {
+    using System.IO;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Configuration;
 
@@ -31,6 +32,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     /// </summary>
     public class QueryEntityMetadataRegistrationTest
     {
+        /** */
+        private static readonly string SpringConfig = Path.Combine("Config", "query-entity-metadata-registration.xml");
+        
         // TODO:
         // * Code config
         // * Spring config

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -52,6 +52,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             {
                 var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
                 {
+                    // TODO: Add caches here and test them too
                     SpringConfigUrl = Path.Combine("Config", "query-entity-metadata-registration.xml"),
                     IgniteInstanceName = i.ToString()
                 };

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -80,6 +80,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void TestCacheStartFromCodeRegistersMetaForQueryEntityTypes()
         {
+            // TODO: Test scenario with missing class using a Java-only node
             var cfg = new CacheConfiguration
             {
                 Name = TestUtils.TestName,
@@ -139,7 +140,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void TestCacheStartFromThinClientRegistersMetaForQueryEntityTypes()
         {
-            // TODO: How can we test a scenario with missing class?
+            // TODO: Test scenario with missing class using a Java-only node
             var cfg = new CacheClientConfiguration
             {
                 Name = TestUtils.TestName,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -45,7 +45,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [TestFixtureSetUp]
         public void StartGrids()
         {
-            // TODO: Test for KeyFieldName and ValueFieldName
+            // TODO: Test for KeyFieldName and ValueFieldName, and combined with QuerySqlField
             for (int i = 0; i < 2; i++)
             {
                 var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
@@ -19,7 +19,6 @@
 #pragma warning disable 649
 namespace Apache.Ignite.Core.Tests.Client.Cache
 {
-    using System.IO;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Client;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
@@ -37,47 +37,22 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     /// </summary>
     public class ClientQueryEntityMetadataRegistrationTest
     {
-        /** */
-        private const string CacheName = "cache1";
-
-        /** */
-        private const string StartTask = "org.apache.ignite.platform.PlatformStartIgniteTask";
-
-        /** */
-        private const string StopTask = "org.apache.ignite.platform.PlatformStopIgniteTask";
-
-        /** */
-        private static readonly IgniteConfiguration TempConfig =TestUtils.GetTestConfiguration(name: "tmp");
-
-        /** */
-        private string _javaNodeName;
-
         /// <summary>
         /// Fixture set up.
         /// </summary>
         [TestFixtureSetUp]
-        public void FixtureSetUp()
+        public virtual void FixtureSetUp()
         {
-            var springConfig = Path.Combine("Config", "query-entity-metadata-registration.xml");
-
-            using (var ignite = Ignition.Start(TempConfig))
-            {
-                _javaNodeName = ignite.GetCompute().ExecuteJavaTask<string>(StartTask, springConfig);
-                Assert.IsTrue(ignite.WaitTopology(2, 5000));
-            }
+            Ignition.Start(TestUtils.GetTestConfiguration());
         }
 
         /// <summary>
         /// Fixture tear down.
         /// </summary>
         [TestFixtureTearDown]
-        public void FixtureTearDown()
+        public virtual void FixtureTearDown()
         {
-            using (var ignite = Ignition.Start(TempConfig))
-            {
-                ignite.GetCompute().ExecuteJavaTask<object>(StopTask, _javaNodeName);
-                Assert.IsTrue(ignite.WaitTopology(1, 5000));
-            }
+            Ignition.StopAll(true);
         }
 
         /// <summary>
@@ -104,7 +79,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                 }
             };
 
-            using (var client = Ignition.StartClient(new IgniteClientConfiguration("localhost:10801")))
+            using (var client = Ignition.StartClient(new IgniteClientConfiguration("localhost:10800..10801")))
             {
                 client.CreateCache<Key1, Value1>(cfg);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
@@ -56,7 +56,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// Fixture set up.
         /// </summary>
         [TestFixtureSetUp]
-        public void StartGrids()
+        public void FixtureSetUp()
         {
             var springConfig = Path.Combine("Config", "query-entity-metadata-registration.xml");
 
@@ -71,7 +71,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// Fixture tear down.
         /// </summary>
         [TestFixtureTearDown]
-        public void StopGrids()
+        public void FixtureTearDown()
         {
             using (var ignite = Ignition.Start(TempConfig))
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ReSharper disable UnusedMember.Local
+#pragma warning disable 649
+namespace Apache.Ignite.Core.Tests.Client.Cache
+{
+    using System.IO;
+    using Apache.Ignite.Core.Cache.Affinity;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests that <see cref="QueryEntity.KeyTypeName"/> and <see cref="QueryEntity.ValueTypeName"/>
+    /// settings trigger binary metadata registration on cache start for the specified types.
+    /// <para />
+    /// Normally, binary metadata is registered in the cluster when an object of the given type is first serialized
+    /// (for cache storage or other purposes - Services, Compute, etc).
+    /// However, query engine requires metadata for key/value types on cache start, so an eager registration
+    /// should be performed.
+    /// </summary>
+    public class ClientQueryEntityMetadataRegistrationTest
+    {
+        /** */
+        private const string CacheName = "cache1";
+
+        /** */
+        private const string StartTask = "org.apache.ignite.platform.PlatformStartIgniteTask";
+
+        /** */
+        private const string StopTask = "org.apache.ignite.platform.PlatformStopIgniteTask";
+
+        /** */
+        private string _javaNodeName;
+
+        /// <summary>
+        /// Fixture set up.
+        /// </summary>
+        [TestFixtureSetUp]
+        public void StartGrids()
+        {
+            var springConfig = Path.Combine("Config", "query-entity-metadata-registration.xml");
+
+            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
+            {
+                _javaNodeName = ignite.GetCompute().ExecuteJavaTask<string>(StartTask, springConfig);
+                Assert.IsTrue(ignite.WaitTopology(2, 5000));
+            }
+        }
+
+        /// <summary>
+        /// Fixture tear down.
+        /// </summary>
+        [TestFixtureTearDown]
+        public void StopGrids()
+        {
+            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
+            {
+                ignite.GetCompute().ExecuteJavaTask<object>(StopTask, _javaNodeName);
+                Assert.IsTrue(ignite.WaitTopology(1, 5000));
+            }
+        }
+
+        /// <summary>
+        /// Tests that starting a cache from thin client with a <see cref="QueryEntity"/>
+        /// causes binary type registration for key and value types.
+        /// <para />
+        /// * Connect .NET thin client to a Java-only node.
+        /// * Start a new cache with code configuration from thin client.
+        /// * Check that query entity is populated correctly
+        /// * Check that key and value types are registered in the cluster
+        /// </summary>
+        [Test]
+        public void TestCacheStartFromThinClientRegistersMetaForQueryEntityTypes()
+        {
+            var cfg = new CacheClientConfiguration
+            {
+                Name = TestUtils.TestName,
+                QueryEntities = new[]
+                {
+                    new QueryEntity
+                    {
+                        KeyType = typeof(Key1),
+                        ValueType = typeof(Value1)
+                    }
+                }
+            };
+
+            using (var client = Ignition.StartClient(new IgniteClientConfiguration("localhost:10801")))
+            {
+                client.CreateCache<Key1, Value1>(cfg);
+            }
+        }
+
+        /** */
+        private class Key1
+        {
+            /** */
+            [QuerySqlField]
+            public string Foo;
+
+            /** */
+            [AffinityKeyMapped]
+            public int Bar;
+        }
+
+        /** */
+        private class Value1
+        {
+            /** */
+            [QuerySqlField]
+            public string Name { get; set; }
+
+            /** */
+            [QuerySqlField]
+            public long Value { get; set; }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
@@ -47,6 +47,9 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         private const string StopTask = "org.apache.ignite.platform.PlatformStopIgniteTask";
 
         /** */
+        private static readonly IgniteConfiguration TempConfig =TestUtils.GetTestConfiguration(name: "tmp");
+
+        /** */
         private string _javaNodeName;
 
         /// <summary>
@@ -57,7 +60,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         {
             var springConfig = Path.Combine("Config", "query-entity-metadata-registration.xml");
 
-            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
+            using (var ignite = Ignition.Start(TempConfig))
             {
                 _javaNodeName = ignite.GetCompute().ExecuteJavaTask<string>(StartTask, springConfig);
                 Assert.IsTrue(ignite.WaitTopology(2, 5000));
@@ -70,7 +73,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestFixtureTearDown]
         public void StopGrids()
         {
-            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
+            using (var ignite = Ignition.Start(TempConfig))
             {
                 ignite.GetCompute().ExecuteJavaTask<object>(StopTask, _javaNodeName);
                 Assert.IsTrue(ignite.WaitTopology(1, 5000));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTest.cs
@@ -84,10 +84,9 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// Tests that starting a cache from thin client with a <see cref="QueryEntity"/>
         /// causes binary type registration for key and value types.
         /// <para />
-        /// * Connect .NET thin client to a Java-only node.
-        /// * Start a new cache with code configuration from thin client.
-        /// * Check that query entity is populated correctly
-        /// * Check that key and value types are registered in the cluster
+        /// * Connect .NET thin client to a Java-only node
+        /// * Start a new cache with code configuration from thin client
+        /// * Check that key and value types are registered in the cluster correctly
         /// </summary>
         [Test]
         public void TestCacheStartFromThinClientRegistersMetaForQueryEntityTypes()
@@ -108,6 +107,10 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             using (var client = Ignition.StartClient(new IgniteClientConfiguration("localhost:10801")))
             {
                 client.CreateCache<Key1, Value1>(cfg);
+
+                var type = client.GetBinary().GetBinaryType(typeof(Key1));
+
+                Assert.AreEqual("Bar", type.AffinityKeyFieldName);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs
@@ -1,0 +1,64 @@
+namespace Apache.Ignite.Core.Tests.Client.Cache
+{
+    using System.IO;
+    using Apache.Ignite.Core.Cache.Affinity;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests that <see cref="QueryEntity.KeyTypeName"/> and <see cref="QueryEntity.ValueTypeName"/>
+    /// settings trigger binary metadata registration on cache start for the specified types.
+    /// <para />
+    /// Normally, binary metadata is registered in the cluster when an object of the given type is first serialized
+    /// (for cache storage or other purposes - Services, Compute, etc).
+    /// However, query engine requires metadata for key/value types on cache start, so an eager registration
+    /// should be performed.
+    /// </summary>
+    public class ClientQueryEntityMetadataRegistrationTestJavaOnlyServer : ClientQueryEntityMetadataRegistrationTest
+    {
+        /** */
+        private const string CacheName = "cache1";
+
+        /** */
+        private const string StartTask = "org.apache.ignite.platform.PlatformStartIgniteTask";
+
+        /** */
+        private const string StopTask = "org.apache.ignite.platform.PlatformStopIgniteTask";
+
+        /** */
+        private static readonly IgniteConfiguration TempConfig =TestUtils.GetTestConfiguration(name: "tmp");
+
+        /** */
+        private string _javaNodeName;
+
+        /// <summary>
+        /// Fixture set up.
+        /// </summary>
+        [TestFixtureSetUp]
+        public override void FixtureSetUp()
+        {
+            var springConfig = Path.Combine("Config", "query-entity-metadata-registration.xml");
+
+            using (var ignite = Ignition.Start(TempConfig))
+            {
+                _javaNodeName = ignite.GetCompute().ExecuteJavaTask<string>(StartTask, springConfig);
+                Assert.IsTrue(ignite.WaitTopology(2, 5000));
+            }
+        }
+
+        /// <summary>
+        /// Fixture tear down.
+        /// </summary>
+        [TestFixtureTearDown]
+        public override void FixtureTearDown()
+        {
+            using (var ignite = Ignition.Start(TempConfig))
+            {
+                ignite.GetCompute().ExecuteJavaTask<object>(StopTask, _javaNodeName);
+                Assert.IsTrue(ignite.WaitTopology(1, 5000));
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs
@@ -30,6 +30,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     /// However, query engine requires metadata for key/value types on cache start, so an eager registration
     /// should be performed.
     /// </summary>
+    [Ignore("IGNITE-13607")]
     public class ClientQueryEntityMetadataRegistrationTestJavaOnlyServer : ClientQueryEntityMetadataRegistrationTest
     {
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs
@@ -1,10 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Apache.Ignite.Core.Tests.Client.Cache
 {
     using System.IO;
-    using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Configuration;
-    using Apache.Ignite.Core.Client;
-    using Apache.Ignite.Core.Client.Cache;
     using NUnit.Framework;
 
     /// <summary>
@@ -18,9 +32,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     /// </summary>
     public class ClientQueryEntityMetadataRegistrationTestJavaOnlyServer : ClientQueryEntityMetadataRegistrationTest
     {
-        /** */
-        private const string CacheName = "cache1";
-
         /** */
         private const string StartTask = "org.apache.ignite.platform.PlatformStartIgniteTask";
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/native-client-test-cache-affinity.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/native-client-test-cache-affinity.xml
@@ -50,6 +50,17 @@
                     <property name="cacheMode" value="PARTITIONED"/>
                     <property name="name" value="default"/>
                 </bean>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="cache1"/>
+                    <property name="queryEntities">
+                        <list>
+                            <bean class="org.apache.ignite.cache.QueryEntity">
+                                <property name="keyType" value="Apache.Ignite.Core.Tests.Cache.Affinity.AffinityTest+QueryEntityKey"/>
+                                <property name="valueType" value="Apache.Ignite.Core.Tests.Cache.Affinity.AffinityTest+QueryEntityValue"/>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
             </list>
         </property>
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
@@ -42,10 +42,10 @@
                         </list>
                     </property>
                 </bean>
-                
+
                 <!-- Query entity with key/value types that don't exist -->
                 <bean class="org.apache.ignite.configuration.CacheConfiguration">
-                    <property name="name" value="cache2"/>
+                    <property name="name" value="cache_bad"/>
                     <property name="queryEntities">
                         <list>
                             <bean class="org.apache.ignite.cache.QueryEntity">

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
@@ -42,6 +42,19 @@
                         </list>
                     </property>
                 </bean>
+                
+                <!-- Query entity with key/value types that don't exist -->
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="cache2"/>
+                    <property name="queryEntities">
+                        <list>
+                            <bean class="org.apache.ignite.cache.QueryEntity">
+                                <property name="keyType" value="Apache.Ignite.Core.Tests.Cache.Query.QueryEntityMetadataRegistrationTest+ERR"/>
+                                <property name="valueType" value="Apache.Ignite.Core.Tests.Cache.Query.QueryEntityMetadataRegistrationTest+ERR"/>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
             </list>
         </property>
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
@@ -33,7 +33,6 @@
             <list>
                 <bean class="org.apache.ignite.configuration.CacheConfiguration">
                     <property name="name" value="cache1"/>
-
                     <property name="queryEntities">
                         <list>
                             <bean class="org.apache.ignite.cache.QueryEntity">

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/query-entity-metadata-registration.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+        <property name="lateAffinityAssignment" value="false"/>
+
+        <property name="cacheConfiguration">
+            <list>
+                <bean class="org.apache.ignite.configuration.CacheConfiguration">
+                    <property name="name" value="cache1"/>
+
+                    <property name="queryEntities">
+                        <list>
+                            <bean class="org.apache.ignite.cache.QueryEntity">
+                                <property name="keyType" value="Apache.Ignite.Core.Tests.Cache.Query.QueryEntityMetadataRegistrationTest+Key2"/>
+                                <property name="valueType" value="Apache.Ignite.Core.Tests.Cache.Query.QueryEntityMetadataRegistrationTest+Value2"/>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+            </list>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/QueryEntity.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/QueryEntity.cs
@@ -156,14 +156,14 @@ namespace Apache.Ignite.Core.Cache.Configuration
         /// <summary>
         /// Gets or sets the name of the field that is used to denote the entire key.
         /// <para />
-        /// By default, entite key can be accessed with a special "_key" field name.
+        /// By default, entity key can be accessed with a special "_key" field name.
         /// </summary>
         public string KeyFieldName { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the field that is used to denote the entire value.
         /// <para />
-        /// By default, entite value can be accessed with a special "_val" field name.
+        /// By default, entity value can be accessed with a special "_val" field name.
         /// </summary>
         public string ValueFieldName { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Marshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Marshaller.cs
@@ -457,8 +457,14 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// Gets descriptor for type name.
         /// </summary>
         /// <param name="typeName">Type name.</param>
+        /// <param name="requiresType">If set to true, resulting descriptor must have Type property populated.
+        /// <para />
+        /// When working in binary mode, we don't need Type. And there is no Type at all in some cases.
+        /// So we should not attempt to call BinaryProcessor right away.
+        /// Only when we really deserialize the value, requiresType is set to true
+        /// and we attempt to resolve the type by all means.</param>
         /// <returns>Descriptor.</returns>
-        public IBinaryTypeDescriptor GetDescriptor(string typeName)
+        public IBinaryTypeDescriptor GetDescriptor(string typeName, bool requiresType = false)
         {
             BinaryFullTypeDescriptor desc;
 
@@ -469,7 +475,7 @@ namespace Apache.Ignite.Core.Impl.Binary
 
             var typeId = GetTypeId(typeName, _cfg.IdMapper);
 
-            return GetDescriptor(true, typeId, typeName: typeName);
+            return GetDescriptor(true, typeId, typeName: typeName, requiresType: requiresType);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbackOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbackOp.cs
@@ -91,6 +91,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         OnCacheStopped = 72,
         OnAffinityTopologyVersionChanged = 73,
         ComputeOutFuncExecute = 74,
-        ComputeActionExecute = 75
+        ComputeActionExecute = 75,
+        BinaryTypeGet = 76
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
@@ -235,10 +235,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         /// <summary>
         /// Adds the handler.
         /// </summary>
-        private void AddHandler(UnmanagedCallbackOp op, InLongLongLongObjectOutLongFunc func, 
+        private void AddHandler(UnmanagedCallbackOp op, InLongLongLongObjectOutLongFunc func,
             bool allowUninitialized = false)
         {
-            _inLongLongLongObjectOutLongHandlers[(int)op] 
+            _inLongLongLongObjectOutLongHandlers[(int)op]
                 = new InLongLongLongObjectOutLongHandler(func, allowUninitialized);
         }
 
@@ -430,7 +430,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
             return holder.Process(key, val, val != null, grid);
         }
-        
+
         /// <summary>
         /// Updates platform cache entry.
         /// </summary>
@@ -447,7 +447,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
             return 0;
         }
-        
+
         /// <summary>
         /// Updates platform cache entry.
         /// </summary>
@@ -458,10 +458,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
             _ignite.PlatformCacheManager.UpdateFromThreadLocal(
                 cacheId, partition, new AffinityTopologyVersion(verMajor, (int) verMinor));
-                
+
             return 0;
         }
-        
+
         /// <summary>
         /// Called on cache stop.
         /// </summary>
@@ -469,10 +469,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         private long OnCacheStopped(long cacheId)
         {
             _ignite.PlatformCacheManager.Stop((int) cacheId);
-            
+
             return 0;
         }
-        
+
         /// <summary>
         /// Called on affinity topology version change.
         /// </summary>
@@ -480,9 +480,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             long topologyVersion, long minorTopologyVersion, long unused, void* arg)
         {
             var affinityTopologyVersion = new AffinityTopologyVersion(topologyVersion, (int) minorTopologyVersion);
-            
+
             _ignite.PlatformCacheManager.OnAffinityTopologyVersionChanged(affinityTopologyVersion);
-            
+
             return 0;
         }
 
@@ -621,7 +621,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         {
             return _handleRegistry.Get<ComputeJobHolder>(jobPtr);
         }
-        
+
         /// <summary>
         /// Executes <see cref="IComputeOutFunc"/>.
         /// </summary>
@@ -633,9 +633,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 var func = stream.ReadBool()
                     ? _handleRegistry.Get<object>(stream.ReadLong(), true)
                     : _ignite.Marshaller.Unmarshal<object>(stream);
-                
+
                 stream.Reset();
-                
+
                 var invoker = DelegateTypeDescriptor.GetComputeOutFunc(func.GetType());
                 ComputeRunner.ExecuteJobAndWriteResults(_ignite, stream, func, invoker);
             }
@@ -654,9 +654,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 var action = stream.ReadBool()
                     ? _handleRegistry.Get<IComputeAction>(stream.ReadLong(), true)
                     : _ignite.Marshaller.Unmarshal<IComputeAction>(stream);
-                
+
                 stream.Reset();
-                
+
                 ComputeRunner.ExecuteJobAndWriteResults(_ignite, stream, action, act =>
                 {
                     act.Invoke();
@@ -1229,7 +1229,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
             return 0;
         }
-        
+
         private long BinaryTypeGet(long memPtr)
         {
             return SafeCall(() =>
@@ -1238,9 +1238,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 {
                     var marsh = _ignite.Marshaller;
                     var typeName = marsh.StartUnmarshal(stream).ReadString();
-                    
-                    // TODO: This does not register type name with type ID
-                    // Create a test to reproduce (with thin client or remote node).
                     var desc = marsh.GetDescriptor(typeName, requiresType: true);
 
                     if (desc == null || desc.Type == null)
@@ -1248,7 +1245,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
                     stream.Reset();
                     marsh.Marshal(stream, w => BinaryProcessor.WriteBinaryType(w, new BinaryType(desc, marsh)));
-                    
+
                     return 1;
                 }
             });
@@ -1338,7 +1335,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         #endregion
 
         #region PLUGINS
-  
+
         private long PluginCallbackInLongLongOutLong(long callbackId, long inPtr, long outPtr, void* arg)
         {
             return _ignite.PluginProcessor.InvokeCallback(callbackId, inPtr, outPtr);
@@ -1383,7 +1380,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         }
 
         #endregion
-        
+
         /// <summary>
         /// Gets the log.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
@@ -1238,6 +1238,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 {
                     var marsh = _ignite.Marshaller;
                     var typeName = marsh.StartUnmarshal(stream).ReadString();
+                    
+                    // TODO: This does not register type name with type ID
+                    // Create a test to reproduce (with thin client or remote node).
                     var desc = marsh.GetDescriptor(typeName, requiresType: true);
 
                     if (desc == null || desc.Type == null)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
@@ -1238,11 +1238,12 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 {
                     var marsh = _ignite.Marshaller;
                     var typeName = marsh.StartUnmarshal(stream).ReadString();
-                    var desc = marsh.GetDescriptor(typeName);
+                    var type = marsh.ResolveType(typeName);
 
-                    if (desc == null || desc.Type == null)
+                    if (type == null)
                         return 0;
 
+                    var desc = marsh.GetDescriptor(type);
                     var meta = new BinaryType(desc, marsh);
                     
                     stream.Reset();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
@@ -1238,16 +1238,18 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 {
                     var marsh = _ignite.Marshaller;
                     var typeName = marsh.StartUnmarshal(stream).ReadString();
-
-                    // TODO: Check if type was found.
                     var desc = marsh.GetDescriptor(typeName);
+
+                    if (desc == null || desc.Type == null)
+                        return 0;
+
                     var meta = new BinaryType(desc, marsh);
                     
                     stream.Reset();
                     marsh.Marshal(stream, w => BinaryProcessor.WriteBinaryType(w, meta));
+                    
+                    return 1;
                 }
-                
-                return 0;
             });
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
@@ -1238,16 +1238,13 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 {
                     var marsh = _ignite.Marshaller;
                     var typeName = marsh.StartUnmarshal(stream).ReadString();
-                    var type = marsh.ResolveType(typeName);
+                    var desc = marsh.GetDescriptor(typeName, requiresType: true);
 
-                    if (type == null)
+                    if (desc == null || desc.Type == null)
                         return 0;
 
-                    var desc = marsh.GetDescriptor(type);
-                    var meta = new BinaryType(desc, marsh);
-                    
                     stream.Reset();
-                    marsh.Marshal(stream, w => BinaryProcessor.WriteBinaryType(w, meta));
+                    marsh.Marshal(stream, w => BinaryProcessor.WriteBinaryType(w, new BinaryType(desc, marsh)));
                     
                     return 1;
                 }


### PR DESCRIPTION
* Register binary metadata for QueryEntity key and value .NET types on cache start (same way as we do for Java types - IGNITE-5795, 3bb03444246f863096063d084393676a84d2bc0e)
* Move `registerMetadataForRegisteredCaches` call to `onCacheKernalStart` so that `PlatformProcessor` is available

This builds on the fix from IGNITE-5795 by adding a platform callback to get metadata for .NET types. It has the same limitations as the original fix: does not work when classes are not present on the server node, in particular, for thin clients. IGNITE-13607 filed to deal with that separately.