### PR TITLE
IGNITE-14064 .NET: Fix SQL table name for generic query types

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -116,6 +116,9 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
         if (idx < 0)
             idx = clsName.lastIndexOf('.');
 
+
+        // TODO: We should string namespaces from .NET generics here
+        // Foo.Bar.GenericTest2`1[[System.String]] => GenericTest2`1[[String]]
         return idx >= 0 ? clsName.substring(idx + 1) : clsName;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -91,8 +91,16 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
         // Example: Foo.Bar`1[[Baz.Qux`1[[System.String],[System.Int32]]]]
         int genericIdx = clsName.indexOf("[[");
 
-        if (genericIdx > 0)
-            clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
+        if (genericIdx > 0) {
+            int genericPartIdx = clsName.indexOf("],[", genericIdx);
+
+            if (genericPartIdx > genericIdx)
+                clsName = clsName.substring(0, genericIdx + 2) +
+                        simpleName(clsName.substring(genericIdx + 2, genericPartIdx + 3)) +
+                        simpleName(clsName.substring(genericPartIdx + 3));
+            else
+                clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
+        }
 
         int idx = clsName.lastIndexOf('$');
 

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -88,7 +88,7 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
         assert clsName != null;
 
         // .NET generic, not valid for Java class name. Clean up every generic part recursively.
-        // Example: Foo.Bar`1[[Baz.Qux`1[[System.String]]]]
+        // Example: Foo.Bar`1[[Baz.Qux`1[[System.String],[System.Int32]]]]
         int genericIdx = clsName.indexOf("[[");
 
         if (genericIdx > 0)

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -88,6 +88,7 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
         assert clsName != null;
 
         // .NET generic, not valid for Java class name. Clean up every generic part recursively.
+        // Example: Foo.Bar`1[[Baz.Qux`1[[System.String]]]]
         int genericIdx = clsName.indexOf("[[");
 
         if (genericIdx > 0)

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -122,9 +122,6 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
         if (idx < 0)
             idx = clsName.lastIndexOf('.');
 
-
-        // TODO: We should string namespaces from .NET generics here
-        // Foo.Bar.GenericTest2`1[[System.String]] => GenericTest2`1[[String]]
         return idx >= 0 ? clsName.substring(idx + 1) : clsName;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -91,16 +91,13 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
         // Example: Foo.Bar`1[[Baz.Qux`1[[System.String],[System.Int32]]]]
         int genericIdx = clsName.indexOf("[[");
 
-        if (genericIdx > 0) {
-            int genericPartIdx = clsName.indexOf("],[", genericIdx);
+        if (genericIdx > 0)
+            clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
 
-            if (genericPartIdx > genericIdx)
-                clsName = clsName.substring(0, genericIdx + 2) +
-                        simpleName(clsName.substring(genericIdx + 2, genericPartIdx + 3)) +
-                        simpleName(clsName.substring(genericPartIdx + 3));
-            else
-                clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
-        }
+        genericIdx = clsName.indexOf("],[", genericIdx);
+
+        if (genericIdx > 0)
+            clsName = clsName.substring(0, genericIdx + 3) + simpleName(clsName.substring(genericIdx + 3));
 
         int idx = clsName.lastIndexOf('$');
 

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -87,6 +87,12 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
     private static String simpleName(String clsName) {
         assert clsName != null;
 
+        // .NET generic, not valid for Java class name. Clean up every generic part recursively.
+        int genericIdx = clsName.indexOf("[[");
+
+        if (genericIdx > 0)
+            clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
+
         int idx = clsName.lastIndexOf('$');
 
         if (idx == clsName.length() - 1)

--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryBasicNameMapper.java
@@ -87,17 +87,7 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
     private static String simpleName(String clsName) {
         assert clsName != null;
 
-        // .NET generic, not valid for Java class name. Clean up every generic part recursively.
-        // Example: Foo.Bar`1[[Baz.Qux`1[[System.String],[System.Int32]]]]
-        int genericIdx = clsName.indexOf("[[");
-
-        if (genericIdx > 0)
-            clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
-
-        genericIdx = clsName.indexOf("],[", genericIdx);
-
-        if (genericIdx > 0)
-            clsName = clsName.substring(0, genericIdx + 3) + simpleName(clsName.substring(genericIdx + 3));
+        clsName = simplifyDotNetGenerics(clsName);
 
         int idx = clsName.lastIndexOf('$');
 
@@ -129,6 +119,28 @@ public class BinaryBasicNameMapper implements BinaryNameMapper {
             idx = clsName.lastIndexOf('.');
 
         return idx >= 0 ? clsName.substring(idx + 1) : clsName;
+    }
+
+    /**
+     * Converts .NET generic type arguments to a simple form (without namespaces and outer classes classes).
+     *
+     * @param clsName Class name.
+     * @return Simplified class name.
+     */
+    private static String simplifyDotNetGenerics(String clsName) {
+        // .NET generic part starts with [[ (not valid for Java class name). Clean up every generic part recursively.
+        // Example: Foo.Bar`1[[Baz.Qux`2[[System.String],[System.Int32]]]]
+        int genericIdx = clsName.indexOf("[[");
+
+        if (genericIdx > 0)
+            clsName = clsName.substring(0, genericIdx + 2) + simpleName(clsName.substring(genericIdx + 2));
+
+        genericIdx = clsName.indexOf("],[", genericIdx);
+
+        if (genericIdx > 0)
+            clsName = clsName.substring(0, genericIdx + 3) + simpleName(clsName.substring(genericIdx + 3));
+
+        return clsName;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -1115,6 +1115,11 @@ public class QueryUtils {
      * @return Type name.
      */
     public static String typeName(String clsName) {
+        int genericStart = clsName.indexOf('`');  // .NET generic
+
+        if (genericStart >= 0)
+            clsName = clsName.substring(0, genericStart);
+
         int pkgEnd = clsName.lastIndexOf('.');
 
         if (pkgEnd >= 0 && pkgEnd < clsName.length() - 1)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -1115,7 +1115,7 @@ public class QueryUtils {
      * @return Type name.
      */
     public static String typeName(String clsName) {
-        int genericStart = clsName.indexOf('`');  // .NET generic
+        int genericStart = clsName.indexOf('`');  // .NET generic, not valid for Java class name.
 
         if (genericStart >= 0)
             clsName = clsName.substring(0, genericStart);

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryBasicNameMapperSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryBasicNameMapperSelfTest.java
@@ -47,11 +47,16 @@ public class BinaryBasicNameMapperSelfTest extends GridCommonAbstractTest {
 
         assertEquals("Baz", mapper.typeName("Foo.Bar.Baz"));
 
-        assertEquals("Bar`1[[Qux`2[[C],[Int32]]]]",
-                mapper.typeName("Foo.Outer+Bar`1[[Baz.Outer2+Qux`2[[A.B+C],[System.Int32]]]]"));
+        assertEquals("Bar`1[[Qux]]", mapper.typeName("Foo.Bar`1[[Baz.Qux]]"));
+
+        assertEquals("List`1[[Int32[]]]",
+                mapper.typeName("System.Collections.Generic.List`1[[System.Int32[]]]"));
 
         assertEquals("Bar`1[[Qux`2[[String],[Int32]]]]",
                 mapper.typeName("Foo.Bar`1[[Baz.Qux`2[[System.String],[System.Int32]]]]"));
+
+        assertEquals("Bar`1[[Qux`2[[C],[Int32]]]]",
+                mapper.typeName("Foo.Outer+Bar`1[[Baz.Outer2+Qux`2[[A.B+C],[System.Int32]]]]"));
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryBasicNameMapperSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryBasicNameMapperSelfTest.java
@@ -42,6 +42,22 @@ public class BinaryBasicNameMapperSelfTest extends GridCommonAbstractTest {
      * @throws Exception If failed.
      */
     @Test
+    public void testSimpleNameDotNet() throws Exception {
+        BinaryBasicNameMapper mapper = new BinaryBasicNameMapper(true);
+
+        assertEquals("Baz", mapper.typeName("Foo.Bar.Baz"));
+
+        assertEquals("Bar`1[[Qux`2[[C],[Int32]]]]",
+                mapper.typeName("Foo.Outer+Bar`1[[Baz.Outer2+Qux`2[[A.B+C],[System.Int32]]]]"));
+
+        assertEquals("Bar`1[[Qux`2[[String],[Int32]]]]",
+                mapper.typeName("Foo.Bar`1[[Baz.Qux`2[[System.String],[System.Int32]]]]"));
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
     public void testFullName() throws Exception {
         BinaryBasicNameMapper mapper = new BinaryBasicNameMapper(false);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -270,16 +270,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var queryEntity = cache.GetConfiguration().QueryEntities.Single();
             Assert.AreEqual(expectedTypeName, queryEntity.ValueTypeName);
 
-            var tableName = cache.Query(new SqlFieldsQuery(
-                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
-                .Single().Single();
-
-            var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Foo, Bar from \"{0}\"", tableName)))
-                .Single();
+            var sqlRes = cache.Query(new SqlFieldsQuery("SELECT Foo, Bar from GENERICTEST2")).Single();
 
             Assert.AreEqual(key.Foo, sqlRes[0]);
             Assert.AreEqual(value.Bar, sqlRes[1]);
-            Assert.AreEqual(expectedTypeName.Split('`', 1)[0], tableName);
         }
 
         /// <summary>
@@ -299,20 +293,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var value = new GenericTest<GenericTest2<string>>(new GenericTest2<string>("foobar"));
             cache[1] = value;
 
-            var tableName = cache.Query(new SqlFieldsQuery(
-                    "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
-                .Single().Single(); // The table name is weird, see IGNITE-14064.
-
-            var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Bar from \"{0}\"", tableName)))
-                .Single().Single();
+            var sqlRes = cache.Query(new SqlFieldsQuery("SELECT Bar from GENERICTEST")).Single().Single();
 
             Assert.AreEqual(value.Foo.Bar, sqlRes);
 
             var valTypeName = value.GetType().FullName;
             Assert.IsNotNull(valTypeName);
-
-            var expectedTableName = valTypeName.Split('`')[0];
-            Assert.AreEqual(expectedTableName, tableName);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -272,13 +272,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
             var tableName = cache.Query(new SqlFieldsQuery(
                 "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
-                .Single().Single(); // The table name is weird, see IGNITE-14064.
+                .Single().Single();
 
             var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Foo, Bar from \"{0}\"", tableName)))
                 .Single();
 
             Assert.AreEqual(key.Foo, sqlRes[0]);
             Assert.AreEqual(value.Bar, sqlRes[1]);
+            Assert.AreEqual(expectedTypeName.Split('`', 1)[0], tableName);
         }
 
         /// <summary>
@@ -306,6 +307,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 .Single().Single();
 
             Assert.AreEqual(value.Foo.Bar, sqlRes);
+
+            var valTypeName = value.GetType().FullName;
+            Assert.IsNotNull(valTypeName);
+
+            var expectedTableName = valTypeName.Split('`')[0];
+            Assert.AreEqual(expectedTableName, tableName);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -398,13 +398,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             cache[key] = value;
 
             var query = cache.AsCacheQueryable()
-                .Where(x => x.Key.Foo == 1 && x.Value.Bar == "foo");
+                .Where(x => x.Key.Foo == key.Foo && x.Value.Bar == value.Bar);
 
             var sql = query.ToCacheQueryable().GetFieldsQuery().Sql;
             var res = query.ToList();
 
             Assert.AreEqual(1, res.Count);
-            Assert.AreEqual("foo", res[0].Value.Bar);
+            Assert.AreEqual(value.Bar, res[0].Value.Bar);
 
             var expectedSql = string.Format("select _T0._KEY, _T0._VAL from \"{0}\".GENERICTEST2", cache.Name);
             StringAssert.StartsWith(expectedSql, sql);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -445,7 +445,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
         /// Tests queries when cache val type has two generic type arguments.
         /// </summary>
         [Test]
-        public void TestTwoGenericArgumentsCacheTypes()
+        public void TestTwoGenericArgumentsCacheType()
         {
             var cfg = new CacheConfiguration(TestUtils.TestName)
             {
@@ -458,16 +458,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             cache[key] = value;
 
             var query = cache.AsCacheQueryable()
-                .Where(x => x.Value.Bar == value.Bar && x.Value.Qux == value.Qux)
-                .Select(x => x.Value.Bar);
+                .Where(x => x.Value.Baz == value.Baz && x.Value.Qux == value.Qux)
+                .Select(x => x.Value.Baz);
 
             var sql = query.ToCacheQueryable().GetFieldsQuery().Sql;
             var res = query.ToList();
 
             Assert.AreEqual(1, res.Count);
-            Assert.AreEqual(value.Bar, res[0]);
+            Assert.AreEqual(value.Baz, res[0]);
 
-            var expectedSql = string.Format("select _T0.FOO from \"{0}\".GENERICTEST as", cache.Name);
+            var expectedSql = string.Format("select _T0.BAZ from \"{0}\".GENERICTEST3 as", cache.Name);
             StringAssert.StartsWith(expectedSql, sql);
         }
 
@@ -511,13 +511,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             /** */
             public GenericTest3(T baz, T2 qux)
             {
-                Bar = baz;
+                Baz = baz;
                 Qux = qux;
             }
 
             /** */
             [QuerySqlField]
-            public T Bar { get; set; }
+            public T Baz { get; set; }
             
             /** */
             [QuerySqlField]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -449,16 +449,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
         {
             var cfg = new CacheConfiguration(TestUtils.TestName)
             {
-                QueryEntities = new[] {new QueryEntity(typeof(int), typeof(GenericTest3<int, string>))}
+                QueryEntities = new[] {new QueryEntity(typeof(int), typeof(GenericTest3<int, string, bool>))}
             };
 
-            var cache = Ignition.GetIgnite().GetOrCreateCache<int, GenericTest3<int, string>>(cfg);
+            var cache = Ignition.GetIgnite().GetOrCreateCache<int, GenericTest3<int, string, bool>>(cfg);
             var key = 1;
-            var value = new GenericTest3<int, string>(2, "3");
+            var value = new GenericTest3<int, string, bool>(2, "3", true);
             cache[key] = value;
 
             var query = cache.AsCacheQueryable()
-                .Where(x => x.Value.Baz == value.Baz && x.Value.Qux == value.Qux)
+                .Where(x => x.Value.Baz == value.Baz && x.Value.Qux == value.Qux && x.Value.Quz)
                 .Select(x => x.Value.Baz);
 
             var sql = query.ToCacheQueryable().GetFieldsQuery().Sql;
@@ -506,13 +506,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
         /// <summary>
         /// Generic query type with two generic arguments.
         /// </summary>
-        private class GenericTest3<T, T2>
+        private class GenericTest3<T, T2, T3>
         {
             /** */
-            public GenericTest3(T baz, T2 qux)
+            public GenericTest3(T baz, T2 qux, T3 quz)
             {
                 Baz = baz;
                 Qux = qux;
+                Quz = quz;
             }
 
             /** */
@@ -522,6 +523,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             /** */
             [QuerySqlField]
             public T2 Qux { get; set; }
+            
+            /** */
+            [QuerySqlField]
+            public T3 Quz { get; set; }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -406,10 +406,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             Assert.AreEqual(1, res.Count);
             Assert.AreEqual("foo", res[0].Value.Bar);
 
-            // ReSharper disable once PossibleNullReferenceException
-            var expectedSql = string.Format("select _T0._KEY, _T0._VAL from \"{0}\".{1}", cache.Name,
-                value.GetType().FullName.Split('`')[0]);
-
+            var expectedSql = string.Format("select _T0._KEY, _T0._VAL from \"{0}\".GENERICTEST2", cache.Name);
             StringAssert.StartsWith(expectedSql, sql);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -31,6 +31,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
     using System.Linq.Expressions;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Linq;
     using NUnit.Framework;
     using NUnit.Framework.Constraints;
@@ -402,7 +403,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
 
             var sql = query.ToCacheQueryable().GetFieldsQuery().Sql;
             var res = query.ToList();
+            var sqlRes = cache.Query(new SqlFieldsQuery("SELECT * FROM GENERICTEST2")).ToArray(); // TODO: Remove
 
+            Assert.AreEqual(1, sqlRes.Length);
             Assert.AreEqual(1, res.Count);
             Assert.AreEqual(value.Bar, res[0].Value.Bar);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -31,7 +31,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
     using System.Linq.Expressions;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
-    using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Linq;
     using NUnit.Framework;
     using NUnit.Framework.Constraints;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Misc.cs
@@ -398,15 +398,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             cache[key] = value;
 
             var query = cache.AsCacheQueryable()
-                .Where(x => x.Key.Foo == key.Foo && x.Value.Bar == value.Bar);
+                .Where(x => x.Key.Foo == key.Foo && x.Value.Bar == value.Bar)
+                .Select(x => x.Value.Bar);
 
             var sql = query.ToCacheQueryable().GetFieldsQuery().Sql;
             var res = query.ToList();
 
             Assert.AreEqual(1, res.Count);
-            Assert.AreEqual(value.Bar, res[0].Value.Bar);
+            Assert.AreEqual(value.Bar, res[0]);
 
-            var expectedSql = string.Format("select _T0._KEY, _T0._VAL from \"{0}\".GENERICTEST2 as", cache.Name);
+            var expectedSql = string.Format("select _T0.BAR from \"{0}\".GENERICTEST2 as", cache.Name);
             StringAssert.StartsWith(expectedSql, sql);
         }
 
@@ -427,15 +428,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             cache[key] = value;
 
             var query = cache.AsCacheQueryable()
-                .Where(x => x.Value.Foo.Bar == value.Foo.Bar);
+                .Where(x => x.Value.Foo.Bar == value.Foo.Bar)
+                .Select(x => x.Value.Foo);
 
             var sql = query.ToCacheQueryable().GetFieldsQuery().Sql;
             var res = query.ToList();
 
             Assert.AreEqual(1, res.Count);
-            Assert.AreEqual(value.Foo.Bar, res[0].Value.Foo.Bar);
+            Assert.AreEqual(value.Foo.Bar, res[0].Bar);
 
-            var expectedSql = string.Format("select _T0._KEY, _T0._VAL from \"{0}\".GENERICTEST as", cache.Name);
+            var expectedSql = string.Format("select _T0.FOO from \"{0}\".GENERICTEST as", cache.Name);
             StringAssert.StartsWith(expectedSql, sql);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1536,8 +1536,6 @@ namespace Apache.Ignite.Core.Impl.Binary
             // cacheObjects().typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId.
             // Additionally, this type name is passed back to UnmanagedCallbacks.BinaryTypeGet to register the
             // query types on cache start.
-
-            // TODO: Can we use configured mapper here?
             return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1536,6 +1536,8 @@ namespace Apache.Ignite.Core.Impl.Binary
             // cacheObjects().typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId.
             // Additionally, this type name is passed back to UnmanagedCallbacks.BinaryTypeGet to register the
             // query types on cache start.
+
+            // TODO: Can we use configured mapper here?
             return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 


### PR DESCRIPTION
* Fix `BinaryNameMapper.simpleName` to strip namespaces from generic types
* Fix `QueryUtils.typeName` to strip generic part