### PR TITLE
IGNITE-14103 .NET: Add thin client automatic binary configuration

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -45,8 +45,11 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
     DEFAULT_QRY_TIMEOUT(6),
 
-    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
-    QRY_PARTITIONS_BATCH_SIZE(7);
+    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize. */
+    QRY_PARTITIONS_BATCH_SIZE(7),
+
+    /** Binary configuration retrieval. */
+    BINARY_CONFIGURATION(8);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -224,6 +224,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
     /** */
     private static final short OP_BINARY_TYPE_PUT = 3003;
 
+    /** */
+    private static final short OP_BINARY_CONFIGURATION_GET = 3004;
+
     /** Start new transaction. */
     private static final short OP_TX_START = 4000;
 
@@ -325,6 +328,10 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
             case OP_BINARY_TYPE_PUT:
                 return new ClientBinaryTypePutRequest(reader);
+
+            case OP_BINARY_CONFIGURATION_GET:
+                // TODO
+                return null;
 
             case OP_QUERY_SCAN:
                 return new ClientCacheScanQueryRequest(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -29,6 +29,7 @@ import org.apache.ignite.internal.processors.odbc.ClientListenerMessageParser;
 import org.apache.ignite.internal.processors.odbc.ClientListenerRequest;
 import org.apache.ignite.internal.processors.odbc.ClientListenerResponse;
 import org.apache.ignite.internal.processors.odbc.ClientMessage;
+import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryConfigurationGetRequest;
 import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryTypeGetRequest;
 import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryTypeNameGetRequest;
 import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryTypeNamePutRequest;
@@ -330,8 +331,7 @@ public class ClientMessageParser implements ClientListenerMessageParser {
                 return new ClientBinaryTypePutRequest(reader);
 
             case OP_BINARY_CONFIGURATION_GET:
-                // TODO
-                return null;
+                return new ClientBinaryConfigurationGetRequest(reader);
 
             case OP_QUERY_SCAN:
                 return new ClientCacheScanQueryRequest(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.binary;
+
+import org.apache.ignite.binary.BinaryBasicNameMapper;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.configuration.BinaryConfiguration;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientRequest;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Binary configuration retrieval request.
+ */
+public class ClientBinaryConfigurationGetRequest extends ClientRequest {
+    /** */
+    private static final byte NAME_MAPPER_BASIC_FULL = 0;
+
+    /** */
+    private static final byte NAME_MAPPER_BASIC_SIMPLE = 1;
+
+    /** */
+    private static final byte NAME_MAPPER_CUSTOM = 2;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientBinaryConfigurationGetRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        BinaryConfiguration cfg = ctx.kernalContext().config().getBinaryConfiguration();
+        boolean compactFooter = cfg != null && cfg.isCompactFooter();
+        byte nameMapperType = getMapperType(cfg);
+
+        return new ClientBinaryConfigurationGetResponse(requestId(), compactFooter, nameMapperType);
+    }
+
+    /**
+     * Gets the binary name mapper type code.
+     * @param cfg Binary configuration.
+     *
+     * @return Mapper type code.
+     */
+    private static byte getMapperType(BinaryConfiguration cfg) {
+        if (cfg == null || cfg.getNameMapper() == null)
+            return NAME_MAPPER_BASIC_FULL;
+
+        if (!(cfg.getNameMapper() instanceof BinaryBasicNameMapper))
+            return NAME_MAPPER_CUSTOM;
+
+        BinaryBasicNameMapper basicNameMapper = (BinaryBasicNameMapper)cfg.getNameMapper();
+
+        return basicNameMapper.isSimpleName() ? NAME_MAPPER_BASIC_SIMPLE : NAME_MAPPER_BASIC_FULL;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
@@ -50,7 +50,7 @@ public class ClientBinaryConfigurationGetRequest extends ClientRequest {
     @Override public ClientResponse process(ClientConnectionContext ctx) {
         BinaryConfiguration cfg = ctx.kernalContext().config().getBinaryConfiguration();
         boolean compactFooter = cfg != null && cfg.isCompactFooter();
-        byte nameMapperType = getMapperType(cfg);
+        byte nameMapperType = getNameMapperType(cfg);
 
         return new ClientBinaryConfigurationGetResponse(requestId(), compactFooter, nameMapperType);
     }
@@ -61,7 +61,7 @@ public class ClientBinaryConfigurationGetRequest extends ClientRequest {
      *
      * @return Mapper type code.
      */
-    private static byte getMapperType(BinaryConfiguration cfg) {
+    private static byte getNameMapperType(BinaryConfiguration cfg) {
         if (cfg == null || cfg.getNameMapper() == null)
             return NAME_MAPPER_BASIC_FULL;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
@@ -23,6 +23,7 @@ import org.apache.ignite.configuration.BinaryConfiguration;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientRequest;
 import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Binary configuration retrieval request.
@@ -61,7 +62,7 @@ public class ClientBinaryConfigurationGetRequest extends ClientRequest {
      *
      * @return Mapper type code.
      */
-    private static byte getNameMapperType(BinaryConfiguration cfg) {
+    private static byte getNameMapperType(@Nullable BinaryConfiguration cfg) {
         if (cfg == null || cfg.getNameMapper() == null)
             return BinaryBasicNameMapper.DFLT_SIMPLE_NAME ? NAME_MAPPER_BASIC_SIMPLE : NAME_MAPPER_BASIC_FULL;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
@@ -66,7 +66,7 @@ public class ClientBinaryConfigurationGetRequest extends ClientRequest {
         if (cfg == null || cfg.getNameMapper() == null)
             return BinaryBasicNameMapper.DFLT_SIMPLE_NAME ? NAME_MAPPER_BASIC_SIMPLE : NAME_MAPPER_BASIC_FULL;
 
-        if (!(cfg.getNameMapper() instanceof BinaryBasicNameMapper))
+        if (!cfg.getNameMapper().getClass().equals(BinaryBasicNameMapper.class))
             return NAME_MAPPER_CUSTOM;
 
         BinaryBasicNameMapper basicNameMapper = (BinaryBasicNameMapper)cfg.getNameMapper();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
@@ -49,7 +49,7 @@ public class ClientBinaryConfigurationGetRequest extends ClientRequest {
     /** {@inheritDoc} */
     @Override public ClientResponse process(ClientConnectionContext ctx) {
         BinaryConfiguration cfg = ctx.kernalContext().config().getBinaryConfiguration();
-        boolean compactFooter = cfg != null && cfg.isCompactFooter();
+        boolean compactFooter = cfg == null ? BinaryConfiguration.DFLT_COMPACT_FOOTER : cfg.isCompactFooter();
         byte nameMapperType = getNameMapperType(cfg);
 
         return new ClientBinaryConfigurationGetResponse(requestId(), compactFooter, nameMapperType);
@@ -63,7 +63,7 @@ public class ClientBinaryConfigurationGetRequest extends ClientRequest {
      */
     private static byte getNameMapperType(BinaryConfiguration cfg) {
         if (cfg == null || cfg.getNameMapper() == null)
-            return NAME_MAPPER_BASIC_FULL;
+            return BinaryBasicNameMapper.DFLT_SIMPLE_NAME ? NAME_MAPPER_BASIC_SIMPLE : NAME_MAPPER_BASIC_FULL;
 
         if (!(cfg.getNameMapper() instanceof BinaryBasicNameMapper))
             return NAME_MAPPER_CUSTOM;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.binary;
+
+import org.apache.ignite.internal.binary.BinaryRawWriterEx;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+import org.apache.ignite.internal.processors.platform.utils.PlatformUtils;
+
+/**
+ * Binary meta response.
+ */
+public class ClientBinaryConfigurationGetResponse extends ClientResponse {
+    /** */
+    private final boolean compactFooter;
+
+    /** */
+    private final byte nameMapperType;
+
+    /**
+     * Constructor.
+     * @param requestId Request id.
+     * @param compactFooter Compact footer flag.
+     * @param nameMapperType Name mapper type.
+     */
+    ClientBinaryConfigurationGetResponse(long requestId, boolean compactFooter, byte nameMapperType) {
+        super(requestId);
+
+        this.compactFooter = compactFooter;
+        this.nameMapperType = nameMapperType;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void encode(ClientConnectionContext ctx, BinaryRawWriterEx writer) {
+        super.encode(ctx, writer);
+
+        writer.writeBoolean(compactFooter);
+        writer.writeByte(nameMapperType);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetResponse.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.processors.platform.client.binary;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientResponse;
-import org.apache.ignite.internal.processors.platform.utils.PlatformUtils;
 
 /**
  * Binary meta response.

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryBasicNameMapper.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryBasicNameMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import org.apache.ignite.binary.BinaryBasicNameMapper;
+
+/**
+ * Custom name mapper for tests.
+ */
+public class PlatformCustomBinaryBasicNameMapper extends BinaryBasicNameMapper {
+    /** {@inheritDoc} */
+    @Override public String typeName(String clsName) {
+        return clsName + "_";
+    }
+
+    /** {@inheritDoc} */
+    @Override public String fieldName(String fieldName) {
+        return fieldName;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryNameMapper.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryNameMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import org.apache.ignite.binary.BinaryNameMapper;
+
+/**
+ * Custom name mapper for tests.
+ */
+public class PlatformCustomBinaryNameMapper implements BinaryNameMapper {
+    /** {@inheritDoc} */
+    @Override public String typeName(String clsName) {
+        return clsName + "_";
+    }
+
+    /** {@inheritDoc} */
+    @Override public String fieldName(String fieldName) {
+        return fieldName;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.TestDll2/Properties/AssemblyInfo.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.TestDll2/Properties/AssemblyInfo.cs
@@ -16,7 +16,6 @@
 */
 
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Apache.Ignite.Core.Tests.TestDll2")]
 [assembly: AssemblyDescription("Apache Ignite.NET Tests Library 2")]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -99,6 +99,9 @@
     <None Update="Config\binary-custom-name-mapper.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\binary-custom-name-mapper2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
 
   </ItemGroup>
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -96,6 +96,9 @@
     <None Update="Config\query-entity-metadata-registration.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\binary-custom-name-mapper.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
 
   </ItemGroup>
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Cache\Query\QueryEntityMetadataRegistrationTest.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestCodeConfig.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestSharedFactory.cs" />
+    <Compile Include="Client\Binary\BinaryConfigurationRetrievalTest.cs" />
     <Compile Include="Client\Cache\ClientQueryEntityMetadataRegistrationTest.cs" />
     <Compile Include="Client\Cache\ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs" />
     <Compile Include="Client\Cache\ContinuousQueryTest.cs" />
@@ -438,6 +439,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Config\binary-custom-name-mapper.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Config\cache-attribute-node-filter.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -442,6 +442,9 @@
     <Content Include="Config\binary-custom-name-mapper.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Config\binary-custom-name-mapper2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Config\cache-attribute-node-filter.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -69,5 +69,27 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 // TODO: Check log message.
             }
         }
+
+        /// <summary>
+        /// Tests that with default configuration on server and client there is no warnings and no changes at runtime.
+        /// </summary>
+        [Test]
+        public void TestDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
+        {
+            var logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace});
+            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString());
+
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                var resCfg = client.GetConfiguration();
+
+                Assert.IsNull(resCfg.BinaryConfiguration);
+
+                // TODO: Create a binary object to verify the behavior.
+                // TODO: Check log message.
+            }
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -159,7 +159,9 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 var resCfg = client.GetConfiguration().BinaryConfiguration;
                 Assert.IsNotNull(resCfg);
                 Assert.IsTrue(((BinaryBasicNameMapper)resCfg.NameMapper).IsSimpleName);
-                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Binary name mapper mismatch: local=BasicSimple, server=BasicFull" &&
+                    e.Level == LogLevel.Warn));
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -135,15 +135,10 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
 
             using (var client = Ignition.StartClient(clientCfg))
             {
-                // TODO
-                var resCfg = client.GetConfiguration();
-                Assert.IsNull(resCfg.BinaryConfiguration);
-
-                AssertCompactFooter(client, true);
-
-                Assert.AreEqual(1, logger.Entries.Count(e => e.Message == "Server binary configuration " +
-                    "retrieved: BinaryConfigurationClientInternal [CompactFooter=True, NameMapperMode=BasicFull]"));
-
+                var resCfg = client.GetConfiguration().BinaryConfiguration;
+                Assert.IsNotNull(resCfg);
+                Assert.IsTrue(resCfg.CompactFooter);
+                Assert.IsFalse(((BinaryBasicNameMapper)resCfg.NameMapper).IsSimpleName);
                 Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Binary
+{
+    using System.Net;
+    using Apache.Ignite.Core.Binary;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests automatic binary configuration retrieval.
+    /// </summary>
+    public class BinaryConfigurationRetrievalTest
+    {
+        /// <summary>
+        /// Tears down the fixture.
+        /// </summary>
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="BinaryConfiguration.CompactFooter"/> sets to false on the client when it is false
+        /// on the server.
+        /// </summary>
+        [Test]
+        public void TestCompactFooterDisablesOnClientWhenDisabledOnServer()
+        {
+            var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    CompactFooter = false
+                }
+            };
+
+            var logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace});
+            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString());
+
+            Ignition.Start(serverCfg);
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                var resCfg = client.GetConfiguration();
+
+                Assert.IsNotNull(resCfg.BinaryConfiguration);
+                Assert.IsFalse(resCfg.BinaryConfiguration.CompactFooter);
+
+                // TODO: Create a binary object to verify the behavior.
+                // TODO: Check log message.
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -235,6 +235,31 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
             }
         }
 
+        /// <summary>
+        /// Tests that custom mapper that extends basic name mapper on server and default mapper on client
+        /// results in a warning.
+        /// </summary>
+        [Test]
+        public void TestCustomNameMapperExtendingBasicMapperOnServerProducesLogWarning()
+        {
+            var logger = GetLogger();
+
+            var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "binary-custom-name-mapper2.xml")
+            };
+
+            Ignition.Start(serverCfg);
+
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
+            {
+                Assert.IsNull(client.GetConfiguration().BinaryConfiguration);
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Binary name mapper mismatch: local=BasicFull, server=Custom" &&
+                    e.Level == LogLevel.Warn));
+            }
+        }
+
         [Test]
         public void TestCustomNameMapperOnServerAndClientProducesNoLogWarning()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Core.Tests.Client.Binary
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.Net;
     using Apache.Ignite.Core.Binary;
@@ -175,11 +176,7 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
 
             var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
-                BinaryConfiguration = new BinaryConfiguration
-                {
-                    // TODO: This should be set in Spring.
-                    NameMapper = new TestNameMapper()
-                }
+                SpringConfigUrl = Path.Combine("Config", "binary-custom-name-mapper.xml")
             };
 
             Ignition.Start(serverCfg);
@@ -207,10 +204,7 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
 
             var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
-                BinaryConfiguration = new BinaryConfiguration
-                {
-                    NameMapper = new TestNameMapper()
-                }
+                SpringConfigUrl = Path.Combine("Config", "binary-custom-name-mapper.xml")
             };
 
             Ignition.Start(serverCfg);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -56,15 +56,11 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 }
             };
 
-            var logger = GetLogger();
-            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString())
-            {
-                Logger = logger
-            };
-
             Ignition.Start(serverCfg);
 
-            using (var client = Ignition.StartClient(clientCfg))
+            var logger = GetLogger();
+
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
             {
                 var resCfg = client.GetConfiguration();
 
@@ -90,14 +86,10 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
         public void TestDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
         {
             var logger = GetLogger();
-            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString())
-            {
-                Logger = logger
-            };
 
             Ignition.Start(TestUtils.GetTestConfiguration());
 
-            using (var client = Ignition.StartClient(clientCfg))
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
             {
                 var resCfg = client.GetConfiguration();
                 Assert.IsNull(resCfg.BinaryConfiguration);
@@ -143,6 +135,9 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
             }
         }
 
+        /// <summary>
+        /// Tests that simple/full name mapping mismatch produces a warning.
+        /// </summary>
         [Test]
         public void TestBasicNameMapperSettingsMismatchProducesLogWarning()
         {
@@ -181,6 +176,17 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
             })
             {
                 EnabledLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray()
+            };
+        }
+
+        /// <summary>
+        /// Gets the client configuration.
+        /// </summary>
+        private static IgniteClientConfiguration GetClientConfiguration(ListLogger logger)
+        {
+            return new IgniteClientConfiguration(IPAddress.Loopback.ToString())
+            {
+                Logger = logger
             };
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -32,10 +32,10 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
     public class BinaryConfigurationRetrievalTest
     {
         /// <summary>
-        /// Tears down the fixture.
+        /// Tears down the test.
         /// </summary>
-        [TestFixtureTearDown]
-        public void FixtureTearDown()
+        [TearDown]
+        public void TearDown()
         {
             Ignition.StopAll(true);
         }
@@ -73,7 +73,7 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 AssertCompactFooter(client, false);
 
                 var expectedLog = "Server binary configuration retrieved: BinaryConfigurationClientInternal " +
-                                  "[CompactFooter=True, NameMapperMode=BasicFull]";
+                                  "[CompactFooter=False, NameMapperMode=BasicFull]";
 
                 Assert.AreEqual(1, logger.Entries.Count(e => e.Message == expectedLog));
                 Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -112,6 +112,61 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
         }
 
         /// <summary>
+        /// Tests that with explicit default configuration on client there is no warnings and no changes at runtime.
+        /// </summary>
+        [Test]
+        public void TestExplicitDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
+        {
+            var logger = GetLogger();
+            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString())
+            {
+                Logger = logger,
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    CompactFooter = true,
+                    NameMapper = new BinaryBasicNameMapper
+                    {
+                        IsSimpleName = false
+                    }
+                }
+            };
+
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                // TODO
+                var resCfg = client.GetConfiguration();
+                Assert.IsNull(resCfg.BinaryConfiguration);
+
+                AssertCompactFooter(client, true);
+
+                Assert.AreEqual(1, logger.Entries.Count(e => e.Message == "Server binary configuration " +
+                    "retrieved: BinaryConfigurationClientInternal [CompactFooter=True, NameMapperMode=BasicFull]"));
+
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+            }
+        }
+
+        [Test]
+        public void TestBasicNameMapperSettingsMismatchProducesLogWarning()
+        {
+            // TODO
+        }
+
+        [Test]
+        public void TestCustomNameMapperOnServerProducesLogWarning()
+        {
+            // TODO
+        }
+
+        [Test]
+        public void TestCustomNameMapperOnServerAndClientProducesNoLogWarning()
+        {
+            // TODO
+        }
+
+        /// <summary>
         /// Checks the actual compact footer behavior.
         /// </summary>
         private static void AssertCompactFooter(IIgniteClient client, bool expected)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -70,8 +70,13 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 Assert.IsNotNull(resCfg.BinaryConfiguration);
                 Assert.IsFalse(resCfg.BinaryConfiguration.CompactFooter);
 
-                // TODO: Create a binary object to verify the behavior.
-                // TODO: Check log message.
+                AssertCompactFooter(client, false);
+
+                var expectedLog = "Server binary configuration retrieved: BinaryConfigurationClientInternal " +
+                                  "[CompactFooter=True, NameMapperMode=BasicFull]";
+
+                Assert.AreEqual(1, logger.Entries.Count(e => e.Message == expectedLog));
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
             }
         }
 
@@ -94,8 +99,7 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 var resCfg = client.GetConfiguration();
                 Assert.IsNull(resCfg.BinaryConfiguration);
 
-                var binObj = (BinaryObject)client.GetBinary().GetBuilder("foo").Build();
-                Assert.IsTrue(binObj.Header.Flags.HasFlag(BinaryObjectHeader.Flag.CompactFooter));
+                AssertCompactFooter(client, true);
 
                 var expectedLog = "Server binary configuration retrieved: BinaryConfigurationClientInternal " +
                                   "[CompactFooter=True, NameMapperMode=BasicFull]";
@@ -103,6 +107,15 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 Assert.AreEqual(1, logger.Entries.Count(e => e.Message == expectedLog));
                 Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
             }
+        }
+
+        /// <summary>
+        /// Checks the actual compact footer behavior.
+        /// </summary>
+        private static void AssertCompactFooter(IIgniteClient client, bool expected)
+        {
+            var binObj = (BinaryObject) client.GetBinary().GetBuilder("foo").Build();
+            Assert.AreEqual(expected, binObj.Header.Flags.HasFlag(BinaryObjectHeader.Flag.CompactFooter));
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Core.Tests.Client.Binary
 {
+    using System.Linq;
     using System.Net;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client;
@@ -54,7 +55,10 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
             };
 
             var logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace});
-            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString());
+            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString())
+            {
+                Logger = logger
+            };
 
             Ignition.Start(serverCfg);
 
@@ -77,7 +81,10 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
         public void TestDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
         {
             var logger = new ListLogger(new ConsoleLogger {MinLevel = LogLevel.Trace});
-            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString());
+            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString())
+            {
+                Logger = logger
+            };
 
             Ignition.Start(TestUtils.GetTestConfiguration());
 
@@ -86,6 +93,12 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                 var resCfg = client.GetConfiguration();
 
                 Assert.IsNull(resCfg.BinaryConfiguration);
+
+                var expectedLog = "Server binary configuration retrieved: BinaryConfigurationClientInternal " +
+                                  "[CompactFooter=True, NameMapperMode=BasicFull]";
+                Assert.AreEqual(1, logger.Entries.Count(e => e.Message == expectedLog));
+
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
 
                 // TODO: Create a binary object to verify the behavior.
                 // TODO: Check log message.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
     using System.Net;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Log;
     using Apache.Ignite.Core.Tests.Client.Cache;
     using NUnit.Framework;
@@ -91,17 +92,16 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
             using (var client = Ignition.StartClient(clientCfg))
             {
                 var resCfg = client.GetConfiguration();
-
                 Assert.IsNull(resCfg.BinaryConfiguration);
+
+                var binObj = (BinaryObject)client.GetBinary().GetBuilder("foo").Build();
+                Assert.IsTrue(binObj.Header.Flags.HasFlag(BinaryObjectHeader.Flag.CompactFooter));
 
                 var expectedLog = "Server binary configuration retrieved: BinaryConfigurationClientInternal " +
                                   "[CompactFooter=True, NameMapperMode=BasicFull]";
+
                 Assert.AreEqual(1, logger.Entries.Count(e => e.Message == expectedLog));
-
                 Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
-
-                // TODO: Create a binary object to verify the behavior.
-                // TODO: Check log message.
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -110,9 +110,8 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
         public void TestExplicitDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
         {
             var logger = GetLogger();
-            var clientCfg = new IgniteClientConfiguration(IPAddress.Loopback.ToString())
+            var clientCfg = new IgniteClientConfiguration(GetClientConfiguration(logger))
             {
-                Logger = logger,
                 BinaryConfiguration = new BinaryConfiguration
                 {
                     CompactFooter = true,
@@ -141,7 +140,27 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
         [Test]
         public void TestBasicNameMapperSettingsMismatchProducesLogWarning()
         {
-            // TODO
+            var logger = GetLogger();
+            var clientCfg = new IgniteClientConfiguration(GetClientConfiguration(logger))
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    NameMapper = new BinaryBasicNameMapper
+                    {
+                        IsSimpleName = true
+                    }
+                }
+            };
+
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                var resCfg = client.GetConfiguration().BinaryConfiguration;
+                Assert.IsNotNull(resCfg);
+                Assert.IsTrue(((BinaryBasicNameMapper)resCfg.NameMapper).IsSimpleName);
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+            }
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -101,8 +101,7 @@ namespace Apache.Ignite.Core.Tests.Client.Binary
                     CompactFooter = false
                 }
             };
-"Server binary configuration " +
-                    "retrieved: BinaryConfigurationClientInternal [CompactFooter=True, NameMapperMode=BasicFull]"
+
             using (var client = Ignition.StartClient(clientConfiguration))
             {
                 var resCfg = client.GetConfiguration();

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientFeaturesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientFeaturesTest.cs
@@ -37,7 +37,7 @@ namespace Apache.Ignite.Core.Tests.Client
             foreach (ClientOp clientOp in Enum.GetValues(typeof(ClientOp)))
             {
                 var minVersion = ClientFeatures.GetMinVersion(clientOp);
-                
+
                 Assert.IsTrue(minVersion >= ClientSocket.Ver100);
                 Assert.IsTrue(minVersion <= ClientSocket.CurrentProtocolVersion);
             }
@@ -66,8 +66,12 @@ namespace Apache.Ignite.Core.Tests.Client
             var expected = Enum.GetValues(typeof(ClientBitmaskFeature))
                 .Cast<int>()
                 .Aggregate(0, (a, b) => a | (1 << b));
-            
-            Assert.AreEqual(expected, ClientFeatures.AllFeatures.Single());
+
+            var actual = ClientFeatures.AllFeatures
+                .Select((x, i) => (int) x << i * 8)
+                .Aggregate(0, (a, b) => a | b);
+
+            Assert.AreEqual(expected, actual);
         }
 
         /// <summary>
@@ -77,7 +81,7 @@ namespace Apache.Ignite.Core.Tests.Client
         public void TestHasFeature()
         {
             var features = ClientFeatures.CurrentFeatures;
-            
+
             Assert.IsTrue(features.HasFeature(ClientBitmaskFeature.ClusterGroupGetNodesEndpoints));
             Assert.IsFalse(features.HasFeature((ClientBitmaskFeature) (-1)));
             Assert.IsFalse(features.HasFeature((ClientBitmaskFeature) 12345));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="binaryConfiguration">
+            <bean class="org.apache.ignite.configuration.BinaryConfiguration">
+                <property name="nameMapper">
+                    <bean class="org.apache.ignite.platform.PlatformCustomBinaryNameMapper" />
+                </property>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper2.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper2.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="binaryConfiguration">
+            <bean class="org.apache.ignite.configuration.BinaryConfiguration">
+                <property name="nameMapper">
+                    <bean class="org.apache.ignite.platform.PlatformCustomBinaryBasicNameMapper" />
+                </property>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -27,7 +27,6 @@ namespace Apache.Ignite.Core.Tests.Services
     using Apache.Ignite.Core.Cluster;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Impl;
-    using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Resource;
     using Apache.Ignite.Core.Services;
     using NUnit.Framework;
@@ -299,7 +298,7 @@ namespace Apache.Ignite.Core.Tests.Services
 
             // Check err method
             Assert.Throws<ServiceInvocationException>(() => prx.ErrMethod(123));
- 
+
             Assert.AreEqual(42, svc.TestOverload(2, ServicesTypeAutoResolveTest.Emps));
             Assert.AreEqual(3, svc.TestOverload(1, 2));
             Assert.AreEqual(5, svc.TestOverload(3, 2));
@@ -365,7 +364,7 @@ namespace Apache.Ignite.Core.Tests.Services
             // Exception in service.
             ex = Assert.Throws<ServiceInvocationException>(() => prx.ErrMethod(123));
             Assert.AreEqual("ExpectedException", (ex.InnerException ?? ex).Message.Substring(0, 17));
- 
+
             Assert.AreEqual(42, svc.TestOverload(2, ServicesTypeAutoResolveTest.Emps));
             Assert.AreEqual(3, svc.TestOverload(1, 2));
             Assert.AreEqual(5, svc.TestOverload(3, 2));
@@ -1635,7 +1634,7 @@ namespace Apache.Ignite.Core.Tests.Services
             /** */
             public int Field { get; set; }
         }
-        
+
 #if NETCOREAPP
         /// <summary>
         /// Adds support of the local dates to the Ignite timestamp serialization.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1647,13 +1647,15 @@ namespace Apache.Ignite.Core.Tests.Services
                 if (date.Kind == DateTimeKind.Local)
                     date = date.ToUniversalTime();
 
-                BinaryUtils.ToJavaDate(date, out high, out low);
+                Impl.Binary.BinaryUtils.ToJavaDate(date, out high, out low);
             }
 
             /** <inheritdoc /> */
             public DateTime FromJavaTicks(long high, int low)
             {
-                return new DateTime(BinaryUtils.JavaDateTicks + high * TimeSpan.TicksPerMillisecond + low / 100, DateTimeKind.Utc);
+                return new DateTime(
+                    Impl.Binary.BinaryUtils.JavaDateTicks + high * TimeSpan.TicksPerMillisecond + low / 100,
+                    DateTimeKind.Utc);
             }
         }
 #endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -989,12 +989,14 @@ namespace Apache.Ignite.Core.Tests.Services
             // Test standard java checked exception.
             Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ThreadInterruptedException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test standard java unchecked exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ArgumentException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
@@ -1005,17 +1007,20 @@ namespace Apache.Ignite.Core.Tests.Services
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test user defined unmapped exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<IgniteException>(ex);
             var javaEx = ex.InnerException as JavaException;
             Assert.IsNotNull(javaEx);
@@ -1145,12 +1150,14 @@ namespace Apache.Ignite.Core.Tests.Services
             // Test standard java checked exception.
             Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ThreadInterruptedException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test standard java unchecked exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ArgumentException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
@@ -1161,17 +1168,20 @@ namespace Apache.Ignite.Core.Tests.Services
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test user defined unmapped exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<IgniteException>(ex);
             var javaEx = ex.InnerException as JavaException;
             Assert.IsNotNull(javaEx);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Impl\Cache\Query\IQueryBaseInternal.cs" />
     <Compile Include="Impl\Cache\Query\PlatformCacheQueryCursor.cs" />
     <Compile Include="Impl\Cache\Query\QueryCursorField.cs" />
+    <Compile Include="Impl\Client\Binary\BinaryConfigurationClientInternal.cs" />
+    <Compile Include="Impl\Client\Binary\BinaryNameMapperMode.cs" />
     <Compile Include="Impl\Client\Cache\Query\ClientContinuousQueryHandle.cs" />
     <Compile Include="Impl\Client\ClientBitmaskFeature.cs" />
     <Compile Include="Impl\Client\ClientConnection.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Core.Impl.Client.Binary
 {
+    using System;
     using System.Diagnostics;
     using Apache.Ignite.Core.Impl.Binary.IO;
 
@@ -56,6 +57,13 @@ namespace Apache.Ignite.Core.Impl.Client.Binary
         public BinaryNameMapperMode NameMapperMode
         {
             get { return _nameMapperMode; }
+        }
+
+        /** <inheritDoc /> */
+        public override string ToString()
+        {
+            return string.Format("BinaryConfigurationClientInternal [CompactFooter={0}, NameMapperMode={1}]",
+                CompactFooter, NameMapperMode);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client.Binary
+{
+    using System.Diagnostics;
+    using Apache.Ignite.Core.Impl.Binary.IO;
+
+    /// <summary>
+    /// Thin client binary configuration.
+    /// </summary>
+    internal class BinaryConfigurationClientInternal
+    {
+        /** */
+        private readonly bool _compactFooter;
+
+        /** */
+        private readonly BinaryNameMapperMode _nameMapperMode;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="BinaryConfigurationClientInternal"/> class.
+        /// </summary>
+        public BinaryConfigurationClientInternal(IBinaryStream stream)
+        {
+            Debug.Assert(stream != null);
+
+            _compactFooter = stream.ReadBool();
+            _nameMapperMode = (BinaryNameMapperMode) stream.ReadByte();
+        }
+
+        /// <summary>
+        /// Gets a flag indicating whether compact footer mode should be used.
+        /// </summary>
+        public bool CompactFooter
+        {
+            get { return _compactFooter; }
+        }
+
+        /// <summary>
+        /// Gets the binary name mapper mode.
+        /// </summary>
+        public BinaryNameMapperMode NameMapperMode
+        {
+            get { return _nameMapperMode; }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Core.Impl.Client.Binary
 {
-    using System;
     using System.Diagnostics;
     using Apache.Ignite.Core.Impl.Binary.IO;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryNameMapperMode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryNameMapperMode.cs
@@ -15,22 +15,28 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Core.Impl.Client
+namespace Apache.Ignite.Core.Impl.Client.Binary
 {
+    using Apache.Ignite.Core.Binary;
+
     /// <summary>
-    /// Client feature ids. Values represent the index in the bit array.
-    /// Unsupported flags must be commented out.
+    /// Represents the binary name mapper mode.
     /// </summary>
-    internal enum ClientBitmaskFeature
+    internal enum BinaryNameMapperMode
     {
-        // UserAttributes = 0,
-        ExecuteTaskByName = 1,
-        // ClusterStates = 2,
-        ClusterGroupGetNodesEndpoints = 3,
-        ClusterGroups = 4,
-        ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
-        // DefaultQueryTimeout = 6, // IGNITE-13692
-        QueryPartitionsBatchSize = 7,
-        BinaryConfiguration = 8
+        /// <summary>
+        /// Default full name mapper, see <see cref="BinaryBasicNameMapper.FullNameInstance"/>.
+        /// </summary>
+        BasicFull = 0,
+
+        /// <summary>
+        /// Simple name mapper, see <see cref="BinaryBasicNameMapper.SimpleNameInstance"/>.
+        /// </summary>
+        BasicSimple = 1,
+
+        /// <summary>
+        /// Custom user-defined mapper.
+        /// </summary>
+        Custom = 2
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -478,7 +478,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
                     _config.BinaryConfiguration.CompactFooter = false;
 
-                    _logger.Debug("BinaryConfiguration.CompactFooter set to false on client " +
+                    _logger.Info("BinaryConfiguration.CompactFooter set to false on client " +
                                   "according to server configuration.");
                 }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -452,16 +452,23 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 _logger.Debug("Server binary configuration retrieved: " + binaryCfg);
 
+                if (binaryCfg.CompactFooter && !_marsh.CompactFooter)
+                {
+                    // Changing from full to compact is not safe: some clients do not support compact footers.
+                    // Print a warning, but don't change the configuration.
+                    // TODO: Warn or Info? If the user has disabled it explicitly, maybe they know what they are doing?
+                    _logger.Warn("TODO");
+                }
+
                 if (!binaryCfg.CompactFooter && _marsh.CompactFooter)
                 {
+                    // Changing from compact to full footer is safe, do it automatically.
                     _logger.Debug("Compact footer disabled according to server configuration.");
                     _marsh.CompactFooter = false;
                     _config.BinaryConfiguration.CompactFooter = false;
                 }
 
-                // TODO: Update binary config
-                // TODO: Warn if there is a mapper mismatch
-                // TODO: Warn if there is a Custom mapper, but BinaryConfiguration.Mapper is not set
+                // Warn if there is a mapper mismatch, but don't change
                 if (binaryCfg.NameMapperMode == BinaryNameMapperMode.Custom &&
                     (_config.BinaryConfiguration.NameMapper == null ||
                      _config.BinaryConfiguration.NameMapper is BinaryBasicNameMapper))

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -470,13 +470,19 @@ namespace Apache.Ignite.Core.Impl.Client
                 {
                     // Changing from compact to full footer is safe, do it automatically.
                     _marsh.CompactFooter = false;
+
+                    if (_config.BinaryConfiguration == null)
+                    {
+                        _config.BinaryConfiguration = new BinaryConfiguration();
+                    }
+
                     _config.BinaryConfiguration.CompactFooter = false;
 
                     _logger.Debug("BinaryConfiguration.CompactFooter set to false on client " +
                                   "according to server configuration.");
                 }
 
-                // Warn if there is a mapper mismatch, but don't change
+                // TODO: Warn if there is a mapper mismatch, but don't change.
                 if (binaryCfg.NameMapperMode == BinaryNameMapperMode.Custom &&
                     (_config.BinaryConfiguration.NameMapper == null ||
                      _config.BinaryConfiguration.NameMapper is BinaryBasicNameMapper))

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -450,6 +450,15 @@ namespace Apache.Ignite.Core.Impl.Client
                     ctx => { },
                     ctx => new BinaryConfigurationClientInternal(ctx.Reader.Stream));
 
+                _logger.Debug("Server binary configuration retrieved: " + binaryCfg);
+
+                if (!binaryCfg.CompactFooter && _marsh.CompactFooter)
+                {
+                    _logger.Debug("Compact footer disabled according to server configuration.");
+                    _marsh.CompactFooter = false;
+                    _config.BinaryConfiguration.CompactFooter = false;
+                }
+
                 // TODO: Update binary config
                 // TODO: Warn if there is a mapper mismatch
                 // TODO: Warn if there is a Custom mapper, but BinaryConfiguration.Mapper is not set

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -26,6 +26,7 @@ namespace Apache.Ignite.Core.Impl.Client
     using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
+    using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Impl.Binary;
@@ -449,8 +450,15 @@ namespace Apache.Ignite.Core.Impl.Client
                     ctx => { },
                     ctx => new BinaryConfigurationClientInternal(ctx.Reader.Stream));
 
+                // TODO: Update binary config
                 // TODO: Warn if there is a mapper mismatch
                 // TODO: Warn if there is a Custom mapper, but BinaryConfiguration.Mapper is not set
+                if (binaryCfg.NameMapperMode == BinaryNameMapperMode.Custom &&
+                    (_config.BinaryConfiguration.NameMapper == null ||
+                     _config.BinaryConfiguration.NameMapper is BinaryBasicNameMapper))
+                {
+                    _logger.Warn("TODO");
+                }
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFeatures.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFeatures.cs
@@ -58,7 +58,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 {ClientOp.ClusterGroupGetNodeIds, ClientBitmaskFeature.ClusterGroups},
                 {ClientOp.ClusterGroupGetNodesInfo, ClientBitmaskFeature.ClusterGroups}
             };
-        
+
         /** */
         private readonly ClientProtocolVersion _protocolVersion;
 
@@ -66,7 +66,7 @@ namespace Apache.Ignite.Core.Impl.Client
         private readonly BitArray _features;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="ClientFeatures"/>. 
+        /// Initializes a new instance of <see cref="ClientFeatures"/>.
         /// </summary>
         public ClientFeatures(ClientProtocolVersion protocolVersion, BitArray features)
         {
@@ -93,7 +93,7 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /// <summary>
-        /// Checks whether WithExpiryPolicy request flag is supported. Throws an exception when not supported. 
+        /// Checks whether WithExpiryPolicy request flag is supported. Throws an exception when not supported.
         /// </summary>
         public void ValidateWithExpiryPolicyFlag()
         {
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Core.Impl.Client
         {
             return _protocolVersion >= ClientSocket.Ver120;
         }
-        
+
         /// <summary>
         /// Returns a value indicating whether <see cref="CacheConfiguration.ExpiryPolicyFactory"/> is supported.
         /// </summary>
@@ -121,7 +121,7 @@ namespace Apache.Ignite.Core.Impl.Client
         {
             return _protocolVersion >= ClientSocket.Ver160;
         }
-        
+
         /// <summary>
         /// Gets minimum protocol version that is required to perform specified operation.
         /// </summary>
@@ -130,9 +130,9 @@ namespace Apache.Ignite.Core.Impl.Client
         public static ClientProtocolVersion GetMinVersion(ClientOp op)
         {
             ClientProtocolVersion minVersion;
-            
-            return OpVersion.TryGetValue(op, out minVersion) 
-                ? minVersion 
+
+            return OpVersion.TryGetValue(op, out minVersion)
+                ? minVersion
                 : ClientSocket.Ver100;
         }
 
@@ -144,14 +144,14 @@ namespace Apache.Ignite.Core.Impl.Client
         {
             ValidateOp(operation, true);
         }
-        
+
         /// <summary>
         /// Validates specified op code against current protocol version and features.
         /// </summary>
         private bool ValidateOp(ClientOp operation, bool shouldThrow)
         {
             var requiredProtocolVersion = GetMinVersion(operation);
-            
+
             if (_protocolVersion < requiredProtocolVersion)
             {
                 if (shouldThrow)
@@ -214,14 +214,16 @@ namespace Apache.Ignite.Core.Impl.Client
                 .Cast<int>()
                 .ToArray();
 
-            var bits = new BitArray(values.Max() + 1);
+            var max = values.Max();
+
+            var bits = new BitArray(max + 1);
 
             foreach (var feature in values)
             {
                 bits.Set(feature, true);
             }
-            
-            var bytes = new byte[1 + values.Length / 8];
+
+            var bytes = new byte[1 + max / 8];
             bits.CopyTo(bytes, 0);
 
             return bytes;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
@@ -71,6 +71,7 @@ namespace Apache.Ignite.Core.Impl.Client
         BinaryTypeNamePut = 3001,
         BinaryTypeGet = 3002,
         BinaryTypePut = 3003,
+        BinaryConfigurationGet = 3004,
 
         // Transactions
         TxStart = 4000,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
@@ -102,7 +102,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
             _binProc = _configuration.BinaryProcessor ?? new BinaryProcessorClient(_socket);
 
-            _binary = new Binary(_marsh);
+            _binary = new Impl.Binary.Binary(_marsh);
 
             _cluster = new ClientCluster(this);
 


### PR DESCRIPTION
* Add `OP_BINARY_CONFIGURATION_GET` to the protocol, and `BINARY_CONFIGURATION` feature flag
* Retrieve the configuration in .NET thin client
* The only automatic adjustment: change `CompactFooter` from `true` to `false` on the client
* Log warnings in other cases of configuration mismatch: we can't change name mapper automatically, and we can't enable compact footers automatically, because it can break other clients which don't have compact footer support or rely on a specific name mapping.