### PR TITLE
ducktape-better-params

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/discovery.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/discovery.py
@@ -49,6 +49,7 @@ class ZookeeperDiscoverySpi(DiscoverySpi):
         self.connection_string = zoo_service.connection_string()
         self.port = zoo_service.settings.client_port
         self.root_path = root_path
+        self.session_timeout = zoo_service.settings.min_session_timeout
 
     @property
     def type(self):

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/discovery_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/discovery_macro.j2
@@ -39,6 +39,7 @@
     <bean class="org.apache.ignite.spi.discovery.zk.ZookeeperDiscoverySpi">
         <property name="zkConnectionString" value="{{ spi.connection_string }}"/>
         <property name="zkRootPath" value="{{ spi.root_path }}"/>
+        <property name="sessionTimeout" value="{{ spi.session_timeout }}"/>
     </bean>
 {% endmacro %}
 
@@ -46,6 +47,9 @@
     <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
         {% if spi.local_address %}
             <property name="localAddress" value="{{ spi.local_address }}"/>
+        {% endif %}
+        {% if spi.so_linger is defined %}
+            <property name="soLinger" value="{{ spi.so_linger }}"/>
         {% endif %}
         <property name="localPort" value="{{ spi.port }}"/>
         <property name="localPortRange" value="{{ spi.port_range }}"/>

--- a/modules/ducktests/tests/ignitetest/services/zk/templates/zookeeper.properties.j2
+++ b/modules/ducktests/tests/ignitetest/services/zk/templates/zookeeper.properties.j2
@@ -19,6 +19,7 @@ tickTime={{ settings.tick_time }}
 minSessionTimeout={{ settings.min_session_timeout }}
 initLimit={{ settings.init_limit }}
 syncLimit={{ settings.sync_limit }}
+forceSync={{ settings.force_sync }}
 dataDir={{ data_dir }}
 clientPort={{ settings.client_port }}
 {% for node in nodes %}
@@ -26,4 +27,3 @@ server.{{ loop.index }}={{ node.account.hostname }}:2888:3888
 {% endfor %}
 txnLogSizeLimitInKb=5120
 preAllocSize=5120
-forceSync=no

--- a/modules/ducktests/tests/ignitetest/services/zk/zookeeper.py
+++ b/modules/ducktests/tests/ignitetest/services/zk/zookeeper.py
@@ -22,7 +22,6 @@ from distutils.version import LooseVersion
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
-
 from ignitetest.services.utils.log_utils import monitor_log
 from ignitetest.services.utils.path import PathAware
 
@@ -36,6 +35,7 @@ class ZookeeperSettings:
         self.tick_time = kwargs.get('tick_time', self.min_session_timeout // 3)
         self.init_limit = kwargs.get('init_limit', 10)
         self.sync_limit = kwargs.get('sync_limit', 5)
+        self.force_sync = kwargs.get('force_sync', 'no')
         self.client_port = kwargs.get('client_port', 2181)
 
         version = kwargs.get("version")

--- a/modules/ducktests/tests/ignitetest/tests/discovery_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/discovery_test.py
@@ -36,7 +36,7 @@ from ignitetest.services.utils.time_utils import epoch_mills
 from ignitetest.services.zk.zookeeper import ZookeeperService, ZookeeperSettings
 from ignitetest.utils import ignite_versions, version_if, cluster
 from ignitetest.utils.ignite_test import IgniteTest
-from ignitetest.utils.version import DEV_BRANCH, LATEST, V_2_8_0, IgniteVersion
+from ignitetest.utils.version import DEV_BRANCH, LATEST, LATEST_2_7, V_2_8_0, V_2_9_0, IgniteVersion
 from ignitetest.utils.enum import constructible
 
 
@@ -165,6 +165,9 @@ class DiscoveryTest(IgniteTest):
             discovery_spi = from_zookeeper_cluster(zk_quorum)
         else:
             discovery_spi = TcpDiscoverySpi()
+
+            if LATEST_2_7 < test_config.version <= V_2_9_0:
+                discovery_spi.so_linger = 0
 
         ignite_config = IgniteConfiguration(
             version=test_config.version,


### PR DESCRIPTION
Introduces soLinger for Ignite 2.8.1 to reduce node failure detection. + other minor params.