### PR TITLE
IGNITE-13591 added metric LastCheckpointStart

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/DataStorageMetrics.java
+++ b/modules/core/src/main/java/org/apache/ignite/DataStorageMetrics.java
@@ -99,6 +99,13 @@ public interface DataStorageMetrics {
     public long getLastCheckpointDuration();
 
     /**
+     * Start timestamp of the last checkpoint
+     *
+     * @return Timestamp when the last checkpoint was started
+     * */
+    public long getLastCheckpointStarted();
+
+    /**
      * Gets the duration of last checkpoint lock wait in milliseconds.
      *
      * @return Checkpoint lock wait time in milliseconds.

--- a/modules/core/src/main/java/org/apache/ignite/DataStorageMetrics.java
+++ b/modules/core/src/main/java/org/apache/ignite/DataStorageMetrics.java
@@ -99,9 +99,9 @@ public interface DataStorageMetrics {
     public long getLastCheckpointDuration();
 
     /**
-     * Start timestamp of the last checkpoint
+     * Returns time when the last checkpoint was started.
      *
-     * @return Timestamp when the last checkpoint was started
+     * @return Time when the last checkpoint was started.
      * */
     public long getLastCheckpointStarted();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataStorageMetricsImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataStorageMetricsImpl.java
@@ -63,6 +63,9 @@ public class DataStorageMetricsImpl implements DataStorageMetricsMXBean {
     private final AtomicLongMetric lastCpDuration;
 
     /** */
+    private final AtomicLongMetric lastCpStart;
+
+    /** */
     private final AtomicLongMetric lastCpFsyncDuration;
 
     /** */
@@ -163,6 +166,9 @@ public class DataStorageMetricsImpl implements DataStorageMetricsMXBean {
         lastCpDuration = mreg.longMetric("LastCheckpointDuration",
             "Duration of the last checkpoint in milliseconds.");
 
+        lastCpStart = mreg.longMetric("LastCheckpointStart",
+            "Start timestamp of the last checkpoint.");
+
         lastCpFsyncDuration = mreg.longMetric("LastCheckpointFsyncDuration",
             "Duration of the sync phase of the last checkpoint in milliseconds.");
 
@@ -248,6 +254,14 @@ public class DataStorageMetricsImpl implements DataStorageMetricsMXBean {
             return 0;
 
         return lastCpDuration.value();
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getLastCheckpointStarted() {
+        if (!metricsEnabled)
+            return 0;
+
+        return lastCpStart.value();
     }
 
     /** {@inheritDoc} */
@@ -597,6 +611,7 @@ public class DataStorageMetricsImpl implements DataStorageMetricsMXBean {
         long pagesWriteDuration,
         long fsyncDuration,
         long duration,
+        long start,
         long totalPages,
         long dataPages,
         long cowPages
@@ -607,6 +622,7 @@ public class DataStorageMetricsImpl implements DataStorageMetricsMXBean {
             lastCpPagesWriteDuration.value(pagesWriteDuration);
             lastCpFsyncDuration.value(fsyncDuration);
             lastCpDuration.value(duration);
+            lastCpStart.value(start);
             lastCpTotalPages.value(totalPages);
             lastCpDataPages.value(dataPages);
             lastCpCowPages.value(cowPages);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataStorageMetricsSnapshot.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataStorageMetricsSnapshot.java
@@ -44,6 +44,9 @@ public class DataStorageMetricsSnapshot implements DataStorageMetrics {
     private long lastCpDuration;
 
     /** */
+    private long lastCpStart;
+
+    /** */
     private long lastCpLockWaitDuration;
 
     /** */
@@ -119,6 +122,7 @@ public class DataStorageMetricsSnapshot implements DataStorageMetrics {
         walFsyncTimeAvg = metrics.getWalFsyncTimeAverage();
         walBuffPollSpinsNum = metrics.getWalBuffPollSpinsRate();
         lastCpDuration = metrics.getLastCheckpointDuration();
+        lastCpStart = metrics.getLastCheckpointStarted();
         lastCpLockWaitDuration = metrics.getLastCheckpointLockWaitDuration();
         lastCpMmarkDuration = metrics.getLastCheckpointMarkDuration();
         lastCpPagesWriteDuration = metrics.getLastCheckpointPagesWriteDuration();
@@ -171,6 +175,11 @@ public class DataStorageMetricsSnapshot implements DataStorageMetrics {
     /** {@inheritDoc} */
     @Override public long getLastCheckpointDuration() {
         return lastCpDuration;
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getLastCheckpointStarted() {
+        return lastCpStart;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/Checkpointer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/Checkpointer.java
@@ -581,6 +581,7 @@ public class Checkpointer extends GridWorker {
                 tracker.pagesWriteDuration(),
                 tracker.fsyncDuration(),
                 tracker.totalDuration(),
+                tracker.checkpointStartTime(),
                 chp.pagesSize,
                 tracker.dataPagesWritten(),
                 tracker.cowPagesWritten()

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorPersistenceMetrics.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorPersistenceMetrics.java
@@ -230,9 +230,9 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
     }
 
     /**
-     * Start timestamp of the last checkpoint
+     * Returns time when the last checkpoint was started.
      *
-     * @return Timestamp when the last checkpoint was started
+     * @return Time when the last checkpoint was started.
      * */
     public long getLastCheckpointStarted() {
         return lastCpStart;

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorPersistenceMetrics.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorPersistenceMetrics.java
@@ -58,6 +58,9 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
     private long lastCpDuration;
 
     /** */
+    private long lastCpStart;
+
+    /** */
     private long lastCpLockWaitDuration;
 
     /** */
@@ -136,6 +139,7 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
         cpTotalTm = m.getCheckpointTotalTime();
 
         lastCpDuration = m.getLastCheckpointDuration();
+        lastCpStart = m.getLastCheckpointStarted();
         lastCpLockWaitDuration = m.getLastCheckpointLockWaitDuration();
         lastCpMmarkDuration = m.getLastCheckpointMarkDuration();
         lastCpPagesWriteDuration = m.getLastCheckpointPagesWriteDuration();
@@ -223,6 +227,15 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
      */
     public long getLastCheckpointingDuration() {
         return lastCpDuration;
+    }
+
+    /**
+     * Start timestamp of the last checkpoint
+     *
+     * @return Timestamp when the last checkpoint was started
+     * */
+    public long getLastCheckpointStarted() {
+        return lastCpStart;
     }
 
     /**
@@ -360,7 +373,7 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
 
     /** {@inheritDoc} */
     @Override public byte getProtocolVersion() {
-        return V3;
+        return V4;
     }
 
     /** {@inheritDoc} */
@@ -397,6 +410,9 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
         // V3
         out.writeLong(storageSize);
         out.writeLong(sparseStorageSize);
+
+        // V4
+        out.writeLong(lastCpStart);
     }
 
     /** {@inheritDoc} */
@@ -435,6 +451,9 @@ public class VisorPersistenceMetrics extends VisorDataTransferObject {
             storageSize = in.readLong();
             sparseStorageSize = in.readLong();
         }
+
+        if (protoVer > V3)
+            lastCpStart = in.readLong();
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/mxbean/DataStorageMetricsMXBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/mxbean/DataStorageMetricsMXBean.java
@@ -77,7 +77,7 @@ public interface DataStorageMetricsMXBean extends DataStorageMetrics {
     @Override long getLastCheckpointDuration();
 
     /** {@inheritDoc} */
-    @MXBeanDescription("Start timestamp of the last checkpoint.")
+    @MXBeanDescription("Time when the last checkpoint was started.")
     @Override long getLastCheckpointStarted();
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/mxbean/DataStorageMetricsMXBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/mxbean/DataStorageMetricsMXBean.java
@@ -77,6 +77,10 @@ public interface DataStorageMetricsMXBean extends DataStorageMetrics {
     @Override long getLastCheckpointDuration();
 
     /** {@inheritDoc} */
+    @MXBeanDescription("Start timestamp of the last checkpoint")
+    @Override long getLastCheckpointStarted();
+
+    /** {@inheritDoc} */
     @MXBeanDescription("Duration of the checkpoint lock wait in milliseconds.")
     @Override long getLastCheckpointLockWaitDuration();
 

--- a/modules/core/src/main/java/org/apache/ignite/mxbean/DataStorageMetricsMXBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/mxbean/DataStorageMetricsMXBean.java
@@ -77,7 +77,7 @@ public interface DataStorageMetricsMXBean extends DataStorageMetrics {
     @Override long getLastCheckpointDuration();
 
     /** {@inheritDoc} */
-    @MXBeanDescription("Start timestamp of the last checkpoint")
+    @MXBeanDescription("Start timestamp of the last checkpoint.")
     @Override long getLastCheckpointStarted();
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Added methods for reading of new metrics:
 - DataStorageMetrics.getLastCheckpointStartDate()
 - DataStorageMetricsImpl.getLastCheckpointStartDate()
 - DataStorageMetricsMXBean.getLastCheckpointStartDate() 
 - DataStorageMetricsSnapshot.getLastCheckpointStartDate()

Added metric registration:
 - DataStorageMetricsImpl (see class constructor)

Added metric value update:
 - DataStorageMetricsImpl.onCheckpoint()
 - GridCacheDatabaseSharedManager.updateMetrics()