### PR TITLE
IGNITE-14208 .NET: Enable examples multi-targeting

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ExamplePaths.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ExamplePaths.cs
@@ -27,7 +27,7 @@ namespace Apache.Ignite.Core.Tests.Examples
     {
         /** */
         public const string SharedProjFileName = "Shared.csproj";
-        
+
         /** */
         public static readonly string SourcesPath =
             Path.Combine(Impl.Common.IgniteHome.Resolve(), "modules", "platforms", "dotnet", "examples");
@@ -49,19 +49,19 @@ namespace Apache.Ignite.Core.Tests.Examples
         /// </summary>
         public static string GetAssemblyPath(string projFile)
         {
-            var targetFw = GetTargetFramework(projFile);
+            var targetFw = GetTargetFrameworks(projFile);
             var name = Path.GetFileNameWithoutExtension(projFile);
             var path = Path.GetDirectoryName(projFile);
-            
+
             return Path.Combine(path, "bin", "Debug", targetFw, $"{name}.dll");
         }
 
         /// <summary>
         /// Gets the target framework for the given project.
         /// </summary>
-        public static string GetTargetFramework(string projFile)
+        public static string GetTargetFrameworks(string projFile)
         {
-            return Regex.Match(File.ReadAllText(projFile), "<TargetFramework>(.*?)</TargetFramework>").Groups[1].Value;
+            return Regex.Match(File.ReadAllText(projFile), "<TargetFrameworks>(.*?)</TargetFrameworks>").Groups[1].Value;
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ExamplePaths.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ExamplePaths.cs
@@ -18,6 +18,7 @@
 namespace Apache.Ignite.Core.Tests.Examples
 {
     using System.IO;
+    using System.Linq;
     using System.Text.RegularExpressions;
 
     /// <summary>
@@ -49,7 +50,7 @@ namespace Apache.Ignite.Core.Tests.Examples
         /// </summary>
         public static string GetAssemblyPath(string projFile)
         {
-            var targetFw = GetTargetFrameworks(projFile);
+            var targetFw = GetTargetFrameworks(projFile).Split(';').First();
             var name = Path.GetFileNameWithoutExtension(projFile);
             var path = Path.GetDirectoryName(projFile);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ProjectFilesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ProjectFilesTest.cs
@@ -43,7 +43,7 @@ namespace Apache.Ignite.Core.Tests.Examples
         private static readonly string LaunchJsonText = File.ReadAllText(ExamplePaths.LaunchJsonFile);
 
         /** */
-        private static readonly string TargetFramework = ExamplePaths.GetTargetFramework(ExamplePaths.SharedProjFile);
+        private static readonly string TargetFrameworks = ExamplePaths.GetTargetFrameworks(ExamplePaths.SharedProjFile);
 
         /** */
         private static readonly string[] ThickOnlyExamples = {
@@ -63,7 +63,7 @@ namespace Apache.Ignite.Core.Tests.Examples
             var text = File.ReadAllText(example.ProjectFile);
 
             StringAssert.Contains("<OutputType>Exe</OutputType>", text);
-            StringAssert.Contains($"<TargetFramework>{TargetFramework}</TargetFramework>", text);
+            StringAssert.Contains($"<TargetFrameworks>{TargetFrameworks}</TargetFrameworks>", text);
             StringAssert.Contains("<ProjectReference Include=\"..\\..\\..\\Shared\\Shared.csproj", text);
             StringAssert.Contains($"{example.Name}.csproj", ExamplesSlnText);
             StringAssert.Contains($"{example.Name}.dll", LaunchJsonText);

--- a/modules/platforms/dotnet/examples/ServerNode/ServerNode.csproj
+++ b/modules/platforms/dotnet/examples/ServerNode/ServerNode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.ServerNode</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Shared/Shared.csproj
+++ b/modules/platforms/dotnet/examples/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Shared</RootNamespace>
     <NoWarn>CS0649</NoWarn>
   </PropertyGroup>

--- a/modules/platforms/dotnet/examples/Thick/Cache/BinaryMode/BinaryMode.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/BinaryMode/BinaryMode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.BinaryMode</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/DataStreamer/DataStreamer.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/DataStreamer/DataStreamer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.DataStreamer</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/EntryProcessor/EntryProcessor.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/EntryProcessor/EntryProcessor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.EntryProcessor</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/MultiTieredCache/MultiTieredCache.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/MultiTieredCache/MultiTieredCache.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.MultiTieredCache</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/NearCache/NearCache.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/NearCache/NearCache.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.NearCache</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/OptimisticTransaction/OptimisticTransaction.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/OptimisticTransaction/OptimisticTransaction.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.OptimisticTransaction</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/PutGet/PutGet.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/PutGet/PutGet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.PutGet</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/QueryContinuous/QueryContinuous.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/QueryContinuous/QueryContinuous.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.QueryContinuous</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/QueryFullText/QueryFullText.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/QueryFullText/QueryFullText.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.QueryFullText</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/QueryScan/QueryScan.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/QueryScan/QueryScan.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.QueryScan</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/Store/Store.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/Store/Store.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.Store</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/Transaction/Transaction.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/Transaction/Transaction.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.Transaction</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/TransactionDeadlockDetection/TransactionDeadlockDetection.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/TransactionDeadlockDetection/TransactionDeadlockDetection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.TransactionDeadlockDetection</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Compute/Func/Func.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Compute/Func/Func.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Compute.Func</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Compute/PeerAssemblyLoading/PeerAssemblyLoading.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Compute/PeerAssemblyLoading/PeerAssemblyLoading.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Compute.PeerAssemblyLoading</RootNamespace>
         <AssemblyVersion>1.0.*</AssemblyVersion>
         <Deterministic>false</Deterministic>

--- a/modules/platforms/dotnet/examples/Thick/Compute/Task/Task.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Compute/Task/Task.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Compute.Task</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicLong/AtomicLong.csproj
+++ b/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicLong/AtomicLong.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.DataStructures.AtomicLong</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicReference/AtomicReference.csproj
+++ b/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicReference/AtomicReference.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.DataStructures.AtomicReference</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicSequence/AtomicSequence.csproj
+++ b/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicSequence/AtomicSequence.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.DataStructures.AtomicSequence</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/ClientReconnect/ClientReconnect.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/ClientReconnect/ClientReconnect.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.ClientReconnect</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Events/Events.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Events/Events.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Events</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Lifecycle/Lifecycle.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Lifecycle/Lifecycle.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Lifecycle</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Messaging/Messaging.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Messaging/Messaging.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Messaging</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Services/Services.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Services/Services.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Services</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Ddl/Ddl.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Ddl/Ddl.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Ddl</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Dml/Dml.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Dml/Dml.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Dml</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Linq/Linq.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Linq/Linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Linq</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Sql/Sql.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Sql/Sql.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Sql</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/BinaryModeThin/BinaryModeThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/BinaryModeThin/BinaryModeThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thin.Cache.BinaryModeThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/OptimisticTransactionThin/OptimisticTransactionThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/OptimisticTransactionThin/OptimisticTransactionThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.OptimisticTransactionThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/PutGetThin/PutGetThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/PutGetThin/PutGetThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thin.Cache.PutGetThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/QueryContinuousThin/QueryContinuousThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/QueryContinuousThin/QueryContinuousThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.QueryContinuousThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/QueryScanThin/QueryScanThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/QueryScanThin/QueryScanThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.QueryScanThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/TransactionThin/TransactionThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/TransactionThin/TransactionThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.TransactionThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Misc/ServicesThin/ServicesThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Misc/ServicesThin/ServicesThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thin.Misc.ServicesThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/DdlThin/DdlThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/DdlThin/DdlThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Sql.DdlThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/DmlThin/DmlThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/DmlThin/DmlThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Sql.DmlThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/LinqThin/LinqThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/LinqThin/LinqThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thin.Sql.LinqThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/SqlThin/SqlThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/SqlThin/SqlThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
         <RootNamespace>Apache.Ignite.Examples.Thin.Sql.SqlThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/templates/internal/Apache.Ignite.Example/ExampleProject.csproj
+++ b/modules/platforms/dotnet/templates/internal/Apache.Ignite.Example/ExampleProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Apache.Ignite.Examples.Thick.ExampleProject</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/templates/internal/Apache.Ignite.ExampleThin/ExampleProjectThin.csproj
+++ b/modules/platforms/dotnet/templates/internal/Apache.Ignite.ExampleThin/ExampleProjectThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>
 	<RootNamespace>Apache.Ignite.Examples.Thin.ExampleProjectThin</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Use `<TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5</TargetFrameworks>` so that examples can be built with any current SDK.