### PR TITLE
IGNITE-8884 .NET: Fix async key-val operations - use WriteObjectDetached

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
@@ -2330,7 +2330,7 @@ namespace Apache.Ignite.Core.Tests.Cache
         }
 
         /// <summary>
-        /// Tests that key and value objects can reference the same nested object.
+        /// Tests that value object can reference key object.
         /// </summary>
         [Test]
         public void TestPutGetWithKeyObjectReferenceInValue([Values(true, false)] bool async)
@@ -2346,6 +2346,26 @@ namespace Apache.Ignite.Core.Tests.Cache
             
             Assert.AreEqual(2, res.Id);
             Assert.AreEqual(1, res.Inner.Id);
+        }
+
+        /// <summary>
+        /// Tests that key and value objects can reference the same nested object.
+        /// </summary>
+        [Test]
+        public void TestPutGetWithSharedObjectReferenceInKeyAndValue([Values(true, false)] bool async)
+        {
+            var cache = Cache<Container, Container>(async);
+
+            var inner = new Container {Id = -1};
+            var key = new Container {Id = 1, Inner = inner};
+            var val = new Container {Id = 2, Inner = inner};
+
+            cache.Put(key, val);
+            
+            var res = cache.Get(key);
+            
+            Assert.AreEqual(2, res.Id);
+            Assert.AreEqual(-1, res.Inner.Id);
         }
 
         private void TestKeepBinaryFlag(bool async)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
@@ -2345,7 +2345,7 @@ namespace Apache.Ignite.Core.Tests.Cache
             var res = cache.Get(key);
             
             Assert.AreEqual(2, res.Id);
-            Assert.AreEqual(2, res.Inner.Id);
+            Assert.AreEqual(1, res.Inner.Id);
         }
 
         private void TestKeepBinaryFlag(bool async)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
@@ -2329,6 +2329,25 @@ namespace Apache.Ignite.Core.Tests.Cache
             Assert.AreEqual(2, cache[1]);
         }
 
+        /// <summary>
+        /// Tests that key and value objects can reference the same nested object.
+        /// </summary>
+        [Test]
+        public void TestPutGetWithKeyObjectReferenceInValue([Values(true, false)] bool async)
+        {
+            var cache = Cache<Container, Container>(async);
+
+            var key = new Container {Id = 1};
+            var val = new Container {Id = 2, Inner = key};
+
+            cache.Put(key, val);
+            
+            var res = cache.Get(key);
+            
+            Assert.AreEqual(2, res.Id);
+            Assert.AreEqual(2, res.Inner.Id);
+        }
+
         private void TestKeepBinaryFlag(bool async)
         {
             var cache0 = async ? Cache().WrapAsync() : Cache();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/PlatformTargetAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/PlatformTargetAdapter.cs
@@ -427,8 +427,8 @@ namespace Apache.Ignite.Core.Impl
         {
             return GetFuture<TR>((futId, futType) => DoOutOp(type, w =>
             {
-                w.WriteObject(val1);
-                w.WriteObject(val2);
+                w.WriteObjectDetached(val1);
+                w.WriteObjectDetached(val2);
                 w.WriteLong(futId);
                 w.WriteInt(futType);
             })).Task;


### PR DESCRIPTION
Fix async cache operations when key and value objects reference each other or have references to the same object.
Async key-val operations used `WriteObject` instead `WriteObjectDetached`, so references to the same inner object were shared in the binary stream (referenced object is written once). However, cache stores key and val binary objects separately, so the reference to the inner object gets broken.

`WriteObjectDetached` disables reference sharing and writes both object independently.