### PR TITLE
IGNITE-12941 .NET: Fix and document single file deployment on .NET 5

### DIFF
--- a/docs/_docs/net-specific/net-deployment-options.adoc
+++ b/docs/_docs/net-specific/net-deployment-options.adoc
@@ -59,6 +59,8 @@ TODO:
 * Document `IncludeAllContentForSelfExtract`
 * Document workaround for pre-2.11 versions on .NET 5
 
+xref:net-troubleshooting.adoc#libcoreclr-not-found[DllNotFoundException workaround]
+
 ```
 NativeLibrary.SetDllImportResolver(
     typeof(Ignition).Assembly,

--- a/docs/_docs/net-specific/net-deployment-options.adoc
+++ b/docs/_docs/net-specific/net-deployment-options.adoc
@@ -52,23 +52,17 @@ tab:MyApp.csproj[]
 ----
 --
 
-== Single-file Publish
+== Single File Deployment
 
-TODO:
+Ignite.NET supports https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file[Single file deployment] that is available in .NET Core 3 / .NET 5+.
 
-* Document `IncludeAllContentForSelfExtract`
-* Document workaround for pre-2.11 versions on .NET 5
+* Use `IncludeAllContentForSelfExtract` MSBuild property to include jar files into the single-file bundle, or ship them separately.
+* See xref:net-troubleshooting.adoc#libcoreclr-not-found[Troubleshooting: DllNotFoundException] for a workaround that is required
+on .NET 5 with some Ignite versions.
 
-xref:net-troubleshooting.adoc#libcoreclr-not-found[DllNotFoundException workaround]
+Publish command example:
 
-```
-NativeLibrary.SetDllImportResolver(
-    typeof(Ignition).Assembly,
-    (libraryName, _, _) => libraryName == "libcoreclr.so"
-        ? (IntPtr) (-1)
-        : IntPtr.Zero);
-
-```
+`dotnet publish --self-contained true -r linux-x64 -p:PublishSingleFile=true -p:IncludeAllContentForSelfExtract=true`
 
 == Full Binary Package Deployment
 

--- a/docs/_docs/net-specific/net-deployment-options.adoc
+++ b/docs/_docs/net-specific/net-deployment-options.adoc
@@ -56,7 +56,7 @@ tab:MyApp.csproj[]
 
 Ignite.NET supports https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file[single file deployment] that is available in .NET Core 3 / .NET 5+.
 
-* Use `IncludeAllContentForSelfExtract` MSBuild property to include jar files into the single-file bundle, or ship them separately.
+* Use the `IncludeAllContentForSelfExtract` MSBuild property to include jar files into the single-file bundle, or ship them separately.
 * See xref:net-troubleshooting.adoc#libcoreclr-not-found[Troubleshooting: DllNotFoundException] for a workaround that is required
 on .NET 5 with some Ignite versions.
 

--- a/docs/_docs/net-specific/net-deployment-options.adoc
+++ b/docs/_docs/net-specific/net-deployment-options.adoc
@@ -54,7 +54,7 @@ tab:MyApp.csproj[]
 
 == Single File Deployment
 
-Ignite.NET supports https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file[single file deployment] that is available in .NET Core 3 / .NET 5+.
+Ignite.NET supports link:https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file[single file deployment] that is available in .NET Core 3 / .NET 5+.
 
 * Use the `IncludeAllContentForSelfExtract` MSBuild property to include jar files into the single-file bundle, or ship them separately.
 * See xref:net-troubleshooting.adoc#libcoreclr-not-found[Troubleshooting: DllNotFoundException] for a workaround that is required

--- a/docs/_docs/net-specific/net-deployment-options.adoc
+++ b/docs/_docs/net-specific/net-deployment-options.adoc
@@ -54,7 +54,7 @@ tab:MyApp.csproj[]
 
 == Single File Deployment
 
-Ignite.NET supports https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file[Single file deployment] that is available in .NET Core 3 / .NET 5+.
+Ignite.NET supports https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file[single file deployment] that is available in .NET Core 3 / .NET 5+.
 
 * Use `IncludeAllContentForSelfExtract` MSBuild property to include jar files into the single-file bundle, or ship them separately.
 * See xref:net-troubleshooting.adoc#libcoreclr-not-found[Troubleshooting: DllNotFoundException] for a workaround that is required

--- a/docs/_docs/net-specific/net-deployment-options.adoc
+++ b/docs/_docs/net-specific/net-deployment-options.adoc
@@ -24,7 +24,7 @@ This page introduces several most-commonly used deployment options of Ignite.NET
 
 == NuGet Deployment
 
-`Apache.Ignite` NuGet package includes a `lib` folder with all the required jar files. This folder has 
+`Apache.Ignite` NuGet package includes a `lib` folder with all the required jar files. This folder has
 the `<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>` build action, and is copied automatically to the output directory
 during the build or publish process.
 
@@ -52,6 +52,21 @@ tab:MyApp.csproj[]
 ----
 --
 
+== Single-file Publish
+
+TODO:
+
+* Document `IncludeAllContentForSelfExtract`
+* Document workaround for pre-2.11 versions on .NET 5
+
+```
+NativeLibrary.SetDllImportResolver(
+    typeof(Ignition).Assembly,
+    (libraryName, _, _) => libraryName == "libcoreclr.so"
+        ? (IntPtr) (-1)
+        : IntPtr.Zero);
+
+```
 
 == Full Binary Package Deployment
 

--- a/docs/_docs/net-specific/net-troubleshooting.adoc
+++ b/docs/_docs/net-specific/net-troubleshooting.adoc
@@ -160,7 +160,7 @@ move the process handling logic to Java side and invoke it with
 link:developers-guide/distributed-computing/distributed-computing[Compute] `ExecuteJavaTask` API.
 Alternatively, use Services API to call Java service from .NET.
 
-=== DllNotFoundException: Unable to load shared library 'libcoreclr.so' or one of its dependencies
+=== [[libcoreclr-not-found]] DllNotFoundException: Unable to load shared library 'libcoreclr.so' or one of its dependencies
 
 Occurs on .NET 5 in a single-file publish mode (e.g. `dotnet publish --self-contained true -r linux-x64 -p:PublishSingleFile=true`).
 

--- a/docs/_docs/net-specific/net-troubleshooting.adoc
+++ b/docs/_docs/net-specific/net-troubleshooting.adoc
@@ -159,3 +159,22 @@ For example, when `direct-io` is used, and .NET code requires starting a child p
 move the process handling logic to Java side and invoke it with
 link:developers-guide/distributed-computing/distributed-computing[Compute] `ExecuteJavaTask` API.
 Alternatively, use Services API to call Java service from .NET.
+
+=== DllNotFoundException: Unable to load shared library 'libcoreclr.so' or one of its dependencies
+
+Occurs on .NET 5 in a single-file publish mode (e.g. `dotnet publish --self-contained true -r linux-x64 -p:PublishSingleFile=true`).
+
+==== Workaround
+
+Add the following code before starting the Ignite node:
+
+[tabs]
+--
+tab:C#[]
+[source,csharp]
+----
+NativeLibrary.SetDllImportResolver(
+    typeof(Ignition).Assembly,
+    (lib, _, _) => lib == "libcoreclr.so" ? (IntPtr) (-1) : IntPtr.Zero);
+----
+--

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
@@ -112,29 +112,26 @@ namespace Apache.Ignite.Core.Tests
             
             var csFiles = TestUtils.GetDotNetSourceDir().GetFiles("*.cs", SearchOption.AllDirectories);
 
-            Assert.Multiple(() =>
+            foreach (var csFile in csFiles)
             {
-                foreach (var csFile in csFiles)
+                if (excluded.Contains(csFile.Name))
                 {
-                    if (excluded.Contains(csFile.Name))
-                    {
-                        continue;
-                    }
-                    
-                    var text = File.ReadAllText(csFile.FullName);
-
-                    if (!text.Contains("namespace Apache.Ignite.Core.Impl"))
-                    {
-                        continue;
-                    }
-
-                    StringAssert.DoesNotContain("public class", text, csFile.FullName);
-                    StringAssert.DoesNotContain("public static class", text, csFile.FullName);
-                    StringAssert.DoesNotContain("public interface", text, csFile.FullName);
-                    StringAssert.DoesNotContain("public enum", text, csFile.FullName);
-                    StringAssert.DoesNotContain("public struct", text, csFile.FullName);
+                    continue;
                 }
-            });
+
+                var text = File.ReadAllText(csFile.FullName);
+
+                if (!text.Contains("namespace Apache.Ignite.Core.Impl"))
+                {
+                    continue;
+                }
+
+                StringAssert.DoesNotContain("public class", text, csFile.FullName);
+                StringAssert.DoesNotContain("public static class", text, csFile.FullName);
+                StringAssert.DoesNotContain("public interface", text, csFile.FullName);
+                StringAssert.DoesNotContain("public enum", text, csFile.FullName);
+                StringAssert.DoesNotContain("public struct", text, csFile.FullName);
+            }
         }
 
 #if NETCOREAPP

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
@@ -87,6 +87,56 @@ namespace Apache.Ignite.Core.Tests
                 "Invalid optimize setting in release mode: ");
         }
 
+        /// <summary>
+        /// Tests that there are no public types in Apache.Ignite.Core.Impl namespace.
+        /// </summary>
+        [Test]
+        public void TestImplNamespaceHasNoPublicTypes()
+        {
+            var excluded = new[]
+            {
+                "ProjectFilesTest.cs", 
+                "CopyOnWriteConcurrentDictionary.cs",
+                "IgniteArgumentCheck.cs",
+                "DelegateConverter.cs",
+                "IgniteHome.cs",
+                "TypeCaster.cs",
+                "FutureType.cs",
+                "CollectionExtensions.cs",
+                "IQueryEntityInternal.cs",
+                "ICacheInternal.cs",
+                "CacheEntry.cs",
+                "HandleRegistry.cs",
+                "BinaryObjectHeader.cs"
+            };
+            
+            var csFiles = TestUtils.GetDotNetSourceDir().GetFiles("*.cs", SearchOption.AllDirectories);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var csFile in csFiles)
+                {
+                    if (excluded.Contains(csFile.Name))
+                    {
+                        continue;
+                    }
+                    
+                    var text = File.ReadAllText(csFile.FullName);
+
+                    if (!text.Contains("namespace Apache.Ignite.Core.Impl"))
+                    {
+                        continue;
+                    }
+
+                    StringAssert.DoesNotContain("public class", text, csFile.FullName);
+                    StringAssert.DoesNotContain("public static class", text, csFile.FullName);
+                    StringAssert.DoesNotContain("public interface", text, csFile.FullName);
+                    StringAssert.DoesNotContain("public enum", text, csFile.FullName);
+                    StringAssert.DoesNotContain("public struct", text, csFile.FullName);
+                }
+            });
+        }
+
 #if NETCOREAPP
         /// <summary>
         /// Tests that all .cs files are included in the project.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Impl\Transactions\TransactionRollbackOnlyProxy.cs" />
     <Compile Include="Impl\Transactions\TransactionCollectionImpl.cs" />
     <Compile Include="Impl\Unmanaged\Jni\Jvm.CrossAppDomain.cs" />
+    <Compile Include="Impl\Unmanaged\NativeLibraryUtils.cs" />
     <Compile Include="Impl\Unmanaged\UnmanagedThread.cs" />
     <Compile Include="Log\ConsoleLogger.cs" />
     <Compile Include="Log\IDateTimeProvider.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
@@ -47,6 +47,14 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private const int ERROR_MOD_NOT_FOUND = 126;
 
         /// <summary>
+        /// Initializes the <see cref="DllLoader"/> class.
+        /// </summary>
+        static DllLoader()
+        {
+            NativeLibraryUtils.SetDllImportResolvers();
+        }
+
+        /// <summary>
         /// Loads specified DLL.
         /// </summary>
         /// <returns>Library handle and error message.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
@@ -47,6 +47,17 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private const int ERROR_MOD_NOT_FOUND = 126;
 
         /// <summary>
+        /// Initializes the <see cref="DllLoader"/> class.
+        /// </summary>
+        static DllLoader()
+        {
+            if (Os.IsLinux)
+            {
+                NativeLibraryUtils.SetDllImportResolvers();
+            }
+        }
+
+        /// <summary>
         /// Loads specified DLL.
         /// </summary>
         /// <returns>Library handle and error message.</returns>
@@ -70,8 +81,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
 
             if (Os.IsLinux)
             {
-                NativeLibraryUtils.SetDllImportResolvers();
-
                 if (Os.IsMono)
                 {
                     var ptr = NativeMethodsMono.dlopen(dllPath, RtldGlobal | RtldLazy);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
@@ -47,14 +47,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private const int ERROR_MOD_NOT_FOUND = 126;
 
         /// <summary>
-        /// Initializes the <see cref="DllLoader"/> class.
-        /// </summary>
-        static DllLoader()
-        {
-            NativeLibraryUtils.SetDllImportResolvers();
-        }
-
-        /// <summary>
         /// Loads specified DLL.
         /// </summary>
         /// <returns>Library handle and error message.</returns>
@@ -78,6 +70,8 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
 
             if (Os.IsLinux)
             {
+                NativeLibraryUtils.SetDllImportResolvers();
+
                 if (Os.IsMono)
                 {
                     var ptr = NativeMethodsMono.dlopen(dllPath, RtldGlobal | RtldLazy);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
@@ -51,10 +51,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         /// </summary>
         static DllLoader()
         {
-            if (Os.IsLinux)
-            {
-                NativeLibraryUtils.SetDllImportResolvers();
-            }
+            NativeLibraryUtils.SetDllImportResolvers();
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -44,7 +44,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                     return;
                 }
 
-                SetDllImportResolversImpl();
+                if (Os.IsLinux)
+                {
+                    SetLibcoreclrResolver();
+                }
 
                 _resolversInitialized = true;
             }
@@ -53,7 +56,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         /// <summary>
         /// Sets dll import resolvers.
         /// </summary>
-        private static void SetDllImportResolversImpl()
+        private static void SetLibcoreclrResolver()
         {
             // Init custom resolver for .NET 5+ single-file apps.
             // Do it with Reflection, because SetDllImportResolver is not available on some frameworks,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -63,14 +63,13 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 return;
             }
 
-            var resolveMethod = typeof(NativeLibraryUtils).GetMethod("Resolve", BindingFlags.Static | BindingFlags.NonPublic);
-            Debug.Assert(resolveMethod != null);
-
             var libraryName = Expression.Parameter(typeof(string));
             var assembly = Expression.Parameter(typeof(Assembly));
             var searchPath = Expression.Parameter(typeof(Nullable<>).MakeGenericType(dllImportSearchPathType));
 
-            var resolve = Expression.Call(resolveMethod, libraryName);
+            Expression<Func<string, IntPtr>> call = lib => Resolve(lib);
+            var resolve = Expression.Invoke(call, libraryName);
+
             var dllImportResolver = Expression.Lambda(dllImportResolverType, resolve, libraryName, assembly, searchPath);
             var resolveDelegate = dllImportResolver.Compile();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -56,17 +56,20 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             var resolveMethod = typeof(NativeLibraryUtils).GetMethod("Resolve", BindingFlags.Static | BindingFlags.NonPublic);
             Debug.Assert(resolveMethod != null);
 
-            var libraryNameArg = Expression.Parameter(typeof(string), "libraryName");
-            var asmArg = Expression.Parameter(typeof(Assembly), "asm");
-            var searchPathArg = Expression.Parameter(typeof(Nullable<>).MakeGenericType(dllImportSearchPathType), "searchPath");
+            var libraryName = Expression.Parameter(typeof(string));
+            var assembly = Expression.Parameter(typeof(Assembly));
+            var searchPath = Expression.Parameter(typeof(Nullable<>).MakeGenericType(dllImportSearchPathType));
 
-            var invokeImplExpr = Expression.Call(resolveMethod, libraryNameArg);
-            var dllImportResolver = Expression.Lambda(dllImportResolverType, invokeImplExpr, libraryNameArg, asmArg, searchPathArg);
+            var resolve = Expression.Call(resolveMethod, libraryName);
+            var dllImportResolver = Expression.Lambda(dllImportResolverType, resolve, libraryName, assembly, searchPath);
             var resolveDelegate = dllImportResolver.Compile();
 
             setDllImportResolverMethod.Invoke(null, new object[] {typeof(Ignition).Assembly, resolveDelegate});
         }
 
+        /// <summary>
+        /// Resolves the native library.
+        /// </summary>
         // ReSharper disable once UnusedMember.Local (reflection).
         private static IntPtr Resolve(string libraryName)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Core.Impl.Unmanaged
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq.Expressions;
     using System.Reflection;
 
@@ -96,7 +97,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         /// <summary>
         /// Resolves the native library.
         /// </summary>
-        // ReSharper disable once UnusedMember.Local (reflection).
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Reflection")]
         private static IntPtr Resolve(string libraryName)
         {
             return libraryName == "libcoreclr.so"

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Unmanaged
+{
+    using System;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public static class NativeLibraryUtils
+    {
+        public static void SetDllImportResolvers()
+        {
+            // Init custom resolver for .NET 5+ single-file apps.
+            // TODO: Do it with Reflection
+            // Type.GetType("System.Runtime.InteropServices.NativeLibrary")
+            // NativeLibrary.SetDllImportResolver(typeof(NativeLibraryUtils).Assembly,
+            //     (string libraryName, Assembly assembly, DllImportSearchPath searchPath) =>
+            //         Resolve(libraryName, assembly, searchPath));
+        }
+
+        private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath searchPath)
+        {
+            return libraryName == "libcoreclr.so"
+                ? (IntPtr) (-1)  // Self-referencing binary.
+                : IntPtr.Zero;   // Skip.
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -25,7 +25,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
     /// <summary>
     /// Native library call utilities.
     /// </summary>
-    public static class NativeLibraryUtils
+    internal static class NativeLibraryUtils
     {
         /** */
         private static readonly object SyncRoot = new object();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -30,13 +30,14 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         {
             // Init custom resolver for .NET 5+ single-file apps.
             // TODO: Do it with Reflection
+            // TODO: DllImportSearchPath is not available on .NET 4.
             // Type.GetType("System.Runtime.InteropServices.NativeLibrary")
             // NativeLibrary.SetDllImportResolver(typeof(NativeLibraryUtils).Assembly,
             //     (string libraryName, Assembly assembly, DllImportSearchPath searchPath) =>
             //         Resolve(libraryName, assembly, searchPath));
         }
 
-        private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath searchPath)
+        private static IntPtr Resolve(string libraryName)
         {
             return libraryName == "libcoreclr.so"
                 ? (IntPtr) (-1)  // Self-referencing binary.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -21,7 +21,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
     using System.Diagnostics;
     using System.Linq.Expressions;
     using System.Reflection;
-    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Native library call utilities.
@@ -36,7 +35,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             // Init custom resolver for .NET 5+ single-file apps.
             // Do it with Reflection, because SetDllImportResolver is not available on some frameworks,
             // and multi-targeting is not yet implemented.
-            // TODO: Cache all of this.
+            //
+            // The code below is equivalent to:
+            // NativeLibrary.SetDllImportResolver(typeof(Ignition).Assembly, (libName, _, _) => Resolve(libName);
             var dllImportResolverType = Type.GetType("System.Runtime.InteropServices.DllImportResolver");
             var dllImportSearchPathType = Type.GetType("System.Runtime.InteropServices.DllImportSearchPath");
             var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary");

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -21,17 +21,26 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
     using System.Diagnostics;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Threading;
 
     /// <summary>
     /// Native library call utilities.
     /// </summary>
     public static class NativeLibraryUtils
     {
+        /** */
+        private static int _resolversInitialized;
+
         /// <summary>
         /// Sets dll import resolvers.
         /// </summary>
         public static void SetDllImportResolvers()
         {
+            if (Interlocked.CompareExchange(ref _resolversInitialized, 1, 0) != 0)
+            {
+                return;
+            }
+
             // Init custom resolver for .NET 5+ single-file apps.
             // Do it with Reflection, because SetDllImportResolver is not available on some frameworks,
             // and multi-targeting is not yet implemented.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -37,7 +37,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             // and multi-targeting is not yet implemented.
             //
             // The code below is equivalent to:
-            // NativeLibrary.SetDllImportResolver(typeof(Ignition).Assembly, (libName, _, _) => Resolve(libName);
+            // NativeLibrary.SetDllImportResolver(typeof(Ignition).Assembly, (libName, _, _) => Resolve(libName));
             var dllImportResolverType = Type.GetType("System.Runtime.InteropServices.DllImportResolver");
             var dllImportSearchPathType = Type.GetType("System.Runtime.InteropServices.DllImportSearchPath");
             var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary");

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
@@ -34,6 +34,14 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         public delegate void ThreadExitCallback(IntPtr threadLocalValue);
 
         /// <summary>
+        /// Initializes the <see cref="UnmanagedThread"/> class.
+        /// </summary>
+        static UnmanagedThread()
+        {
+            NativeLibraryUtils.SetDllImportResolvers();
+        }
+
+        /// <summary>
         /// Sets the thread exit callback, and returns an id to pass to <see cref="EnableCurrentThreadExitEvent"/>.
         /// </summary>
         /// <param name="callbackPtr">
@@ -103,10 +111,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             }
             else if (Os.IsLinux)
             {
-                var res = Os.IsMono 
+                var res = Os.IsMono
                     ? NativeMethodsMono.pthread_key_delete(callbackId)
                     : NativeMethodsLinux.pthread_key_delete(callbackId);
-                
+
                 NativeMethodsLinux.CheckResult(res);
             }
             else
@@ -139,10 +147,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             }
             else if (Os.IsLinux)
             {
-                var res = Os.IsMono 
+                var res = Os.IsMono
                     ? NativeMethodsMono.pthread_setspecific(callbackId, threadLocalValue)
                     : NativeMethodsLinux.pthread_setspecific(callbackId, threadLocalValue);
-                
+
                 NativeMethodsLinux.CheckResult(res);
             }
             else
@@ -220,7 +228,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             [DllImport("libSystem.dylib")]
             public static extern int pthread_setspecific(int key, IntPtr value);
         }
-        
+
         /// <summary>
         /// Mono on Linux requires __Internal instead of libcoreclr.so.
         /// </summary>
@@ -229,7 +237,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Reviewed.")]
             [DllImport("__Internal")]
             public static extern int pthread_key_create(IntPtr key, IntPtr destructorCallback);
-            
+
             [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Reviewed.")]
             [DllImport("__Internal")]
             public static extern int pthread_key_delete(int key);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
@@ -34,14 +34,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         public delegate void ThreadExitCallback(IntPtr threadLocalValue);
 
         /// <summary>
-        /// Initializes the <see cref="UnmanagedThread"/> class.
-        /// </summary>
-        static UnmanagedThread()
-        {
-            NativeLibraryUtils.SetDllImportResolvers();
-        }
-
-        /// <summary>
         /// Sets the thread exit callback, and returns an id to pass to <see cref="EnableCurrentThreadExitEvent"/>.
         /// </summary>
         /// <param name="callbackPtr">
@@ -75,6 +67,8 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
             if (Os.IsLinux)
             {
+                NativeLibraryUtils.SetDllImportResolvers();
+
                 int tlsIndex;
                 var res = Os.IsMono
                     ? NativeMethodsMono.pthread_key_create(new IntPtr(&tlsIndex), callbackPtr)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
@@ -38,10 +38,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         /// </summary>
         static UnmanagedThread()
         {
-            if (Os.IsLinux)
-            {
-                NativeLibraryUtils.SetDllImportResolvers();
-            }
+            NativeLibraryUtils.SetDllImportResolvers();
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
@@ -34,6 +34,17 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         public delegate void ThreadExitCallback(IntPtr threadLocalValue);
 
         /// <summary>
+        /// Initializes the <see cref="UnmanagedThread"/> class.
+        /// </summary>
+        static UnmanagedThread()
+        {
+            if (Os.IsLinux)
+            {
+                NativeLibraryUtils.SetDllImportResolvers();
+            }
+        }
+
+        /// <summary>
         /// Sets the thread exit callback, and returns an id to pass to <see cref="EnableCurrentThreadExitEvent"/>.
         /// </summary>
         /// <param name="callbackPtr">
@@ -67,8 +78,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
 
             if (Os.IsLinux)
             {
-                NativeLibraryUtils.SetDllImportResolvers();
-
                 int tlsIndex;
                 var res = Os.IsMono
                     ? NativeMethodsMono.pthread_key_create(new IntPtr(&tlsIndex), callbackPtr)

--- a/modules/platforms/dotnet/DEVNOTES.txt
+++ b/modules/platforms/dotnet/DEVNOTES.txt
@@ -54,10 +54,10 @@ Getting started:
   dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj
 
 * Run specific test:
+  dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter CacheTest  
+
+* Run a smaller subset of tests - exclude long tests and examples tests:
   dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter "TestCategory!=LONG_TEST&TestCategory!=EXAMPLES_TEST"
-
-* Run a smaller subset of tests:
-
 
 * IDE: Open Apache.Ignite.DotNetCore.sln
 


### PR DESCRIPTION
* Fix `DllNotFoundException: Unable to load shared library 'libcoreclr.so'` error in single file mode on .NET 5 by adding a custom `DllImportResolver`
* Update Deployment and Troubleshooting documentation