### PR TITLE
IGNITE-13619 Thread dumps on failure processor invocation should be enabled by default

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/failure/FailureProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/failure/FailureProcessor.java
@@ -48,10 +48,11 @@ public class FailureProcessor extends GridProcessorAdapter {
     public static final int DFLT_FAILURE_HANDLER_RESERVE_BUFFER_SIZE = 64 * 1024;
 
     /** Value of the system property that enables threads dumping on failure. */
-    private final boolean igniteDumpThreadsOnFailure = IgniteSystemProperties.getBoolean(IGNITE_DUMP_THREADS_ON_FAILURE);
+    private final boolean igniteDumpThreadsOnFailure =
+        IgniteSystemProperties.getBoolean(IGNITE_DUMP_THREADS_ON_FAILURE, true);
 
     /** Timeout for throttling of thread dumps generation. */
-    long dumpThreadsTrottlingTimeout;
+    private long dumpThreadsTrottlingTimeout;
 
     /** Ignored failure log message. */
     static final String IGNORED_FAILURE_LOG_MSG = "Possible failure suppressed accordingly to a configured handler ";
@@ -61,7 +62,7 @@ public class FailureProcessor extends GridProcessorAdapter {
         "Will be handled accordingly to configured handler ";
 
     /** Thread dump per failure type timestamps. */
-    private Map<FailureType, Long> threadDumpPerFailureTypeTime;
+    private final Map<FailureType, Long> threadDumpPerFailureTypeTs;
 
     /** Ignite. */
     private final Ignite ignite;
@@ -83,6 +84,8 @@ public class FailureProcessor extends GridProcessorAdapter {
 
         ignite = ctx.grid();
 
+        Map<FailureType, Long> threadDumpPerFailureTypeTs = null;
+
         if (igniteDumpThreadsOnFailure) {
             dumpThreadsTrottlingTimeout =
                     IgniteSystemProperties.getLong(
@@ -91,12 +94,14 @@ public class FailureProcessor extends GridProcessorAdapter {
                     );
 
             if (dumpThreadsTrottlingTimeout > 0) {
-                threadDumpPerFailureTypeTime = new EnumMap<>(FailureType.class);
+                threadDumpPerFailureTypeTs = new EnumMap<>(FailureType.class);
 
                 for (FailureType type : FailureType.values())
-                    threadDumpPerFailureTypeTime.put(type, 0L);
+                    threadDumpPerFailureTypeTs.put(type, 0L);
             }
         }
+
+        this.threadDumpPerFailureTypeTs = threadDumpPerFailureTypeTs;
     }
 
     /** {@inheritDoc} */
@@ -124,7 +129,8 @@ public class FailureProcessor extends GridProcessorAdapter {
     }
 
     /**
-     * This method is used to initialize local failure handler if {@link IgniteConfiguration} don't contain configured one.
+     * This method is used to initialize local failure handler if {@link IgniteConfiguration}
+     * doesn't contain configured one.
      *
      * @return Default {@link FailureHandler} implementation.
      */
@@ -202,7 +208,16 @@ public class FailureProcessor extends GridProcessorAdapter {
     }
 
     /**
-     * Defines whether thread dump should be throttled for givn failure type or not.
+     * Returns timeout for throttling of thread dumps generation.
+     *
+     * @return Timeout for throttling of thread dumps generation.
+     */
+    long dumpThreadsTrottlingTimeout() {
+        return dumpThreadsTrottlingTimeout;
+    }
+
+    /**
+     * Defines whether thread dump should be throttled for given failure type or not.
      *
      * @param type Failure type.
      * @return {@code True} if thread dump generation should be throttled fro given failure type.
@@ -213,14 +228,14 @@ public class FailureProcessor extends GridProcessorAdapter {
 
         long curr = U.currentTimeMillis();
 
-        Long last = threadDumpPerFailureTypeTime.get(type);
+        Long last = threadDumpPerFailureTypeTs.get(type);
 
         assert last != null : "Unknown failure type " + type;
 
         boolean throttle = curr - last < dumpThreadsTrottlingTimeout;
 
         if (!throttle)
-            threadDumpPerFailureTypeTime.put(type, curr);
+            threadDumpPerFailureTypeTs.put(type, curr);
         else {
             if (log.isInfoEnabled()) {
                 log.info("Thread dump is hidden due to throttling settings. " +

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/failure/FailureProcessorThreadDumpThrottlingTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/failure/FailureProcessorThreadDumpThrottlingTest.java
@@ -196,7 +196,7 @@ public class FailureProcessorThreadDumpThrottlingTest extends GridCommonAbstract
         IgniteEx ignite = ignite(0);
 
         assertEquals(
-                ignite.context().failure().dumpThreadsTrottlingTimeout,
+                ignite.context().failure().dumpThreadsTrottlingTimeout(),
                 ignite.configuration().getFailureDetectionTimeout().longValue()
         );
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-13619

Thread dumps on failure processor invocations should be enabled by default. 
It seems this feature was disabled accidentally.

