### PR TITLE
IGNITE-13730 Unify fallback property for SSL key store provider.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/IgniteJdbcDriver.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteJdbcDriver.java
@@ -31,6 +31,10 @@ import org.apache.ignite.cache.affinity.AffinityKey;
 import org.apache.ignite.internal.jdbc.JdbcConnection;
 import org.apache.ignite.internal.jdbc.JdbcDriverPropertyInfo;
 
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_SSL_PROTOCOL;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
+
 /**
  * JDBC driver implementation for In-Memory Data Grid.
  * <p>
@@ -485,10 +489,10 @@ public class IgniteJdbcDriver implements Driver {
                     info.getProperty("ignite.client.ssl.enabled", "false"),
                     "Flag indicating that SSL is needed for connection."),
                 new JdbcDriverPropertyInfo("ignite.client.ssl.protocol",
-                    info.getProperty("ignite.client.ssl.protocol", "TLS"),
+                    info.getProperty("ignite.client.ssl.protocol", DFLT_SSL_PROTOCOL),
                     "SSL protocol."),
                 new JdbcDriverPropertyInfo("ignite.client.ssl.key.algorithm",
-                    info.getProperty("ignite.client.ssl.key.algorithm", "SunX509"),
+                    info.getProperty("ignite.client.ssl.key.algorithm", DFLT_KEY_ALGORITHM),
                     "Key manager algorithm."),
                 new JdbcDriverPropertyInfo("ignite.client.ssl.keystore.location",
                     info.getProperty("ignite.client.ssl.keystore.location", ""),
@@ -497,7 +501,7 @@ public class IgniteJdbcDriver implements Driver {
                     info.getProperty("ignite.client.ssl.keystore.password", ""),
                     "Key store password."),
                 new JdbcDriverPropertyInfo("ignite.client.ssl.keystore.type",
-                    info.getProperty("ignite.client.ssl.keystore.type", "jks"),
+                    info.getProperty("ignite.client.ssl.keystore.type", DFLT_STORE_TYPE),
                     "Key store type."),
                 new JdbcDriverPropertyInfo("ignite.client.ssl.truststore.location",
                     info.getProperty("ignite.client.ssl.truststore.location", ""),
@@ -506,7 +510,7 @@ public class IgniteJdbcDriver implements Driver {
                     info.getProperty("ignite.client.ssl.truststore.password", ""),
                     "Trust store password."),
                 new JdbcDriverPropertyInfo("ignite.client.ssl.truststore.type",
-                    info.getProperty("ignite.client.ssl.truststore.type", "jks"),
+                    info.getProperty("ignite.client.ssl.truststore.type", DFLT_STORE_TYPE),
                     "Trust store type."),
                 new JdbcDriverPropertyInfo("ignite.client.credentials",
                     info.getProperty("ignite.client.credentials", ""),

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/GridClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/GridClientConfiguration.java
@@ -39,6 +39,10 @@ import org.apache.ignite.plugin.security.SecurityCredentialsBasicProvider;
 import org.apache.ignite.plugin.security.SecurityCredentialsProvider;
 import org.jetbrains.annotations.Nullable;
 
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_SSL_PROTOCOL;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
+
 /**
  * Java client configuration.
  */
@@ -721,8 +725,8 @@ public class GridClientConfiguration {
 
         String sslEnabled = in.getProperty(prefix + "ssl.enabled");
 
-        String sslProto = in.getProperty(prefix + "ssl.protocol", "TLS");
-        String sslKeyAlg = in.getProperty(prefix + "ssl.key.algorithm", "SunX509");
+        String sslProto = in.getProperty(prefix + "ssl.protocol");
+        String sslKeyAlg = in.getProperty(prefix + "ssl.key.algorithm");
 
         String keyStorePath = in.getProperty(prefix + "ssl.keystore.location");
         String keyStorePwd = in.getProperty(prefix + "ssl.keystore.password");
@@ -780,8 +784,8 @@ public class GridClientConfiguration {
         if (!F.isEmpty(sslEnabled) && Boolean.parseBoolean(sslEnabled)) {
             GridSslBasicContextFactory factory = new GridSslBasicContextFactory();
 
-            factory.setProtocol(F.isEmpty(sslProto) ? "TLS" : sslProto);
-            factory.setKeyAlgorithm(F.isEmpty(sslKeyAlg) ? "SunX509" : sslKeyAlg);
+            factory.setProtocol(F.isEmpty(sslProto) ? DFLT_SSL_PROTOCOL : sslProto);
+            factory.setKeyAlgorithm(F.isEmpty(sslKeyAlg) ? DFLT_KEY_ALGORITHM : sslKeyAlg);
 
             if (F.isEmpty(keyStorePath))
                 throw new IllegalArgumentException("SSL key store location is not specified.");
@@ -791,7 +795,7 @@ public class GridClientConfiguration {
             if (keyStorePwd != null)
                 factory.setKeyStorePassword(keyStorePwd.toCharArray());
 
-            factory.setKeyStoreType(F.isEmpty(keyStoreType) ? "jks" : keyStoreType);
+            factory.setKeyStoreType(F.isEmpty(keyStoreType) ? DFLT_STORE_TYPE : keyStoreType);
 
             if (F.isEmpty(trustStorePath))
                 factory.setTrustManagers(GridSslBasicContextFactory.getDisabledTrustManager());
@@ -801,7 +805,7 @@ public class GridClientConfiguration {
                 if (trustStorePwd != null)
                     factory.setTrustStorePassword(trustStorePwd.toCharArray());
 
-                factory.setTrustStoreType(F.isEmpty(trustStoreType) ? "jks" : trustStoreType);
+                factory.setTrustStoreType(F.isEmpty(trustStoreType) ? DFLT_STORE_TYPE : trustStoreType);
             }
 
             setSslContextFactory(factory);

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/ssl/GridSslBasicContextFactory.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/ssl/GridSslBasicContextFactory.java
@@ -37,6 +37,7 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.ssl.SSLContextWrapper;
+import org.apache.ignite.ssl.SslContextFactory;
 
 import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
 import static org.apache.ignite.ssl.SslContextFactory.DFLT_SSL_PROTOCOL;
@@ -101,8 +102,8 @@ public class GridSslBasicContextFactory implements GridSslContextFactory {
     }
 
     /**
-     * Sets key store type used in context initialization. If not provided, {@link #DFLT_STORE_TYPE} will
-     * be used.
+     * Sets key store type used in context initialization. If not provided, {@link SslContextFactory#DFLT_STORE_TYPE}
+     * will be used.
      *
      * @param keyStoreType Key store type.
      */
@@ -122,8 +123,8 @@ public class GridSslBasicContextFactory implements GridSslContextFactory {
     }
 
     /**
-     * Sets trust store type used in context initialization. If not provided, {@link #DFLT_STORE_TYPE} will
-     * be used.
+     * Sets trust store type used in context initialization. If not provided, {@link SslContextFactory#DFLT_STORE_TYPE}
+     * will be used.
      *
      * @param trustStoreType Trust store type.
      */
@@ -143,7 +144,7 @@ public class GridSslBasicContextFactory implements GridSslContextFactory {
     }
 
     /**
-     * Sets protocol for secure transport. If not specified, {@link #DFLT_SSL_PROTOCOL} will be used.
+     * Sets protocol for secure transport. If not specified, {@link SslContextFactory#DFLT_SSL_PROTOCOL} will be used.
      *
      * @param proto SSL protocol name.
      */
@@ -154,7 +155,7 @@ public class GridSslBasicContextFactory implements GridSslContextFactory {
     }
 
     /**
-     * Gets algorithm that will be used to create a key manager. If not specified, {@link #DFLT_KEY_ALGORITHM}
+     * Gets algorithm that will be used to create a key manager. If not specified, {@link SslContextFactory#DFLT_KEY_ALGORITHM}
      * will be used.
      *
      * @return Key manager algorithm.

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/ssl/GridSslBasicContextFactory.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/ssl/GridSslBasicContextFactory.java
@@ -38,6 +38,10 @@ import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.ssl.SSLContextWrapper;
 
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_SSL_PROTOCOL;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
+
 /**
  * Basic ssl context factory that provides ssl context configuration with specified key
  * and trust stores.
@@ -54,15 +58,6 @@ import org.apache.ignite.ssl.SSLContextWrapper;
  */
 @Deprecated
 public class GridSslBasicContextFactory implements GridSslContextFactory {
-    /** Default key store type. */
-    public static final String DFLT_STORE_TYPE = "JKS";
-
-    /** Default SSL protocol. */
-    public static final String DFLT_SSL_PROTOCOL = "TLS";
-
-    /** Default key manager algorithm. */
-    public static final String DFLT_KEY_ALGORITHM = "SunX509";
-
     /** SSL protocol. */
     private String proto = DFLT_SSL_PROTOCOL;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -103,6 +103,8 @@ import static org.apache.ignite.internal.client.thin.ProtocolVersion.V1_7_0;
 import static org.apache.ignite.internal.client.thin.ProtocolVersionFeature.AUTHORIZATION;
 import static org.apache.ignite.internal.client.thin.ProtocolVersionFeature.BITMAP_FEATURES;
 import static org.apache.ignite.internal.client.thin.ProtocolVersionFeature.PARTITION_AWARENESS;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
 
 /**
  * Implements {@link ClientChannel} over TCP.
@@ -922,7 +924,7 @@ class TcpClientChannel implements ClientChannel {
 
             String keyStoreType = or.apply(
                 cfg.getSslClientCertificateKeyStoreType(),
-                or.apply(System.getProperty("javax.net.ssl.keyStoreType"), "JKS")
+                or.apply(System.getProperty("javax.net.ssl.keyStoreType"), DFLT_STORE_TYPE)
             );
 
             String keyStorePwd = or.apply(
@@ -937,7 +939,7 @@ class TcpClientChannel implements ClientChannel {
 
             String trustStoreType = or.apply(
                 cfg.getSslTrustCertificateKeyStoreType(),
-                or.apply(System.getProperty("javax.net.ssl.trustStoreType"), "JKS")
+                or.apply(System.getProperty("javax.net.ssl.trustStoreType"), DFLT_STORE_TYPE)
             );
 
             String trustStorePwd = or.apply(
@@ -945,7 +947,7 @@ class TcpClientChannel implements ClientChannel {
                 System.getProperty("javax.net.ssl.trustStorePassword")
             );
 
-            String algorithm = or.apply(cfg.getSslKeyAlgorithm(), "SunX509");
+            String algorithm = or.apply(cfg.getSslKeyAlgorithm(), DFLT_KEY_ALGORITHM);
 
             String proto = toString(cfg.getSslProtocol());
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/ConnectionPropertiesImpl.java
@@ -138,7 +138,7 @@ public class ConnectionPropertiesImpl implements ConnectionProperties, Serializa
 
     /** SSL: Key algorithm name. */
     private StringProperty sslKeyAlgorithm = new StringProperty("sslKeyAlgorithm",
-        "SSL key algorithm name", "SunX509", null, false, null);
+        "SSL key algorithm name", null, null, false, null);
 
     /** SSL: Client certificate key store url. */
     private StringProperty sslClientCertificateKeyStoreUrl =

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinSSLUtil.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinSSLUtil.java
@@ -33,6 +33,10 @@ import org.apache.ignite.internal.processors.odbc.SqlStateCode;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.ssl.SslContextFactory;
 
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_SSL_PROTOCOL;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
+
 /**
  * SSL utility method to create SSL connetion.
  */
@@ -136,7 +140,7 @@ public class JdbcThinSSLUtil {
             cliCertKeyStorePwd = System.getProperty("javax.net.ssl.keyStorePassword");
 
         if (cliCertKeyStoreType == null)
-            cliCertKeyStoreType = System.getProperty("javax.net.ssl.keyStoreType", "JKS");
+            cliCertKeyStoreType = System.getProperty("javax.net.ssl.keyStoreType", DFLT_STORE_TYPE);
 
         if (trustCertKeyStoreUrl == null)
             trustCertKeyStoreUrl = System.getProperty("javax.net.ssl.trustStore");
@@ -145,10 +149,13 @@ public class JdbcThinSSLUtil {
             trustCertKeyStorePwd = System.getProperty("javax.net.ssl.trustStorePassword");
 
         if (trustCertKeyStoreType == null)
-            trustCertKeyStoreType = System.getProperty("javax.net.ssl.trustStoreType", "JKS");
+            trustCertKeyStoreType = System.getProperty("javax.net.ssl.trustStoreType", DFLT_STORE_TYPE);
 
         if (sslProtocol == null)
-            sslProtocol = "TLS";
+            sslProtocol = DFLT_SSL_PROTOCOL;
+
+        if (keyAlgorithm == null)
+            keyAlgorithm = DFLT_KEY_ALGORITHM;
 
         SslContextFactory f = new SslContextFactory();
 

--- a/modules/core/src/main/java/org/apache/ignite/ssl/SslContextFactory.java
+++ b/modules/core/src/main/java/org/apache/ignite/ssl/SslContextFactory.java
@@ -60,14 +60,25 @@ public class SslContextFactory implements Factory<SSLContext> {
     /** */
     private static final long serialVersionUID = 0L;
 
-    /** Default key store type. */
-    public static final String DFLT_STORE_TYPE = "JKS";
+    /** Default key / trust store type. */
+    public static final String DFLT_STORE_TYPE = System.getProperty("javax.net.ssl.keyStoreType", "JKS");
 
     /** Default SSL protocol. */
     public static final String DFLT_SSL_PROTOCOL = "TLS";
 
-    /** Default key manager algorithm. */
-    public static final String DFLT_KEY_ALGORITHM = "SunX509";
+    /**
+     * Property name to specify default key/trust manager algorithm.
+     *
+     * @deprecated Use {@code "ssl.KeyManagerFactory.algorithm"} instead as per JSSE standard.
+     *
+     * Should be considered for deletion in 9.0.
+     */
+    @Deprecated
+    public static final String IGNITE_KEY_ALGORITHM_PROPERTY = "ssl.key.algorithm";
+
+    /** Default key manager / trust manager algorithm. Specifying different trust manager algorithm is not supported. */
+    public static final String DFLT_KEY_ALGORITHM = System.getProperty("ssl.KeyManagerFactory.algorithm",
+        System.getProperty(IGNITE_KEY_ALGORITHM_PROPERTY, "SunX509"));
 
     /** SSL protocol. */
     private String proto = DFLT_SSL_PROTOCOL;
@@ -178,8 +189,7 @@ public class SslContextFactory implements Factory<SSLContext> {
     }
 
     /**
-     * Sets key manager algorithm that will be used to create a key manager. Notice that in most cased default value
-     * suites well, however, on Android platform this value need to be set to <tt>X509<tt/>.
+     * Sets key manager algorithm that will be used to create a key manager.
      *
      * @param keyAlgorithm Key algorithm name.
      */

--- a/modules/core/src/test/java/org/apache/ignite/client/ClientConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ClientConfigurationTest.java
@@ -42,6 +42,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -63,12 +65,12 @@ public class ClientConfigurationTest {
             )
             .setSslMode(SslMode.REQUIRED)
             .setSslClientCertificateKeyStorePath("client.jks")
-            .setSslClientCertificateKeyStoreType("JKS")
+            .setSslClientCertificateKeyStoreType(DFLT_STORE_TYPE)
             .setSslClientCertificateKeyStorePassword("123456")
             .setSslTrustCertificateKeyStorePath("trust.jks")
-            .setSslTrustCertificateKeyStoreType("JKS")
+            .setSslTrustCertificateKeyStoreType(DFLT_STORE_TYPE)
             .setSslTrustCertificateKeyStorePassword("123456")
-            .setSslKeyAlgorithm("SunX509");
+            .setSslKeyAlgorithm(DFLT_KEY_ALGORITHM);
 
         ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
 

--- a/modules/core/src/test/java/org/apache/ignite/testframework/GridTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/GridTestUtils.java
@@ -123,6 +123,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager.DFLT_STORE_DIR;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_SSL_PROTOCOL;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -1931,13 +1934,13 @@ public final class GridTestUtils {
      * @throws IOException If keystore cannot be accessed.
      */
     public static SSLContext sslContext() throws GeneralSecurityException, IOException {
-        SSLContext ctx = SSLContext.getInstance("TLS");
+        SSLContext ctx = SSLContext.getInstance(DFLT_SSL_PROTOCOL);
 
         char[] storePass = keyStorePassword().toCharArray();
 
-        KeyManagerFactory keyMgrFactory = KeyManagerFactory.getInstance("SunX509");
+        KeyManagerFactory keyMgrFactory = KeyManagerFactory.getInstance(DFLT_KEY_ALGORITHM);
 
-        KeyStore keyStore = KeyStore.getInstance("JKS");
+        KeyStore keyStore = KeyStore.getInstance(DFLT_STORE_TYPE);
 
         keyStore.load(new FileInputStream(U.resolveIgnitePath(GridTestProperties.getProperty("ssl.keystore.path"))),
             storePass);

--- a/modules/indexing/src/test/java/org/apache/ignite/client/SecurityTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/client/SecurityTest.java
@@ -40,6 +40,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_KEY_ALGORITHM;
+import static org.apache.ignite.ssl.SslContextFactory.DFLT_STORE_TYPE;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -113,12 +115,12 @@ public class SecurityTest {
             try (IgniteClient client = Ignition.startClient(clientCfg
                 .setSslMode(SslMode.REQUIRED)
                 .setSslClientCertificateKeyStorePath(rsrcPath.apply("/client.jks"))
-                .setSslClientCertificateKeyStoreType("JKS")
+                .setSslClientCertificateKeyStoreType(DFLT_STORE_TYPE)
                 .setSslClientCertificateKeyStorePassword("123456")
                 .setSslTrustCertificateKeyStorePath(rsrcPath.apply("/trust.jks"))
-                .setSslTrustCertificateKeyStoreType("JKS")
+                .setSslTrustCertificateKeyStoreType(DFLT_STORE_TYPE)
                 .setSslTrustCertificateKeyStorePassword("123456")
-                .setSslKeyAlgorithm("SunX509")
+                .setSslKeyAlgorithm(DFLT_KEY_ALGORITHM)
                 .setSslTrustAll(false)
                 .setSslProtocol(SslProtocol.TLS)
             )) {


### PR DESCRIPTION
Use JSSE-specified "javax.net.ssl.keyStoreProvider".
Replace "JKS", "TLS" and "SunX509" literals with constants.