### PR TITLE
IGNITE-13705 : Another node fails with failure of target node.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -213,7 +213,7 @@ class ServerImpl extends TcpDiscoveryImpl {
     private static final TcpDiscoveryAbstractMessage WAKEUP = new TcpDiscoveryDummyWakeupMessage();
 
     /** Maximal interval of connection check to next node in the ring. */
-    private static final long MAX_NEXT_NODE_PING_INTERVAL = 500;
+    private static final long MAX_CON_CHECK_INTERVAL = 500;
 
     /** Interval of checking connection to next node in the ring. */
     private long connCheckInterval;
@@ -395,7 +395,7 @@ class ServerImpl extends TcpDiscoveryImpl {
 
         // Since we take in account time of last sent message, the interval should be quite short to give enough piece
         // of failure detection timeout as send-and-acknowledge timeout of the message to send.
-        connCheckInterval = Math.min(effectiveExchangeTimeout() / 4, MAX_NEXT_NODE_PING_INTERVAL);
+        connCheckInterval = Math.min(effectiveExchangeTimeout() / 4, MAX_CON_CHECK_INTERVAL);
 
         connectionCheckTimeout = effectiveExchangeTimeout() / 5;
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -6900,7 +6900,7 @@ class ServerImpl extends TcpDiscoveryImpl {
                                 }
 
                                 // Connection recoverty to next node has timeout {@code connectionCheckTimeout}.
-                                // We need to suppose network delays. So we use hals of this time.
+                                // We need to suppose network delays. So we use half of this time.
                                 liveAddr = checkConnection(new ArrayList<>(nodeAddrs), (int)connectionCheckTimeout / 2);
 
                                 if (log.isInfoEnabled()) {

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -213,13 +213,13 @@ class ServerImpl extends TcpDiscoveryImpl {
     private static final TcpDiscoveryAbstractMessage WAKEUP = new TcpDiscoveryDummyWakeupMessage();
 
     /** Maximal interval of connection check to next node in the ring. */
-    private static final long MAX_CON_CHECK_INTERVAL = 500;
-
-    /** Minimal timeout to find connection to some next node in the ring while connection recovering. */
-    private static final long MIN_RECOVERY_TIMEOUT = 200;
+    private static final long MAX_NEXT_NODE_PING_INTERVAL = 500;
 
     /** Interval of checking connection to next node in the ring. */
-    private long connCheckInterval;
+    private long nextNodePingInterval;
+
+    /** Fundamental value for connection checking actions. */
+    private long connectionCheckTimeout;
 
     /** */
     private IgniteThreadPoolExecutor utilityPool;
@@ -380,7 +380,7 @@ class ServerImpl extends TcpDiscoveryImpl {
 
     /** {@inheritDoc} */
     @Override public long connectionCheckInterval() {
-        return connCheckInterval;
+        return nextNodePingInterval;
     }
 
     /** {@inheritDoc} */
@@ -395,7 +395,9 @@ class ServerImpl extends TcpDiscoveryImpl {
 
         // Since we take in account time of last sent message, the interval should be quite short to give enough piece
         // of failure detection timeout as send-and-acknowledge timeout of the message to send.
-        connCheckInterval = Math.min(effectiveExchangeTimeout() / 4, MAX_CON_CHECK_INTERVAL);
+        nextNodePingInterval = Math.min(effectiveExchangeTimeout() / 4, MAX_NEXT_NODE_PING_INTERVAL);
+
+        connectionCheckTimeout = effectiveExchangeTimeout() / 5;
 
         utilityPool = new IgniteThreadPoolExecutor("disco-pool",
             spi.ignite().name(),
@@ -6506,7 +6508,7 @@ class ServerImpl extends TcpDiscoveryImpl {
          * Check connection to next node in the ring.
          */
         private void checkConnection() {
-            long elapsed = (lastRingMsgSentTime + U.millisToNanos(connCheckInterval)) - System.nanoTime();
+            long elapsed = (lastRingMsgSentTime + U.millisToNanos(nextNodePingInterval)) - System.nanoTime();
 
             if (elapsed > 0)
                 return;
@@ -6530,34 +6532,12 @@ class ServerImpl extends TcpDiscoveryImpl {
      */
     private IgniteSpiOperationTimeoutHelper serverOperationTimeoutHelper(@Nullable CrossRingMessageSendState sndState,
         long lastOperationNanos) {
-        long absoluteThreshold = -1;
-
-        // Active send-state means we lost connection to next node and have to find another.
-        // We don't know how many nodes failed. May be several failed in a row. But we got only one
-        // connectionRecoveryTimeout to establish new connection to the ring. We can't spend this timeout wholly on one
-        // or two next nodes. We should slice it and try to travers as many as we can.
-        if (sndState != null) {
-            int nodesLeft = ring.serverNodes().size() - 1 - sndState.failedNodes;
-
-            assert nodesLeft > 0;
-
-            long now = System.nanoTime();
-
-            // In case of large cluster and small connectionRecoveryTimeout we have to provide reasonable minimal
-            // timeout per one of the next nodes. It should not appear too small like 1, 5 or 10ms.
-            long perNodeTimeout = Math.max((sndState.failTimeNanos - now) / nodesLeft, MIN_RECOVERY_TIMEOUT);
-
-            if (log.isDebugEnabled()) {
-                log.debug("Connection recovery timeout: totalTimeLeft=" +
-                    U.nanosToMillis(sndState.failTimeNanos - now) + ", perNodeTimeout=" + perNodeTimeout +
-                    ", totalServers=" + ring.serverNodes().size() + ", failedServers=" + sndState.failedNodes +
-                    ", aliveServers=" + nodesLeft + ", minPerNodeTimeout=" + MIN_RECOVERY_TIMEOUT);
-            }
-
-            absoluteThreshold = Math.min(sndState.failTimeNanos, now + perNodeTimeout);
-        }
-
-        return new IgniteSpiOperationTimeoutHelper(spi, true, lastOperationNanos, absoluteThreshold);
+        // Active send-state means we lost connection to next node and have to find another. We don't know how many
+        // nodes failed. May be several failed in a row. But we got only one connectionRecoveryTimeout to establish new
+        // connection. We should travers rest of the cluster with sliced timeout for each node. connectionCheckTimeout
+        // is doubled because the backward connection is performed with this timeout. And network delays are supposed.
+        return new IgniteSpiOperationTimeoutHelper(spi, true, lastOperationNanos, sndState == null ? -1 :
+            Math.min(sndState.failTimeNanos, System.nanoTime() + connectionCheckTimeout * 2));
     }
 
     /** Fixates time of last sent message. */
@@ -6917,22 +6897,12 @@ class ServerImpl extends TcpDiscoveryImpl {
                                 (req.checkPreviousNodeId() == null || previous.id().equals(req.checkPreviousNodeId()))) {
                                 Collection<InetSocketAddress> nodeAddrs = spi.getNodeAddresses(previous, false);
 
-                                // If node loses connection, it determines piece of the connection recovery timeout for
-                                // each node left in the ring to establish connection with. Current node has no
-                                // reason to do any checks longer. Otherwise, the requesting node can get segmented.
-                                // Also, we have to suppose network delays. We put half of the timeout on it.
-                                // @see serverOperationTimeoutHelper(CrossRingMessageSendState, long)
-                                // @see MIN_RECOVERY_TIMEOUT
-                                int checkTimeout = (int)(req.maxAwaitMills() > 0 ?
-                                    Math.min(req.maxAwaitMills() / 2, U.nanosToMillis(timeThreshold - now)) :
-                                    U.nanosToMillis(timeThreshold - now));
-
                                 if (log.isDebugEnabled()) {
                                     log.debug("Remote node requests topology change. Checking connection to " +
-                                        "previous node [" + previous + "] with timeout " + checkTimeout);
+                                        "previous node [" + previous + "] with timeout " + (int)connectionCheckTimeout);
                                 }
 
-                                liveAddr = checkConnection(new ArrayList<>(nodeAddrs), checkTimeout);
+                                liveAddr = checkConnection(new ArrayList<>(nodeAddrs), (int)connectionCheckTimeout);
 
                                 if (log.isInfoEnabled()) {
                                     log.info("Connection check to previous node done: [liveAddr=" + liveAddr
@@ -6953,7 +6923,7 @@ class ServerImpl extends TcpDiscoveryImpl {
                                 ", checkPreviousNodeId=" + req.checkPreviousNodeId() +
                                 ", actualPreviousNode=" + previous +
                                 ", lastMessageReceivedTime=" + rcvdTime + ", now=" + now +
-                                ", connCheckInterval=" + connCheckInterval + ']');
+                                ", connCheckInterval=" + nextNodePingInterval + ']');
                         }
                     }
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/messages/TcpDiscoveryHandshakeRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/messages/TcpDiscoveryHandshakeRequest.java
@@ -30,6 +30,9 @@ public class TcpDiscoveryHandshakeRequest extends TcpDiscoveryAbstractMessage {
     /** */
     private UUID prevNodeId;
 
+    /** Max await time for response. If > 0, responding can use it to estimate available time for additional actions. */
+    private long maxAwaitMills;
+
     /**
      * Constructor.
      *
@@ -59,6 +62,13 @@ public class TcpDiscoveryHandshakeRequest extends TcpDiscoveryAbstractMessage {
     }
 
     /**
+     * @return maximal await mills for the handshake response. Actual if positive.
+     */
+    public long maxAwaitMills() {
+        return maxAwaitMills;
+    }
+
+    /**
      * Sets topology change flag and previous node ID to check.<br>
      *
      * @param prevNodeId If not {@code null}, will set topology check flag and set node ID to check.
@@ -68,6 +78,19 @@ public class TcpDiscoveryHandshakeRequest extends TcpDiscoveryAbstractMessage {
 
         this.prevNodeId = prevNodeId;
     }
+
+    /**
+     * Sets topology change flag and previous node ID to check.<br>
+     *
+     * @param prevNodeId If not {@code null}, will set topology check flag and set node ID to check.
+     * @param maxAwaitMills Maximal await mills for the handshake response. Actual if positive.
+     */
+    public void changeTopology(UUID prevNodeId, long maxAwaitMills) {
+        changeTopology(prevNodeId);
+
+        this.maxAwaitMills = maxAwaitMills;
+    }
+
 
     /** {@inheritDoc} */
     @Override public String toString() {

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/messages/TcpDiscoveryHandshakeRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/messages/TcpDiscoveryHandshakeRequest.java
@@ -30,9 +30,6 @@ public class TcpDiscoveryHandshakeRequest extends TcpDiscoveryAbstractMessage {
     /** */
     private UUID prevNodeId;
 
-    /** Max await time for response. If > 0, responding can use it to estimate available time for additional actions. */
-    private long maxAwaitMills;
-
     /**
      * Constructor.
      *
@@ -62,13 +59,6 @@ public class TcpDiscoveryHandshakeRequest extends TcpDiscoveryAbstractMessage {
     }
 
     /**
-     * @return maximal await mills for the handshake response. Actual if positive.
-     */
-    public long maxAwaitMills() {
-        return maxAwaitMills;
-    }
-
-    /**
      * Sets topology change flag and previous node ID to check.<br>
      *
      * @param prevNodeId If not {@code null}, will set topology check flag and set node ID to check.
@@ -78,19 +68,6 @@ public class TcpDiscoveryHandshakeRequest extends TcpDiscoveryAbstractMessage {
 
         this.prevNodeId = prevNodeId;
     }
-
-    /**
-     * Sets topology change flag and previous node ID to check.<br>
-     *
-     * @param prevNodeId If not {@code null}, will set topology check flag and set node ID to check.
-     * @param maxAwaitMills Maximal await mills for the handshake response. Actual if positive.
-     */
-    public void changeTopology(UUID prevNodeId, long maxAwaitMills) {
-        changeTopology(prevNodeId);
-
-        this.maxAwaitMills = maxAwaitMills;
-    }
-
 
     /** {@inheritDoc} */
     @Override public String toString() {

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryNetworkIssuesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryNetworkIssuesTest.java
@@ -21,7 +21,9 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -211,16 +213,31 @@ public class TcpDiscoveryNetworkIssuesTest extends GridCommonAbstractTest {
      * Ensures sequential failure of two nodes has no additional issues.
      */
     @Test
-    public void testFailTwoNodes() throws Exception {
+    public void testSequentialFailTwoNodes() throws Exception {
+        simulateFailureOfTwoNodes(true);
+    }
+
+    /**
+     * Ensures sequential failure of two nodes has no additional issues.
+     */
+    @Test
+    public void testNotSequentialFailTwoNodes() throws Exception {
+        simulateFailureOfTwoNodes(false);
+    }
+
+    /** */
+    private void simulateFailureOfTwoNodes(boolean sequentionally) throws Exception {
         failureDetectionTimeout = 1000;
 
-        startGrids(5);
+        int gridCnt = 20;
+
+        startGrids(gridCnt);
 
         awaitPartitionMapExchange();
 
         final CountDownLatch failLatch = new CountDownLatch(2);
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < gridCnt; i++) {
             ignite(i).events().localListen(evt -> {
                 failLatch.countDown();
 
@@ -236,20 +253,28 @@ public class TcpDiscoveryNetworkIssuesTest extends GridCommonAbstractTest {
             }, EVT_NODE_SEGMENTED);
         }
 
-        processNetworkThreads(ignite(2), t -> t.suspend());
-        processNetworkThreads(ignite(3), t -> t.suspend());
+        Set<Integer> failedNodes = new HashSet<>();
+
+        failedNodes.add(2);
+
+        if (sequentionally)
+            failedNodes.add(3);
+        else
+            failedNodes.add(4);
+
+        failedNodes.forEach(idx -> processNetworkThreads(ignite(idx), Thread::suspend));
 
         try {
             failLatch.await(10, TimeUnit.SECONDS);
         }
         finally {
-            processNetworkThreads(ignite(2), t -> t.resume());
-            processNetworkThreads(ignite(3), t -> t.resume());
+            failedNodes.forEach(idx -> processNetworkThreads(ignite(idx), Thread::resume));
         }
 
-        assertFalse(segmentedNodes.contains(0));
-        assertFalse(segmentedNodes.contains(1));
-        assertFalse(segmentedNodes.contains(4));
+        for (int i = 0; i < gridCnt; i++) {
+            if (!failedNodes.contains(i))
+                assertFalse(segmentedNodes.contains(i));
+        }
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryNetworkIssuesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryNetworkIssuesTest.java
@@ -227,7 +227,7 @@ public class TcpDiscoveryNetworkIssuesTest extends GridCommonAbstractTest {
 
     /** */
     private void simulateFailureOfTwoNodes(boolean sequentionally) throws Exception {
-        failureDetectionTimeout = 700;
+        failureDetectionTimeout = 1000;
 
         int gridCnt = 7;
 

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryNetworkIssuesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryNetworkIssuesTest.java
@@ -227,9 +227,9 @@ public class TcpDiscoveryNetworkIssuesTest extends GridCommonAbstractTest {
 
     /** */
     private void simulateFailureOfTwoNodes(boolean sequentionally) throws Exception {
-        failureDetectionTimeout = 1000;
+        failureDetectionTimeout = 700;
 
-        int gridCnt = 20;
+        int gridCnt = 7;
 
         startGrids(gridCnt);
 


### PR DESCRIPTION
Scenario:
The nodes have relative places in the ring: N and N+1. Node N detects failure of node N+1. Node N tries to connect to node N+2. Node N+2 checks backward connection to node N+1.

Problem: 
Node N can fail too.

Cause: 
The timeout on node N to recover connection to node N+2 appears shorter than timeout on node N+2 to check connection to N+1.

Fix:
Introduced a fundamental timeout value to check/recover connection based on current configuration. The mentioned timeouts have been turned relative. The timeout of backward connection check is now generally shorter than the timeout to recover connection.

Additions:
Brought some logs to have diagnostoc ability. It was hard to realize the issue without them.