### PR TITLE
IGNITE-12508: Add Missing Cache Remove Instance in ClusterCachesInfo

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/ClusterCachesInfo.java
@@ -232,6 +232,7 @@ public class ClusterCachesInfo {
 
             if (!locCaches.contains(e.getKey())) {
                 cachesIter.remove();
+                registeredCachesById.remove(e.getValue());
 
                 ctx.discovery().removeCacheFilter(e.getKey());
             }


### PR DESCRIPTION
In IGNITE-12508, we added a new cache mapping. This commit adds a missing remove operation where an entry gets deleted from the main cache but not the mapping.