### PR TITLE
.NET: Fix logos and NuGet link in README.md

### DIFF
--- a/modules/platforms/dotnet/README.md
+++ b/modules/platforms/dotnet/README.md
@@ -3,6 +3,7 @@
 <a href="https://ignite.apache.org/"><img src="https://ignite.apache.org/images/ignite_logo_full.svg" hspace="20" width="300px" /></a>
 
 <a href="https://www.nuget.org/packages?q=Apache.Ignite"><img src="https://img.shields.io/nuget/v/Apache.Ignite.svg" /></a>
+
 ## Getting Started
 
 For information on how to get started with Apache Ignite, please visit: [Getting Started][getting-started].

--- a/modules/platforms/dotnet/README.md
+++ b/modules/platforms/dotnet/README.md
@@ -1,6 +1,6 @@
 # Apache Ignite.NET SDK
 
-<a href="https://ignite.apache.org/"><img src="https://ignite.apache.org/images/ignite_logo_full.svg" hspace="20" width="400px" /></a>
+<a href="https://ignite.apache.org/"><img src="https://ignite.apache.org/images/ignite_logo_full.svg" hspace="20" width="300px" /></a>
 
 <a href="https://www.nuget.org/packages?q=Apache.Ignite"><img src="https://img.shields.io/nuget/v/Apache.Ignite.svg" /></a>
 ## Getting Started

--- a/modules/platforms/dotnet/README.md
+++ b/modules/platforms/dotnet/README.md
@@ -1,9 +1,8 @@
 # Apache Ignite.NET SDK
 
-<a href="https://ignite.apache.org/"><img src="https://ignite.apache.org/images/logo3.png" hspace="20"/></a><img src="https://ptupitsyn.github.io/images/net-framework.png" hspace="20" />
+<a href="https://ignite.apache.org/"><img src="https://ignite.apache.org/images/ignite_logo_full.svg" hspace="20" width="400px" /></a>
 
-<a href="https://www.nuget.org/packages?q=GridGain.Ignite"><img src="https://img.shields.io/nuget/v/GridGain.Ignite.svg" /></a>
-
+<a href="https://www.nuget.org/packages?q=Apache.Ignite"><img src="https://img.shields.io/nuget/v/Apache.Ignite.svg" /></a>
 ## Getting Started
 
 For information on how to get started with Apache Ignite, please visit: [Getting Started][getting-started].


### PR DESCRIPTION
* Fix NuGet link to point to Ignite packages
* Remove old .NET logo
* Fix Ignite logo