### PR TITLE
IGNITE-13825: Fix precision and scale for columns in SQL result set

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/odbc/OdbcUtils.java
@@ -256,7 +256,7 @@ public class OdbcUtils {
      * @return Odbc query field metadata.
      */
     public static Collection<OdbcColumnMeta> convertMetadata(Collection<GridQueryFieldMetadata> meta,
-                                                              ClientListenerProtocolVersion ver) {
+        ClientListenerProtocolVersion ver) {
         List<OdbcColumnMeta> res = new ArrayList<>();
 
         if (meta != null) {

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2Utils.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2Utils.java
@@ -706,8 +706,13 @@ public class H2Utils {
     private static String dbTypeFromClass(Class<?> cls, int precision, int scale) {
         String dbType = H2DatabaseType.fromClass(cls).dBTypeAsString();
 
-        if (precision != -1 && dbType.equalsIgnoreCase(H2DatabaseType.VARCHAR.dBTypeAsString()))
-            return dbType + "(" + precision + ")";
+        if (precision != -1 && scale != -1 && dbType.equalsIgnoreCase(H2DatabaseType.DECIMAL.dBTypeAsString()))
+            return dbType + "(" + precision + ", " + scale + ')';
+
+        if (precision != -1 && (
+                dbType.equalsIgnoreCase(H2DatabaseType.VARCHAR.dBTypeAsString())
+                        || dbType.equalsIgnoreCase(H2DatabaseType.DECIMAL.dBTypeAsString())))
+            return dbType + '(' + precision + ')';
 
         return dbType;
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheAbstractFieldsQuerySelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheAbstractFieldsQuerySelfTest.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.processors.cache;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -336,7 +337,8 @@ public abstract class IgniteCacheAbstractFieldsQuerySelfTest extends GridCommonA
                 }
                 else if (DEFAULT_CACHE_NAME.equals(meta.cacheName()) || noOpCache.getName().equals(meta.cacheName()))
                     assertTrue("Invalid types size", types.isEmpty());
-                else if (!"cacheWithCustomKeyPrecision".equalsIgnoreCase(meta.cacheName()))
+                else if (!"cacheWithCustomKeyPrecision".equalsIgnoreCase(meta.cacheName()) &&
+                         !"cacheWithDecimalPrecisionAndScale".equalsIgnoreCase(meta.cacheName()))
                     fail("Unknown cache: " + meta.cacheName());
             }
         }
@@ -405,6 +407,51 @@ public abstract class IgniteCacheAbstractFieldsQuerySelfTest extends GridCommonA
 
             assertEquals(999, meta.precision());
         }
+    }
+
+    /**
+     * Test that scale and precision returned correctly for Decimal column in result set:
+     *
+     * 1. Start node;
+     * 2. Create table with Decimal(3,0) column;
+     * 3. Insert a new row into the table;
+     * 4. Execute select with decimal row;
+     * 5. Check that selected decimal column has precision 3 and scale 0.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testDecimalColumnScaleAndPrecision() throws Exception {
+        QueryEntity qeWithPrecision = new QueryEntity()
+                .setKeyType("java.lang.Long")
+                .setValueType("TestType")
+                .addQueryField("age", "java.math.BigDecimal", "age")
+                .setFieldsPrecision(ImmutableMap.of("age", 3))
+                .setFieldsScale(ImmutableMap.of("age", 0));
+
+        grid(0).getOrCreateCache(cacheConfiguration()
+                .setName("cacheWithDecimalPrecisionAndScale")
+                .setQueryEntities(Collections.singleton(qeWithPrecision)));
+
+        GridQueryProcessor qryProc = grid(0).context().query();
+
+        qryProc.querySqlFields(
+                new SqlFieldsQuery("INSERT INTO TestType(_key, age) VALUES(?, ?)")
+                        .setSchema("cacheWithDecimalPrecisionAndScale")
+                        .setArgs(1, new BigDecimal(160)), true);
+
+        QueryCursorImpl<List<?>> cursor = (QueryCursorImpl<List<?>>)qryProc.querySqlFields(
+                new SqlFieldsQuery("SELECT age FROM TestType")
+                        .setSchema("cacheWithDecimalPrecisionAndScale"), true);
+
+        List<GridQueryFieldMetadata> fieldsMeta = cursor.fieldsMeta();
+
+        assertEquals(1, fieldsMeta.size());
+
+        GridQueryFieldMetadata meta = fieldsMeta.get(0);
+
+        assertEquals(3, meta.precision());
+        assertEquals(0, meta.scale());
     }
 
     @Test

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/SqlResultSetMetaSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/SqlResultSetMetaSelfTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.cache.QueryCursorImpl;
+import org.apache.ignite.internal.processors.cache.index.AbstractIndexingCommonTest;
+import org.junit.Test;
+
+/**
+ * Tests for result set metadata.
+ */
+public class SqlResultSetMetaSelfTest extends AbstractIndexingCommonTest {
+    /** Node. */
+    private IgniteEx node;
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        node = (IgniteEx)startGrid();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+
+        node = null;
+    }
+
+    /**
+     * Test that scale and precision returned correctly for Decimal column in result set:
+     *
+     * 1. Start node;
+     * 2. Create table with Decimal(3,0) column;
+     * 3. Insert a new row into the table;
+     * 4. Execute select with decimal row;
+     * 5. Check that selected decimal column has precision 3 and scale 0.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testDecimalColumnScaleAndPrecision() throws Exception {
+        GridQueryProcessor qryProc = node.context().query();
+
+        qryProc.querySqlFields(
+                new SqlFieldsQuery("CREATE TABLE Person(id int, age decimal(3,0), primary key (id))")
+                        .setSchema("PUBLIC"), true);
+
+        qryProc.querySqlFields(
+                new SqlFieldsQuery("INSERT INTO Person(id, age) VALUES(?, ?)")
+                        .setSchema("PUBLIC")
+                        .setArgs(1, new BigDecimal(160)), true);
+
+        QueryCursorImpl<List<?>> cursor = (QueryCursorImpl<List<?>>)qryProc.querySqlFields(
+                new SqlFieldsQuery("SELECT age FROM Person")
+                        .setSchema("PUBLIC"), true);
+
+        List<GridQueryFieldMetadata> fieldsMeta = cursor.fieldsMeta();
+
+        assertEquals(1, fieldsMeta.size());
+
+        GridQueryFieldMetadata meta = fieldsMeta.get(0);
+
+        assertEquals(3, meta.precision());
+        assertEquals(0, meta.scale());
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
@@ -233,6 +233,7 @@ import org.apache.ignite.internal.processors.query.SqlNotNullKeyValueFieldTest;
 import org.apache.ignite.internal.processors.query.SqlPushDownFunctionTest;
 import org.apache.ignite.internal.processors.query.SqlQueryHistoryFromClientSelfTest;
 import org.apache.ignite.internal.processors.query.SqlQueryHistorySelfTest;
+import org.apache.ignite.internal.processors.query.SqlResultSetMetaSelfTest;
 import org.apache.ignite.internal.processors.query.SqlSchemaSelfTest;
 import org.apache.ignite.internal.processors.query.SqlSystemViewsSelfTest;
 import org.apache.ignite.internal.processors.query.h2.GridIndexRebuildSelfTest;
@@ -313,6 +314,8 @@ import org.junit.runners.Suite;
     SqlSchemaSelfTest.class,
     SqlIllegalSchemaSelfTest.class,
     MultipleStatementsSqlQuerySelfTest.class,
+
+    SqlResultSetMetaSelfTest.class,
 
     BasicIndexTest.class,
     ArrayIndexTest.class,


### PR DESCRIPTION
Added info for precision and scale to result set meta for columns.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
