### PR TITLE
IGNITE-14116 .NET: Update tests with LongRunning category

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheLocalAtomicTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheLocalAtomicTest.cs
@@ -17,6 +17,9 @@
 
 namespace Apache.Ignite.Core.Tests.Cache
 {
+    using NUnit.Framework;
+
+    [Category(TestUtils.CategoryIntensive)]
     public class CacheLocalAtomicTest : CacheAbstractTest
     {
         protected override int CachePartitions()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheLocalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheLocalTest.cs
@@ -17,6 +17,9 @@
 
 namespace Apache.Ignite.Core.Tests.Cache
 {
+    using NUnit.Framework;
+
+    [Category(TestUtils.CategoryIntensive)]
     public class CacheLocalTest : CacheAbstractTransactionalTest
     {
         protected override int CachePartitions()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PersistenceTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PersistenceTest.cs
@@ -66,6 +66,7 @@ namespace Apache.Ignite.Core.Tests.Cache
         /// Tests that cache data survives node restart.
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestCacheDataSurvivesNodeRestart(
             [Values(true, false)] bool withCacheStore,
             [Values(true, false)] bool withCustomAffinity)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTopologyChangeTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTopologyChangeTest.cs
@@ -32,6 +32,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
     /// <summary>
     /// Tests platform cache behavior when cluster topology changes.
     /// </summary>
+    [Category(TestUtils.CategoryIntensive)]
     public class PlatformCacheTopologyChangeTest
     {
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheDmlQueriesTestSimpleName.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheDmlQueriesTestSimpleName.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     /// Test with simple name mapper.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class CacheDmlQueriesTestSimpleName : CacheDmlQueriesTest
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTestSimpleName.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTestSimpleName.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     /// Test with simple name mapper.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class CacheQueriesTestSimpleName : CacheQueriesTest
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryTest.cs
@@ -37,6 +37,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
         /// This tests verifies that there are no exception on Java side during event delivery.
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestSameQueryMultipleNodes()
         {
             using (var ignite = StartIgnite())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTestSimpleName.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTestSimpleName.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
     /// LINQ test with simple name mapper.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class CacheLinqTestSimpleName : CacheLinqTest
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTestSqlEscapeAll.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTestSqlEscapeAll.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
     /// LINQ test with simple name mapper.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class CacheLinqTestSqlEscapeAll : CacheLinqTest
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestAsync.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestAsync.cs
@@ -27,6 +27,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     /// Async cache test.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public sealed class CacheTestAsync : CacheTest
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestSsl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestSsl.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     /// SSL cache test.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public sealed class CacheTestSsl : CacheTest
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -138,6 +138,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// - Update cache and verify that continuous query listeners receive correct events
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestComputeWorksWhenContinuousQueryIsActive()
         {
             var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName);
@@ -541,6 +542,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// - Versify that results are correct
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestMultipleQueriesMultithreaded()
         {
             var cache = Ignition.GetIgnite().GetOrCreateCache<int, int>(TestUtils.TestName);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTests.cs
@@ -48,6 +48,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         /// Tests random topology changes.
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestClientDiscoveryWithRandomTopologyChanges()
         {
             var nodes = new Stack<IIgnite>();

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBaselineTopology.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBaselineTopology.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
     /// Tests client cluster discovery with baseline topology.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class ClientClusterDiscoveryTestsBaselineTopology : ClientClusterDiscoveryTests
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsNoLocalhost.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsNoLocalhost.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
     /// Discovery test with no <see cref="IgniteConfiguration.Localhost"/> set.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class ClientClusterDiscoveryTestsNoLocalhost : ClientClusterDiscoveryTests
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsSsl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsSsl.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
     /// Tests client discovery with SSL enabled.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class ClientClusterDiscoveryTestsSsl : ClientClusterDiscoveryTestsBase
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compute/ComputeClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compute/ComputeClientTests.cs
@@ -409,6 +409,7 @@ namespace Apache.Ignite.Core.Tests.Client.Compute
         /// Tests <see cref="IComputeClient.ExecuteJavaTaskAsync{TRes}(string,object)"/> from multiple threads.
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestExecuteJavaTaskAsyncMultithreaded()
         {
             var count = 5000;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -191,15 +191,13 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             var cluster = _grid1.GetCluster();
 
-            IClusterMetrics metrics = cluster.GetMetrics();
+            var metrics = cluster.GetMetrics();
 
             Assert.IsNotNull(metrics);
-
             Assert.AreEqual(cluster.GetNodes().Count, metrics.TotalNodes);
 
-            Thread.Sleep(2000);
-
-            IClusterMetrics newMetrics = cluster.GetMetrics();
+            TestUtils.WaitForTrueCondition(() => cluster.GetMetrics().LastUpdateTime > metrics.LastUpdateTime, 2000);
+            var newMetrics = cluster.GetMetrics();
 
             Assert.IsFalse(metrics == newMetrics);
             Assert.IsTrue(metrics.LastUpdateTime < newMetrics.LastUpdateTime);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTestFullFooter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTestFullFooter.cs
@@ -25,6 +25,7 @@ namespace Apache.Ignite.Core.Tests.Compute
     /// Compute API test with compact footers disabled.
     /// </summary>
     [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class ComputeApiTestFullFooter : ComputeApiTest
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -421,6 +421,7 @@ namespace Apache.Ignite.Core.Tests
         /// Tests the static ip finder.
         /// </summary>
         [Test]
+        [NUnit.Framework.Category(TestUtils.CategoryIntensive)]
         public void TestStaticIpFinder()
         {
             TestIpFinders(new TcpDiscoveryStaticIpFinder
@@ -436,6 +437,7 @@ namespace Apache.Ignite.Core.Tests
         /// Tests the multicast ip finder.
         /// </summary>
         [Test]
+        [NUnit.Framework.Category(TestUtils.CategoryIntensive)]
         public void TestMulticastIpFinder()
         {
             TestIpFinders(

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -372,6 +372,7 @@ namespace Apache.Ignite.Core.Tests
         /// Tests the default spi.
         /// </summary>
         [Test]
+        [NUnit.Framework.Category(TestUtils.CategoryIntensive)]
         public void TestDefaultSpi()
         {
             var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteLockTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteLockTests.cs
@@ -274,6 +274,7 @@ namespace Apache.Ignite.Core.Tests
         /// Tests that fair lock favors granting access to the longest-waiting thread
         /// </summary>
         [Test]
+        [Category(TestUtils.CategoryIntensive)]
         public void TestFairLockGuaranteesOrder()
         {
             const int count = 20;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTestAsync.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTestAsync.cs
@@ -18,10 +18,13 @@
 namespace Apache.Ignite.Core.Tests.Services
 {
     using Apache.Ignite.Core.Services;
+    using NUnit.Framework;
 
     /// <summary>
     /// Services async tests.
     /// </summary>
+    [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class ServicesTestAsync : ServicesTest
     {
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTestFullFooter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTestFullFooter.cs
@@ -17,9 +17,13 @@
 
 namespace Apache.Ignite.Core.Tests.Services
 {
+    using NUnit.Framework;
+
     /// <summary>
     /// Services test with compact footers disabled.
     /// </summary>
+    [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
     public class ServicesTestFullFooter : ServicesTest
     {
         /// <summary>

--- a/modules/platforms/dotnet/DEVNOTES.txt
+++ b/modules/platforms/dotnet/DEVNOTES.txt
@@ -48,11 +48,17 @@ Requirements:
 Getting started:
 * Build Java and .NET:
   ./build.sh
+
 * Run tests:
   cd Apache.Ignite.Core.Tests
   dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj
+
 * Run specific test:
-  dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter CacheTest
+  dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter "TestCategory\!=LONG_TEST&TestCategory\!=EXAMPLES_TEST"
+
+* Run a smaller subset of tests:
+
+
 * IDE: Open Apache.Ignite.DotNetCore.sln
 
 

--- a/modules/platforms/dotnet/DEVNOTES.txt
+++ b/modules/platforms/dotnet/DEVNOTES.txt
@@ -54,7 +54,7 @@ Getting started:
   dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj
 
 * Run specific test:
-  dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter "TestCategory\!=LONG_TEST&TestCategory\!=EXAMPLES_TEST"
+  dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter "TestCategory!=LONG_TEST&TestCategory!=EXAMPLES_TEST"
 
 * Run a smaller subset of tests:
 


### PR DESCRIPTION
* Review all tests duration and mark slow ones with `[Category(TestUtils.CategoryIntensive)]`
* Update DEVNOTES with a command to run quick tests only

|          | All Tests | Quick Tests |
|----------|-----------|-------------|
| Count    | 3242      | 1777        |
| Run time | 35 min    | 4 min       |