### PR TITLE
IGNITE-12724 avoid skips in tests

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/WarmUpCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/WarmUpCommand.java
@@ -98,7 +98,7 @@ public class WarmUpCommand extends AbstractCommand<Void> {
     /**
      * Warm-up command arguments name.
      */
-    private enum WarmUpCommandArg implements CommandArg {
+    enum WarmUpCommandArg implements CommandArg {
         /** Stop warm-up argument. */
         STOP("--stop");
 


### PR DESCRIPTION
Previously we skipped commands that required subcommands in
CommandHandlerParsingTest. This commit appends hard coded valid
arguments to such commands before calling
CommonArgParser.parseAndValidate() to have all CommandList commands
used in tests to increase test coverage.


### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
