### PR TITLE
IGNITE-13949 improved concurrent behaviour in PartitionUpdateCounterT…

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/PartitionUpdateCounterMvccImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/PartitionUpdateCounterMvccImpl.java
@@ -17,17 +17,19 @@
 
 package org.apache.ignite.internal.processors.cache;
 
-import java.util.TreeMap;
-
 /**
  * Update counter implementation for MVCC mode.
  */
 public class PartitionUpdateCounterMvccImpl extends PartitionUpdateCounterTrackingImpl {
+
+    private final CacheGroupContext grp;
+
     /**
      * @param grp Group.
      */
     public PartitionUpdateCounterMvccImpl(CacheGroupContext grp) {
         super(grp);
+        this.grp = grp;
     }
 
     /** {@inheritDoc} */
@@ -43,18 +45,5 @@ public class PartitionUpdateCounterMvccImpl extends PartitionUpdateCounterTracki
     /** {@inheritDoc} */
     @Override protected PartitionUpdateCounterTrackingImpl createInstance() {
         return new PartitionUpdateCounterMvccImpl(grp);
-    }
-
-    /** {@inheritDoc} */
-    @Override public PartitionUpdateCounter copy() {
-        PartitionUpdateCounterMvccImpl copy = new PartitionUpdateCounterMvccImpl(grp);
-
-        copy.cntr.set(cntr.get());
-        copy.first = first;
-        copy.queue = new TreeMap<>(queue);
-        copy.initCntr = initCntr;
-        copy.reserveCntr.set(reserveCntr.get());
-
-        return copy;
     }
 }


### PR DESCRIPTION
Substituted AtomicLong's for volatile long for several reasons:
- I think it's not worth it to have almost the same visibility benefits with AtomicLong's and create unnecessary objects for them. Native locks and volatile fields should be sufficient here;
- almost everywhere there are compound actions which require a separate synchronisation for themselves to be atomic, so AtomicLong's are overkill.

Also added necessary synchronisation in toString, copy and some other methods, since they we have reads over mutable variables.

Making iterator method synchronised is pointless, call to the iterator should be synced externally.