### PR TITLE
IGNITE-13608 .NET: Add Partitions and UpdateBatchSize to SqlFieldsQuery

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
@@ -409,6 +409,8 @@ public class SqlFieldsQuery extends Query<List<?>> {
      * @return {@code this} for chaining.
      */
     public SqlFieldsQuery setUpdateBatchSize(int updateBatchSize) {
+        A.ensure(updateBatchSize >= 1, "updateBatchSize cannot be lower than 1");
+
         this.updateBatchSize = updateBatchSize;
 
         return this;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -524,6 +524,8 @@ final class ClientUtils {
         out.writeBoolean(qry.isLazy());
         out.writeLong(qry.getTimeout());
         out.writeBoolean(true); // include column names
+        out.writeIntArray(qry.getPartitions());
+        out.writeInt(qry.getUpdateBatchSize());
     }
 
     /** Write Ignite binary object to output stream. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -60,7 +60,6 @@ import org.apache.ignite.internal.binary.BinarySchema;
 import org.apache.ignite.internal.binary.BinaryThreadLocalContext;
 import org.apache.ignite.internal.binary.BinaryUtils;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
-import org.apache.ignite.internal.binary.GridBinaryMarshaller;
 import org.apache.ignite.internal.binary.streams.BinaryHeapInputStream;
 import org.apache.ignite.internal.binary.streams.BinaryInputStream;
 import org.apache.ignite.internal.binary.streams.BinaryOutputStream;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -60,6 +60,7 @@ import org.apache.ignite.internal.binary.BinarySchema;
 import org.apache.ignite.internal.binary.BinaryThreadLocalContext;
 import org.apache.ignite.internal.binary.BinaryUtils;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
+import org.apache.ignite.internal.binary.GridBinaryMarshaller;
 import org.apache.ignite.internal.binary.streams.BinaryHeapInputStream;
 import org.apache.ignite.internal.binary.streams.BinaryInputStream;
 import org.apache.ignite.internal.binary.streams.BinaryOutputStream;
@@ -524,7 +525,16 @@ final class ClientUtils {
         out.writeBoolean(qry.isLazy());
         out.writeLong(qry.getTimeout());
         out.writeBoolean(true); // include column names
-        out.writeIntArray(qry.getPartitions());
+
+        if (qry.getPartitions() != null) {
+            out.writeInt(qry.getPartitions().length);
+
+            for (int part : qry.getPartitions())
+                out.writeInt(part);
+        }
+        else
+            out.writeInt(-1);
+
         out.writeInt(qry.getUpdateBatchSize());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -524,8 +524,6 @@ final class ClientUtils {
         out.writeBoolean(qry.isLazy());
         out.writeLong(qry.getTimeout());
         out.writeBoolean(true); // include column names
-        out.writeIntArray(qry.getPartitions());
-        out.writeInt(qry.getUpdateBatchSize());
     }
 
     /** Write Ignite binary object to output stream. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -43,11 +43,7 @@ public enum ProtocolBitmaskFeature {
     SERVICE_INVOKE(5),
 
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
-    DEFAULT_QRY_TIMEOUT(6),
-
-    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
-    QRY_PARTITIONS_BATCH_SIZE(7);
-
+    DEFAULT_QRY_TIMEOUT(6);
 
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -43,7 +43,11 @@ public enum ProtocolBitmaskFeature {
     SERVICE_INVOKE(5),
 
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
-    DEFAULT_QRY_TIMEOUT(6);
+    DEFAULT_QRY_TIMEOUT(6),
+
+    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
+    QRY_PARTITIONS_BATCH_SIZE(7);
+
 
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -48,7 +48,6 @@ public enum ProtocolBitmaskFeature {
     /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
     QRY_PARTITIONS_BATCH_SIZE(7);
 
-
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =
         EnumSet.allOf(ProtocolBitmaskFeature.class);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
@@ -1455,6 +1455,8 @@ public class PlatformCache extends PlatformAbstractTarget {
         boolean replicated = reader.readBoolean();
         boolean collocated = reader.readBoolean();
         String schema = reader.readString();
+        int[] partitions = reader.readIntArray();
+        int updateBatchSize = reader.readInt();
 
         SqlFieldsQuery qry = QueryUtils.withQueryTimeout(new SqlFieldsQuery(sql), timeout, TimeUnit.MILLISECONDS)
                 .setPageSize(pageSize)
@@ -1465,7 +1467,9 @@ public class PlatformCache extends PlatformAbstractTarget {
                 .setLazy(lazy)
                 .setReplicatedOnly(replicated)
                 .setCollocated(collocated)
-                .setSchema(schema);
+                .setSchema(schema)
+                .setPartitions(partitions)
+                .setUpdateBatchSize(updateBatchSize);
 
         return qry;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -39,7 +39,7 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     /** Cluster groups. */
     CLUSTER_GROUPS(4),
 
-    /** Service invocation. */
+    /** Service invocation. This flag is not necessary and exists for legacy reasons. */
     SERVICE_INVOKE(5),
 
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -43,7 +43,10 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     SERVICE_INVOKE(5),
 
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
-    DEFAULT_QRY_TIMEOUT(6);
+    DEFAULT_QRY_TIMEOUT(6),
+
+    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
+    QRY_PARTITIONS_BATCH_SIZE(7);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheSqlFieldsQueryRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheSqlFieldsQueryRequest.java
@@ -104,7 +104,16 @@ public class ClientCacheSqlFieldsQueryRequest extends ClientCacheDataRequest imp
 
         if (protocolCtx.isFeatureSupported(ClientBitmaskFeature.QRY_PARTITIONS_BATCH_SIZE)) {
             // Set qry values in process method so that validation errors are reported to the client.
-            partitions = reader.readIntArray();
+            int partCnt = reader.readInt();
+
+            if (partCnt >= 0) {
+                partitions = new int[partCnt];
+
+                for (int i = 0; i < partCnt; i++)
+                    partitions[i] = reader.readInt();
+            } else
+                partitions = null;
+
             updateBatchSize = reader.readInt();
         } else {
             partitions = null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheSqlFieldsQueryRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheSqlFieldsQueryRequest.java
@@ -94,6 +94,11 @@ public class ClientCacheSqlFieldsQueryRequest extends ClientCacheDataRequest imp
         if (protocolCtx.isFeatureSupported(ClientBitmaskFeature.DEFAULT_QRY_TIMEOUT) || timeout > 0)
             QueryUtils.withQueryTimeout(qry, timeout, TimeUnit.MILLISECONDS);
 
+        if (protocolCtx.isFeatureSupported(ClientBitmaskFeature.QRY_PARTITIONS_BATCH_SIZE)) {
+            qry.setPartitions(reader.readIntArray());
+            qry.setUpdateBatchSize(reader.readInt());
+        }
+
         this.qry = qry;
     }
 

--- a/modules/indexing/src/test/java/org/apache/ignite/client/FunctionalQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/client/FunctionalQueryTest.java
@@ -270,6 +270,12 @@ public class FunctionalQueryTest {
         }
     }
 
+    /** Tests {@link SqlFieldsQuery} parameter validation. */
+    @Test
+    public void testSqlParameterValidation() {
+        // TODO
+    }
+
     /** */
     private static ClientConfiguration getClientConfiguration() {
         return new ClientConfiguration().setAddresses(Config.SERVER)

--- a/modules/indexing/src/test/java/org/apache/ignite/client/FunctionalQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/client/FunctionalQueryTest.java
@@ -43,6 +43,7 @@ import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * Thin client functional tests.
@@ -274,6 +275,7 @@ public class FunctionalQueryTest {
     @Test
     public void testSqlParameterValidation() {
         // TODO
+        fail();
     }
 
     /** */

--- a/modules/platforms/cpp/core/include/ignite/cache/query/query_sql_fields.h
+++ b/modules/platforms/cpp/core/include/ignite/cache/query/query_sql_fields.h
@@ -383,6 +383,9 @@ namespace ignite
                         writer.WriteNull();
                     else
                         writer.WriteString(schema);
+
+                    writer.WriteInt32Array(NULL, 0); // Partitions
+                    writer.WriteInt32(0);                // UpdateBatchSize
                 }
 
             private:

--- a/modules/platforms/cpp/core/include/ignite/cache/query/query_sql_fields.h
+++ b/modules/platforms/cpp/core/include/ignite/cache/query/query_sql_fields.h
@@ -385,7 +385,7 @@ namespace ignite
                         writer.WriteString(schema);
 
                     writer.WriteInt32Array(NULL, 0); // Partitions
-                    writer.WriteInt32(0);                // UpdateBatchSize
+                    writer.WriteInt32(1);                // UpdateBatchSize
                 }
 
             private:

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
@@ -940,12 +940,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         public void TestPartitionsValidation()
         {
             var cache = Cache();
-
-            // Get before iteration.
-            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson")
-            {
-                Partitions = new int[0]
-            };
+            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson") { Partitions = new int[0] };
 
             var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
             StringAssert.EndsWith("Partitions must not be empty.", ex.Message);
@@ -953,6 +948,19 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             qry.Partitions = new[] {-1, -2};
             ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
             StringAssert.EndsWith("Illegal partition", ex.Message);
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.UpdateBatchSize"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestUpdateBatchSizeValidation()
+        {
+            var cache = Cache();
+            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson") { UpdateBatchSize = -1 };
+
+            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("updateBatchSize cannot be lower than 1", ex.Message);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
@@ -70,7 +70,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 });
             }
         }
-        
+
         /// <summary>
         /// Gets the name mapper.
         /// </summary>
@@ -89,7 +89,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [SetUp]
         public void BeforeTest()
@@ -98,7 +98,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [TearDown]
         public void AfterTest()
@@ -127,7 +127,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         private static ICache<int, QueryPerson> Cache()
@@ -348,7 +348,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// Check SQL query.
         /// </summary>
         [Test]
-        public void TestSqlQuery([Values(true, false)] bool loc, [Values(true, false)] bool keepBinary, 
+        public void TestSqlQuery([Values(true, false)] bool loc, [Values(true, false)] bool keepBinary,
             [Values(true, false)] bool distrJoin)
         {
             var cache = Cache();
@@ -377,7 +377,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// Check SQL fields query.
         /// </summary>
         [Test]
-        public void TestSqlFieldsQuery([Values(true, false)] bool loc, [Values(true, false)] bool distrJoin, 
+        public void TestSqlFieldsQuery([Values(true, false)] bool loc, [Values(true, false)] bool distrJoin,
             [Values(true, false)] bool enforceJoinOrder, [Values(true, false)] bool lazy)
         {
             int cnt = MaxItemCnt;
@@ -609,7 +609,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             // Exception
             exp = PopulateCache(cache, loc, cnt, x => x < 50);
             qry = new ScanQuery<int, TV>(new ScanQueryFilter<TV> {ThrowErr = true});
-            
+
             var ex = Assert.Throws<IgniteException>(() => ValidateQueryResults(cache, qry, exp, keepBinary));
             Assert.AreEqual(ScanQueryFilter<TV>.ErrMessage, ex.Message);
         }
@@ -658,7 +658,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
                 ValidateQueryResults(cache, qry, exp0, keepBinary);
             }
-            
+
         }
 
         /// <summary>
@@ -791,7 +791,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             cache[1] = new QueryPerson("John", 33);
 
             row = cache.Query(new SqlFieldsQuery("select * from QueryPerson")).GetAll()[0];
-            
+
             Assert.AreEqual(3, row.Count);
             Assert.AreEqual(33, row[0]);
             Assert.AreEqual(1, row[1]);
@@ -861,7 +861,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var names = cur.FieldNames;
 
             Assert.AreEqual(new[] {"AGE", "NAME" }, names);
-            
+
             cur.Dispose();
             Assert.AreSame(names, cur.FieldNames);
 
@@ -878,7 +878,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             qry.Sql = "SELECT 1, AGE FROM QueryPerson";
             cur = cache.Query(qry);
             cur.Dispose();
-            
+
             Assert.AreEqual(new[] { "1", "AGE" }, cur.FieldNames);
         }
 
@@ -931,6 +931,28 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 new[] {typeof(int), typeof(int)},
                 new[] {"java.lang.Integer", "java.lang.Integer"}
             );
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.Partitions"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestPartitionsValidation()
+        {
+            var cache = Cache();
+
+            // Get before iteration.
+            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson")
+            {
+                Partitions = new int[0]
+            };
+
+            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Partitions must not be empty.", ex.Message);
+
+            qry.Partitions = new[] {-1, -2};
+            ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Illegal partition", ex.Message);
         }
 
         /// <summary>
@@ -1045,7 +1067,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// <summary>
         /// Asserts that all expected entries have been received.
         /// </summary>
-        private static void AssertMissingExpectedKeys(ICollection<int> exp, ICache<int, QueryPerson> cache, 
+        private static void AssertMissingExpectedKeys(ICollection<int> exp, ICache<int, QueryPerson> cache,
             IList<ICacheEntry<int, object>> all)
         {
             if (exp.Count == 0)
@@ -1058,7 +1080,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             {
                 var part = aff.GetPartition(key);
                 sb.AppendFormat(
-                    "Query did not return expected key '{0}' (exists: {1}), partition '{2}', partition nodes: ", 
+                    "Query did not return expected key '{0}' (exists: {1}), partition '{2}', partition nodes: ",
                     key, cache.Get(key) != null, part);
 
                 var partNodes = aff.MapPartitionToPrimaryAndBackups(part);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
@@ -106,7 +106,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
 
             // Check fields query
             var fieldsQuery = cache
-                .AsCacheQueryable(new QueryOptions {Partitions = new[] {1, 2}})
+                .AsCacheQueryable(new QueryOptions {PartitionsTodo = new[] {1, 2}})
                 .Select(x => x.Value.Name)
                 .ToCacheQueryable();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
@@ -79,7 +79,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             Assert.IsTrue(fq.Local);
             Assert.AreEqual(PersonCount - 11, cache.Query(fq).GetAll().Count);
             Assert.AreEqual(999, fq.PageSize);
-            Assert.IsFalse(fq.EnableDistributedJoins);
             Assert.IsTrue(fq.EnforceJoinOrder);
 #pragma warning disable 618
             Assert.IsTrue(fq.ReplicatedOnly);
@@ -96,13 +95,15 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                 ? "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0._KEY, _T0._VAL from PERSON_ORG_SCHEMA.\"Person\" as _T0 where " +
                   "(_T0.\"_KEY\" > ?), Arguments=[10], " +
-                  "Local=True, PageSize=999, EnableDistributedJoins=False, EnforceJoinOrder=True, " +
-                  "Timeout=00:00:02.5000000, ReplicatedOnly=True, Colocated=True, Schema=, Lazy=True]]"
+                  "Local=True, PageSize=999, EnableDistributedJoins=True, EnforceJoinOrder=True, " +
+                  "Timeout=00:00:02.5000000, Partitions=[1, 2], UpdateBatchSize=12, " +
+                  "Colocated=True, Schema=, Lazy=True]]"
                 : "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0._KEY, _T0._VAL from PERSON_ORG_SCHEMA.Person as _T0 where " +
                   "(_T0._KEY > ?), Arguments=[10], " +
-                  "Local=True, PageSize=999, EnableDistributedJoins=False, EnforceJoinOrder=True, " +
-                  "Timeout=00:00:02.5000000, ReplicatedOnly=True, Colocated=True, Schema=, Lazy=True]]", str);
+                  "Local=True, PageSize=999, EnableDistributedJoins=True, EnforceJoinOrder=True, " +
+                  "Timeout=00:00:02.5000000, Partitions=[1, 2], UpdateBatchSize=12, " +
+                  "Colocated=True, Schema=, Lazy=True]]", str);
 
             // Check fields query
             var fieldsQuery = cache.AsCacheQueryable().Select(x => x.Value.Name).ToCacheQueryable();
@@ -129,11 +130,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                 ? "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0.\"Name\" from PERSON_ORG_SCHEMA.\"Person\" as _T0, Arguments=[], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=False, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]"
+                  "Timeout=00:00:00, Partitions=[], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]"
                 : "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0.NAME from PERSON_ORG_SCHEMA.Person as _T0, Arguments=[], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=False, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]", str);
+                  "Timeout=00:00:00, Partitions=[], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]", str);
 
             // Check distributed joins flag propagation
             var distrQuery = cache.AsCacheQueryable(new QueryOptions { EnableDistributedJoins = true })
@@ -150,13 +151,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                   "(((_T0.\"_KEY\" > ?) and (_T0.\"age1\" > ?)) " +
                   "and (_T0.\"Name\" like \'%\' || ? || \'%\') ), Arguments=[10, 20, x], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=True, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]"
+                  "Timeout=00:00:00, Partitions=[], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]"
                 : "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0._KEY, _T0._VAL from PERSON_ORG_SCHEMA.Person as _T0 where " +
                   "(((_T0._KEY > ?) and (_T0.AGE1 > ?)) " +
                   "and (_T0.NAME like \'%\' || ? || \'%\') ), Arguments=[10, 20, x], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=True, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]", str);
+                  "Timeout=00:00:00, Partitions=[], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]", str);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
@@ -56,7 +56,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                 ReplicatedOnly = true,
 #pragma warning restore 618
                 Colocated = true,
-                Lazy = true
+                Lazy = true,
+                Partitions = new[]{1,2},
+                UpdateBatchSize = 12,
+                EnableDistributedJoins = true
             }).Where(x => x.Key > 10).ToCacheQueryable();
 
             Assert.AreEqual(cache.Name, query.CacheName);
@@ -84,6 +87,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             Assert.IsTrue(fq.Colocated);
             Assert.AreEqual(TimeSpan.FromSeconds(2.5), fq.Timeout);
             Assert.IsTrue(fq.Lazy);
+            Assert.IsTrue(fq.EnableDistributedJoins);
+            Assert.AreEqual(12, fq.UpdateBatchSize);
+            Assert.AreEqual(new[]{1,2}, fq.Partitions);
 
             var str = query.ToString();
             Assert.AreEqual(GetSqlEscapeAll()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
@@ -106,7 +106,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
 
             // Check fields query
             var fieldsQuery = cache
-                .AsCacheQueryable(new QueryOptions {PartitionsTodo = new[] {1, 2}})
+                .AsCacheQueryable(new QueryOptions {Partitions = new[] {1, 2}})
                 .Select(x => x.Value.Name)
                 .ToCacheQueryable();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
@@ -80,7 +80,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var qry = new SqlQuery(typeof(Person),
                 string.Format("from \"{0}\".Person, \"{1}\".Person as p2 where Person.Id = 11 - p2.Id",
                     CacheName, CacheName2));
-            
+
             Assert.Greater(Count, cache.Query(qry).Count());
 
             // Distributed join fixes the problem.
@@ -136,7 +136,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             // Non-distributed join returns incomplete results.
             var qry = new SqlFieldsQuery(string.Format(
-                "select p2.Name from \"{0}\".Person, \"{1}\".Person as p2 where Person.Id = 11 - p2.Id", 
+                "select p2.Name from \"{0}\".Person, \"{1}\".Person as p2 where Person.Id = 11 - p2.Id",
                 CacheName, CacheName2));
 
             Assert.Greater(Count, cache.Query(qry).Count());
@@ -227,6 +227,36 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             Assert.AreEqual(1, res[0][0]);
             Assert.AreEqual("baz", cache[-10].Name);
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.Partitions"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestPartitionsValidation()
+        {
+            var cache = GetClientCache<Person>();
+            var qry = new SqlFieldsQuery("SELECT * FROM Person") { Partitions = new int[0] };
+
+            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Partitions must not be empty.", ex.Message);
+
+            qry.Partitions = new[] {-1, -2};
+            ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Illegal partition", ex.Message);
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.UpdateBatchSize"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestUpdateBatchSizeValidation()
+        {
+            var cache = GetClientCache<Person>();
+            var qry = new SqlFieldsQuery("SELECT * FROM Person") { UpdateBatchSize = -1 };
+
+            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("updateBatchSize cannot be lower than 1", ex.Message);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
@@ -238,11 +238,11 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var cache = GetClientCache<Person>();
             var qry = new SqlFieldsQuery("SELECT * FROM Person") { Partitions = new int[0] };
 
-            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            var ex = Assert.Throws<IgniteClientException>(() => cache.Query(qry).GetAll());
             StringAssert.EndsWith("Partitions must not be empty.", ex.Message);
 
             qry.Partitions = new[] {-1, -2};
-            ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            ex = Assert.Throws<IgniteClientException>(() => cache.Query(qry).GetAll());
             StringAssert.EndsWith("Illegal partition", ex.Message);
         }
 
@@ -255,7 +255,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var cache = GetClientCache<Person>();
             var qry = new SqlFieldsQuery("SELECT * FROM Person") { UpdateBatchSize = -1 };
 
-            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            var ex = Assert.Throws<IgniteClientException>(() => cache.Query(qry).GetAll());
             StringAssert.EndsWith("updateBatchSize cannot be lower than 1", ex.Message);
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -161,6 +161,7 @@ namespace Apache.Ignite.Core.Cache.Query
         /// <para />
         /// The query will be executed only on nodes which are primary for specified partitions.
         /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public int[] Partitions { get; set; }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -32,6 +32,9 @@ namespace Apache.Ignite.Core.Cache.Query
         /// <summary> Default page size. </summary>
         public const int DefaultPageSize = 1024;
 
+        /// <summary> Default value for <see cref="UpdateBatchSize"/>. </summary>
+        public const int DefaultUpdateBatchSize = 1;
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -151,6 +154,20 @@ namespace Apache.Ignite.Core.Cache.Query
         /// consumption at the cost of moderate performance hit.
         /// </summary>
         public bool Lazy { get; set; }
+
+        /// <summary>
+        /// Gets or sets partitions for the query.
+        /// <para />
+        /// The query will be executed only on nodes which are primary for specified partitions.
+        /// </summary>
+        public int[] Partitions { get; set; }
+
+        /// <summary>
+        /// Gets or sets batch size for update queries.
+        /// <para />
+        /// Default is 1 (<see cref="DefaultUpdateBatchSize"/>.
+        /// </summary>
+        public int UpdateBatchSize { get; set; }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -58,6 +58,7 @@ namespace Apache.Ignite.Core.Cache.Query
             Arguments = args;
 
             PageSize = DefaultPageSize;
+            UpdateBatchSize = DefaultUpdateBatchSize;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -177,15 +177,19 @@ namespace Apache.Ignite.Core.Cache.Query
         /// </returns>
         public override string ToString()
         {
-            var args = string.Join(", ", Arguments.Select(x => x == null ? "null" : x.ToString()));
+            var args = Arguments == null
+                ? ""
+                : string.Join(", ", Arguments.Select(x => x == null ? "null" : x.ToString()));
+
+            var parts = Partitions == null
+                ? ""
+                : string.Join(", ", Partitions.Select(x => x.ToString()));
 
             return string.Format("SqlFieldsQuery [Sql={0}, Arguments=[{1}], Local={2}, PageSize={3}, " +
-                                 "EnableDistributedJoins={4}, EnforceJoinOrder={5}, Timeout={6}, ReplicatedOnly={7}" +
-                                 ", Colocated={8}, Schema={9}, Lazy={10}]", Sql, args, Local,
-#pragma warning disable 618
-                                 PageSize, EnableDistributedJoins, EnforceJoinOrder, Timeout, ReplicatedOnly,
-#pragma warning restore 618
-                                 Colocated, Schema, Lazy);
+                                 "EnableDistributedJoins={4}, EnforceJoinOrder={5}, Timeout={6}, Partitions={7}, " +
+                                 "UpdateBatchSize={8}, Colocated={9}, Schema={10}, Lazy={11}]", Sql, args, Local,
+                                 PageSize, EnableDistributedJoins, EnforceJoinOrder, Timeout, parts,
+                                 UpdateBatchSize, Colocated, Schema, Lazy);
         }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -187,7 +187,7 @@ namespace Apache.Ignite.Core.Cache.Query
                 : string.Join(", ", Partitions.Select(x => x.ToString()));
 
             return string.Format("SqlFieldsQuery [Sql={0}, Arguments=[{1}], Local={2}, PageSize={3}, " +
-                                 "EnableDistributedJoins={4}, EnforceJoinOrder={5}, Timeout={6}, Partitions={7}, " +
+                                 "EnableDistributedJoins={4}, EnforceJoinOrder={5}, Timeout={6}, Partitions=[{7}], " +
                                  "UpdateBatchSize={8}, Colocated={9}, Schema={10}, Lazy={11}]", Sql, args, Local,
                                  PageSize, EnableDistributedJoins, EnforceJoinOrder, Timeout, parts,
                                  UpdateBatchSize, Colocated, Schema, Lazy);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -219,6 +219,8 @@ namespace Apache.Ignite.Core.Cache.Query
 #pragma warning restore 618
             writer.WriteBoolean(Colocated);
             writer.WriteString(Schema); // Schema
+            writer.WriteIntArray(Partitions);
+            writer.WriteInt(UpdateBatchSize);
         }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -114,6 +114,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             return GetComplexTypeHashCode(val, marsh, affinityKeyFieldIds);
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static int GetComplexTypeHashCode<T>(T val, Marshaller marsh, IDictionary<int, int> affinityKeyFieldIds)
         {
             using (var stream = new BinaryHeapStream(128))

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -951,7 +951,21 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             writer.WriteBoolean(qry.Lazy);
             writer.WriteTimeSpanAsLong(qry.Timeout);
             writer.WriteBoolean(includeColumns);
-            writer.WriteIntArray(qry.Partitions);
+
+            if (qry.Partitions != null)
+            {
+                writer.WriteInt(qry.Partitions.Length);
+
+                foreach (var part in qry.Partitions)
+                {
+                    writer.WriteInt(part);
+                }
+            }
+            else
+            {
+                writer.WriteInt(-1);
+            }
+
             writer.WriteInt(qry.UpdateBatchSize);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -331,7 +331,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             IgniteArgumentCheck.NotNull(val, "val");
 
             _ignite.Transactions.StartTxIfNeeded();
-            
+
             return DoOutInOpAffinity(ClientOp.CacheGetAndReplace, key, val, UnmarshalCacheResult<TV>);
         }
 
@@ -951,6 +951,8 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             writer.WriteBoolean(qry.Lazy);
             writer.WriteTimeSpanAsLong(qry.Timeout);
             writer.WriteBoolean(includeColumns);
+            writer.WriteIntArray(qry.Partitions);
+            writer.WriteInt(qry.UpdateBatchSize);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
@@ -26,6 +26,9 @@ namespace Apache.Ignite.Core.Impl.Client
         ExecuteTaskByName = 1,
         // ClusterStates = 2,
         ClusterGroupGetNodesEndpoints = 3,
-        ClusterGroups = 4
+        ClusterGroups = 4,
+        ServiceInvoke = 5,
+        DefaultQueryTimeout = 6,
+        QueryPartitionsBatchSize = 7
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Core.Impl.Client
 {
     /// <summary>
     /// Client feature ids. Values represent the index in the bit array.
+    /// Unsupported flags must be commented out.
     /// </summary>
     internal enum ClientBitmaskFeature
     {
@@ -27,8 +28,8 @@ namespace Apache.Ignite.Core.Impl.Client
         // ClusterStates = 2,
         ClusterGroupGetNodesEndpoints = 3,
         ClusterGroups = 4,
-        ServiceInvoke = 5,
-        DefaultQueryTimeout = 6,
+        ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
+        // DefaultQueryTimeout = 6, // IGNITE-13692
         QueryPartitionsBatchSize = 7
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;CODE_ANALYSIS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -38,7 +38,7 @@ namespace Apache.Ignite.Linq.Impl
     {
         /** */
         private readonly ICacheInternal _cache;
-        
+
         /** */
         private readonly QueryOptions _options;
 
@@ -210,7 +210,9 @@ namespace Apache.Ignite.Linq.Impl
                 Colocated = _options.Colocated,
                 Local = _options.Local,
                 Arguments = args,
-                Lazy = _options.Lazy
+                Lazy = _options.Lazy,
+                UpdateBatchSize = _options.UpdateBatchSize,
+                Partitions = _options.Partitions
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -212,7 +212,7 @@ namespace Apache.Ignite.Linq.Impl
                 Arguments = args,
                 Lazy = _options.Lazy,
                 UpdateBatchSize = _options.UpdateBatchSize,
-                Partitions = _options.Partitions
+                Partitions = _options.PartitionsTodo
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -212,7 +212,7 @@ namespace Apache.Ignite.Linq.Impl
                 Arguments = args,
                 Lazy = _options.Lazy,
                 UpdateBatchSize = _options.UpdateBatchSize,
-                Partitions = _options.PartitionsTodo
+                Partitions = _options.Partitions
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Linq
 {
     using System;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Cache.Query;
 
@@ -134,6 +135,7 @@ namespace Apache.Ignite.Linq
         /// <para />
         /// The query will be executed only on nodes which are primary for specified partitions.
         /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public int[] Partitions { get; set; }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
@@ -135,7 +135,8 @@ namespace Apache.Ignite.Linq
         /// <para />
         /// The query will be executed only on nodes which are primary for specified partitions.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
+            Justification = "Consistency")]
         public int[] Partitions { get; set; }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
@@ -135,9 +135,8 @@ namespace Apache.Ignite.Linq
         /// <para />
         /// The query will be executed only on nodes which are primary for specified partitions.
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
-            Justification = "Consistency")]
-        public int[] PartitionsTodo { get; set; }
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public int[] Partitions { get; set; }
 
         /// <summary>
         /// Gets or sets batch size for update queries.

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
@@ -137,7 +137,7 @@ namespace Apache.Ignite.Linq
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays",
             Justification = "Consistency")]
-        public int[] Partitions { get; set; }
+        public int[] PartitionsTodo { get; set; }
 
         /// <summary>
         /// Gets or sets batch size for update queries.

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
@@ -30,16 +30,20 @@ namespace Apache.Ignite.Linq
         /// <summary> Default page size. </summary>
         public const int DefaultPageSize = SqlFieldsQuery.DefaultPageSize;
 
+        /// <summary> Default value for <see cref="UpdateBatchSize"/>. </summary>
+        public const int DefaultUpdateBatchSize = SqlFieldsQuery.DefaultUpdateBatchSize;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryOptions"/> class.
         /// </summary>
         public QueryOptions()
         {
             PageSize = DefaultPageSize;
+            UpdateBatchSize = DefaultUpdateBatchSize;
         }
 
         /// <summary>
-        /// Local flag. When set query will be executed only on local node, so only local 
+        /// Local flag. When set query will be executed only on local node, so only local
         /// entries will be returned as query result.
         /// <para />
         /// Defaults to <c>false</c>.
@@ -53,7 +57,7 @@ namespace Apache.Ignite.Linq
         public int PageSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the table. 
+        /// Gets or sets the name of the table.
         /// <para />
         /// Table name is equal to short class name of a cache value.
         /// When a cache has only one type of values, or only one <see cref="QueryEntity" /> defined,
@@ -124,5 +128,19 @@ namespace Apache.Ignite.Linq
         /// consumption at the cost of moderate performance hit.
         /// </summary>
         public bool Lazy { get; set; }
+
+        /// <summary>
+        /// Gets or sets partitions for the query.
+        /// <para />
+        /// The query will be executed only on nodes which are primary for specified partitions.
+        /// </summary>
+        public int[] Partitions { get; set; }
+
+        /// <summary>
+        /// Gets or sets batch size for update queries.
+        /// <para />
+        /// Default is 1 (<see cref="DefaultUpdateBatchSize"/>.
+        /// </summary>
+        public int UpdateBatchSize { get; set; }
     }
 }


### PR DESCRIPTION
* Add `Partitions` and `UpdateBatchSize` to `SqlFieldsQuery` and `QueryOptions` (LINQ) for thick and thin APIs
* Add `updateBatchSize` validation on the server side (invalid values were ignored previously)
* Propagate `updateBatchSize` and `partitions` in Java thin client