### PR TITLE
IGNITE-12508: Fix GridCacheProcessor#cacheDescriptor's Time Complexity

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
@@ -2423,7 +2423,7 @@ public class ClusterCachesInfo {
     }
 
     /**
-     * @return Cache ID to Cache Name Mapping
+     * @return Registered caches by Id
      */
     ConcurrentMap<Integer, DynamicCacheDescriptor> registeredCachesById() {
         return registeredCachesById;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
@@ -127,7 +127,8 @@ public class ClusterCachesInfo {
     /** Dynamic caches. */
     private final ConcurrentMap<String, DynamicCacheDescriptor> registeredCaches = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Integer, DynamicCacheDescriptor> cacheIdToNameMapping = new ConcurrentHashMap<>();
+    /** Mapping of caches by cache ID */
+    private final ConcurrentMap<Integer, DynamicCacheDescriptor> registeredCachesById = new ConcurrentHashMap<>();
 
     /** */
     private final ConcurrentMap<Integer, CacheGroupDescriptor> registeredCacheGrps = new ConcurrentHashMap<>();
@@ -816,7 +817,7 @@ public class ClusterCachesInfo {
         markedForDeletionCaches.put(cacheName, old);
 
         DynamicCacheDescriptor removedCacheDescriptor = registeredCaches.remove(cacheName);
-        cacheIdToNameMapping.remove(removedCacheDescriptor.cacheId());
+        registeredCachesById.remove(removedCacheDescriptor.cacheId());
 
         if (req.restart()) {
             IgniteUuid restartId = req.restartId();
@@ -1043,7 +1044,7 @@ public class ClusterCachesInfo {
 
         DynamicCacheDescriptor old = registeredCaches.put(ccfg.getName(), startDesc);
 
-        cacheIdToNameMapping.put(startDesc.cacheId(), startDesc);
+        registeredCachesById.put(startDesc.cacheId(), startDesc);
 
         restartingCaches.remove(ccfg.getName());
 
@@ -1478,7 +1479,7 @@ public class ClusterCachesInfo {
             desc.receivedOnDiscovery(true);
 
             registeredCaches.put(cacheData.cacheConfiguration().getName(), desc);
-            cacheIdToNameMapping.put(desc.cacheId(), desc);
+            registeredCachesById.put(desc.cacheId(), desc);
 
             ctx.discovery().setCacheFilter(
                 desc.cacheId(),
@@ -1591,7 +1592,7 @@ public class ClusterCachesInfo {
      */
     private void cleanCachesAndGroups() {
         registeredCaches.clear();
-        cacheIdToNameMapping.clear();
+        registeredCachesById.clear();
         registeredCacheGrps.clear();
         ctx.discovery().cleanCachesAndGroups();
     }
@@ -2120,7 +2121,7 @@ public class ClusterCachesInfo {
         );
 
         DynamicCacheDescriptor old = registeredCaches.put(cfg.getName(), desc);
-        cacheIdToNameMapping.put(desc.cacheId(), desc);
+        registeredCachesById.put(desc.cacheId(), desc);
 
         assert old == null : old;
     }
@@ -2424,8 +2425,8 @@ public class ClusterCachesInfo {
     /**
      * @return Cache ID to Cache Name Mapping
      */
-    ConcurrentMap<Integer, DynamicCacheDescriptor> cacheIdToNameMapping() {
-        return cacheIdToNameMapping;
+    ConcurrentMap<Integer, DynamicCacheDescriptor> registeredCachesById() {
+        return registeredCachesById;
     }
 
     /**
@@ -2467,7 +2468,7 @@ public class ClusterCachesInfo {
 
         registeredCacheGrps.clear();
         registeredCaches.clear();
-        cacheIdToNameMapping.clear();
+        registeredCachesById.clear();
         registeredTemplates.clear();
 
         clientReconnectReqs = null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
@@ -127,7 +127,7 @@ public class ClusterCachesInfo {
     /** Dynamic caches. */
     private final ConcurrentMap<String, DynamicCacheDescriptor> registeredCaches = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<Integer, String> cacheIdToNameMapping = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Integer, DynamicCacheDescriptor> cacheIdToNameMapping = new ConcurrentHashMap<>();
 
     /** */
     private final ConcurrentMap<Integer, CacheGroupDescriptor> registeredCacheGrps = new ConcurrentHashMap<>();
@@ -1043,7 +1043,7 @@ public class ClusterCachesInfo {
 
         DynamicCacheDescriptor old = registeredCaches.put(ccfg.getName(), startDesc);
 
-        cacheIdToNameMapping.put(startDesc.cacheId(), ccfg.getName());
+        cacheIdToNameMapping.put(startDesc.cacheId(), startDesc);
 
         restartingCaches.remove(ccfg.getName());
 
@@ -1478,7 +1478,7 @@ public class ClusterCachesInfo {
             desc.receivedOnDiscovery(true);
 
             registeredCaches.put(cacheData.cacheConfiguration().getName(), desc);
-            cacheIdToNameMapping.put(desc.cacheId(), cacheData.cacheConfiguration().getName());
+            cacheIdToNameMapping.put(desc.cacheId(), desc);
 
             ctx.discovery().setCacheFilter(
                 desc.cacheId(),
@@ -2120,7 +2120,7 @@ public class ClusterCachesInfo {
         );
 
         DynamicCacheDescriptor old = registeredCaches.put(cfg.getName(), desc);
-        cacheIdToNameMapping.put(desc.cacheId(), cfg.getName());
+        cacheIdToNameMapping.put(desc.cacheId(), desc);
 
         assert old == null : old;
     }
@@ -2424,7 +2424,7 @@ public class ClusterCachesInfo {
     /**
      * @return Cache ID to Cache Name Mapping
      */
-    ConcurrentMap<Integer, String> cacheIdToNameMapping() {
+    ConcurrentMap<Integer, DynamicCacheDescriptor> cacheIdToNameMapping() {
         return cacheIdToNameMapping;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
@@ -1043,7 +1043,7 @@ public class ClusterCachesInfo {
 
         DynamicCacheDescriptor old = registeredCaches.put(ccfg.getName(), startDesc);
 
-        cacheIdToNameMapping.putIfAbsent(startDesc.cacheId(), ccfg.getName());
+        cacheIdToNameMapping.put(startDesc.cacheId(), ccfg.getName());
 
         restartingCaches.remove(ccfg.getName());
 
@@ -1478,7 +1478,7 @@ public class ClusterCachesInfo {
             desc.receivedOnDiscovery(true);
 
             registeredCaches.put(cacheData.cacheConfiguration().getName(), desc);
-            cacheIdToNameMapping.putIfAbsent(desc.cacheId(), cacheData.cacheConfiguration().getName());
+            cacheIdToNameMapping.put(desc.cacheId(), cacheData.cacheConfiguration().getName());
 
             ctx.discovery().setCacheFilter(
                 desc.cacheId(),
@@ -2120,7 +2120,7 @@ public class ClusterCachesInfo {
         );
 
         DynamicCacheDescriptor old = registeredCaches.put(cfg.getName(), desc);
-        cacheIdToNameMapping.putIfAbsent(desc.cacheId(), cfg.getName());
+        cacheIdToNameMapping.put(desc.cacheId(), cfg.getName());
 
         assert old == null : old;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -4569,6 +4569,13 @@ public class GridCacheProcessor extends GridProcessorAdapter {
     }
 
     /**
+     * @return Cache ID to Name Mapping
+     */
+    public Map<Integer, String> cacheIDToNameMapping() {
+        return cachesInfo.cacheIdToNameMapping();
+    }
+
+    /**
      * @return Collection of persistent cache descriptors.
      */
     public Collection<DynamicCacheDescriptor> persistentCaches() {
@@ -4616,6 +4623,13 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Cache descriptor.
      */
     public @Nullable DynamicCacheDescriptor cacheDescriptor(int cacheId) {
+        Map<Integer, String> cacheIdToNameMapping = cacheIDToNameMapping();
+        String name = cacheIdToNameMapping.get(cacheId);
+
+        if (name != null) {
+            return cacheDescriptors().get(name);
+        }
+
         for (DynamicCacheDescriptor cacheDesc : cacheDescriptors().values()) {
             CacheConfiguration ccfg = cacheDesc.cacheConfiguration();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -4571,7 +4571,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
     /**
      * @return Cache ID to Name Mapping
      */
-    public Map<Integer, String> cacheIdToNameMapping() {
+    private Map<Integer, String> cacheIdToNameMapping() {
         return cachesInfo.cacheIdToNameMapping();
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -4569,13 +4569,6 @@ public class GridCacheProcessor extends GridProcessorAdapter {
     }
 
     /**
-     * @return Cache ID to Name Mapping
-     */
-    private Map<Integer, DynamicCacheDescriptor> cacheIdToNameMapping() {
-        return cachesInfo.registeredCachesById();
-    }
-
-    /**
      * @return Collection of persistent cache descriptors.
      */
     public Collection<DynamicCacheDescriptor> persistentCaches() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -4571,7 +4571,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
     /**
      * @return Cache ID to Name Mapping
      */
-    private Map<Integer, String> cacheIdToNameMapping() {
+    private Map<Integer, DynamicCacheDescriptor> cacheIdToNameMapping() {
         return cachesInfo.cacheIdToNameMapping();
     }
 
@@ -4623,13 +4623,10 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Cache descriptor.
      */
     public @Nullable DynamicCacheDescriptor cacheDescriptor(int cacheId) {
-        Map<Integer, String> cacheIdToNameMapping = cacheIdToNameMapping();
-        String name = cacheIdToNameMapping.get(cacheId);
+        Map<Integer, DynamicCacheDescriptor> cacheIdToNameMapping = cacheIdToNameMapping();
+        DynamicCacheDescriptor desc = cacheIdToNameMapping.get(cacheId);
 
-        if (name != null)
-            return cacheDescriptors().get(name);
-
-        return null;
+        return desc;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -4571,7 +4571,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
     /**
      * @return Cache ID to Name Mapping
      */
-    public Map<Integer, String> cacheIDToNameMapping() {
+    public Map<Integer, String> cacheIdToNameMapping() {
         return cachesInfo.cacheIdToNameMapping();
     }
 
@@ -4623,21 +4623,11 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Cache descriptor.
      */
     public @Nullable DynamicCacheDescriptor cacheDescriptor(int cacheId) {
-        Map<Integer, String> cacheIdToNameMapping = cacheIDToNameMapping();
+        Map<Integer, String> cacheIdToNameMapping = cacheIdToNameMapping();
         String name = cacheIdToNameMapping.get(cacheId);
 
-        if (name != null) {
+        if (name != null)
             return cacheDescriptors().get(name);
-        }
-
-        for (DynamicCacheDescriptor cacheDesc : cacheDescriptors().values()) {
-            CacheConfiguration ccfg = cacheDesc.cacheConfiguration();
-
-            assert ccfg != null : cacheDesc;
-
-            if (CU.cacheId(ccfg.getName()) == cacheId)
-                return cacheDesc;
-        }
 
         return null;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -4572,7 +4572,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Cache ID to Name Mapping
      */
     private Map<Integer, DynamicCacheDescriptor> cacheIdToNameMapping() {
-        return cachesInfo.cacheIdToNameMapping();
+        return cachesInfo.registeredCachesById();
     }
 
     /**
@@ -4623,10 +4623,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
      * @return Cache descriptor.
      */
     public @Nullable DynamicCacheDescriptor cacheDescriptor(int cacheId) {
-        Map<Integer, DynamicCacheDescriptor> cacheIdToNameMapping = cacheIdToNameMapping();
-        DynamicCacheDescriptor desc = cacheIdToNameMapping.get(cacheId);
-
-        return desc;
+        return cachesInfo.registeredCachesById().get(cacheId);
     }
 
     /**

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -130,14 +130,6 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>9</source>
-                    <target>9</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -130,6 +130,14 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This commit adds a new mapping from cache ID to cache name, thus allowing
cacheDescriptor method to get the needed cache descriptor in two map
lookups.