### PR TITLE
IGNITE-13357 .NET: Add IncludeExpired to ContinuousQuery and ContinuousQueryClient

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
@@ -977,6 +977,7 @@ public class PlatformCache extends PlatformAbstractTarget {
             case OP_QRY_CONTINUOUS: {
                 long ptr = reader.readLong();
                 boolean loc = reader.readBoolean();
+                boolean includeExpired = reader.readBoolean();
                 boolean hasFilter = reader.readBoolean();
                 Object filter = reader.readObjectDetached();
                 int bufSize = reader.readInt();
@@ -986,7 +987,7 @@ public class PlatformCache extends PlatformAbstractTarget {
 
                 PlatformContinuousQuery qry = platformCtx.createContinuousQuery(ptr, hasFilter, filter);
 
-                qry.start(cache, loc, bufSize, timeInterval, autoUnsubscribe, initQry);
+                qry.start(cache, loc, bufSize, timeInterval, autoUnsubscribe, initQry, includeExpired);
 
                 return new PlatformContinuousQueryProxy(platformCtx, qry);
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQuery.java
@@ -36,10 +36,11 @@ public interface PlatformContinuousQuery extends CacheEntryUpdatedListener, Plat
      * @param timeInterval Time interval.
      * @param autoUnsubscribe Auto-unsubscribe flag.
      * @param initialQry Initial query.
+     * @param includeExpired Whether to include expired events.
      * @throws org.apache.ignite.IgniteCheckedException If failed.
      */
     public void start(IgniteCacheProxy cache, boolean loc, int bufSize, long timeInterval, boolean autoUnsubscribe,
-        Query initialQry) throws IgniteCheckedException;
+        Query initialQry, boolean includeExpired) throws IgniteCheckedException;
 
     /**
      * Close continuous query.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -128,11 +128,12 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
      * @param bufSize Buffer size.
      * @param timeInterval Time interval.
      * @param autoUnsubscribe Auto-unsubscribe flag.
+     * @param includeExpired Whether to include expired events.
      * @param initialQry Initial query.
      */
     @SuppressWarnings("unchecked")
     @Override public void start(IgniteCacheProxy cache, boolean loc, int bufSize, long timeInterval,
-        boolean autoUnsubscribe, Query initialQry) throws IgniteCheckedException {
+        boolean autoUnsubscribe, Query initialQry, boolean includeExpired) throws IgniteCheckedException {
         lock.writeLock().lock();
 
         try {
@@ -148,6 +149,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
                 qry.setTimeInterval(timeInterval);
                 qry.setAutoUnsubscribe(autoUnsubscribe);
                 qry.setInitialQuery(initialQry);
+                qry.setIncludeExpired(includeExpired);
 
                 cursor = cache.query(qry.setLocal(loc));
 

--- a/modules/platforms/cpp/core/src/impl/cache/cache_impl.cpp
+++ b/modules/platforms/cpp/core/src/impl/cache/cache_impl.cpp
@@ -450,6 +450,7 @@ namespace ignite
 
                 rawWriter.WriteInt64(handle);
                 rawWriter.WriteBool(qry0.GetLocal());
+                rawWriter.WriteBool(false); // IncludeExpired
 
                 event::CacheEntryEventFilterHolderBase& filterOp = qry0.GetFilterHolder();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
@@ -32,7 +32,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
     using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Cache.Query.Continuous;
-    using Apache.Ignite.Core.Client.Cache.Query.Continuous;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Impl.Cache.Event;
     using Apache.Ignite.Core.Resource;
@@ -302,11 +301,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
         }
 
         /// <summary>
-        /// Tests that enabling <see cref="ContinuousQueryClient{TK,TV}.IncludeExpired"/> causes
+        /// Tests that enabling <see cref="ContinuousQuery{TK,TV}.IncludeExpired"/> causes
         /// <see cref="CacheEntryEventType.Expired"/> events to be delivered.
         ///
         /// - Create a cache with expiry policy
-        /// - Start a continuous query with <see cref="ContinuousQueryClient{TK,TV}.IncludeExpired"/> set to <c>true</c>
+        /// - Start a continuous query with <see cref="ContinuousQuery{TK,TV}.IncludeExpired"/> set to <c>true</c>
         /// - Check that Expired events are delivered
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
@@ -29,8 +29,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Event;
+    using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Cache.Query.Continuous;
+    using Apache.Ignite.Core.Client.Cache.Query.Continuous;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Impl.Cache.Event;
     using Apache.Ignite.Core.Resource;
@@ -264,6 +266,78 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
             {
                 Assert.IsNotNull(cb.ignite);
             }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="ContinuousQuery{TK,TV}.IncludeExpired"/> is false by default
+        /// and expiration events are not delivered.
+        ///
+        /// - Create a cache with expiry policy
+        /// - Start a continuous query with default settings
+        /// - Check that Created events are delivered, but Expired events are not
+        /// </summary>
+        [Test]
+        public void TestIncludeExpiredIsFalseByDefaultAndExpiredEventsAreSkipped()
+        {
+            var cache = cache1.WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null));
+            var cb = new Listener<BinarizableEntry>();
+            
+            var qry = new ContinuousQuery<int, BinarizableEntry>(cb);
+            Assert.IsFalse(qry.IncludeExpired);
+
+            using (cache.QueryContinuous(qry))
+            {
+                cache[1] = Entry(1);
+
+                TestUtils.WaitForTrueCondition(() => !cache.ContainsKey(1));
+
+                cache[2] = Entry(2);
+            }
+            
+            var events = CB_EVTS.SelectMany(e => e.entries).ToList();
+            Assert.AreEqual(2, events.Count);
+
+            Assert.AreEqual(CacheEntryEventType.Created, events[0].EventType);
+            Assert.AreEqual(CacheEntryEventType.Created, events[1].EventType);
+        }
+
+        /// <summary>
+        /// Tests that enabling <see cref="ContinuousQueryClient{TK,TV}.IncludeExpired"/> causes
+        /// <see cref="CacheEntryEventType.Expired"/> events to be delivered.
+        ///
+        /// - Create a cache with expiry policy
+        /// - Start a continuous query with <see cref="ContinuousQueryClient{TK,TV}.IncludeExpired"/> set to <c>true</c>
+        /// - Check that Expired events are delivered
+        /// </summary>
+        [Test]
+        public void TestExpiredEventsAreDeliveredWhenIncludeExpiredIsTrue()
+        {
+            var cache = cache1.WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null));
+            var cb = new Listener<BinarizableEntry>();
+            
+            var qry = new ContinuousQuery<int, BinarizableEntry>(cb)
+            {
+                IncludeExpired = true
+            };
+
+            using (cache.QueryContinuous(qry))
+            {
+                cache[1] = Entry(2);
+
+                TestUtils.WaitForTrueCondition(() => CB_EVTS.Count == 2);
+            }
+
+            var events = CB_EVTS.SelectMany(e => e.entries).ToList();
+            
+            Assert.AreEqual(2, events.Count);
+            Assert.AreEqual(CacheEntryEventType.Created, events[0].EventType);
+            Assert.AreEqual(CacheEntryEventType.Expired, events[1].EventType);
+            
+            Assert.IsTrue(events[1].HasValue);
+            Assert.IsTrue(events[1].HasOldValue);
+            Assert.AreEqual(2, events[1].Value);
+            Assert.AreEqual(2, events[1].OldValue);
+            Assert.AreEqual(1, events[1].Key);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
@@ -334,8 +334,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
             
             Assert.IsTrue(events[1].HasValue);
             Assert.IsTrue(events[1].HasOldValue);
-            Assert.AreEqual(2, events[1].Value);
-            Assert.AreEqual(2, events[1].OldValue);
+            Assert.AreEqual(2, ((BinarizableEntry)events[1].Value).val);
+            Assert.AreEqual(2, ((BinarizableEntry)events[1].Value).val);
             Assert.AreEqual(1, events[1].Key);
         }
 
@@ -1124,6 +1124,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
                     return new CacheEntryCreateEvent<object, object>(e.Key, e.Value);
                 case CacheEntryEventType.Updated:
                     return new CacheEntryUpdateEvent<object, object>(e.Key, e.OldValue, e.Value);
+                case CacheEntryEventType.Expired:
+                    return new CacheEntryExpireEvent<object, object>(e.Key, e.OldValue);
                 default:
                     return new CacheEntryRemoveEvent<object, object>(e.Key, e.OldValue);
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
@@ -280,7 +280,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
         {
             var cache = cache1.WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null));
             var cb = new Listener<BinarizableEntry>();
-            
+
             var qry = new ContinuousQuery<int, BinarizableEntry>(cb);
             Assert.IsFalse(qry.IncludeExpired);
 
@@ -292,7 +292,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
 
                 cache[2] = Entry(2);
             }
-            
+
             var events = CB_EVTS.SelectMany(e => e.entries).ToList();
             Assert.AreEqual(2, events.Count);
 
@@ -313,7 +313,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
         {
             var cache = cache1.WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null));
             var cb = new Listener<BinarizableEntry>();
-            
+
             var qry = new ContinuousQuery<int, BinarizableEntry>(cb)
             {
                 IncludeExpired = true
@@ -323,15 +323,15 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
             {
                 cache[1] = Entry(2);
 
-                TestUtils.WaitForTrueCondition(() => CB_EVTS.Count == 2);
+                TestUtils.WaitForTrueCondition(() => CB_EVTS.Count == 2, 5000);
             }
 
             var events = CB_EVTS.SelectMany(e => e.entries).ToList();
-            
+
             Assert.AreEqual(2, events.Count);
             Assert.AreEqual(CacheEntryEventType.Created, events[0].EventType);
             Assert.AreEqual(CacheEntryEventType.Expired, events[1].EventType);
-            
+
             Assert.IsTrue(events[1].HasValue);
             Assert.IsTrue(events[1].HasOldValue);
             Assert.AreEqual(2, ((BinarizableEntry)events[1].Value).val);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryTest.cs
@@ -69,7 +69,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
             cache.Put(entry.Id, entry);
 
             // Wait for events.
-            Thread.Sleep(100);
+            TestUtils.WaitForTrueCondition(() => Listener.Events.Count == 2);
 
             ICacheEntryEvent<Guid, Data> e;
 
@@ -100,7 +100,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
 
         private class Listener : ICacheEntryEventListener<Guid, Data>
         {
-            public static readonly ConcurrentStack<ICacheEntryEvent<Guid, Data>> Events 
+            public static readonly ConcurrentStack<ICacheEntryEvent<Guid, Data>> Events
                 = new ConcurrentStack<ICacheEntryEvent<Guid, Data>>();
 
             public void OnEvent(IEnumerable<ICacheEntryEvent<Guid, Data>> evts)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryTest.cs
@@ -21,7 +21,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Threading;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Event;
     using Apache.Ignite.Core.Cache.Query.Continuous;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -701,6 +701,12 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             Assert.AreEqual(2, events.Count);
             Assert.AreEqual(CacheEntryEventType.Created, events[0].EventType);
             Assert.AreEqual(CacheEntryEventType.Expired, events[1].EventType);
+            
+            Assert.IsTrue(events[1].HasValue);
+            Assert.IsTrue(events[1].HasOldValue);
+            Assert.AreEqual(2, events[1].Value);
+            Assert.AreEqual(2, events[1].OldValue);
+            Assert.AreEqual(1, events[1].Key);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -695,7 +695,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             {
                 cache[1] = 2;
 
-                TestUtils.WaitForTrueCondition(() => !cache.ContainsKey(1));
+                TestUtils.WaitForTrueCondition(() => events.Count == 2);
             }
             
             Assert.AreEqual(2, events.Count);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -101,6 +101,7 @@
     <Compile Include="IIgniteLock.cs" />
     <Compile Include="Impl\Binary\BinaryHashCodeUtils.cs" />
     <Compile Include="Impl\Binary\IgniteBiTuple.cs" />
+    <Compile Include="Impl\Cache\Event\CacheEntryExpireEvent.cs" />
     <Compile Include="Impl\Cache\Platform\IPlatformCache.cs" />
     <Compile Include="Impl\Cache\Platform\PlatformCache.cs" />
     <Compile Include="Impl\Cache\Platform\PlatformCacheEntry.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Event/CacheEntryEventType.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Event/CacheEntryEventType.cs
@@ -36,6 +36,11 @@ namespace Apache.Ignite.Core.Cache.Event
         /// <summary>
         /// An event type indicating that the cache entry was removed.
         /// </summary>
-        Removed
+        Removed,
+
+        /// <summary>
+        /// An event type indicating that the cache entry was removed by expiration policy.
+        /// </summary>
+        Expired
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/Continuous/ContinuousQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/Continuous/ContinuousQuery.cs
@@ -166,6 +166,17 @@ namespace Apache.Ignite.Core.Cache.Query.Continuous
         /// Defaults to <c>false</c>.
         /// </summary>
         public bool Local { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether to notify about <see cref="CacheEntryEventType.Expired"/> events.
+        /// <para />
+        /// If <c>true</c>, then the remote listener will get notifications about expired cache entries.
+        /// Otherwise, only <see cref="CacheEntryEventType.Created"/>, <see cref="CacheEntryEventType.Updated"/>, and
+        /// <see cref="CacheEntryEventType.Removed"/> events will be passed to the listener.
+        /// <para />
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        public bool IncludeExpired { get; set; }
 
         /// <summary>
         /// Validate continuous query state.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/ContinuousQueryClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/ContinuousQueryClient.cs
@@ -97,7 +97,6 @@ namespace Apache.Ignite.Core.Client.Cache.Query.Continuous
         /// sent only when buffer is full.
         /// </summary>
         public TimeSpan TimeInterval { get; set; }
-        
                 
         /// <summary>
         /// Gets or sets a value indicating whether to notify about <see cref="CacheEntryEventType.Expired"/> events.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/ContinuousQueryClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/ContinuousQueryClient.cs
@@ -97,5 +97,17 @@ namespace Apache.Ignite.Core.Client.Cache.Query.Continuous
         /// sent only when buffer is full.
         /// </summary>
         public TimeSpan TimeInterval { get; set; }
+        
+                
+        /// <summary>
+        /// Gets or sets a value indicating whether to notify about <see cref="CacheEntryEventType.Expired"/> events.
+        /// <para />
+        /// If <c>true</c>, then the remote listener will get notifications about expired cache entries.
+        /// Otherwise, only <see cref="CacheEntryEventType.Created"/>, <see cref="CacheEntryEventType.Updated"/>, and
+        /// <see cref="CacheEntryEventType.Removed"/> events will be passed to the listener.
+        /// <para />
+        /// Defaults to <c>false</c>.
+        /// </summary>
+        public bool IncludeExpired { get; set; }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Event/CacheEntryExpireEvent.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Event/CacheEntryExpireEvent.cs
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Cache.Event
+{
+    using Apache.Ignite.Core.Cache.Event;
+
+    /// <summary>
+    /// Cache entry expire event.
+    /// </summary>
+    internal class CacheEntryExpireEvent<TK, TV> : ICacheEntryEvent<TK, TV>
+    {
+        /** Key.*/
+        private readonly TK _key;
+        
+        /** Old value.*/
+        private readonly TV _oldVal;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="key">Key.</param>
+        /// <param name="oldVal">Old value.</param>
+        public CacheEntryExpireEvent(TK key, TV oldVal)
+        {
+            _key = key;
+            _oldVal = oldVal;
+        }
+
+        /** <inheritdoc /> */
+        public TK Key
+        {
+            get { return _key; }
+        }
+
+        /** <inheritdoc /> */
+        public TV Value
+        {
+            get { return _oldVal; }
+        }
+
+        /** <inheritdoc /> */
+        public TV OldValue
+        {
+            get { return _oldVal; }
+        }
+
+        /** <inheritdoc /> */
+        public bool HasValue
+        {
+            get { return true; }
+        }
+
+        /** <inheritdoc /> */
+        public bool HasOldValue
+        {
+            get { return true; }
+        }
+
+        /** <inheritdoc /> */
+        public CacheEntryEventType EventType
+        {
+            get { return CacheEntryEventType.Expired; }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/Continuous/ContinuousQueryHandleImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/Continuous/ContinuousQueryHandleImpl.cs
@@ -108,6 +108,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Query.Continuous
                 {
                     writer.WriteLong(_hnd);
                     writer.WriteBoolean(qry.Local);
+                    writer.WriteBoolean(qry.IncludeExpired);
                     writer.WriteBoolean(_filter != null);
 
                     var javaFilter = _filter as PlatformJavaObjectFactoryProxy;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/Continuous/ContinuousQueryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/Continuous/ContinuousQueryUtils.cs
@@ -94,6 +94,8 @@ namespace Apache.Ignite.Core.Impl.Cache.Query.Continuous
                     return new CacheEntryUpdateEvent<TK, TV>(key, oldVal, val);
                 case 2:
                     return new CacheEntryRemoveEvent<TK, TV>(key, oldVal);
+                case 3:
+                    return new CacheEntryExpireEvent<TK, TV>(key, oldVal);
                 default:
                     throw new NotSupportedException(eventType.ToString());
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -1085,7 +1085,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             var w = ctx.Writer;
             w.WriteInt(continuousQuery.BufferSize);
             w.WriteLong((long) continuousQuery.TimeInterval.TotalMilliseconds);
-            w.WriteBoolean(false); // Include expired.
+            w.WriteBoolean(continuousQuery.IncludeExpired);
 
             if (continuousQuery.Filter == null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
+++ b/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
@@ -8,6 +8,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=binarizable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cgroup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=failover/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Multithreaded/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
* Add `IncludeExpired` flag to thin and thick continuous query APIs: `ContinuousQuery`, `ContinuousQueryClient`
* Thin client protocol not affected: the flag is already supported