### PR TITLE
IGNITE-13734 .NET: Register service return type on method invocation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/binary/PlatformBinaryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/binary/PlatformBinaryProcessor.java
@@ -134,10 +134,11 @@ public class PlatformBinaryProcessor extends PlatformAbstractTarget {
 
             case OP_GET_TYPE: {
                 int typeId = reader.readInt();
+                byte platformId = reader.readByte();
 
                 try {
                     String typeName = platformContext().kernalContext().marshallerContext()
-                        .getClassName(MarshallerPlatformIds.DOTNET_ID, typeId);
+                        .getClassName(platformId, typeId);
 
                     writer.writeString(typeName);
                 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/Account.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/Account.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import java.util.Objects;
+
+/** */
+public class Account {
+    /** */
+    private String id;
+
+    /** */
+    private int amount;
+
+    /** */
+    public Account() {
+    }
+
+    public Account(String id, int amount) {
+        this.id = id;
+        this.amount = amount;
+    }
+
+    /** */
+    public String getId() {
+        return id;
+    }
+
+    /** */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /** */
+    public int getAmount() {
+        return amount;
+    }
+
+    /** */
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Account account = (Account)o;
+        return Objects.equals(id, account.id);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
@@ -39,6 +39,15 @@ import org.apache.ignite.compute.ComputeJobResult;
 import org.apache.ignite.compute.ComputeTaskAdapter;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.platform.model.ACL;
+import org.apache.ignite.platform.model.Account;
+import org.apache.ignite.platform.model.Address;
+import org.apache.ignite.platform.model.Department;
+import org.apache.ignite.platform.model.Employee;
+import org.apache.ignite.platform.model.Key;
+import org.apache.ignite.platform.model.Role;
+import org.apache.ignite.platform.model.User;
+import org.apache.ignite.platform.model.Value;
 import org.apache.ignite.resources.IgniteInstanceResource;
 import org.apache.ignite.services.Service;
 import org.apache.ignite.services.ServiceContext;
@@ -506,6 +515,14 @@ public class PlatformDeployServiceTask extends ComputeTaskAdapter<String, Object
             return new Account[] {
                 new Account("123", 42),
                 new Account("321", 0)
+            };
+        }
+
+        /** */
+        public User[] testUsers() {
+            return new User[] {
+                new User(1, ACL.ALLOW, new Role("admin")),
+                new User(2, ACL.DENY, new Role("user"))
             };
         }
 

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
@@ -502,6 +502,14 @@ public class PlatformDeployServiceTask extends ComputeTaskAdapter<String, Object
         }
 
         /** */
+        public Account[] testAccounts() {
+            return new Account[] {
+                new Account("123", 42),
+                new Account("321", 0)
+            };
+        }
+
+        /** */
         public void testDateArray(Timestamp[] dates) {
             assertNotNull(dates);
             assertEquals(2, dates.length);

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/ACL.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/ACL.java
@@ -15,33 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.platform;
+package org.apache.ignite.platform.model;
 
-/** Test value object. */
-public class Address {
-    /** */
-    private String zip;
-
-    /** */
-    private String addr;
-
-    /** */
-    public String getZip() {
-        return zip;
-    }
-
-    /** */
-    public void setZip(String zip) {
-        this.zip = zip;
-    }
-
-    /** */
-    public String getAddr() {
-        return addr;
-    }
-
-    /** */
-    public void setAddr(String addr) {
-        this.addr = addr;
-    }
+/** Test enum. */
+public enum ACL {
+    ALLOW, DENY
 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Account.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Account.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform.model;
+
+import java.util.Objects;
+
+/** */
+public class Account {
+    /** */
+    private String id;
+
+    /** */
+    private int amount;
+
+    /** */
+    public Account() {
+    }
+
+    public Account(String id, int amount) {
+        this.id = id;
+        this.amount = amount;
+    }
+
+    /** */
+    public String getId() {
+        return id;
+    }
+
+    /** */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /** */
+    public int getAmount() {
+        return amount;
+    }
+
+    /** */
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Account account = (Account)o;
+        return Objects.equals(id, account.id);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Address.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Address.java
@@ -15,37 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.platform;
-
-import java.util.Objects;
+package org.apache.ignite.platform.model;
 
 /** Test value object. */
-public class Value {
+public class Address {
     /** */
-    private String val;
+    private String zip;
 
     /** */
-    public Value(String val) {
-        this.val = val;
+    private String addr;
+
+    /** */
+    public String getZip() {
+        return zip;
     }
 
     /** */
-    public String getVal() {
-        return val;
+    public void setZip(String zip) {
+        this.zip = zip;
     }
 
-    /** {@inheritDoc} */
-    @Override public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        Value value = (Value)o;
-        return Objects.equals(val, value.val);
+    /** */
+    public String getAddr() {
+        return addr;
     }
 
-    /** {@inheritDoc} */
-    @Override public int hashCode() {
-        return Objects.hash(val);
+    /** */
+    public void setAddr(String addr) {
+        this.addr = addr;
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Department.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Department.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform.model;
+
+/** Test value object. */
+public class Department {
+    /** */
+    private String name;
+
+    /** */
+    public String getName() {
+        return name;
+    }
+
+    /** */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Employee.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Employee.java
@@ -15,37 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.platform;
+package org.apache.ignite.platform.model;
 
-import java.util.Objects;
-
-/** Test key object. */
-public class Key {
+/** Test value object. */
+public class Employee {
     /** */
-    private long id;
+    private String fio;
 
     /** */
-    public Key(long id) {
-        this.id = id;
+    private long salary;
+
+    /** */
+    public String getFio() {
+        return fio;
     }
 
     /** */
-    public long getId() {
-        return id;
+    public void setFio(String fio) {
+        this.fio = fio;
     }
 
-    /** {@inheritDoc} */
-    @Override public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        Key key = (Key)o;
-        return id == key.id;
+    /** */
+    public long getSalary() {
+        return salary;
     }
 
-    /** {@inheritDoc} */
-    @Override public int hashCode() {
-        return Objects.hash(id);
+    /** */
+    public void setSalary(long salary) {
+        this.salary = salary;
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Key.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Key.java
@@ -15,33 +15,37 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.platform;
+package org.apache.ignite.platform.model;
 
-/** Test value object. */
-public class Employee {
+import java.util.Objects;
+
+/** Test key object. */
+public class Key {
     /** */
-    private String fio;
+    private long id;
 
     /** */
-    private long salary;
-
-    /** */
-    public String getFio() {
-        return fio;
+    public Key(long id) {
+        this.id = id;
     }
 
     /** */
-    public void setFio(String fio) {
-        this.fio = fio;
+    public long getId() {
+        return id;
     }
 
-    /** */
-    public long getSalary() {
-        return salary;
+    /** {@inheritDoc} */
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Key key = (Key)o;
+        return id == key.id;
     }
 
-    /** */
-    public void setSalary(long salary) {
-        this.salary = salary;
+    /** {@inheritDoc} */
+    @Override public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Role.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Role.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform.model;
+
+/** Test value object. */
+public class Role {
+    /** */
+    String name;
+
+    /** */
+    public Role(String name) {
+        this.name = name;
+    }
+
+    /** */
+    public String getName() {
+        return name;
+    }
+
+    /** */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/User.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/User.java
@@ -15,20 +15,53 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.platform;
+package org.apache.ignite.platform.model;
 
 /** Test value object. */
-public class Department {
+public class User {
     /** */
-    private String name;
+    private int id;
 
     /** */
-    public String getName() {
-        return name;
+    private ACL acl;
+
+    /** */
+    private Role role;
+
+    /** */
+    public User(int id, ACL acl, Role role) {
+        this.id = id;
+        this.acl = acl;
+        this.role = role;
     }
 
     /** */
-    public void setName(String name) {
-        this.name = name;
+    public int getId() {
+        return id;
+    }
+
+    /** */
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    /** */
+    public ACL getAcl() {
+        return acl;
+    }
+
+    /** */
+    public void setAcl(ACL acl) {
+        this.acl = acl;
+    }
+
+    /** */
+    public Role getRole() {
+        return role;
+    }
+
+    /** */
+    public void setRole(Role role) {
+        this.role = role;
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/model/Value.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/model/Value.java
@@ -15,57 +15,37 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.platform;
+package org.apache.ignite.platform.model;
 
 import java.util.Objects;
 
-/** */
-public class Account {
+/** Test value object. */
+public class Value {
     /** */
-    private String id;
+    private String val;
 
     /** */
-    private int amount;
-
-    /** */
-    public Account() {
-    }
-
-    public Account(String id, int amount) {
-        this.id = id;
-        this.amount = amount;
+    public Value(String val) {
+        this.val = val;
     }
 
     /** */
-    public String getId() {
-        return id;
+    public String getVal() {
+        return val;
     }
 
-    /** */
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    /** */
-    public int getAmount() {
-        return amount;
-    }
-
-    /** */
-    public void setAmount(int amount) {
-        this.amount = amount;
-    }
-
+    /** {@inheritDoc} */
     @Override public boolean equals(Object o) {
         if (this == o)
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        Account account = (Account)o;
-        return Objects.equals(id, account.id);
+        Value value = (Value)o;
+        return Objects.equals(val, value.val);
     }
 
+    /** {@inheritDoc} */
     @Override public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(val);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/IJavaService.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/IJavaService.cs
@@ -22,7 +22,7 @@ namespace Apache.Ignite.Core.Tests.Services
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Apache.Ignite.Core.Binary;
-    using org.apache.ignite.platform;
+    using org.apache.ignite.platform.model;
 
     /// <summary>
     /// Java service proxy interface.
@@ -173,6 +173,9 @@ namespace Apache.Ignite.Core.Tests.Services
         
         /** */
         Account[] testAccounts();
+
+        /** */
+        User[] testUsers();
 
         /** */
         ICollection testDepartments(ICollection deps);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/IJavaService.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/IJavaService.cs
@@ -170,6 +170,9 @@ namespace Apache.Ignite.Core.Tests.Services
 
         /** */
         Employee[] testEmployees(Employee[] emps);
+        
+        /** */
+        Account[] testAccounts();
 
         /** */
         ICollection testDepartments(ICollection deps);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
@@ -21,7 +21,7 @@ namespace Apache.Ignite.Core.Tests.Services
     using System.Collections;
     using System.Collections.Generic;
     using Apache.Ignite.Core.Binary;
-    using org.apache.ignite.platform;
+    using org.apache.ignite.platform.model;
 
     /// <summary>
     /// Explicit service proxy over dynamic variable.
@@ -322,6 +322,11 @@ namespace Apache.Ignite.Core.Tests.Services
         public Account[] testAccounts()
         {
             return _svc.testAccounts();
+        }
+
+        public User[] testUsers()
+        {
+            return _svc.testUsers();
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
@@ -319,6 +319,11 @@ namespace Apache.Ignite.Core.Tests.Services
             return _svc.testEmployees(emps);
         }
 
+        public Account[] testAccounts()
+        {
+            return _svc.testAccounts();
+        }
+
         /** <inheritDoc /> */
         public ICollection testDepartments(ICollection deps)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/Model.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/Model.cs
@@ -18,6 +18,8 @@
 // ReSharper disable once CheckNamespace
 namespace org.apache.ignite.platform
 {
+    using System;
+
     /// <summary>
     /// A class is a clone of Java class Address with the same namespace.
     /// </summary>
@@ -84,5 +86,34 @@ namespace org.apache.ignite.platform
     public class Value
     {
         public string Val { get; set; }
+    }
+
+    /// <summary>
+    /// A class is a clone of Java class Account with the same namespace.
+    /// </summary>
+    public class Account
+    {
+        public String Id { get; set; }
+        
+        public int Amount { get; set; }
+
+        protected bool Equals(Account other)
+        {
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Account) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
+            return Id.GetHashCode();
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/Model.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/Model.cs
@@ -16,7 +16,7 @@
  */
 
 // ReSharper disable once CheckNamespace
-namespace org.apache.ignite.platform
+namespace org.apache.ignite.platform.model
 {
     using System;
 
@@ -116,4 +116,32 @@ namespace org.apache.ignite.platform
             return Id.GetHashCode();
         }
     }
+
+    /// <summary>
+    /// A enum is a clone of Java class User with the same namespace.
+    /// </summary>
+    public enum ACL
+    {
+        Allow, Deny
+    }
+
+    /// <summary>
+    /// A class is a clone of Java class Role with the same namespace.
+    /// </summary>
+    public class Role
+    {
+        public String Name { get; set; }
+    }
+
+    /// <summary>
+    /// A class is a clone of Java class User with the same namespace.
+    /// </summary>
+    public class User
+    {
+        public int Id { get; set; }
+        
+        public ACL Acl { get; set; }
+        
+        public Role Role { get; set; }
+    }    
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceProxyTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceProxyTest.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Core.Tests.Services
 {
     using System;
-    using System.CodeDom;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceProxyTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceProxyTest.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Core.Tests.Services
 {
     using System;
+    using System.CodeDom;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
@@ -283,32 +284,41 @@ namespace Apache.Ignite.Core.Tests.Services
                 // 1) Write to a stream
                 inStream.WriteBool(SrvKeepBinary);  // WriteProxyMethod does not do this, but Java does
 
-                ServiceProxySerializer.WriteProxyMethod(_marsh.StartMarshal(inStream), method.Name, 
-                    method, args, PlatformType.DotNet);
+                Marshaller.RegisterSameJavaType.Value = true;
 
-                inStream.SynchronizeOutput();
+                try
+                {
+                    ServiceProxySerializer.WriteProxyMethod(_marsh.StartMarshal(inStream), method.Name,
+                        method, args, PlatformType.DotNet);
 
-                inStream.Seek(0, SeekOrigin.Begin);
+                    inStream.SynchronizeOutput();
 
-                // 2) call InvokeServiceMethod
-                string mthdName;
-                object[] mthdArgs;
+                    inStream.Seek(0, SeekOrigin.Begin);
 
-                ServiceProxySerializer.ReadProxyMethod(inStream, _marsh, out mthdName, out mthdArgs);
+                    // 2) call InvokeServiceMethod
+                    string mthdName;
+                    object[] mthdArgs;
 
-                var result = ServiceProxyInvoker.InvokeServiceMethod(_svc, mthdName, mthdArgs);
+                    ServiceProxySerializer.ReadProxyMethod(inStream, _marsh, out mthdName, out mthdArgs);
 
-                ServiceProxySerializer.WriteInvocationResult(outStream, _marsh, result.Key, result.Value);
+                    var result = ServiceProxyInvoker.InvokeServiceMethod(_svc, mthdName, mthdArgs);
 
-                var writer = _marsh.StartMarshal(outStream);
-                writer.WriteString("unused");  // fake Java exception details
-                writer.WriteString("unused");  // fake Java exception details
+                    ServiceProxySerializer.WriteInvocationResult(outStream, _marsh, result.Key, result.Value);
 
-                outStream.SynchronizeOutput();
+                    var writer = _marsh.StartMarshal(outStream);
+                    writer.WriteString("unused"); // fake Java exception details
+                    writer.WriteString("unused"); // fake Java exception details
 
-                outStream.Seek(0, SeekOrigin.Begin);
+                    outStream.SynchronizeOutput();
 
-                return ServiceProxySerializer.ReadInvocationResult(outStream, _marsh, KeepBinary);
+                    outStream.Seek(0, SeekOrigin.Begin);
+
+                    return ServiceProxySerializer.ReadInvocationResult(outStream, _marsh, KeepBinary);
+                }
+                finally 
+                {
+                    Marshaller.RegisterSameJavaType.Value = true;
+                }
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTypeAutoResolveTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTypeAutoResolveTest.cs
@@ -97,11 +97,11 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             // Deploy Java service
             var javaSvcName = TestUtils.DeployJavaService(_grid1);
-            
+
             var svc = _grid1.GetServices().GetServiceProxy<IJavaService>(javaSvcName, false);
 
             doTestService(svc);
-            
+
             Assert.IsNull(svc.testDepartments(null));
 
             var arr  = new[] {"HR", "IT"}.Select(x => new Department() {Name = x}).ToArray();
@@ -153,6 +153,15 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.NotNull(res);
             Assert.AreEqual(1, res.Count);
             Assert.AreEqual("value3", ((Value)res[new Key() {Id = 3}]).Val);
+
+            var accs = svc.testAccounts();
+
+            Assert.NotNull(accs);
+            Assert.AreEqual(2, accs.Length);
+            Assert.AreEqual("123", accs[0].Id);
+            Assert.AreEqual("321", accs[1].Id);
+            Assert.AreEqual(42, accs[0].Amount);
+            Assert.AreEqual(0, accs[1].Amount);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTypeAutoResolveTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTypeAutoResolveTest.cs
@@ -23,7 +23,7 @@ namespace Apache.Ignite.Core.Tests.Services
     using System.IO;
     using System.Linq;
     using NUnit.Framework;
-    using org.apache.ignite.platform;
+    using org.apache.ignite.platform.model;
 
     /// <summary>
     /// Tests checks ability to execute service method without explicit registration of parameter type.
@@ -162,6 +162,17 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual("321", accs[1].Id);
             Assert.AreEqual(42, accs[0].Amount);
             Assert.AreEqual(0, accs[1].Amount);
+
+            var users = svc.testUsers();
+
+            Assert.NotNull(users);
+            Assert.AreEqual(2, users.Length);
+            Assert.AreEqual(1, users[0].Id);
+            Assert.AreEqual(ACL.Allow, users[0].Acl);
+            Assert.AreEqual("admin", users[0].Role.Name);
+            Assert.AreEqual(2, users[1].Id);
+            Assert.AreEqual(ACL.Deny, users[1].Acl);
+            Assert.AreEqual("user", users[1].Role.Name);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryProcessor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryProcessor.cs
@@ -28,10 +28,10 @@ namespace Apache.Ignite.Core.Impl.Binary
     internal class BinaryProcessor : PlatformTargetAdapter, IBinaryProcessor
     {
         /** Java platform id. See org.apache.ignite.internal.MarshallerPlatformIds in Java. */
-        private const byte JavaPlatformId = 0;
+        public const byte JavaPlatformId = 0;
 
         /** Type registry platform id. See org.apache.ignite.internal.MarshallerPlatformIds in Java. */
-        private const byte DotNetPlatformId = 1;
+        public const byte DotNetPlatformId = 1;
 
         /// <summary>
         /// Op codes.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryProcessor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryProcessor.cs
@@ -170,11 +170,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             try
             {
-                return DoOutInOp((int) Op.GetType, w =>
-                {
-                    w.WriteInt(id);
-                    w.WriteByte(DotNetPlatformId);
-                }, r => Marshaller.StartUnmarshal(r).ReadString());
+                return GetTypeName(id, DotNetPlatformId);
             }
             catch (BinaryObjectException)
             {
@@ -183,18 +179,26 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
 
             // Try to get java type name and register corresponding DotNet type.
-            var javaTypeName = DoOutInOp((int) Op.GetType, w =>
-            {
-                w.WriteInt(id);
-                w.WriteByte(JavaPlatformId);
-            }, r => Marshaller.StartUnmarshal(r).ReadString());
+            var javaTypeName = GetTypeName(id, JavaPlatformId);
+            var netTypeName = Marshaller.GetTypeName(javaTypeName);
 
-            RegisterType(id, Marshaller.GetTypeName(javaTypeName), false);
+            RegisterType(id, netTypeName, false);
 
+            return netTypeName;
+        }
+
+        /// <summary>
+        /// Gets the type name by id for specific platform.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <param name="platformId">Platform identifier.</param>
+        /// <returns>Type or null.</returns>
+        private string GetTypeName(int id, byte platformId)
+        {
             return DoOutInOp((int) Op.GetType, w =>
             {
                 w.WriteInt(id);
-                w.WriteByte(DotNetPlatformId);
+                w.WriteByte(platformId);
             }, r => Marshaller.StartUnmarshal(r).ReadString());
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryProcessorClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryProcessorClient.cs
@@ -28,12 +28,6 @@ namespace Apache.Ignite.Core.Impl.Binary
     /// </summary>
     internal class BinaryProcessorClient : IBinaryProcessor
     {
-        /** Java platform id. See org.apache.ignite.internal.MarshallerPlatformIds in Java. */
-        private const byte JavaPlatformId = 0;
-
-        /** Type registry platform id. See org.apache.ignite.internal.MarshallerPlatformIds in Java. */
-        private const byte DotNetPlatformId = 1;
-
         /** Socket. */
         private readonly ClientFailoverSocket _socket;
 
@@ -80,7 +74,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             var res = _socket.DoOutInOp(ClientOp.BinaryTypeNamePut, ctx =>
             {
-                ctx.Stream.WriteByte(DotNetPlatformId);
+                ctx.Stream.WriteByte(BinaryProcessor.DotNetPlatformId);
                 ctx.Stream.WriteInt(id);
                 ctx.Writer.WriteString(typeName);
             }, ctx => ctx.Stream.ReadBool());
@@ -89,7 +83,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             {
                 res = _socket.DoOutInOp(ClientOp.BinaryTypeNamePut, ctx =>
                 {
-                    ctx.Stream.WriteByte(JavaPlatformId);
+                    ctx.Stream.WriteByte(BinaryProcessor.JavaPlatformId);
                     ctx.Stream.WriteInt(id);
                     ctx.Writer.WriteString(typeName);
                 }, ctx => ctx.Stream.ReadBool());
@@ -109,7 +103,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             return _socket.DoOutInOp(ClientOp.BinaryTypeNameGet, ctx =>
                 {
-                    ctx.Stream.WriteByte(DotNetPlatformId);
+                    ctx.Stream.WriteByte(BinaryProcessor.DotNetPlatformId);
                     ctx.Stream.WriteInt(id);
                 },
                 ctx => ctx.Reader.ReadString());

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Marshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Marshaller.cs
@@ -907,7 +907,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// <summary>
         /// Gets the name of the type.
         /// </summary>
-        private string GetTypeName(string fullTypeName, IBinaryNameMapper mapper = null)
+        public string GetTypeName(string fullTypeName, IBinaryNameMapper mapper = null)
         {
             mapper = mapper ?? _cfg.NameMapper ?? GetDefaultNameMapper();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/Services.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/Services.cs
@@ -434,10 +434,20 @@ namespace Apache.Ignite.Core.Impl.Services
         private object InvokeProxyMethod(IPlatformTargetInternal proxy, string methodName,
             MethodBase method, object[] args, PlatformType platformType)
         {
-            return DoOutInOp(OpInvokeMethod,
-                writer => ServiceProxySerializer.WriteProxyMethod(writer, methodName, method, args, platformType),
-                (stream, res) => ServiceProxySerializer.ReadInvocationResult(stream, Marshaller, _keepBinary), 
-                proxy);
+            Marshaller.RegisterSameJavaType.Value = true;
+
+            try
+            {
+                return DoOutInOp(OpInvokeMethod,
+                    writer => ServiceProxySerializer.WriteProxyMethod(writer, methodName, method, args, platformType),
+                    (stream, res) => ServiceProxySerializer.ReadInvocationResult(stream, Marshaller, _keepBinary),
+                    proxy);
+            }
+            finally
+            {
+                Marshaller.RegisterSameJavaType.Value = false;
+            }
+
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes bug that occurs on the invocation of the service method that has not registered return type.

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
