### PR TITLE
IGNITE-13620 : Bind ignite node to 1 address in the ducktests.

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_aware.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_aware.py
@@ -73,7 +73,7 @@ class IgniteAwareService(BackgroundThreadService, IgnitePersistenceAware, metacl
         else:
             config = self.config
 
-        config.discovery_spi.prepare_on_start(cluster=self)
+        config.discovery_spi.prepare_on_start(cluster=self, node=node)
 
         node_config = self.spec.config_template.render(config_dir=self.PERSISTENT_ROOT, work_dir=self.WORK_DIR,
                                                        config=config)

--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/discovery.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/discovery.py
@@ -19,6 +19,7 @@ Module contains classes and utility methods to create discovery configuration fo
 
 from abc import ABCMeta, abstractmethod
 
+import socket
 from ignitetest.services.utils.ignite_aware import IgniteAwareService
 from ignitetest.services.zk.zookeeper import ZookeeperService
 
@@ -101,10 +102,11 @@ class TcpDiscoverySpi(DiscoverySpi):
     """
     TcpDiscoverySpi.
     """
-    def __init__(self, ip_finder=TcpDiscoveryVmIpFinder(), port=47500, port_range=100):
+    def __init__(self, ip_finder=TcpDiscoveryVmIpFinder(), port=47500, port_range=100, local_address=None):
         self.ip_finder = ip_finder
         self.port = port
         self.port_range = port_range
+        self.local_address = local_address
 
     @property
     def type(self):
@@ -112,6 +114,11 @@ class TcpDiscoverySpi(DiscoverySpi):
 
     def prepare_on_start(self, **kwargs):
         self.ip_finder.prepare_on_start(**kwargs)
+
+        node = kwargs.get('node', None)
+
+        if node:
+            self.local_address = socket.gethostbyname(node.account.hostname)
 
 
 def from_ignite_cluster(cluster, subset=None):

--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/discovery.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/discovery.py
@@ -117,7 +117,7 @@ class TcpDiscoverySpi(DiscoverySpi):
 
         node = kwargs.get('node', None)
 
-        if node:
+        if not self.local_address and node:
             self.local_address = socket.gethostbyname(node.account.hostname)
 
 

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/discovery_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/discovery_macro.j2
@@ -44,6 +44,9 @@
 
 {% macro tcp_discovery_spi(spi) %}
     <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+        {% if spi.local_address %}
+            <property name="localAddress" value="{{ spi.local_address }}"/>
+        {% endif %}
         <property name="localPort" value="{{ spi.port }}"/>
         <property name="localPortRange" value="{{ spi.port_range }}"/>
         {{ ip_finder(spi) }}


### PR DESCRIPTION
Ignite node should use one ip address in rcp discovery to make failure detection delay clear.