### PR TITLE
IGNITE-9474 Fix incorrect cache.size() with ttl enabled

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -5788,6 +5788,9 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
         private CacheDataRow oldRow;
 
         /** */
+        private boolean oldRowExpiredFlag;
+
+        /** */
         private IgniteTree.OperationType treeOp = IgniteTree.OperationType.PUT;
 
         /**
@@ -5856,6 +5859,11 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
             return oldRow;
         }
 
+        /** {@inheritDoc} */
+        @Override public boolean oldRowExpiredFlag() {
+            return oldRowExpiredFlag;
+        }
+
         /**
          * Checks row for expiration and fire expire events if needed.
          *
@@ -5901,6 +5909,8 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
             cctx.continuousQueries().onEntryExpired(entry, entry.key(), expiredVal);
 
             entry.updatePlatformCache(null, null);
+
+            oldRowExpiredFlag = true;
 
             return null;
         }
@@ -6049,6 +6059,11 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
         /** {@inheritDoc} */
         @Nullable @Override public CacheDataRow oldRow() {
             return oldRow;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean oldRowExpiredFlag() {
+            return oldRowExpiredFlag;
         }
 
         /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheOffheapManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheOffheapManager.java
@@ -594,6 +594,12 @@ public interface IgniteCacheOffheapManager {
          * @return Old row.
          */
         @Nullable public CacheDataRow oldRow();
+
+        /**
+         * Flag that indicates if oldRow was expired during invoke.
+         * @return {@code true} if old row was expired, {@code false} otherwise.
+         */
+        public boolean oldRowExpiredFlag();
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheOffheapManagerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheOffheapManagerImpl.java
@@ -1717,7 +1717,7 @@ public class IgniteCacheOffheapManagerImpl implements IgniteCacheOffheapManager 
 
                     CacheDataRow oldRow = c.oldRow();
 
-                    finishUpdate(cctx, c.newRow(), oldRow);
+                    finishUpdate(cctx, c.newRow(), oldRow, c.oldRowExpiredFlag());
 
                     break;
                 }
@@ -2623,10 +2623,20 @@ public class IgniteCacheOffheapManagerImpl implements IgniteCacheOffheapManager 
          */
         private void finishUpdate(GridCacheContext cctx, CacheDataRow newRow, @Nullable CacheDataRow oldRow)
             throws IgniteCheckedException {
-            if (oldRow == null)
-                incrementSize(cctx.cacheId());
+            finishUpdate(cctx, newRow, oldRow, false);
+        }
 
-            KeyCacheObject key = newRow.key();
+        /**
+         * @param cctx Cache context.
+         * @param newRow New row.
+         * @param oldRow Old row if available.
+         * @param oldRowExpired Old row expiration flag
+         * @throws IgniteCheckedException If failed.
+         */
+        private void finishUpdate(GridCacheContext cctx, CacheDataRow newRow, @Nullable CacheDataRow oldRow, boolean oldRowExpired)
+            throws IgniteCheckedException {
+            if (oldRow == null && !oldRowExpired)
+                incrementSize(cctx.cacheId());
 
             GridCacheQueryManager qryMgr = cctx.queries();
 
@@ -3163,6 +3173,14 @@ public class IgniteCacheOffheapManagerImpl implements IgniteCacheOffheapManager 
             /** {@inheritDoc} */
             @Nullable @Override public CacheDataRow oldRow() {
                 return oldRow;
+            }
+
+            /**
+            * Flag that indicates if oldRow was expired during invoke.
+            * @return {@code true} if old row was expired, {@code false} otherwise.
+            */
+            @Override public boolean oldRowExpiredFlag() {
+                return false;
             }
 
             /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/PendingEntriesTree.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/PendingEntriesTree.java
@@ -92,7 +92,7 @@ public class PendingEntriesTree extends BPlusTree<PendingRow, PendingRow> {
                 return cmp;
 
             if (row.expireTime == 0 && row.link == 0) {
-                // A search row with a cach ID only is used as a cache bound.
+                // A search row with a cache ID only is used as a cache bound.
                 // The found position will be shifted until the exact cache bound is found;
                 // See for details:
                 // o.a.i.i.p.c.database.tree.BPlusTree.ForwardCursor.findLowerBound()

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/ttl/CacheSizeTtlTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/ttl/CacheSizeTtlTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.ttl;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ModifiedExpiryPolicy;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteDataStreamer;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.CachePeekMode;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteInterruptedCheckedException;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static java.util.Collections.singleton;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.cache.CacheMode.REPLICATED;
+
+/**
+ * Tests for cache.size() with ttl enabled.
+ */
+public class CacheSizeTtlTest extends GridCommonAbstractTest {
+    /** Cache name. */
+    private static final String CACHE_NAME = "TestCache";
+
+    /** Entry expiry duration. */
+    private static final Duration ENTRY_EXPIRY_DURATION = new Duration(SECONDS, 1);
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids();
+    }
+
+    /**
+     * Tests that cache.size() works correctly for massive amount of puts and ttl.
+     */
+    @Test
+    public void testCacheSizeWorksCorrectlyWithTtl() throws IgniteInterruptedCheckedException {
+        startIgniteServer();
+
+        Ignite client = startIgniteClient();
+
+        try (IgniteDataStreamer dataStreamer = client.dataStreamer(CACHE_NAME)) {
+            IntStream.range(0, 100_000)
+                .forEach(i -> dataStreamer.addData(1, LocalDateTime.now()));
+        }
+
+        assertTrue(GridTestUtils.waitForCondition(() -> client.cache(CACHE_NAME).size(CachePeekMode.PRIMARY) == 0,
+            getTestTimeout()));
+    }
+
+    /**
+     * Tests that cache.size() works correctly for massive amount of puts and ttl.
+     */
+    @Test
+    public void testCachePutWorksCorrectlyWithTtl() throws Exception {
+        startIgniteServer();
+
+        Ignite client = startIgniteClient();
+
+        multithreaded(() -> IntStream.range(0, 20_000)
+            .forEach(i -> client.cache(CACHE_NAME).put(1, LocalDateTime.now())), 8);
+
+        assertTrue(GridTestUtils.waitForCondition(() -> client.cache(CACHE_NAME).size(CachePeekMode.PRIMARY) == 0,
+            getTestTimeout()));
+    }
+
+    private static Ignite startIgniteServer() {
+        IgniteConfiguration configuration = new IgniteConfiguration()
+            .setClientMode(false)
+            .setIgniteInstanceName(UUID.randomUUID().toString())
+            .setCacheConfiguration(cacheConfiguration())
+            .setDiscoverySpi(discoveryConfiguration());
+        return Ignition.start(configuration);
+    }
+
+    private static Ignite startIgniteClient() {
+        IgniteConfiguration configuration = new IgniteConfiguration()
+            .setClientMode(true)
+            .setIgniteInstanceName(UUID.randomUUID().toString())
+            .setDiscoverySpi(discoveryConfiguration());
+        return Ignition.start(configuration);
+    }
+
+    @NotNull
+    private static CacheConfiguration<String, LocalDateTime> cacheConfiguration() {
+        return new CacheConfiguration<String, LocalDateTime>()
+            .setName(CACHE_NAME)
+            .setCacheMode(REPLICATED)
+            .setEagerTtl(true)
+            .setExpiryPolicyFactory(ModifiedExpiryPolicy.factoryOf(ENTRY_EXPIRY_DURATION));
+    }
+
+    private static TcpDiscoverySpi discoveryConfiguration() {
+        TcpDiscoveryVmIpFinder ipFinder = new TcpDiscoveryVmIpFinder();
+        ipFinder.setAddresses(singleton("127.0.0.1:48550..48551"));
+        TcpDiscoverySpi tcpDiscoverySpi = new TcpDiscoverySpi();
+        tcpDiscoverySpi.setIpFinder(ipFinder);
+        tcpDiscoverySpi.setLocalPort(48550);
+        tcpDiscoverySpi.setLocalPortRange(1);
+
+        return tcpDiscoverySpi;
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
@@ -44,6 +44,7 @@ import org.apache.ignite.internal.processors.cache.IgniteClientReconnectQueriesT
 import org.apache.ignite.internal.processors.cache.WrongIndexedTypesTest;
 import org.apache.ignite.internal.processors.cache.index.H2TreeCorruptedTreeExceptionTest;
 import org.apache.ignite.internal.processors.cache.persistence.RebuildIndexLogMessageTest;
+import org.apache.ignite.internal.processors.cache.ttl.CacheSizeTtlTest;
 import org.apache.ignite.internal.processors.cache.ttl.CacheTtlAtomicLocalSelfTest;
 import org.apache.ignite.internal.processors.cache.ttl.CacheTtlAtomicPartitionedSelfTest;
 import org.apache.ignite.internal.processors.cache.ttl.CacheTtlReadOnlyModeSelfTest;
@@ -69,6 +70,7 @@ import org.junit.runners.Suite;
     CacheTtlAtomicLocalSelfTest.class,
     CacheTtlAtomicPartitionedSelfTest.class,
     CacheTtlReadOnlyModeSelfTest.class,
+    CacheSizeTtlTest.class,
 
     GridCacheOffheapIndexGetSelfTest.class,
     GridCacheOffheapIndexEntryEvictTest.class,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-9474

Fixed an issue where the cache size could return a wrong value when TTL is enabled.