### PR TITLE
IGNITE-14068 : Infinite node persistance in the ring while outgoing connections are lost

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -6505,7 +6505,7 @@ class ServerImpl extends TcpDiscoveryImpl {
     }
 
     /**
-     * Segment local node if is being pinged while missing any outgoing ring connection.
+     * Segment local node if ring connection failed while incoming traffic is present.
      *
      * @param skipNodes If not {@code null}, aren't taken in account when observing nodes left in the ring.
      */

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -6553,7 +6553,6 @@ class ServerImpl extends TcpDiscoveryImpl {
         notifyDiscovery(EVT_NODE_SEGMENTED, ring.topologyVersion(), locNode);
     }
 
-
     /**
      * Creates proper timeout helper taking in account current send state and ring state.
      *

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -8238,7 +8238,7 @@ class ServerImpl extends TcpDiscoveryImpl {
         /** */
         private int failedNodes;
 
-        /** Maximal time point forany recovery operation. Nanos. */
+        /** Maximal time point for any recovery operation. Nanos. */
         private final long absoluteTimeout;
 
         /** Time of the failure in nanos. */

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -3949,7 +3949,7 @@ class ServerImpl extends TcpDiscoveryImpl {
                 if (!sent) {
                     assert next == null : next;
 
-                    checkOutgoingConnection(failedNodes);
+                    checkOutgoingConnection();
 
                     if (log.isDebugEnabled())
                         log.debug("Pending messages will be resent to local node");
@@ -6506,16 +6506,14 @@ class ServerImpl extends TcpDiscoveryImpl {
 
     /**
      * Segment local node if ring connection failed while incoming traffic is present.
-     *
-     * @param skipNodes If not {@code null}, aren't taken in account when observing nodes left in the ring.
      */
-    private void checkOutgoingConnection(Collection<TcpDiscoveryNode> skipNodes) {
+    private void checkOutgoingConnection() {
         // Skip if there is no msg sending failure or wait for ping comming after the failure.
         if (msgNotSentNanos == 0 || lastRingMsgReceivedTime < msgNotSentNanos + U.millisToNanos(connCheckInterval))
             return;
 
         synchronized (mux) {
-            if (spiState == CONNECTED && ring.serverNodes(skipNodes).size() == 1)
+            if (spiState == CONNECTED && ring.serverNodes(failedNodes.keySet()).size() == 1)
                 segmentLocalNodeOnSendFail(failedNodes.keySet());
         }
     }
@@ -7409,7 +7407,7 @@ class ServerImpl extends TcpDiscoveryImpl {
         private void ringMessageReceived() {
             lastRingMsgReceivedTime = System.nanoTime();
 
-            checkOutgoingConnection(null);
+            checkOutgoingConnection();
         }
 
         /** @return Alive address if was able to connected to. {@code Null} otherwise. */

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -8247,10 +8247,10 @@ class ServerImpl extends TcpDiscoveryImpl {
         /**
          *
          */
-        CrossRingMessageSendState(long failTimeNamos) {
-            initNanos = failTimeNamos;
+        CrossRingMessageSendState(long failTimeNanos) {
+            initNanos = failTimeNanos;
 
-            failTimeNanos = U.millisToNanos(spi.getEffectiveConnectionRecoveryTimeout()) + initNanos;
+            this.failTimeNanos = U.millisToNanos(spi.getEffectiveConnectionRecoveryTimeout()) + initNanos;
         }
 
         /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -3439,6 +3439,10 @@ class ServerImpl extends TcpDiscoveryImpl {
                         addMessage(msg, true);
                     }
 
+                    if (sndState != null && !failedNodes.isEmpty() &&
+                        lastRingMsgReceivedTime - U.millisToNanos(connCheckInterval) > sndState.initNanos)
+                        segmentLocalNodeOnSendFail(failedNodes);
+
                     break;
                 }
 
@@ -8211,11 +8215,16 @@ class ServerImpl extends TcpDiscoveryImpl {
         /** */
         private final long failTimeNanos;
 
+        /** */
+        private final long initNanos;
+
         /**
          *
          */
         CrossRingMessageSendState() {
-            failTimeNanos = U.millisToNanos(spi.getEffectiveConnectionRecoveryTimeout()) + System.nanoTime();
+            initNanos = System.nanoTime();
+
+            failTimeNanos = U.millisToNanos(spi.getEffectiveConnectionRecoveryTimeout()) + initNanos;
         }
 
         /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
@@ -379,7 +379,7 @@ abstract class TcpDiscoveryImpl {
      *                  timeout of certain net operation will be used.
      * @see #simulateNetFailure(Socket, long)
      */
-    void simulateNetTimeout(int direction, int delay){
+    void simulateNetTimeout(int direction, int delay) {
         simulateNetTimeout = new IgnitePair<>(direction, delay < 0 ? null : delay);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
@@ -18,6 +18,8 @@
 package org.apache.ignite.spi.discovery.tcp;
 
 import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,6 +39,7 @@ import org.apache.ignite.internal.IgniteFeatures;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.processors.tracing.NoopTracing;
 import org.apache.ignite.internal.processors.tracing.Tracing;
+import org.apache.ignite.internal.util.lang.IgnitePair;
 import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.LT;
@@ -126,6 +129,13 @@ abstract class TcpDiscoveryImpl {
 
     /** Tracing. */
     protected Tracing tracing;
+
+    /**
+     * FOR TEST ONLY!!
+     * If not {@code null}, enables network timeout simulation.
+     * First value switches traffic droppage: negative for all incoming, positive for all outgoing, 0 for both.
+     */
+    protected volatile IgnitePair<Integer> simulateNetTimeout;
 
     /**
      * Upcasts collection type.
@@ -357,6 +367,54 @@ abstract class TcpDiscoveryImpl {
      * This method is intended for test purposes only.
      */
     abstract void simulateNodeFailure();
+
+    /**
+     * <strong>FOR TEST ONLY!!!</strong>
+     * <p>
+     * Enabled network timeout simulation.
+     *
+     * @param direction If negative, enables timeout simulation for reading incomming traffic. If positive, enables
+     *                  timeout simulation on traffic.
+     * @param delay     Milliseconds of awaiting before raising {@code SocketTimeoutException}. If negative, the passed
+     *                  timeout of certain net operation will be used.
+     * @see #simulateNetFailure(Socket, long)
+     */
+    void simulateNetTimeout(int direction, int delay){
+        simulateNetTimeout = new IgnitePair<>(direction, delay < 0 ? null : delay);
+    }
+
+    /**
+     * <strong>FOR TEST ONLY!!!</strong>
+     * <p>
+     * If enabled, simulates network timeout. Throws {@code SocketTimeoutException} after a delay.
+     *
+     * @param sock  The socket
+     * @param delay The delay before raising {@code SocketTimeoutException}. Ignored if preset with {@link
+     *              #simulateNetTimeout(int, int)}
+     * @see #simulateNetTimeout(int, int)
+     */
+    void simulateNetFailure(Socket sock, long delay) throws SocketTimeoutException {
+        IgnitePair<Integer> simulateNetTimeout = this.simulateNetTimeout;
+
+        if (simulateNetTimeout == null)
+            return;
+
+        boolean incoming = sock.getLocalPort() < spi.locPort + spi.locPortRange + 1;
+
+        if (incoming && simulateNetTimeout.get1() > 0 || !incoming && simulateNetTimeout.get1() < 0)
+            return;
+
+        long wait = simulateNetTimeout.get2() == null ? delay : simulateNetTimeout.get2();
+
+        try {
+            Thread.sleep(wait);
+        }
+        catch (InterruptedException ignored) {
+            // No-op.
+        }
+
+        throw new SocketTimeoutException("Simulated failure after delay: " + wait + "ms.");
+    }
 
     /**
      * FOR TEST PURPOSE ONLY!

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
@@ -379,7 +379,7 @@ abstract class TcpDiscoveryImpl {
      *                  timeout of certain net operation will be used.
      * @see #simulateNetFailure(Socket, long)
      */
-    void simulateNetTimeout(int direction, int delay) {
+    void enableNetworkTimeoutSimulation(int direction, int delay) {
         simulateNetTimeout = new IgnitePair<>(direction, delay < 0 ? null : delay);
     }
 
@@ -390,8 +390,8 @@ abstract class TcpDiscoveryImpl {
      *
      * @param sock  The socket
      * @param delay The delay before raising {@code SocketTimeoutException}. Ignored if preset with {@link
-     *              #simulateNetTimeout(int, int)}
-     * @see #simulateNetTimeout(int, int)
+     *              #enableNetworkTimeoutSimulation(int, int)}
+     * @see #enableNetworkTimeoutSimulation(int, int)
      */
     void simulateNetFailure(Socket sock, long delay) throws SocketTimeoutException {
         IgnitePair<Integer> simulateNetTimeout = this.simulateNetTimeout;

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -1587,6 +1587,8 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
 
             assert addr != null;
 
+            impl.simulateNetFailure(sock, timeoutHelper.nextTimeoutChunk(sockTimeout));
+
             sock.connect(resolved, (int)timeoutHelper.nextTimeoutChunk(sockTimeout));
 
             writeToSocket(sock, null, U.IGNITE_HEADER, timeoutHelper.nextTimeoutChunk(sockTimeout));
@@ -1650,6 +1652,8 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
 
         try {
             OutputStream out = sock.getOutputStream();
+
+            impl.simulateNetFailure(sock, timeout);
 
             out.write(data);
 
@@ -1761,6 +1765,8 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
         IgniteCheckedException err = null;
 
         try {
+            impl.simulateNetFailure(sock, timeout);
+
             U.marshal(marshaller(), msg, out);
         }
         catch (IgniteCheckedException e) {
@@ -1804,6 +1810,8 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
         IOException err = null;
 
         try {
+            impl.simulateNetFailure(sock, timeout);
+
             out.write(res);
 
             out.flush();

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNodesRing.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNodesRing.java
@@ -681,7 +681,7 @@ public class TcpDiscoveryNodesRing {
      * @param excluded Nodes to exclude from the search (optional).
      * @return Collection of server nodes.
      */
-    private Collection<TcpDiscoveryNode> serverNodes(@Nullable final Collection<TcpDiscoveryNode> excluded) {
+    public Collection<TcpDiscoveryNode> serverNodes(@Nullable final Collection<TcpDiscoveryNode> excluded) {
         final boolean excludedEmpty = F.isEmpty(excluded);
 
         return F.view(nodes, new P1<TcpDiscoveryNode>() {

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -432,7 +432,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
 
         TcpDiscoverySpi failSpi = ((TcpDiscoverySpi)grid(gridCnt - 1).configuration().getDiscoverySpi());
 
-        failSpi.impl.simulateNetTimeout(1, (int)failSpi.getEffectiveConnectionRecoveryTimeout() / (gridCnt + 1));
+        failSpi.impl.enableNetworkTimeoutSimulation(1, (int)failSpi.getEffectiveConnectionRecoveryTimeout() / (gridCnt + 1));
 
         waitNodeStop(grid(gridCnt - 1).name());
 

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -416,6 +416,8 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
     }
 
     /**
+     * Checks node
+     *
      * @throws Exception If any error occurs.
      */
     @Test
@@ -433,6 +435,10 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
         failSpi.impl.simulateNetTimeout(1, (int)failSpi.getEffectiveConnectionRecoveryTimeout() / (gridCnt + 1));
 
         waitNodeStop(grid(gridCnt - 1).name());
+
+        assert grid(0).cluster().nodes().size() == 3;
+        assert grid(1).cluster().nodes().size() == 3;
+        assert grid(2).cluster().nodes().size() == 3;
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -137,7 +137,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
     private SegmentationPolicy segPlc;
 
     /** */
-    private int failireDetectionTimeout = 7500;
+    private int failureDetectionTimeout = 7500;
 
     /**
      * @throws Exception If fails.
@@ -173,7 +173,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
 
         cfg.setDiscoverySpi(spi);
 
-        cfg.setFailureDetectionTimeout(failireDetectionTimeout);
+        cfg.setFailureDetectionTimeout(failureDetectionTimeout);
 
         if (ccfgs != null)
             cfg.setCacheConfiguration(ccfgs);
@@ -424,7 +424,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
     public void testOutgoingConnectionsFailure() throws Exception {
         final int gridCnt = 4;
 
-        failireDetectionTimeout = 2000;
+        failureDetectionTimeout = 2000;
 
         startGrids(gridCnt);
 

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -136,6 +136,9 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
     /** */
     private SegmentationPolicy segPlc;
 
+    /** */
+    private int failireDetectionTimeout = 7500;
+
     /**
      * @throws Exception If fails.
      */
@@ -170,7 +173,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
 
         cfg.setDiscoverySpi(spi);
 
-        cfg.setFailureDetectionTimeout(7500);
+        cfg.setFailureDetectionTimeout(failireDetectionTimeout);
 
         if (ccfgs != null)
             cfg.setCacheConfiguration(ccfgs);
@@ -410,6 +413,26 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
         finally {
             stopAllGrids();
         }
+    }
+
+    /**
+     * @throws Exception If any error occurs.
+     */
+    @Test
+    public void testOutgoingConnectionsFailure() throws Exception {
+        final int gridCnt = 4;
+
+        failireDetectionTimeout = 2000;
+
+        startGrids(gridCnt);
+
+        awaitPartitionMapExchange();
+
+        TcpDiscoverySpi failSpi = ((TcpDiscoverySpi)grid(gridCnt - 1).configuration().getDiscoverySpi());
+
+        failSpi.impl.simulateNetTimeout(1, (int)failSpi.getEffectiveConnectionRecoveryTimeout() / (gridCnt + 1));
+
+        waitNodeStop(grid(gridCnt - 1).name());
     }
 
     /**


### PR DESCRIPTION
If node looses outgoing connections, it can decide it is alone in the cluster and won't fail. Happens on small clusters where failed node attempts to connect to every other node before connRecoveryTimeout expires.

Consider:
- The cluster n1 -> n2 -> n3 -> n4 -> n1
- n4 looses all outgoing connections.
- n3 keeps successful ping to n4.
- n4 attempts to connect to n1, n2, n3. Fails with each due to outgoing network failure.
- spi.connrecoveryTimeout is not reached. n4 decides it is alone and continues working.
- n3 still sends messages to n4. n4 does not lack incoming connections.
- ring is actually broken because of n4. n3 cannot determine failure of n4.

Solution: node could watch its incoming traffic which notyfies of the incoming network. If all the outgoing connections are lost but messages are received, node must left the grid to prevent ring break.