### PR TITLE
IGNITE-12508 GridCacheProcessor#cacheDescriptor(int) has O(N) complexity

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheAffinitySharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheAffinitySharedManager.java
@@ -204,7 +204,7 @@ public class CacheAffinitySharedManager<K, V> extends GridCacheSharedManagerAdap
      */
     public IgniteInternalFuture<?> initCachesOnLocalJoin(
         Map<Integer, CacheGroupDescriptor> grpDescs,
-        Map<String, DynamicCacheDescriptor> cacheDescs
+        Map<Integer, DynamicCacheDescriptor> cacheDescs
     ) {
         return cachesRegistry.init(grpDescs, cacheDescs);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheNodeCommonDiscoveryData.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheNodeCommonDiscoveryData.java
@@ -47,7 +47,7 @@ public class CacheNodeCommonDiscoveryData implements Serializable {
     private final Map<String, Map<UUID, Boolean>> clientNodesMap;
 
     /** */
-    private Collection<String> restartingCaches;
+    private final Collection<Integer> restartingCaches;
 
     /**
      * @param caches Started caches.
@@ -59,7 +59,7 @@ public class CacheNodeCommonDiscoveryData implements Serializable {
         Map<String, CacheData> templates,
         Map<Integer, CacheGroupData> cacheGrps,
         Map<String, Map<UUID, Boolean>> clientNodesMap,
-        Collection<String> restartingCaches
+        Collection<Integer> restartingCaches
     ) {
         assert caches != null;
         assert templates != null;
@@ -104,7 +104,7 @@ public class CacheNodeCommonDiscoveryData implements Serializable {
     /**
      * @return A collection of restarting cache names.
      */
-    Collection<String> restartingCaches() {
+    Collection<Integer> restartingCaches() {
         return restartingCaches;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CachesRegistry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CachesRegistry.java
@@ -75,7 +75,7 @@ public class CachesRegistry {
      */
     public IgniteInternalFuture<?> init(
         Map<Integer, CacheGroupDescriptor> groupDescriptors,
-        Map<String, DynamicCacheDescriptor> cacheDescriptors
+        Map<Integer, DynamicCacheDescriptor> cacheDescriptors
     ) {
         unregisterAll();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -1618,7 +1618,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
         }
 
         if (start) {
-            for (Map.Entry<String, DynamicCacheDescriptor> e : cachesInfo.registeredCaches().entrySet()) {
+            for (Map.Entry<Integer, DynamicCacheDescriptor> e : cachesInfo.registeredCaches().entrySet()) {
                 DynamicCacheDescriptor desc = e.getValue();
 
                 if (!desc.cacheType().userCache() || desc.cacheConfiguration().getCacheMode() == LOCAL)
@@ -3173,7 +3173,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
             }
 
             for (String cacheName : msg.caches()) {
-                DynamicCacheDescriptor desc = cachesInfo.registeredCaches().get(cacheName);
+                DynamicCacheDescriptor desc = cachesInfo.registeredCaches().get(CU.cacheId(cacheName));
 
                 if (desc != null) {
                     if (desc.cacheConfiguration().isStatisticsEnabled() != msg.enabled()) {
@@ -4566,13 +4566,13 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Descriptor.
      */
     public DynamicCacheDescriptor cacheDescriptor(String name) {
-        return cachesInfo.registeredCaches().get(name);
+        return cachesInfo.registeredCaches().get(CU.cacheId(name));
     }
 
     /**
      * @return Cache descriptors.
      */
-    public Map<String, DynamicCacheDescriptor> cacheDescriptors() {
+    public Map<Integer, DynamicCacheDescriptor> cacheDescriptors() {
         return cachesInfo.registeredCaches();
     }
 
@@ -4624,16 +4624,8 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Cache descriptor.
      */
     public @Nullable DynamicCacheDescriptor cacheDescriptor(int cacheId) {
-        for (DynamicCacheDescriptor cacheDesc : cacheDescriptors().values()) {
-            CacheConfiguration ccfg = cacheDesc.cacheConfiguration();
 
-            assert ccfg != null : cacheDesc;
-
-            if (CU.cacheId(ccfg.getName()) == cacheId)
-                return cacheDesc;
-        }
-
-        return null;
+        return cacheDescriptors().get(cacheId);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/LocalJoinCachesContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/LocalJoinCachesContext.java
@@ -49,7 +49,7 @@ public class LocalJoinCachesContext {
 
     /** */
     @GridToStringInclude
-    private Map<String, DynamicCacheDescriptor> cacheDescs;
+    private Map<Integer, DynamicCacheDescriptor> cacheDescs;
 
     /**
      * @param locJoinStartCaches Local caches to start on join.
@@ -61,7 +61,7 @@ public class LocalJoinCachesContext {
         List<T2<DynamicCacheDescriptor, NearCacheConfiguration>> locJoinStartCaches,
         List<DynamicCacheDescriptor> locJoinInitCaches,
         Map<Integer, CacheGroupDescriptor> cacheGrpDescs,
-        Map<String, DynamicCacheDescriptor> cacheDescs
+        Map<Integer, DynamicCacheDescriptor> cacheDescs
     ) {
         this.locJoinStartCaches = locJoinStartCaches;
         this.locJoinInitCaches = locJoinInitCaches;
@@ -93,7 +93,7 @@ public class LocalJoinCachesContext {
     /**
      * @return Cache descriptors.
      */
-    public Map<String, DynamicCacheDescriptor> cacheDescriptors() {
+    public Map<Integer, DynamicCacheDescriptor> cacheDescriptors() {
         return cacheDescs;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ValidationOnNodeJoinUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ValidationOnNodeJoinUtils.java
@@ -716,7 +716,7 @@ public class ValidationOnNodeJoinUtils {
     @Nullable static IgniteNodeValidationResult validateHashIdResolvers(
         ClusterNode node,
         GridKernalContext ctx,
-        Map<String, DynamicCacheDescriptor> map
+        Map<Integer, DynamicCacheDescriptor> map
     ) {
         if (!node.isClient()) {
             for (DynamicCacheDescriptor desc : map.values()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/ViewCacheClosure.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/ViewCacheClosure.java
@@ -108,9 +108,9 @@ public class ViewCacheClosure implements IgniteCallable<List<CacheInfo>> {
                 return cacheInfo;
 
             default:
-                Map<String, DynamicCacheDescriptor> descMap = k.context().cache().cacheDescriptors();
+                Map<Integer, DynamicCacheDescriptor> descMap = k.context().cache().cacheDescriptors();
 
-                for (Map.Entry<String, DynamicCacheDescriptor> entry : descMap.entrySet()) {
+                for (Map.Entry<Integer, DynamicCacheDescriptor> entry : descMap.entrySet()) {
                     DynamicCacheDescriptor desc = entry.getValue();
 
                     if (!desc.cacheType().userCache() || !compiled.matcher(desc.cacheName()).find())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCachePartitionsRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCachePartitionsRequest.java
@@ -87,7 +87,7 @@ public class ClientCachePartitionsRequest extends ClientRequest {
             cacheGroupIds.put(cacheDesc.groupId(), grp);
         }
 
-        Map<String, DynamicCacheDescriptor> allCaches = ctx.kernalContext().cache().cacheDescriptors();
+        Map<Integer, DynamicCacheDescriptor> allCaches = ctx.kernalContext().cache().cacheDescriptors();
 
         // As a second step, check all other caches and add them to groups they are compatible with.
         for (DynamicCacheDescriptor cacheDesc: allCaches.values()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/service/ServiceDeploymentTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/service/ServiceDeploymentTask.java
@@ -198,9 +198,9 @@ class ServiceDeploymentTask {
                             if (change != null) {
                                 Set<String> names = new HashSet<>();
 
-                                ctx.cache().cacheDescriptors().forEach((name, desc) -> {
+                                ctx.cache().cacheDescriptors().values().forEach(desc -> {
                                     if (change.containsKey(desc.groupId()))
-                                        names.add(name);
+                                        names.add(desc.cacheName());
                                 });
 
                                 services.forEach((srvcId, desc) -> {

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/cache/VisorCacheNamesCollectorTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/cache/VisorCacheNamesCollectorTask.java
@@ -68,10 +68,10 @@ public class VisorCacheNamesCollectorTask extends VisorOneNodeTask<Void, VisorCa
             Map<String, IgniteUuid> caches = new HashMap<>();
             Set<String> groups = new HashSet<>();
 
-            for (Map.Entry<String, DynamicCacheDescriptor> item : cacheProc.cacheDescriptors().entrySet()) {
+            for (Map.Entry<Integer, DynamicCacheDescriptor> item : cacheProc.cacheDescriptors().entrySet()) {
                 DynamicCacheDescriptor cd = item.getValue();
 
-                caches.put(item.getKey(), cd.deploymentId());
+                caches.put(cd.cacheName(), cd.deploymentId());
 
                 String grp = cd.groupDescriptor().groupName();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteDiscoDataHandlingInNewClusterTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteDiscoDataHandlingInNewClusterTest.java
@@ -19,6 +19,8 @@ package org.apache.ignite.internal.processors.cache;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
 import org.apache.ignite.cluster.ClusterNode;
@@ -27,6 +29,7 @@ import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.util.typedef.internal.CU;
 import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.messages.TcpDiscoveryAbstractMessage;
@@ -198,11 +201,12 @@ public class IgniteDiscoDataHandlingInNewClusterTest extends GridCommonAbstractT
 
     /** */
     private void verifyCachesAndGroups(IgniteEx ignite, Collection<String> cacheNames) {
-        Map<String, DynamicCacheDescriptor> caches = ignite.context().cache().cacheDescriptors();
+        Collection<Integer> hashedCacheNames = cacheNames.stream().map(CU::cacheId).collect(Collectors.toList());
+        Map<Integer, DynamicCacheDescriptor> caches = ignite.context().cache().cacheDescriptors();
 
         assertEquals(cacheNames.size() + 1, caches.size());
-        assertTrue(caches.keySet().contains(GridCacheUtils.UTILITY_CACHE_NAME));
-        assertTrue(caches.keySet().containsAll(cacheNames));
+        assertTrue(caches.containsKey(CU.cacheId(GridCacheUtils.UTILITY_CACHE_NAME)));
+        assertTrue(caches.keySet().containsAll(hashedCacheNames));
 
         Map<Integer, CacheGroupDescriptor> groups = ignite.context().cache().cacheGroupDescriptors();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsDiscoDataHandlingInNewClusterTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/IgnitePdsDiscoDataHandlingInNewClusterTest.java
@@ -31,6 +31,7 @@ import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.processors.cache.CacheGroupDescriptor;
 import org.apache.ignite.internal.processors.cache.DynamicCacheDescriptor;
 import org.apache.ignite.internal.processors.cache.GridCacheUtils;
+import org.apache.ignite.internal.util.typedef.internal.CU;
 import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.messages.TcpDiscoveryAbstractMessage;
@@ -162,12 +163,12 @@ public class IgnitePdsDiscoDataHandlingInNewClusterTest extends GridCommonAbstra
 
     /** */
     private void verifyCachesAndGroups(IgniteEx ig) {
-        Map<String, DynamicCacheDescriptor> caches = ig.context().cache().cacheDescriptors();
+        Map<Integer, DynamicCacheDescriptor> caches = ig.context().cache().cacheDescriptors();
 
         assertEquals(3, caches.size());
-        assertTrue(caches.keySet().contains(GridCacheUtils.UTILITY_CACHE_NAME));
-        assertTrue(caches.keySet().contains(STATIC_CACHE_NAME_0));
-        assertTrue(caches.keySet().contains(DYNAMIC_CACHE_NAME_0));
+        assertTrue(caches.containsKey(CU.cacheId(GridCacheUtils.UTILITY_CACHE_NAME)));
+        assertTrue(caches.containsKey(CU.cacheId(STATIC_CACHE_NAME_0)));
+        assertTrue(caches.containsKey(CU.cacheId(DYNAMIC_CACHE_NAME_0)));
 
         Map<Integer, CacheGroupDescriptor> groups = ig.context().cache().cacheGroupDescriptors();
 

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/common/GridCommonAbstractTest.java
@@ -2071,12 +2071,12 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
      */
     protected final void checkCacheDiscoveryDataConsistent() {
         Map<Integer, CacheGroupDescriptor> cacheGrps = null;
-        Map<String, DynamicCacheDescriptor> caches = null;
+        Map<Integer, DynamicCacheDescriptor> caches = null;
 
         for (Ignite node : G.allGrids()) {
             Map<Integer, CacheGroupDescriptor> cacheGrps0 =
                 ((IgniteKernal)node).context().cache().cacheGroupDescriptors();
-            Map<String, DynamicCacheDescriptor> caches0 =
+            Map<Integer, DynamicCacheDescriptor> caches0 =
                 ((IgniteKernal)node).context().cache().cacheDescriptors();
 
             assertNotNull(cacheGrps0);
@@ -2097,7 +2097,7 @@ public abstract class GridCommonAbstractTest extends GridAbstractTest {
                     checkGroupDescriptorsData(desc, desc0);
                 }
 
-                for (Map.Entry<String, DynamicCacheDescriptor> e : caches.entrySet()) {
+                for (Map.Entry<Integer, DynamicCacheDescriptor> e : caches.entrySet()) {
                     DynamicCacheDescriptor desc = e.getValue();
                     DynamicCacheDescriptor desc0 = caches.get(e.getKey());
 


### PR DESCRIPTION
Since CHMs with cache descriptors are widely used, I think it's better to use hash of cache name instead of an actual name. 

My reasonings are:
- hash is a one way function, therefore we can't revert hash to readable name, so having cacheId does nothing for us if we have CHM with cache names as keys;
- hashing of String keys are done under the hood by CHM and then cached in string pool, so it incurs minimal overhead in terms of CHM algorithms, if any
- since hashing is just a function to get a unique int for a string, so a hash of an int == that same int
- all in all, we lose almost nothing in terms of performance, simultaneously we gain a lot when looking up values in a map, since it's complexity is constant time value
- string and its hash are unique values (or they are ought to be anyway), so nothing changes in logic

