### PR TITLE
ignite-13906 fix possible deadlock in GridEncryptionManager

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/encryption/GridEncryptionManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/encryption/GridEncryptionManager.java
@@ -1402,18 +1402,19 @@ public class GridEncryptionManager extends GridManagerAdapter<EncryptionSpi> imp
         try {
             getSpi().setMasterKeyName(name);
 
-            ctx.cache().context().database().checkpointReadLock();
+            synchronized (metaStorageMux) {
+                ctx.cache().context().database().checkpointReadLock();
 
-            try {
-                writeKeysToWal();
+                try {
+                    writeKeysToWal();
 
-                synchronized (metaStorageMux) {
                     assert writeToMetaStoreEnabled;
 
                     writeKeysToMetaStore(true);
                 }
-            } finally {
-                ctx.cache().context().database().checkpointReadUnlock();
+                finally {
+                    ctx.cache().context().database().checkpointReadUnlock();
+                }
             }
 
             log.info("Master key successfully changed [masterKeyName=" + name + ']');


### PR DESCRIPTION
Fix possible deadlock between methods in GridEncryptionManager. For more info see related Jira [issue](https://issues.apache.org/jira/browse/IGNITE-13906)