### PR TITLE
IGNITE-13588 .NET: Fix SQL type name for generic query types

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -258,7 +258,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var cache = ignite.GetOrCreateCache<int, GenericTest<string>>(cfg);
             cache[1] = new GenericTest<string> {Prop = "1"};
 
-            var res = cache.Query(new SqlFieldsQuery("select Prop from GenericTest"));
+            var tables = cache.Query(new SqlFieldsQuery("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"))
+                .Select(x => (string) x.Single()).ToArray();
+
+            var res = cache.Query(new SqlFieldsQuery("select Prop from \"0, CULTURE=NEUTRAL, PUBLICKEYTOKEN=7CEC85D7BEA7798E]]\""));
             Assert.AreEqual("1", res.Single().Single());
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -32,7 +32,17 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     /// </summary>
     public class CacheQueriesCodeConfigurationTest
     {
+        // TODO: Make all tests use a single Ignite instance to reduce execution time.
         const string CacheName = "personCache";
+
+        /// <summary>
+        /// Tears down the test fixture.
+        /// </summary>
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Ignition.StopAll(true);
+        }
 
         /// <summary>
         /// Tests the SQL query.
@@ -147,7 +157,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             Assert.AreEqual(-1, idx[1].InlineSize);
             Assert.AreEqual(513, idx[2].InlineSize);
             Assert.AreEqual(-1, idx[3].InlineSize);
-            
+
             Assert.AreEqual(3, idxField.Precision);
             Assert.AreEqual(4, idxField.Scale);
         }
@@ -213,7 +223,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 }
             }
         }
-        
+
         /// <summary>
         /// Tests query entity validation when no <see cref="QuerySqlFieldAttribute"/> has been set.
         /// </summary>
@@ -230,6 +240,15 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
                 cache["1"] = new MissingAttributesTest {Foo = "Bar"};
             }
+        }
+
+        /// <summary>
+        /// Tests that key and value types can be generic.
+        /// </summary>
+        [Test]
+        public void TestGenericQueryTypes()
+        {
+            var ignite = Ignition.Start(TestUtils.GetTestConfiguration());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -249,7 +249,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void TestGenericQueryTypes()
         {
-            // TODO: test generic key as well.
             var ignite = Ignition.Start(TestUtils.GetTestConfiguration());
 
             var cfg = new CacheConfiguration(TestUtils.TestName)
@@ -262,8 +261,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var value = new GenericTest<string>("2");
             cache[key] = value;
 
-            var tables = cache.Query(new SqlFieldsQuery("SELECT * FROM INFORMATION_SCHEMA.TABLES")).GetAll();
-
             var binType = ignite.GetBinary().GetBinaryType(value.GetType());
             var expectedTypeName = BinaryBasicNameMapper.FullNameInstance.GetTypeName(value.GetType().FullName);
             var expectedTypeId = BinaryUtils.GetStringHashCodeLowerCase(expectedTypeName);
@@ -273,6 +270,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
             var queryEntity = cache.GetConfiguration().QueryEntities.Single();
             Assert.AreEqual(expectedTypeName, queryEntity.ValueTypeName);
+
+            var cur = cache.Query(new SqlFieldsQuery(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name));
+            var tableName = cur.Single().Single();
+
+            var sqlRes = cache.Query(new SqlFieldsQuery("SELECT * from " + tableName)).GetAll();
+            Assert.AreEqual("1", sqlRes); // TODO
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -249,6 +249,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         public void TestGenericQueryTypes()
         {
             // TODO: test generic key as well.
+            // TODO: There are two issues at hand:
+            // - bad binary meta with assembly version
+            // - bad table name
+            // TODO: File separate issue for the table name.
             var ignite = Ignition.Start(TestUtils.GetTestConfiguration());
 
             var cfg = new CacheConfiguration(

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -248,7 +248,18 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         [Test]
         public void TestGenericQueryTypes()
         {
+            // TODO: test generic key as well.
             var ignite = Ignition.Start(TestUtils.GetTestConfiguration());
+
+            var cfg = new CacheConfiguration(
+                TestUtils.TestName,
+                new QueryEntity(typeof(int), typeof(GenericTest<string>)));
+
+            var cache = ignite.GetOrCreateCache<int, GenericTest<string>>(cfg);
+            cache[1] = new GenericTest<string> {Prop = "1"};
+
+            var res = cache.Query(new SqlFieldsQuery("select Prop from GenericTest"));
+            Assert.AreEqual("1", res.Single().Single());
         }
 
         /// <summary>
@@ -407,6 +418,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             /// </value>
             [QuerySqlField]
             public string Foo { get; set; }
+        }
+
+        /// <summary>
+        /// Generic query type.
+        /// </summary>
+        private class GenericTest<T>
+        {
+            /** */
+            [QuerySqlField]
+            public T Prop { get; set; }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -270,10 +270,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var queryEntity = cache.GetConfiguration().QueryEntities.Single();
             Assert.AreEqual(expectedTypeName, queryEntity.ValueTypeName);
 
-            var cur = cache.Query(new SqlFieldsQuery(
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name));
-
-            var tableName = cur.Single().Single(); // The value will be weird, see IGNITE-14064.
+            var tableName = cache.Query(new SqlFieldsQuery(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
+                .Single().Single(); // The table name is weird, see IGNITE-14064.
 
             var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Foo, Bar from \"{0}\"", tableName)))
                 .Single();
@@ -299,10 +298,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var value = new GenericTest<GenericTest2<string>>(new GenericTest2<string>("foobar"));
             cache[1] = value;
 
-            var cur = cache.Query(new SqlFieldsQuery(
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name));
-
-            var tableName = cur.Single().Single(); // The value will be weird, see IGNITE-14064.
+            var tableName = cache.Query(new SqlFieldsQuery(
+                    "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
+                .Single().Single(); // The table name is weird, see IGNITE-14064.
 
             var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Bar from \"{0}\"", tableName)))
                 .Single().Single();

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -33,14 +33,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     /// </summary>
     public class CacheQueriesCodeConfigurationTest
     {
-        // TODO: Make all tests use a single Ignite instance to reduce execution time.
         const string CacheName = "personCache";
 
         /// <summary>
         /// Tears down the test fixture.
         /// </summary>
-        [TestFixtureTearDown]
-        public void FixtureTearDown()
+        [TearDown]
+        public void TearDown()
         {
             Ignition.StopAll(true);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1533,8 +1533,12 @@ namespace Apache.Ignite.Core.Impl.Binary
             // Ignite SQL engine always uses simple type name without namespace, parent class, etc.
             // See QueryUtils.typeName
             // TODO: See GridQueryProcessor.store - make sure a matching table is found for generic types
-            // ("Key-value pair is not inserted into any SQL table"...)
-            return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
+            // Java uses typeId to locate corresponding QueryEntity when storing cache data,
+            // so typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId -
+            // how does this work when SimpleMapper is used? typeIds should seemingly be mismatched!
+
+            // return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
+            return type.FullName;
         }
 
         /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1535,7 +1535,8 @@ namespace Apache.Ignite.Core.Impl.Binary
             // TODO: See GridQueryProcessor.store - make sure a matching table is found for generic types
             // Java uses typeId to locate corresponding QueryEntity when storing cache data,
             // so typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId -
-            // how does this work when SimpleMapper is used? typeIds should seemingly be mismatched!
+            // how does this work when SimpleMapper is used? - because NameMapper+IdMapper are used on the Java side
+            // to get the type id from QueryEntity.valueTypeName.
 
             // return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
             return type.FullName;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1538,12 +1538,15 @@ namespace Apache.Ignite.Core.Impl.Binary
             // how does this work when SimpleMapper is used? - because NameMapper+IdMapper are used on the Java side
             // to get the type id from QueryEntity.valueTypeName.
 
-            // return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
-
-            // The following typeIds must match for SQL engine to work correctly (but how does it work with broken generics?):
+            // The following typeIds must match for SQL engine to work correctly
             // * CreateCache -> QueryEntity.ValueTypeName -> Java -> ctx.cacheObjects().typeId()
             // * Cache.Put -> Marshaller.GetTypeId
+            // However, thanks to "IGNITE-13160 .NET: register binary meta during cache start",
+            // we register query types in .NET Marshaller using this same full name below,
+            // so the type ids now match, even though we have bypassed the TypeNameParser, and included assembly versions
+            // in the binary metadata!
             return type.FullName;
+            // return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 
         /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1532,6 +1532,8 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             // Ignite SQL engine always uses simple type name without namespace, parent class, etc.
             // See QueryUtils.typeName
+            // TODO: See GridQueryProcessor.store - make sure a matching table is found for generic types
+            // ("Key-value pair is not inserted into any SQL table"...)
             return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1539,6 +1539,10 @@ namespace Apache.Ignite.Core.Impl.Binary
             // to get the type id from QueryEntity.valueTypeName.
 
             // return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
+
+            // The following typeIds must match for SQL engine to work correctly (but how does it work with broken generics?):
+            // * CreateCache -> QueryEntity.ValueTypeName -> Java -> ctx.cacheObjects().typeId()
+            // * Cache.Put -> Marshaller.GetTypeId
             return type.FullName;
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1530,8 +1530,11 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         public static string GetSqlTypeName(Type type)
         {
-            // SQL always uses simple type name without namespace, parent class, etc.
-            return type.FullName;
+            // TODO: Remove assembly names from generics
+            // TODO: Type name must match whatever gets registered in binary meta.
+            var res = TypeNameParser.Parse(type.FullName);
+
+            return res.GetFullName();
         }
 
         /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1530,23 +1530,13 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         public static string GetSqlTypeName(Type type)
         {
-            // Ignite SQL engine always uses simple type name without namespace, parent class, etc.
-            // See QueryUtils.typeName
-            // TODO: See GridQueryProcessor.store - make sure a matching table is found for generic types
-            // Java uses typeId to locate corresponding QueryEntity when storing cache data,
-            // so typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId -
-            // how does this work when SimpleMapper is used? - because NameMapper+IdMapper are used on the Java side
-            // to get the type id from QueryEntity.valueTypeName.
-
-            // The following typeIds must match for SQL engine to work correctly
-            // * CreateCache -> QueryEntity.ValueTypeName -> Java -> ctx.cacheObjects().typeId()
-            // * Cache.Put -> Marshaller.GetTypeId
-            // However, thanks to "IGNITE-13160 .NET: register binary meta during cache start",
-            // we register query types in .NET Marshaller using this same full name below,
-            // so the type ids now match, even though we have bypassed the TypeNameParser, and included assembly versions
-            // in the binary metadata!
-            return type.FullName;
-            // return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
+            // Ignite SQL engine always uses simple type name without namespace, parent class, etc -
+            // see QueryUtils.typeName.
+            // GridQueryProcessor.store uses this type name to ensure that we put correct data to the cache:
+            // cacheObjects().typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId.
+            // Additionally, this type name is passed back to UnmanagedCallbacks.BinaryTypeGet to register the
+            // query types on cache start.
+            return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 
         /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1530,11 +1530,9 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         public static string GetSqlTypeName(Type type)
         {
-            // TODO: Remove assembly names from generics
-            // TODO: Type name must match whatever gets registered in binary meta.
-            var res = TypeNameParser.Parse(type.FullName);
-
-            return res.GetFullName();
+            // SQL always uses simple type name without namespace, parent class, etc.
+            // TODO: Find that Java code and reference it here
+            return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 
         /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1530,8 +1530,8 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         public static string GetSqlTypeName(Type type)
         {
-            // SQL always uses simple type name without namespace, parent class, etc.
-            // TODO: Find that Java code and reference it here
+            // Ignite SQL engine always uses simple type name without namespace, parent class, etc.
+            // See QueryUtils.typeName
             return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 


### PR DESCRIPTION
`BinaryUtils.GetSqlTypeName` used to return `Type.FullName`, which includes assembly-qualified type names for all generic type arguments, which causes the following problems:
* SQL type name includes assembly versions, so queries stop working if there is a version change
* Incorrect binary type id is registered through the {{UnmanagedCallbacks.BinaryTypeGet}}

Remove assembly part from the SQL type name to tolerate version changes in the same way as we do for regular binary types.