### PR TITLE
IGNITE-14067 CREATE TABLE uses encryptionEnabled property of cache template

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -2000,7 +2000,7 @@ public class GridQueryProcessor extends GridProcessorAdapter {
         @Nullable CacheWriteSynchronizationMode writeSyncMode,
         @Nullable Integer backups,
         boolean ifNotExists,
-        boolean encrypted,
+        @Nullable Boolean encrypted,
         @Nullable Integer qryParallelism
     ) throws IgniteCheckedException {
         assert !F.isEmpty(templateName);
@@ -2050,7 +2050,9 @@ public class GridQueryProcessor extends GridProcessorAdapter {
         if (qryParallelism != null)
             ccfg.setQueryParallelism(qryParallelism);
 
-        ccfg.setEncryptionEnabled(encrypted);
+        if (encrypted != null) {
+            ccfg.setEncryptionEnabled(encrypted);
+        }
         ccfg.setSqlSchema("\"" + schemaName + "\"");
         ccfg.setSqlEscapeAll(true);
         ccfg.setQueryEntities(Collections.singleton(entity));

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sql/GridSqlCreateTable.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sql/GridSqlCreateTable.java
@@ -86,7 +86,7 @@ public class GridSqlCreateTable extends GridSqlStatement {
     private List<String> params;
 
     /** Encrypted flag. */
-    private boolean encrypted;
+    private Boolean encrypted;
 
     /** See {@link CacheConfiguration#getQueryParallelism()}. */
     private Integer parallelism;
@@ -346,7 +346,7 @@ public class GridSqlCreateTable extends GridSqlStatement {
     /**
      * @return Encrypted flag.
      */
-    public boolean encrypted() {
+    public Boolean encrypted() {
         return encrypted;
     }
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/encryption/EncryptedSqlTemplateTableTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/encryption/EncryptedSqlTemplateTableTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.cache.encryption;
 
+import java.util.List;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.apache.ignite.configuration.CacheConfiguration;
@@ -25,8 +26,6 @@ import org.apache.ignite.internal.encryption.EncryptedCacheRestartTest;
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 /** */
 public class EncryptedSqlTemplateTableTest extends EncryptedCacheRestartTest {

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/encryption/EncryptedSqlTemplateTableTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/encryption/EncryptedSqlTemplateTableTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.encryption;
+
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.encryption.EncryptedCacheRestartTest;
+import org.apache.ignite.internal.util.IgniteUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/** */
+public class EncryptedSqlTemplateTableTest extends EncryptedCacheRestartTest {
+    /** {@inheritDoc} */
+    @Override protected void createEncryptedCache(IgniteEx grid0, @Nullable IgniteEx grid1, String cacheName,
+                                                  String cacheGroup, boolean putData) {
+
+        CacheConfiguration templateConfiguration = new CacheConfiguration()
+                .setName("ENCRYPTED_TEMPLATE")
+                .setEncryptionEnabled(true);
+        grid0.addCacheConfiguration(templateConfiguration);
+
+        executeSql(grid0, "CREATE TABLE encrypted(ID BIGINT, NAME VARCHAR(10), PRIMARY KEY (ID)) " +
+                "WITH \"TEMPLATE=ENCRYPTED_TEMPLATE\"");
+        executeSql(grid0, "CREATE INDEX enc0 ON encrypted(NAME)");
+
+        if (putData) {
+            for (int i = 0; i < 100; i++)
+                executeSql(grid0, "INSERT INTO encrypted(ID, NAME) VALUES(?, ?)", i, "" + i);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void checkData(IgniteEx grid0) {
+        IgniteCache cache = grid0.cache(cacheName());
+        CacheConfiguration cacheConfiguration = (CacheConfiguration) cache.getConfiguration(CacheConfiguration.class);
+        assertTrue(cacheConfiguration.isEncryptionEnabled());
+
+        for (int i = 0; i < 100; i++) {
+            List<List<?>> res = executeSql(grid0, "SELECT NAME FROM encrypted WHERE ID = ?", i);
+
+            assertEquals(1, res.size());
+            assertEquals("" + i, res.get(0).get(0));
+        }
+    }
+
+    /** */
+    private List<List<?>> executeSql(IgniteEx grid, String qry, Object...args) {
+        return grid.context().query().querySqlFields(
+                new SqlFieldsQuery(qry).setSchema("PUBLIC").setArgs(args), true).getAll();
+    }
+
+    /** {@inheritDoc} */
+    @NotNull
+    @Override protected String cacheName() {
+        return "SQL_PUBLIC_ENCRYPTED";
+    }
+
+    /** {@inheritDoc} */
+    @Override protected String keystorePath() {
+        return IgniteUtils.resolveIgnitePath("modules/indexing/src/test/resources/tde.jks").getAbsolutePath();
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
@@ -124,6 +124,7 @@ import org.apache.ignite.internal.processors.cache.distributed.replicated.Ignite
 import org.apache.ignite.internal.processors.cache.distributed.replicated.IgniteCacheReplicatedQueryP2PDisabledSelfTest;
 import org.apache.ignite.internal.processors.cache.distributed.replicated.IgniteCacheReplicatedQuerySelfTest;
 import org.apache.ignite.internal.processors.cache.encryption.EncryptedSqlTableTest;
+import org.apache.ignite.internal.processors.cache.encryption.EncryptedSqlTemplateTableTest;
 import org.apache.ignite.internal.processors.cache.index.ArrayIndexTest;
 import org.apache.ignite.internal.processors.cache.index.BasicIndexMultinodeTest;
 import org.apache.ignite.internal.processors.cache.index.BasicIndexTest;
@@ -581,6 +582,7 @@ import org.junit.runners.Suite;
     SqlParserUserSelfTest.class,
     SqlUserCommandSelfTest.class,
     EncryptedSqlTableTest.class,
+    EncryptedSqlTemplateTableTest.class,
 
     // Partition loss.
     IndexingCachePartitionLossPolicySelfTest.class,


### PR DESCRIPTION
When using CREATE TABLE with a cache template, the encryptionEnabled property of the template is ignored. This change the parameter from a boolean to a Boolean, so NULL values are supported.

---

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
