### PR TITLE
IGNITE-13636: Fix ODBC Date metadata

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcColumnMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcColumnMeta.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.processors.odbc.odbc;
 
 import org.apache.ignite.binary.BinaryRawWriter;
 import org.apache.ignite.internal.binary.BinaryUtils;
+import org.apache.ignite.internal.binary.GridBinaryMarshaller;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProtocolVersion;
 import org.apache.ignite.internal.processors.query.GridQueryFieldMetadata;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -128,7 +129,7 @@ public class OdbcColumnMeta {
         writer.writeString(tableName);
         writer.writeString(columnName);
 
-        byte typeId = BinaryUtils.typeByClass(dataType);
+        byte typeId = getTypeId(dataType);
 
         writer.writeByte(typeId);
 
@@ -136,6 +137,18 @@ public class OdbcColumnMeta {
             writer.writeInt(precision);
             writer.writeInt(scale);
         }
+    }
+
+    /**
+     * Get ODBC type ID for the type.
+     * @param dataType Data type class.
+     * @return Type ID.
+     */
+    private static byte getTypeId(Class<?> dataType) {
+        if (dataType.equals(java.sql.Date.class))
+            return GridBinaryMarshaller.DATE;
+
+        return BinaryUtils.typeByClass(dataType);
     }
 
     /** {@inheritDoc} */

--- a/modules/platforms/cpp/odbc-test/src/cursor_binding_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/cursor_binding_test.cpp
@@ -217,13 +217,13 @@ BOOST_AUTO_TEST_CASE(TestCursorBindingColumnWise)
     ret = SQLBindCol(stmt, 7, SQL_C_BIT, boolFields, 0, boolFieldsInd);
     ODBC_THROW_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
 
-    ret = SQLBindCol(stmt, 8, SQL_C_DATE, dateFields, 0, dateFieldsInd);
+    ret = SQLBindCol(stmt, 8, SQL_C_TYPE_DATE, dateFields, 0, dateFieldsInd);
     ODBC_THROW_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
 
-    ret = SQLBindCol(stmt, 9, SQL_C_TIME, timeFields, 0, timeFieldsInd);
+    ret = SQLBindCol(stmt, 9, SQL_C_TYPE_TIME, timeFields, 0, timeFieldsInd);
     ODBC_THROW_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
 
-    ret = SQLBindCol(stmt, 10, SQL_C_TIMESTAMP, timestampFields, 0, timestampFieldsInd);
+    ret = SQLBindCol(stmt, 10, SQL_C_TYPE_TIMESTAMP, timestampFields, 0, timestampFieldsInd);
     ODBC_THROW_ON_ERROR(ret, SQL_HANDLE_STMT, stmt);
 
     ret = SQLBindCol(stmt, 11, SQL_C_BINARY, i8ArrayFields, BUFFER_SIZE, i8ArrayFieldsLen);

--- a/modules/platforms/cpp/odbc-test/src/meta_queries_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/meta_queries_test.cpp
@@ -161,6 +161,91 @@ BOOST_AUTO_TEST_CASE(TestGetTypeInfoAllTypes)
         BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 }
 
+BOOST_AUTO_TEST_CASE(TestDateTypeColumnAttributeCurdate)
+{
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+
+    SQLCHAR req[] = "select CURDATE()";
+    SQLExecDirect(stmt, req, SQL_NTS);
+
+    SQLLEN intVal = 0;
+
+    SQLRETURN ret = SQLColAttribute(stmt, 1, SQL_DESC_TYPE, 0, 0, 0, &intVal);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(intVal, SQL_TYPE_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestDateTypeColumnAttributeLiteral)
+{
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+
+    SQLCHAR req[] = "select DATE '2020-10-25'";
+    SQLExecDirect(stmt, req, SQL_NTS);
+
+    SQLLEN intVal = 0;
+
+    SQLRETURN ret = SQLColAttribute(stmt, 1, SQL_DESC_TYPE, 0, 0, 0, &intVal);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(intVal, SQL_TYPE_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestDateTypeColumnAttributeField)
+{
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+
+    SQLCHAR req[] = "select CAST (dateField as DATE) from TestType";
+    SQLExecDirect(stmt, req, SQL_NTS);
+
+    SQLLEN intVal = 0;
+
+    SQLRETURN ret = SQLColAttribute(stmt, 1, SQL_DESC_TYPE, 0, 0, 0, &intVal);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(intVal, SQL_TYPE_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestTimeTypeColumnAttributeLiteral)
+{
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+
+    SQLCHAR req[] = "select TIME '12:42:13'";
+    SQLExecDirect(stmt, req, SQL_NTS);
+
+    SQLLEN intVal = 0;
+
+    SQLRETURN ret = SQLColAttribute(stmt, 1, SQL_DESC_TYPE, 0, 0, 0, &intVal);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(intVal, SQL_TYPE_TIME);
+}
+
+BOOST_AUTO_TEST_CASE(TestTimeTypeColumnAttributeField)
+{
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+
+    SQLCHAR req[] = "select timeField from TestType";
+    SQLExecDirect(stmt, req, SQL_NTS);
+
+    SQLLEN intVal = 0;
+
+    SQLRETURN ret = SQLColAttribute(stmt, 1, SQL_DESC_TYPE, 0, 0, 0, &intVal);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(intVal, SQL_TYPE_TIME);
+}
+
 BOOST_AUTO_TEST_CASE(TestColAttributesColumnLength)
 {
     Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");

--- a/modules/platforms/cpp/odbc-test/src/odbc_test_suite.cpp
+++ b/modules/platforms/cpp/odbc-test/src/odbc_test_suite.cpp
@@ -584,19 +584,19 @@ namespace ignite
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
             BOOST_TEST_CHECKPOINT("Binding dateFields");
-            ret = SQLBindParameter(stmt, 9, SQL_PARAM_INPUT, SQL_C_DATE, SQL_DATE, 0, 0, dateFields.GetData(), 0, 0);
+            ret = SQLBindParameter(stmt, 9, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_DATE, 0, 0, dateFields.GetData(), 0, 0);
 
             if (!SQL_SUCCEEDED(ret))
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
             BOOST_TEST_CHECKPOINT("Binding timeFields");
-            ret = SQLBindParameter(stmt, 10, SQL_PARAM_INPUT, SQL_C_TIME, SQL_TIME, 0, 0, timeFields.GetData(), 0, 0);
+            ret = SQLBindParameter(stmt, 10, SQL_PARAM_INPUT, SQL_C_TYPE_TIME, SQL_TYPE_TIME, 0, 0, timeFields.GetData(), 0, 0);
 
             if (!SQL_SUCCEEDED(ret))
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
             BOOST_TEST_CHECKPOINT("Binding timestampFields");
-            ret = SQLBindParameter(stmt, 11, SQL_PARAM_INPUT, SQL_C_TIMESTAMP, SQL_TIMESTAMP, 0, 0, timestampFields.GetData(), 0, 0);
+            ret = SQLBindParameter(stmt, 11, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP, 0, 0, timestampFields.GetData(), 0, 0);
 
             if (!SQL_SUCCEEDED(ret))
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));

--- a/modules/platforms/cpp/odbc-test/src/queries_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/queries_test.cpp
@@ -748,15 +748,15 @@ BOOST_AUTO_TEST_CASE(TestNullFields)
     if (!SQL_SUCCEEDED(ret))
         BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-    ret = SQLBindCol(stmt, 9, SQL_C_DATE, &dateColumn, 0, &columnLens[8]);
+    ret = SQLBindCol(stmt, 9, SQL_C_TYPE_DATE, &dateColumn, 0, &columnLens[8]);
     if (!SQL_SUCCEEDED(ret))
         BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-    ret = SQLBindCol(stmt, 10, SQL_C_TIME, &timeColumn, 0, &columnLens[9]);
+    ret = SQLBindCol(stmt, 10, SQL_C_TYPE_TIME, &timeColumn, 0, &columnLens[9]);
     if (!SQL_SUCCEEDED(ret))
         BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-    ret = SQLBindCol(stmt, 11, SQL_C_TIMESTAMP, &timestampColumn, 0, &columnLens[10]);
+    ret = SQLBindCol(stmt, 11, SQL_C_TYPE_TIMESTAMP, &timestampColumn, 0, &columnLens[10]);
     if (!SQL_SUCCEEDED(ret))
         BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 

--- a/modules/platforms/cpp/odbc-test/src/sql_test_suite_fixture.cpp
+++ b/modules/platforms/cpp/odbc-test/src/sql_test_suite_fixture.cpp
@@ -253,7 +253,7 @@ namespace ignite
     {
         SQL_DATE_STRUCT res;
 
-        CheckSingleResult0(request, SQL_C_DATE, &res, 0, 0);
+        CheckSingleResult0(request, SQL_C_TYPE_DATE, &res, 0, 0);
     }
 
     template<>
@@ -261,7 +261,7 @@ namespace ignite
     {
         SQL_TIMESTAMP_STRUCT res;
 
-        CheckSingleResult0(request, SQL_C_TIMESTAMP, &res, 0, 0);
+        CheckSingleResult0(request, SQL_C_TYPE_TIMESTAMP, &res, 0, 0);
     }
 
     template<>
@@ -269,7 +269,7 @@ namespace ignite
     {
         SQL_TIME_STRUCT res;
 
-        CheckSingleResult0(request, SQL_C_TIME, &res, 0, 0);
+        CheckSingleResult0(request, SQL_C_TYPE_TIME, &res, 0, 0);
     }
 
     template<>
@@ -305,7 +305,7 @@ namespace ignite
     {
         SQL_DATE_STRUCT res;
 
-        CheckSingleResult0(request, SQL_C_DATE, &res, 0, 0);
+        CheckSingleResult0(request, SQL_C_TYPE_DATE, &res, 0, 0);
 
         using ignite::impl::binary::BinaryUtils;
         Date actual = common::MakeDateGmt(res.year, res.month, res.day);
@@ -317,7 +317,7 @@ namespace ignite
     {
         SQL_TIMESTAMP_STRUCT res;
 
-        CheckSingleResult0(request, SQL_C_TIMESTAMP, &res, 0, 0);
+        CheckSingleResult0(request, SQL_C_TYPE_TIMESTAMP, &res, 0, 0);
 
         using ignite::impl::binary::BinaryUtils;
         Timestamp actual = common::MakeTimestampGmt(res.year, res.month, res.day, res.hour, res.minute, res.second, res.fraction);
@@ -331,7 +331,7 @@ namespace ignite
     {
         SQL_TIME_STRUCT res;
 
-        CheckSingleResult0(request, SQL_C_TIME, &res, 0, 0);
+        CheckSingleResult0(request, SQL_C_TYPE_TIME, &res, 0, 0);
 
         using ignite::impl::binary::BinaryUtils;
         Time actual = common::MakeTimeGmt(res.hour, res.minute, res.second);

--- a/modules/platforms/cpp/odbc-test/src/sql_types_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/sql_types_test.cpp
@@ -304,4 +304,128 @@ BOOST_AUTO_TEST_CASE(TestTimeInsert)
     BOOST_REQUIRE_EQUAL(out.timeField.GetSeconds(), expected.GetSeconds());
 }
 
+void FetchAndCheckDate(SQLHSTMT stmt, const std::string& req, SQLSMALLINT dataType)
+{
+    std::vector<SQLCHAR> req0(req.begin(), req.end());
+    req0.push_back(0);
+
+    SQLExecDirect(stmt, &req0[0], SQL_NTS);
+
+    SQL_DATE_STRUCT res;
+
+    memset(&res, 0, sizeof(res));
+
+    SQLLEN resLen = 0;
+    SQLRETURN ret = SQLBindCol(stmt, 1, dataType, &res, 0, &resLen);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    ret = SQLFetch(stmt);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(res.day, 25);
+    BOOST_CHECK_EQUAL(res.month, 10);
+    BOOST_CHECK_EQUAL(res.year, 2020);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchLiteralDate)
+{
+    FetchAndCheckDate(stmt, "select DATE '2020-10-25'", SQL_C_TYPE_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchLiteralDateLegacy)
+{
+    FetchAndCheckDate(stmt, "select DATE '2020-10-25'", SQL_C_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchFieldDateAsDate)
+{
+    TestType val1;
+    val1.dateField = common::MakeDateGmt(2020, 10, 25);
+
+    testCache.Put(1, val1);
+
+    FetchAndCheckDate(stmt, "select CAST (dateField as DATE) from TestType", SQL_C_TYPE_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchFieldDateAsDateLegacy)
+{
+    TestType val1;
+    val1.dateField = common::MakeDateGmt(2020, 10, 25);
+
+    testCache.Put(1, val1);
+
+    FetchAndCheckDate(stmt, "select CAST (dateField as DATE) from TestType", SQL_C_DATE);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchFieldDateAsIs)
+{
+    TestType val1;
+    val1.dateField = common::MakeDateGmt(2020, 10, 25);
+
+    testCache.Put(1, val1);
+
+    FetchAndCheckDate(stmt, "select dateField from TestType", SQL_C_TYPE_DATE);
+}
+
+void FetchAndCheckTime(SQLHSTMT stmt, const std::string& req, SQLSMALLINT dataType)
+{
+    std::vector<SQLCHAR> req0(req.begin(), req.end());
+    req0.push_back(0);
+
+    SQLExecDirect(stmt, &req0[0], SQL_NTS);
+
+    SQL_TIME_STRUCT res;
+
+    memset(&res, 0, sizeof(res));
+
+    SQLLEN resLen = 0;
+    SQLRETURN ret = SQLBindCol(stmt, 1, dataType, &res, 0, &resLen);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    ret = SQLFetch(stmt);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(res.hour,   12);
+    BOOST_CHECK_EQUAL(res.minute, 42);
+    BOOST_CHECK_EQUAL(res.second, 13);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchLiteralTime)
+{
+    FetchAndCheckTime(stmt, "select TIME '12:42:13'", SQL_C_TYPE_TIME);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchLiteralTimeLegacy)
+{
+    FetchAndCheckTime(stmt, "select TIME '12:42:13'", SQL_C_TYPE_TIME);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchFieldTimeAsIs)
+{
+    TestType val1;
+    val1.timeField = common::MakeTimeGmt(12, 42, 13);
+
+    testCache.Put(1, val1);
+
+    FetchAndCheckTime(stmt, "select timeField from TestType", SQL_C_TYPE_TIME);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchFieldTimeAsIsLegacy)
+{
+    TestType val1;
+    val1.timeField = common::MakeTimeGmt(12, 42, 13);
+
+    testCache.Put(1, val1);
+
+    FetchAndCheckTime(stmt, "select timeField from TestType", SQL_C_TIME);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/odbc/src/type_traits.cpp
+++ b/modules/platforms/cpp/odbc/src/type_traits.cpp
@@ -336,12 +336,15 @@ namespace ignite
                 case SQL_C_BINARY:
                     return OdbcNativeType::AI_BINARY;
 
+                case SQL_C_DATE:
                 case SQL_C_TYPE_DATE:
                     return OdbcNativeType::AI_TDATE;
 
+                case SQL_C_TIME:
                 case SQL_C_TYPE_TIME:
                     return OdbcNativeType::AI_TTIME;
 
+                case SQL_C_TIMESTAMP:
                 case SQL_C_TYPE_TIMESTAMP:
                     return OdbcNativeType::AI_TTIMESTAMP;
 


### PR DESCRIPTION
Currently, Date collumns reported as SQL_BINARY by ODBC because we only recognize `java.util.Date` as SQL_DATE, not `java.sql.Date`. Added check, that if the column is of type `java.sql.Date` then report it as SQL_DATE also.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
