### PR TITLE
IGNITE-14173 .NET: Fix partition awareness auto-disable on old servers

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientReconnectCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientReconnectCompatibilityTest.cs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#if !NETCOREAPP
 namespace Apache.Ignite.Core.Tests.Client.Compatibility
 {
     using System;
@@ -107,4 +106,3 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
         }
     }
 }
-#endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -134,7 +134,9 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         public static IgniteClientConfiguration GetClientConfiguration()
         {
-            return new IgniteClientConfiguration("127.0.0.1:" + ClientPort);
+            var endpoint = string.Format("127.0.0.1:{0}..{1}", ClientPort, ClientPort + 5);
+
+            return new IgniteClientConfiguration(endpoint);
         }
 
         /// <summary>


### PR DESCRIPTION
* Fix failing `TestReconnectToOldNodeDisablesPartitionAwareness`: when thin client reconnects to a new "default" node, and that node does not support partition awareness, the feature should be disabled automatically. 
* Enable the test on .NET Core
* Fix compatibility test flakiness: add port range to `JavaServer.GetClientConfiguration`