### PR TITLE
IGNITE-14207 Authorize reading from system views

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/AbstractSystemView.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/AbstractSystemView.java
@@ -17,9 +17,15 @@
 
 package org.apache.ignite.internal.managers.systemview;
 
+import java.util.Iterator;
+import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.util.typedef.internal.A;
+import org.apache.ignite.plugin.security.SecurityPermission;
 import org.apache.ignite.spi.systemview.view.SystemView;
 import org.apache.ignite.spi.systemview.view.SystemViewRowAttributeWalker;
+import org.jetbrains.annotations.NotNull;
+
+import static org.apache.ignite.plugin.security.SecurityPermission.SYSTEM_VIEW_READ;
 
 /** Abstract system view. */
 abstract class AbstractSystemView<R> implements SystemView<R> {
@@ -28,6 +34,9 @@ abstract class AbstractSystemView<R> implements SystemView<R> {
 
     /** Description of the view. */
     private final String desc;
+
+    /** {@link IgniteSecurity} for data access authorization. */
+    private final IgniteSecurity security;
 
     /**
      * Row attribute walker.
@@ -41,12 +50,14 @@ abstract class AbstractSystemView<R> implements SystemView<R> {
      * @param desc Description.
      * @param walker Walker.
      */
-    AbstractSystemView(String name, String desc, SystemViewRowAttributeWalker<R> walker) {
+    AbstractSystemView(String name, String desc, SystemViewRowAttributeWalker<R> walker, IgniteSecurity security) {
         A.notNull(walker, "walker");
+        A.notNull(security, "security");
 
         this.name = name;
         this.desc = desc;
         this.walker = walker;
+        this.security = security;
     }
 
     /** {@inheritDoc} */
@@ -62,5 +73,36 @@ abstract class AbstractSystemView<R> implements SystemView<R> {
     /** {@inheritDoc} */
     @Override public SystemViewRowAttributeWalker<R> walker() {
         return walker;
+    }
+
+    /** {@inheritDoc} */
+    @NotNull @Override public final Iterator<R> iterator() {
+        authorize();
+
+        return iteratorNoAuth();
+    }
+
+    /**
+     * {@link Iterable#iterator()} implementation without authorization.
+     */
+    @NotNull protected abstract Iterator<R> iteratorNoAuth();
+
+    /** {@inheritDoc} */
+    @Override public final int size() {
+        authorize();
+
+        return sizeNoAuth();
+    }
+
+    /**
+     * {@link SystemView#size()} implementation without authorization.
+     */
+    protected abstract int sizeNoAuth();
+
+    /**
+     * Authorizes {@link SecurityPermission#SYSTEM_VIEW_READ} permission.
+     */
+    protected final void authorize() {
+        security.authorize(SYSTEM_VIEW_READ);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/FiltrableSystemViewAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/FiltrableSystemViewAdapter.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.spi.systemview.view.FiltrableSystemView;
@@ -43,10 +44,11 @@ public class FiltrableSystemViewAdapter<R, D> extends AbstractSystemView<R> impl
      * @param walker Walker.
      * @param dataSupplier Data supplier.
      * @param rowFunc Row function.
+     * @param security Security processor.
      */
     public FiltrableSystemViewAdapter(String name, String desc, SystemViewRowAttributeWalker<R> walker,
-        Function<Map<String, Object>, Iterable<D>> dataSupplier, Function<D, R> rowFunc) {
-        super(name, desc, walker);
+        Function<Map<String, Object>, Iterable<D>> dataSupplier, Function<D, R> rowFunc, IgniteSecurity security) {
+        super(name, desc, walker, security);
 
         A.notNull(dataSupplier, "dataSupplier");
 
@@ -56,6 +58,8 @@ public class FiltrableSystemViewAdapter<R, D> extends AbstractSystemView<R> impl
 
     /** {@inheritDoc} */
     @NotNull @Override public Iterator<R> iterator(Map<String, Object> filter) {
+        authorize();
+
         if (filter == null)
             filter = Collections.emptyMap();
 
@@ -63,12 +67,12 @@ public class FiltrableSystemViewAdapter<R, D> extends AbstractSystemView<R> impl
     }
 
     /** {@inheritDoc} */
-    @NotNull @Override public Iterator<R> iterator() {
+    @NotNull @Override public Iterator<R> iteratorNoAuth() {
         return iterator(Collections.emptyMap());
     }
 
     /** {@inheritDoc} */
-    @Override public int size() {
+    @Override public int sizeNoAuth() {
         return F.size(dataSupplier.apply(Collections.emptyMap()).iterator());
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/GridSystemViewManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/GridSystemViewManager.java
@@ -145,7 +145,8 @@ public class GridSystemViewManager extends GridManagerAdapter<SystemViewExporter
             desc,
             walker,
             data,
-            rowFunc));
+            rowFunc,
+            ctx.security()));
     }
 
     /**
@@ -168,7 +169,8 @@ public class GridSystemViewManager extends GridManagerAdapter<SystemViewExporter
             walker,
             container,
             dataExtractor,
-            rowFunc));
+            rowFunc,
+            ctx.security()));
     }
 
     /**
@@ -191,7 +193,8 @@ public class GridSystemViewManager extends GridManagerAdapter<SystemViewExporter
             walker,
             container,
             c -> Arrays.asList(dataExtractor.apply(c)),
-            rowFunc));
+            rowFunc,
+            ctx.security()));
     }
 
     /**
@@ -211,7 +214,8 @@ public class GridSystemViewManager extends GridManagerAdapter<SystemViewExporter
             desc,
             walker,
             dataSupplier,
-            rowFunc));
+            rowFunc,
+            ctx.security()));
     }
 
     /**
@@ -231,7 +235,8 @@ public class GridSystemViewManager extends GridManagerAdapter<SystemViewExporter
             desc,
             walker,
             dataSupplier,
-            rowFunc));
+            rowFunc,
+            ctx.security()));
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/ScanQuerySystemView.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/ScanQuerySystemView.java
@@ -29,6 +29,7 @@ import org.apache.ignite.internal.managers.systemview.walker.ScanQueryViewWalker
 import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.query.GridCacheQueryManager;
 import org.apache.ignite.internal.processors.cache.query.GridCacheQueryManager.ScanQueryIterator;
+import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.spi.IgniteSpiCloseableIterator;
@@ -58,15 +59,16 @@ public class ScanQuerySystemView<K, V> extends AbstractSystemView<ScanQueryView>
 
     /**
      * @param cctxs Cache data.
+     * @param security Security processor.
      */
-    public ScanQuerySystemView(Collection<GridCacheContext<K, V>> cctxs) {
-        super(SCAN_QRY_SYS_VIEW, SCAN_QRY_SYS_VIEW_DESC, new ScanQueryViewWalker());
+    public ScanQuerySystemView(Collection<GridCacheContext<K, V>> cctxs, IgniteSecurity security) {
+        super(SCAN_QRY_SYS_VIEW, SCAN_QRY_SYS_VIEW_DESC, new ScanQueryViewWalker(), security);
 
         this.cctxs = cctxs;
     }
 
     /** {@inheritDoc} */
-    @Override public int size() {
+    @Override public int sizeNoAuth() {
         int sz = 0;
 
         QueryDataIterator iter = new QueryDataIterator();
@@ -79,7 +81,7 @@ public class ScanQuerySystemView<K, V> extends AbstractSystemView<ScanQueryView>
     }
 
     /** {@inheritDoc} */
-    @NotNull @Override public Iterator<ScanQueryView> iterator() {
+    @NotNull @Override public Iterator<ScanQueryView> iteratorNoAuth() {
         return new QueryDataIterator();
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/SystemViewAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/SystemViewAdapter.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.spi.systemview.view.SystemViewRowAttributeWalker;
 import org.jetbrains.annotations.NotNull;
@@ -44,10 +45,11 @@ public class SystemViewAdapter<R, D> extends AbstractSystemView<R> {
      * @param walker Walker.
      * @param data Data.
      * @param rowFunc Row function.
+     * @param security Security processor.
      */
     public SystemViewAdapter(String name, String desc, SystemViewRowAttributeWalker<R> walker, Collection<D> data,
-        Function<D, R> rowFunc) {
-        super(name, desc, walker);
+        Function<D, R> rowFunc, IgniteSecurity security) {
+        super(name, desc, walker, security);
 
         A.notNull(data, "data");
 
@@ -61,10 +63,11 @@ public class SystemViewAdapter<R, D> extends AbstractSystemView<R> {
      * @param walker Walker.
      * @param dataSupplier Data supplier.
      * @param rowFunc Row function.
+     * @param security Security processor.
      */
     public SystemViewAdapter(String name, String desc, SystemViewRowAttributeWalker<R> walker,
-        Supplier<Collection<D>> dataSupplier, Function<D, R> rowFunc) {
-        super(name, desc, walker);
+        Supplier<Collection<D>> dataSupplier, Function<D, R> rowFunc, IgniteSecurity security) {
+        super(name, desc, walker, security);
 
         A.notNull(dataSupplier, "dataSupplier");
 
@@ -73,7 +76,7 @@ public class SystemViewAdapter<R, D> extends AbstractSystemView<R> {
     }
 
     /** {@inheritDoc} */
-    @NotNull @Override public Iterator<R> iterator() {
+    @NotNull @Override public Iterator<R> iteratorNoAuth() {
         Iterator<D> dataIter;
 
         if (data != null)
@@ -93,7 +96,7 @@ public class SystemViewAdapter<R, D> extends AbstractSystemView<R> {
     }
 
     /** {@inheritDoc} */
-    @Override public int size() {
+    @Override public int sizeNoAuth() {
         return data == null ? dataSupplier.get().size() : data.size();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/SystemViewInnerCollectionsAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/SystemViewInnerCollectionsAdapter.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.spi.systemview.view.SystemView;
 import org.apache.ignite.spi.systemview.view.SystemViewRowAttributeWalker;
@@ -49,13 +50,15 @@ public class SystemViewInnerCollectionsAdapter<C, R, D> extends AbstractSystemVi
      * @param containers Container of data.
      * @param dataExtractor Data extractor function.
      * @param rowFunc Row function.
+     * @param security Security processor.
      */
     public SystemViewInnerCollectionsAdapter(String name, String desc,
         SystemViewRowAttributeWalker<R> walker,
         Iterable<C> containers,
         Function<C, Collection<D>> dataExtractor,
-        BiFunction<C, D, R> rowFunc) {
-        super(name, desc, walker);
+        BiFunction<C, D, R> rowFunc,
+        IgniteSecurity security) {
+        super(name, desc, walker, security);
 
         this.containers = containers;
         this.dataExtractor = dataExtractor;
@@ -63,7 +66,7 @@ public class SystemViewInnerCollectionsAdapter<C, R, D> extends AbstractSystemVi
     }
 
     /** {@inheritDoc} */
-    @Override public int size() {
+    @Override public int sizeNoAuth() {
         int sz = 0;
 
         for (C c : containers)
@@ -73,7 +76,7 @@ public class SystemViewInnerCollectionsAdapter<C, R, D> extends AbstractSystemVi
     }
 
     /** {@inheritDoc} */
-    @NotNull @Override public Iterator<R> iterator() {
+    @NotNull @Override public Iterator<R> iteratorNoAuth() {
         return F.concat(F.iterator(containers,
                 c -> F.iterator(dataExtractor.apply(c).iterator(),
                     d -> rowFunc.apply(c, d), true), true));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheSharedContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheSharedContext.java
@@ -268,7 +268,7 @@ public class GridCacheSharedContext<K, V> {
 
         ctxMap = new ConcurrentHashMap<>();
 
-        kernalCtx.systemView().registerView(new ScanQuerySystemView<>(ctxMap.values()));
+        kernalCtx.systemView().registerView(new ScanQuerySystemView<>(ctxMap.values(), kernalCtx.security()));
 
         locStoreCnt = new AtomicInteger();
 

--- a/modules/core/src/main/java/org/apache/ignite/plugin/security/SecurityPermission.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/security/SecurityPermission.java
@@ -85,7 +85,10 @@ public enum SecurityPermission {
     ADMIN_WRITE_DISTRIBUTED_PROPERTY,
 
     /** Administration operation with cluster snapshots (CREATE, CANCEL). */
-    ADMIN_SNAPSHOT;
+    ADMIN_SNAPSHOT,
+
+    /** System view read permission. */
+    SYSTEM_VIEW_READ;
 
     /** Enumerated values. */
     private static final SecurityPermission[] VALS = values();

--- a/modules/core/src/main/java/org/apache/ignite/plugin/security/SecurityPermissionSetBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/security/SecurityPermissionSetBuilder.java
@@ -143,7 +143,8 @@ public class SecurityPermissionSetBuilder {
      * @return {@link SecurityPermissionSetBuilder} refer to same permission builder.
      */
     public SecurityPermissionSetBuilder appendSystemPermissions(SecurityPermission... perms) {
-        validate(toCollection("EVENTS_", "ADMIN_", "CACHE_CREATE", "CACHE_DESTROY", "JOIN_AS_SERVER"), perms);
+        validate(toCollection("EVENTS_", "ADMIN_", "CACHE_CREATE", "CACHE_DESTROY", "JOIN_AS_SERVER", "SYSTEM_VIEW_"),
+            perms);
 
         sysPerms.addAll(toCollection(perms));
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/impl/TestSecurityContext.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/impl/TestSecurityContext.java
@@ -70,6 +70,7 @@ public class TestSecurityContext implements SecurityContext, Serializable {
             case ADMIN_OPS:
             case ADMIN_SNAPSHOT:
             case JOIN_AS_SERVER:
+            case SYSTEM_VIEW_READ:
                 return systemOperationAllowed(perm);
 
             default:

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/systemview/SystemViewAuthorizationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/systemview/SystemViewAuthorizationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.security.systemview;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.stream.StreamSupport;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.security.AbstractSecurityTest;
+import org.apache.ignite.internal.util.tostring.GridToStringBuilder;
+import org.apache.ignite.plugin.security.SecurityException;
+import org.apache.ignite.plugin.security.SecurityPermissionSet;
+import org.apache.ignite.plugin.security.SecurityPermissionSetBuilder;
+import org.apache.ignite.spi.systemview.view.ClusterNodeView;
+import org.apache.ignite.spi.systemview.view.FiltrableSystemView;
+import org.apache.ignite.spi.systemview.view.PartitionStateView;
+import org.apache.ignite.spi.systemview.view.SystemView;
+import org.junit.Test;
+
+import static org.apache.ignite.internal.managers.discovery.GridDiscoveryManager.NODES_SYS_VIEW;
+import static org.apache.ignite.internal.processors.cache.GridCacheProcessor.PART_STATES_VIEW;
+import static org.apache.ignite.plugin.security.SecurityPermission.SYSTEM_VIEW_READ;
+import static org.apache.ignite.testframework.GridTestUtils.assertThrowsWithCause;
+
+/**
+ * Tests authorized access to {@link SystemView}s.
+ */
+public class SystemViewAuthorizationTest extends AbstractSecurityTest {
+    /** @throws Exception If failed. */
+    @Test
+    public void testNodesCanStartWithoutPermission() throws Exception {
+        SecurityPermissionSet permSet = new SecurityPermissionSetBuilder().build();
+
+        Ignite srv = startGrid("server", permSet, false);
+        startGrid("client", permSet, true);
+
+        assertEquals(2, srv.cluster().nodes().size());
+    }
+
+    /** @throws Exception If failed. */
+    @Test
+    public void testCanReadViewWhenPermitted() throws Exception {
+        SecurityPermissionSet permSet = new SecurityPermissionSetBuilder()
+            .appendSystemPermissions(SYSTEM_VIEW_READ)
+            .build();
+
+        IgniteEx server = startGrid("server", permSet, false);
+        IgniteEx client = startGrid("client", permSet, true);
+
+        checkReadNodesViewSuceeds(server, 2);
+        checkReadNodesViewSuceeds(client, 2);
+
+        checkReadPartitionsViewSucceeds(server);
+        checkReadPartitionsViewSucceeds(client);
+    }
+
+    /** @throws Exception If failed. */
+    @Test
+    public void testCannotReadViewWithoutPermission() throws Exception {
+        SecurityPermissionSet permSet = new SecurityPermissionSetBuilder().build();
+
+        IgniteEx server = startGrid("server", permSet, false);
+        IgniteEx client = startGrid("client", permSet, true);
+
+        checkReadNodesViewFails(server);
+        checkReadNodesViewFails(client);
+
+        checkReadPartitionsViewFails(server);
+        checkReadPartitionsViewFails(client);
+    }
+
+    /** */
+    @Override public void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids();
+        cleanPersistenceDir();
+    }
+
+    /** */
+    private static void checkReadNodesViewSuceeds(IgniteEx ignite, int expectedNodeCnt) {
+        SystemView<ClusterNodeView> view = ignite.context().systemView().view(NODES_SYS_VIEW);
+
+        assertEquals(expectedNodeCnt, view.size());
+
+        log.info(String.format("View [name=%s, desc=%s, size=%d]", view.name(), view.description(), view.size()));
+
+        assertEquals(expectedNodeCnt, StreamSupport.stream(view.spliterator(), false).count());
+    }
+
+    /** */
+    private static void checkReadPartitionsViewSucceeds(IgniteEx ignite) {
+        SystemView<PartitionStateView> v = ignite.context().systemView().view(PART_STATES_VIEW);
+
+        FiltrableSystemView<PartitionStateView> view = (FiltrableSystemView<PartitionStateView>)v;
+
+        log.info(String.format("View [name=%s, desc=%s, size=%d]", view.name(), view.description(), view.size()));
+
+        for (Iterator<PartitionStateView> iter = view.iterator(Collections.emptyMap()); iter.hasNext(); )
+            log.info(GridToStringBuilder.toString(PartitionStateView.class, iter.next()));
+    }
+
+    /** */
+    @SuppressWarnings("ThrowableNotThrown")
+    private static void checkReadNodesViewFails(IgniteEx ignite) {
+        SystemView<ClusterNodeView> view = ignite.context().systemView().view(NODES_SYS_VIEW);
+
+        assertThrowsWithCause(view::size, SecurityException.class);
+        assertThrowsWithCause(view::iterator, SecurityException.class);
+    }
+
+    /** */
+    @SuppressWarnings("ThrowableNotThrown")
+    private static void checkReadPartitionsViewFails(IgniteEx ignite) {
+        SystemView<PartitionStateView> v = ignite.context().systemView().view(PART_STATES_VIEW);
+
+        FiltrableSystemView<PartitionStateView> view = (FiltrableSystemView<PartitionStateView>)v;
+
+        assertThrowsWithCause(view::size, SecurityException.class);
+        assertThrowsWithCause(() -> view.iterator(Collections.emptyMap()), SecurityException.class);
+    }
+}

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/managers/systemview/SystemViewLocal.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/managers/systemview/SystemViewLocal.java
@@ -141,7 +141,7 @@ class SystemViewLocal<R> extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public Iterator<Row> getRows(Session ses, SearchRow first, SearchRow last) {
+    @Override protected Iterator<Row> getRowsNoAuth(Session ses, SearchRow first, SearchRow last) {
         Iterator<R> rows = viewIterator(first, last);
 
         return new Iterator<Row>() {
@@ -222,12 +222,12 @@ class SystemViewLocal<R> extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public long getRowCount() {
+    @Override public long getRowCountNoAuth() {
         return sysView.size();
     }
 
     /** {@inheritDoc} */
-    @Override public long getRowCountApproximation() {
+    @Override public long getRowCountApproximationNoAuth() {
         // getRowCount() method is not really fast, for some system views it's required to iterate over elements to
         // calculate size, so it's more safe to use constant here.
         return DEFAULT_ROW_COUNT_APPROXIMATION;

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/metric/sql/MetricRegistryLocalSystemView.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/metric/sql/MetricRegistryLocalSystemView.java
@@ -51,7 +51,7 @@ class MetricRegistryLocalSystemView extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public Iterator<Row> getRows(Session ses, SearchRow first, SearchRow last) {
+    @Override public Iterator<Row> getRowsNoAuth(Session ses, SearchRow first, SearchRow last) {
         return new Iterator<Row>() {
             /** */
             private Iterator<ReadOnlyMetricRegistry> grps = mreg.iterator();

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewBaselineNodes.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewBaselineNodes.java
@@ -47,7 +47,7 @@ public class SqlSystemViewBaselineNodes extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public Iterator<Row> getRows(Session ses, SearchRow first, SearchRow last) {
+    @Override public Iterator<Row> getRowsNoAuth(Session ses, SearchRow first, SearchRow last) {
         List<Row> rows = new ArrayList<>();
 
         BaselineTopology blt = ctx.state().clusterState().baselineTopology();
@@ -80,7 +80,7 @@ public class SqlSystemViewBaselineNodes extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public long getRowCount() {
+    @Override public long getRowCountNoAuth() {
         BaselineTopology blt = ctx.state().clusterState().baselineTopology();
 
         return blt == null ? 0 : blt.consistentIds().size();

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewCacheGroupsIOStatistics.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewCacheGroupsIOStatistics.java
@@ -57,7 +57,7 @@ public class SqlSystemViewCacheGroupsIOStatistics extends SqlAbstractLocalSystem
     }
 
     /** {@inheritDoc} */
-    @Override public Iterator<Row> getRows(Session ses, SearchRow first, SearchRow last) {
+    @Override public Iterator<Row> getRowsNoAuth(Session ses, SearchRow first, SearchRow last) {
         SqlSystemViewColumnCondition nameCond = conditionForColumn("CACHE_GROUP_NAME", first, last);
 
         if (nameCond.isEquality()) {
@@ -118,7 +118,7 @@ public class SqlSystemViewCacheGroupsIOStatistics extends SqlAbstractLocalSystem
     }
 
     /** {@inheritDoc} */
-    @Override public long getRowCount() {
+    @Override public long getRowCountNoAuth() {
         return ctx.cache().cacheGroups().size();
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewNodeAttributes.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewNodeAttributes.java
@@ -47,8 +47,7 @@ public class SqlSystemViewNodeAttributes extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @SuppressWarnings("unchecked")
-    @Override public Iterator<Row> getRows(Session ses, SearchRow first, SearchRow last) {
+    @Override public Iterator<Row> getRowsNoAuth(Session ses, SearchRow first, SearchRow last) {
         Collection<ClusterNode> nodes;
 
         SqlSystemViewColumnCondition idCond = conditionForColumn("NODE_ID", first, last);

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewNodeMetrics.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/sys/view/SqlSystemViewNodeMetrics.java
@@ -102,7 +102,7 @@ public class SqlSystemViewNodeMetrics extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public Iterator<Row> getRows(Session ses, SearchRow first, SearchRow last) {
+    @Override public Iterator<Row> getRowsNoAuth(Session ses, SearchRow first, SearchRow last) {
         List<Row> rows = new ArrayList<>();
 
         Collection<ClusterNode> nodes;
@@ -205,7 +205,7 @@ public class SqlSystemViewNodeMetrics extends SqlAbstractLocalSystemView {
     }
 
     /** {@inheritDoc} */
-    @Override public long getRowCount() {
+    @Override public long getRowCountNoAuth() {
         return F.concat(false, ctx.discovery().allNodes(), ctx.discovery().daemonNodes()).size();
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/SqlSystemViewAuthorizationTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/SqlSystemViewAuthorizationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.query.h2.sys.view.SqlSystemView;
+import org.apache.ignite.internal.processors.security.AbstractSecurityTest;
+import org.apache.ignite.internal.util.tostring.GridToStringBuilder;
+import org.apache.ignite.plugin.security.SecurityException;
+import org.apache.ignite.plugin.security.SecurityPermissionSet;
+import org.apache.ignite.plugin.security.SecurityPermissionSetBuilder;
+import org.junit.Test;
+
+import static org.apache.ignite.internal.processors.query.h2.SchemaManager.SQL_VIEWS_VIEW;
+import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_CREATE;
+import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_READ;
+import static org.apache.ignite.plugin.security.SecurityPermission.SYSTEM_VIEW_READ;
+import static org.apache.ignite.testframework.GridTestUtils.assertThrowsWithCause;
+
+/**
+ * Tests authorized access to {@link SqlSystemView}s.
+ */
+public class SqlSystemViewAuthorizationTest extends AbstractSecurityTest {
+    /** */
+    private static final SqlFieldsQuery QUERY_ALL = new SqlFieldsQuery("SELECT * FROM SYS." + SQL_VIEWS_VIEW);
+
+    /** */
+    private static final SqlFieldsQuery QUERY_COUNT = new SqlFieldsQuery("SELECT count(*) FROM SYS." + SQL_VIEWS_VIEW);
+
+    /** @throws Exception If failed. */
+    @Test
+    public void testCanReadViewWhenPermitted() throws Exception {
+        SecurityPermissionSet permSet = new SecurityPermissionSetBuilder()
+            .appendSystemPermissions(SYSTEM_VIEW_READ)
+            .appendCachePermissions(DEFAULT_CACHE_NAME, CACHE_CREATE, CACHE_READ)
+            .build();
+
+        IgniteEx server = startGrid("server", permSet, false);
+        IgniteEx client = startGrid("client", permSet, true);
+
+        checkReadViewSuceeds(server);
+        checkReadViewSuceeds(client);
+    }
+
+    /** @throws Exception If failed. */
+    @Test
+    public void testCannotReadViewWithoutPermission() throws Exception {
+        SecurityPermissionSet permSet = new SecurityPermissionSetBuilder()
+            .appendCachePermissions(DEFAULT_CACHE_NAME, CACHE_CREATE, CACHE_READ)
+            .build();
+
+        IgniteEx server = startGrid("server", permSet, false);
+        IgniteEx client = startGrid("client", permSet, true);
+
+        checkReadViewFails(server);
+        checkReadViewFails(client);
+    }
+
+    /** */
+    @Override public void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids();
+        cleanPersistenceDir();
+    }
+
+    /** */
+    private static void checkReadViewSuceeds(Ignite ignite) {
+        IgniteCache<String, String> cache = ignite.getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        for (List<?> row : cache.query(QUERY_ALL).getAll())
+            log.info(row.stream().map(Object::toString).collect(Collectors.joining("|")));
+
+        log.info(cache.query(QUERY_COUNT).iterator().next().get(0).toString());
+    }
+
+    /** */
+    @SuppressWarnings("ThrowableNotThrown")
+    private static void checkReadViewFails(Ignite ignite) {
+        IgniteCache<String, String> cache = ignite.getOrCreateCache(DEFAULT_CACHE_NAME);
+
+        assertThrowsWithCause(() -> cache.query(QUERY_ALL).getAll(), SecurityException.class);
+        assertThrowsWithCause(() -> cache.query(QUERY_COUNT).iterator().next().get(0), SecurityException.class);
+    }
+}


### PR DESCRIPTION
New SecurityPermission is introduced: SYSTEM_VIEW_READ.

Authorization is added to view rows / row count accessors. Perfectly, column set information should be also covered, but this can break existing security-enabled installations: these accessors are used at node start time and new permission authorization may fail for nodes that are not aware of the permission.