### PR TITLE
IGNITE-14012 fix ducktape jmx_tools MBean pattern

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/jmx_utils.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/jmx_utils.py
@@ -187,7 +187,7 @@ class IgniteJmxMixin:
         """
         :return: IgniteKernal MBean.
         """
-        return self.jmx_client().find_mbean('.*group=Kernal,name=IgniteKernal')
+        return self.jmx_client().find_mbean('.*group=Kernal.*name=IgniteKernal')
 
     @memoize
     def disco_mbean(self):
@@ -197,6 +197,6 @@ class IgniteJmxMixin:
         disco_spi = next(self.kernal_mbean().DiscoverySpiFormatted).strip()
 
         if 'ZookeeperDiscoverySpi' in disco_spi:
-            return self.jmx_client().find_mbean('.*group=SPIs,name=ZookeeperDiscoverySpi')
+            return self.jmx_client().find_mbean('.*group=SPIs.*name=ZookeeperDiscoverySpi')
 
-        return self.jmx_client().find_mbean('.*group=SPIs,name=TcpDiscoverySpi')
+        return self.jmx_client().find_mbean('.*group=SPIs.*name=TcpDiscoverySpi')


### PR DESCRIPTION
Sometimes MBeans structure looks like:
org.apache:clsLdr=764c12b6,group=Kernal,igniteInstanceName=Server_Example_Xml_-676757500,name=IgniteKernal
but jmx_utils works only if it looks like:
.*group=Kernal,name=IgniteKernal

This PR change search pattern

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
