### PR TITLE
IGNITE-13555 Java thin: add IPv6 address support

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
@@ -201,7 +201,7 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
                 if (lastErr != null)
                     throw new IgniteCheckedException("Failed to bind to any [host:port] from the range [" +
                         "host=" + host + ", portFrom=" + cliConnCfg.getPort() + ", portTo=" + portTo +
-                        ", lastErr=" + lastErr + ']');
+                        ", lastErr=" + lastErr + ']', lastErr);
 
                 if (!U.IGNITE_MBEANS_DISABLED)
                     registerMBean();

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/HostAndPortRange.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/HostAndPortRange.java
@@ -65,7 +65,7 @@ public class HostAndPortRange implements Serializable {
             if (hostEndIdx == -1) {
                 throw createParseError(addrStr, errMsgPrefix, "IPv6 host is incorrect");
             }
-            host = addrStr.substring(0, hostEndIdx + 1);
+            host = addrStr.substring(1, hostEndIdx);
             if (hostEndIdx == addrStr.length() - 1) { // no port specified, using default
                 portFrom = dfltPortFrom;
                 portTo = dfltPortTo;

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/HostAndPortRange.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/HostAndPortRange.java
@@ -64,10 +64,12 @@ public class HostAndPortRange implements Serializable {
 
         if (addrStr.charAt(0) == '[') { // IPv6 with port(s)
             int hostEndIdx = addrStr.indexOf(']');
+            
             if (hostEndIdx == -1)
                 throw createParseError(addrStr, errMsgPrefix, "Failed to parse IPv6 address, missing ']'");
 
             host = addrStr.substring(1, hostEndIdx);
+            
             if (hostEndIdx == addrStr.length() - 1) { // no port specified, using default
                 portFrom = dfltPortFrom;
                 portTo = dfltPortTo;
@@ -80,9 +82,9 @@ public class HostAndPortRange implements Serializable {
                 portTo = ports[1];
             }
         }
-
         else { // IPv4 || IPv6 without port || empty host
             final int colIdx = addrStr.lastIndexOf(':');
+            
             if (colIdx > 0) {
                 if (addrStr.lastIndexOf(':', colIdx - 1) != -1) { // IPv6 without [] and port
                     try {

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.client;
 
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.ClientConfiguration;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -68,6 +69,7 @@ public class ConnectionTest {
     }
 
     /** */
+    @Ignore("IPv6 is not enabled by default on some systems.")
     @Test
     public void testIPv6NodeAddresses() throws Exception {
         testConnection(IPv6_HOST, "[::1]:10800");

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -25,47 +25,60 @@ import org.junit.Test;
  * Checks if it can connect to a valid address from the node address list.
  */
 public class ConnectionTest {
+    /** IPv4 default host. */
+    public static final String IPv4_HOST = "127.0.0.1";
+
+    /** IPv6 default host. */
+    public static final String IPv6_HOST = "::1";
+
     /** */
     @Test(expected = org.apache.ignite.client.ClientException.class)
     public void testEmptyNodeAddress() throws Exception {
-        testConnection("");
+        testConnection(IPv4_HOST, "");
     }
 
     /** */
     @Test(expected = org.apache.ignite.client.ClientException.class)
     public void testNullNodeAddress() throws Exception {
-        testConnection(null);
+        testConnection(IPv4_HOST, null);
     }
 
     /** */
     @Test(expected = org.apache.ignite.client.ClientException.class)
     public void testNullNodeAddresses() throws Exception {
-        testConnection(null, null);
+        testConnection(IPv4_HOST, null, null);
     }
 
     /** */
     @Test
     public void testValidNodeAddresses() throws Exception {
-        testConnection(Config.SERVER);
+        testConnection(IPv4_HOST, Config.SERVER);
     }
 
     /** */
     @Test(expected = org.apache.ignite.client.ClientConnectionException.class)
     public void testInvalidNodeAddresses() throws Exception {
-        testConnection("127.0.0.1:47500", "127.0.0.1:10801");
+        testConnection(IPv4_HOST, "127.0.0.1:47500", "127.0.0.1:10801");
     }
 
     /** */
     @Test
     public void testValidInvalidNodeAddressesMix() throws Exception {
-        testConnection("127.0.0.1:47500", "127.0.0.1:10801", Config.SERVER);
+        testConnection(IPv4_HOST, "127.0.0.1:47500", "127.0.0.1:10801", Config.SERVER);
+    }
+
+    /** */
+    @Test
+    public void testIPv6NodeAddresses() throws Exception {
+        testConnection(IPv6_HOST, "[::1]:10800");
     }
 
     /**
      * @param addrs Addresses to connect.
+     * @param host LocalIgniteCluster host.
      */
-    private void testConnection(String... addrs) throws Exception {
-        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+    private void testConnection(String host, String... addrs) throws Exception {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1, host);
              IgniteClient client = Ignition.startClient(new ClientConfiguration()
                      .setAddresses(addrs))) {
         }

--- a/modules/core/src/test/java/org/apache/ignite/client/LocalIgniteCluster.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/LocalIgniteCluster.java
@@ -35,7 +35,7 @@ import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
  */
 public class LocalIgniteCluster implements AutoCloseable {
     /** Host. */
-    private static final String HOST = "127.0.0.1";
+    private static String host = "127.0.0.1";
 
     /** Randomizer. */
     private static final Random rnd = new Random();
@@ -68,9 +68,17 @@ public class LocalIgniteCluster implements AutoCloseable {
     }
 
     /**
-     * Create and start start the cluster.
+     * Create and start start the cluster with default host.
      */
     public static LocalIgniteCluster start(int initSize) {
+        return new LocalIgniteCluster(initSize);
+    }
+
+    /**
+     * Create and start start the cluster with custom host.
+     */
+    public static LocalIgniteCluster start(int initSize, String host) {
+        LocalIgniteCluster.host = host;
         return new LocalIgniteCluster(initSize);
     }
 
@@ -155,7 +163,7 @@ public class LocalIgniteCluster implements AutoCloseable {
         IgniteConfiguration igniteCfg = Config.getServerConfiguration();
 
         igniteCfg.setClientConnectorConfiguration(new ClientConnectorConfiguration()
-            .setHost(HOST)
+            .setHost(host)
             .setPort(nodeCfg.getClientPort())
         );
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.internal.util;
 
 import org.apache.ignite.IgniteCheckedException;
@@ -7,6 +24,10 @@ import static org.junit.Assert.assertEquals;
 
 public class HostAndPortRangeTest {
 
+    /**
+     * tests correct input address with IPv4 host and port range.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test
     public void testParseIPv4WithPortRange() throws IgniteCheckedException {
         String addrStr = "127.0.0.1:8080..8090";
@@ -18,6 +39,10 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+    /**
+     * tests correct input address with IPv4 host and single port.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test
     public void testParseIPv4WithSinglePort() throws IgniteCheckedException {
         String addrStr = "127.0.0.1:8080";
@@ -29,6 +54,10 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+    /**
+     * ests correct input address with IPv4 host and no port.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test
     public void testParseIPv4NoPort() throws IgniteCheckedException {
         String addrStr = "127.0.0.1";
@@ -40,6 +69,10 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+    /**
+     * tests correct input address with IPv6 host and port range.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test
     public void testParseIPv6WithPortRange() throws IgniteCheckedException {
         String addrStr = "[::1]:8080..8090";
@@ -51,6 +84,10 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+    /**
+     * tests correct input address with IPv6 host and single port.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test
     public void testParseIPv6WithSinglePort() throws IgniteCheckedException {
         String addrStr = "[3ffe:2a00:100:7031::]:8080";
@@ -62,6 +99,10 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+    /**
+     * tests correct input address with IPv6 host and no port.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test
     public void testParseIPv6NoPort() throws IgniteCheckedException {
         String addrStr = "[::FFFF:129.144.52.38]";
@@ -73,6 +114,10 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+    /**
+     * tests incorrect input address with IPv6 host (no brackets) and port.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test(expected = IgniteCheckedException.class)
     public void testParseIPv6IncorrectHost() throws IgniteCheckedException {
         String addrStr = "3ffe:2a00:100:7031:::8080";
@@ -83,6 +128,10 @@ public class HostAndPortRangeTest {
 
     }
 
+    /**
+     * tests empty host and port.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test(expected = IgniteCheckedException.class)
     public void testParseNoHost() throws IgniteCheckedException {
         String addrStr = ":8080";
@@ -92,6 +141,10 @@ public class HostAndPortRangeTest {
         HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
     }
 
+    /**
+     * tests empty address string.
+     * @throws IgniteCheckedException on incorrect host/port
+     */
     @Test(expected = IgniteCheckedException.class)
     public void testParseNoAddress() throws IgniteCheckedException {
         String addrStr = "";

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -17,9 +17,11 @@
 
 package org.apache.ignite.internal.util;
 
+import java.net.UnknownHostException;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.testframework.junits.common.GridCommonTest;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,9 +31,9 @@ import org.junit.rules.ExpectedException;
  */
 @GridCommonTest(group = "Utils")
 public class HostAndPortRangeTest extends GridCommonAbstractTest {
-
     /**
-     * tests correct input address with IPv4 host and port range.
+     * Tests correct input address with IPv4 host and port range.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -46,7 +48,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * tests correct input address with IPv4 host and single port.
+     * Tests correct input address with IPv4 host and single port.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -61,7 +64,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * ests correct input address with IPv4 host and no port.
+     * Tests correct input address with IPv4 host and no port.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -76,7 +80,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * tests correct input address with IPv6 host and port range.
+     * Tests correct input address with IPv6 host and port range.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -91,7 +96,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * tests correct input address with IPv6 host and single port.
+     * Tests correct input address with IPv6 host and single port.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -106,7 +112,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * tests correct input address with IPv6 host and no port.
+     * Tests correct input address with IPv6 host and no port.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -124,13 +131,15 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     /**
-     * tests incorrect input address with IPv6 host (no brackets) and port.
+     * Tests incorrect input address with IPv6 host (no brackets) and port.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
     public void testParseIPv6IncorrectHost() throws IgniteCheckedException {
         expectedEx.expect(IgniteCheckedException.class);
         expectedEx.expectMessage("IPv6 is incorrect");
+        expectedEx.expectCause(IsInstanceOf.instanceOf(UnknownHostException.class));
         String addrStr = "3ffe:2a00:100:7031";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
@@ -139,7 +148,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * tests empty host and port.
+     * Tests empty host and port.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test
@@ -154,7 +164,8 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
     }
 
     /**
-     * tests empty address string.
+     * Tests empty address string.
+     *
      * @throws IgniteCheckedException on incorrect host/port
      */
     @Test

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -48,35 +48,35 @@ public class HostAndPortRangeTest {
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;
         HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
-        HostAndPortRange expected = new HostAndPortRange("[::1]", 8080, 8090);
+        HostAndPortRange expected = new HostAndPortRange("::1", 8080, 8090);
         assertEquals(expected, actual);
     }
 
     @Test
     public void testParseIPv6WithSinglePort() throws IgniteCheckedException {
-        String addrStr = "[::1]:8080";
+        String addrStr = "[3ffe:2a00:100:7031::]:8080";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;
         HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
-        HostAndPortRange expected = new HostAndPortRange("[::1]", 8080, 8080);
+        HostAndPortRange expected = new HostAndPortRange("3ffe:2a00:100:7031::", 8080, 8080);
         assertEquals(expected, actual);
     }
 
     @Test
     public void testParseIPv6NoPort() throws IgniteCheckedException {
-        String addrStr = "[::1]";
+        String addrStr = "[::FFFF:129.144.52.38]";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;
         HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
-        HostAndPortRange expected = new HostAndPortRange("[::1]", 18360, 18362);
+        HostAndPortRange expected = new HostAndPortRange("::FFFF:129.144.52.38", 18360, 18362);
         assertEquals(expected, actual);
     }
 
     @Test(expected = IgniteCheckedException.class)
     public void testParseIPv6IncorrectHost() throws IgniteCheckedException {
-        String addrStr = "1::1:8080";
+        String addrStr = "3ffe:2a00:100:7031:::8080";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -18,11 +18,17 @@
 package org.apache.ignite.internal.util;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.apache.ignite.testframework.junits.common.GridCommonTest;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-
-public class HostAndPortRangeTest {
+/**
+ * Tests HostAndPortRange parse method.
+ */
+@GridCommonTest(group = "Utils")
+public class HostAndPortRangeTest extends GridCommonAbstractTest {
 
     /**
      * tests correct input address with IPv4 host and port range.
@@ -105,7 +111,7 @@ public class HostAndPortRangeTest {
      */
     @Test
     public void testParseIPv6NoPort() throws IgniteCheckedException {
-        String addrStr = "[::FFFF:129.144.52.38]";
+        String addrStr = "::FFFF:129.144.52.38";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;
@@ -114,39 +120,48 @@ public class HostAndPortRangeTest {
         assertEquals(expected, actual);
     }
 
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
     /**
      * tests incorrect input address with IPv6 host (no brackets) and port.
      * @throws IgniteCheckedException on incorrect host/port
      */
-    @Test(expected = IgniteCheckedException.class)
+    @Test
     public void testParseIPv6IncorrectHost() throws IgniteCheckedException {
-        String addrStr = "3ffe:2a00:100:7031:::8080";
+        expectedEx.expect(IgniteCheckedException.class);
+        expectedEx.expectMessage("IPv6 is incorrect");
+        String addrStr = "3ffe:2a00:100:7031";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;
-        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
-
+        HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
     }
 
     /**
      * tests empty host and port.
      * @throws IgniteCheckedException on incorrect host/port
      */
-    @Test(expected = IgniteCheckedException.class)
+    @Test
     public void testParseNoHost() throws IgniteCheckedException {
+        expectedEx.expect(IgniteCheckedException.class);
+        expectedEx.expectMessage("Host name is empty");
         String addrStr = ":8080";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;
         int dfltPortTo = 18362;
-        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
     }
 
     /**
      * tests empty address string.
      * @throws IgniteCheckedException on incorrect host/port
      */
-    @Test(expected = IgniteCheckedException.class)
+    @Test
     public void testParseNoAddress() throws IgniteCheckedException {
+        expectedEx.expect(IgniteCheckedException.class);
+        expectedEx.expectMessage("Address is empty");
         String addrStr = "";
         String errMsgPrefix = "";
         int dfltPortFrom = 18360;

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-
 public class HostAndPortRangeTest {
 
     @Test

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -120,7 +120,6 @@ public class HostAndPortRangeTest extends GridCommonAbstractTest {
         assertEquals(expected, actual);
     }
 
-
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/HostAndPortRangeTest.java
@@ -1,0 +1,104 @@
+package org.apache.ignite.internal.util;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class HostAndPortRangeTest {
+
+    @Test
+    public void testParseIPv4WithPortRange() throws IgniteCheckedException {
+        String addrStr = "127.0.0.1:8080..8090";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange expected = new HostAndPortRange("127.0.0.1", 8080, 8090);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseIPv4WithSinglePort() throws IgniteCheckedException {
+        String addrStr = "127.0.0.1:8080";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange expected = new HostAndPortRange("127.0.0.1", 8080, 8080);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseIPv4NoPort() throws IgniteCheckedException {
+        String addrStr = "127.0.0.1";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange expected = new HostAndPortRange("127.0.0.1", 18360, 18362);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseIPv6WithPortRange() throws IgniteCheckedException {
+        String addrStr = "[::1]:8080..8090";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange expected = new HostAndPortRange("[::1]", 8080, 8090);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseIPv6WithSinglePort() throws IgniteCheckedException {
+        String addrStr = "[::1]:8080";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange expected = new HostAndPortRange("[::1]", 8080, 8080);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testParseIPv6NoPort() throws IgniteCheckedException {
+        String addrStr = "[::1]";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+        HostAndPortRange expected = new HostAndPortRange("[::1]", 18360, 18362);
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = IgniteCheckedException.class)
+    public void testParseIPv6IncorrectHost() throws IgniteCheckedException {
+        String addrStr = "1::1:8080";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+
+    }
+
+    @Test(expected = IgniteCheckedException.class)
+    public void testParseNoHost() throws IgniteCheckedException {
+        String addrStr = ":8080";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+    }
+
+    @Test(expected = IgniteCheckedException.class)
+    public void testParseNoAddress() throws IgniteCheckedException {
+        String addrStr = "";
+        String errMsgPrefix = "";
+        int dfltPortFrom = 18360;
+        int dfltPortTo = 18362;
+        HostAndPortRange actual = HostAndPortRange.parse(addrStr, dfltPortFrom, dfltPortTo, errMsgPrefix);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteUtilSelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteUtilSelfTestSuite.java
@@ -25,6 +25,7 @@ import org.apache.ignite.internal.util.DistributedProcessCoordinatorLeftTest;
 import org.apache.ignite.internal.util.GridArraysSelfTest;
 import org.apache.ignite.internal.util.GridConcurrentMultiPairQueueTest;
 import org.apache.ignite.internal.util.GridCountDownCallbackTest;
+import org.apache.ignite.internal.util.HostAndPortRangeTest;
 import org.apache.ignite.internal.util.IgniteDevOnlyLogTest;
 import org.apache.ignite.internal.util.IgniteExceptionRegistrySelfTest;
 import org.apache.ignite.internal.util.IgniteUtilsSelfTest;
@@ -140,7 +141,9 @@ import org.junit.runners.Suite;
 
     DistributedProcessCoordinatorLeftTest.class,
 
-    BasicRateLimiterTest.class
+    BasicRateLimiterTest.class,
+
+    HostAndPortRangeTest.class
 })
 public class IgniteUtilSelfTestSuite {
 }


### PR DESCRIPTION
- changed HostAndPortRange.parse method to support addresses like [IPv6_host]:port1..port2, because previous implementation didn't recognized IPv6;
- implemented unit tests for HostAndPortRange.parse method for both IPv4 and IPv6 hosts.