### PR TITLE
IGNITE-14095 : Try to fasten cluster start in the ducktests with decreasing 'spi.reconnectDelay'

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/templates/discovery_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/discovery_macro.j2
@@ -53,6 +53,9 @@
         {% endif %}
         <property name="localPort" value="{{ spi.port }}"/>
         <property name="localPortRange" value="{{ spi.port_range }}"/>
+        {% if spi.reconnectDelay is defined %}
+            <property name="reconnectDelay" value="{{ spi.reconnectDelay }}"/>
+        {% endif %}
         {{ ip_finder(spi) }}
     </bean>
 {% endmacro %}

--- a/modules/ducktests/tests/ignitetest/tests/discovery_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/discovery_test.py
@@ -166,6 +166,8 @@ class DiscoveryTest(IgniteTest):
         else:
             discovery_spi = TcpDiscoverySpi()
 
+            discovery_spi.reconnectDelay = test_config.failure_detection_timeout // 5
+
             if LATEST_2_7 < test_config.version <= V_2_9_0:
                 discovery_spi.so_linger = 0
 


### PR DESCRIPTION
Try to speed up cluster start ath the ducktests with decreasing TcpDiscoverySpi.reconnectDelay