### PR TITLE
IGNITE-8635: Add a Method to Inspect BinaryObject Size

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/binary/BinaryObject.java
+++ b/modules/core/src/main/java/org/apache/ignite/binary/BinaryObject.java
@@ -181,4 +181,10 @@ public interface BinaryObject extends Serializable, Cloneable {
      * @throws BinaryObjectException If object is not enum.
      */
     public String enumName() throws BinaryObjectException;
+
+    /**
+     * Get the size of the object
+     * @return Size of the object
+     */
+    public int size();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
@@ -476,6 +476,10 @@ public class BinaryEnumObjectImpl implements BinaryObjectEx, Externalizable, Cac
 
     /** {@inheritDoc} */
     @Override public int size() {
+        if (valBytes == null) {
+            return -1;
+        }
+
         return BinaryPrimitives.readInt(valBytes, ord + GridBinaryMarshaller.TOTAL_LEN_POS);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
@@ -477,7 +477,11 @@ public class BinaryEnumObjectImpl implements BinaryObjectEx, Externalizable, Cac
     /** {@inheritDoc} */
     @Override public int size() {
         if (valBytes == null) {
-            return -1;
+            try {
+                valBytes = U.marshal(ctx.marshaller(), this);
+            } catch (IgniteCheckedException e) {
+                throw U.convertException(e);
+            }
         }
 
         return BinaryPrimitives.readInt(valBytes, ord + GridBinaryMarshaller.TOTAL_LEN_POS);

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
@@ -473,4 +473,9 @@ public class BinaryEnumObjectImpl implements BinaryObjectEx, Externalizable, Cac
 
         return reader.afterMessageRead(BinaryEnumObjectImpl.class);
     }
+
+    /** {@inheritDoc} */
+    @Override public int size() {
+        return BinaryPrimitives.readInt(valBytes, ord + GridBinaryMarshaller.TOTAL_LEN_POS);
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectImpl.java
@@ -936,6 +936,11 @@ public final class BinaryObjectImpl extends BinaryObjectExImpl implements Extern
     }
 
     /** {@inheritDoc} */
+    @Override public int size() {
+        return length();
+    }
+
+    /** {@inheritDoc} */
     @Override public String toString() {
         if (arr == null || ctx == null)
             return "BinaryObjectImpl [arr= " + (arr != null) + ", ctx=" + (ctx != null) + ", start=" + start + "]";

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectOffheapImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectOffheapImpl.java
@@ -519,6 +519,11 @@ public class BinaryObjectOffheapImpl extends BinaryObjectExImpl implements Exter
         // No-op.
     }
 
+    /** {@inheritDoc} */
+    @Override public int size() {
+        return length();
+    }
+
     /**
      * @return Deserialized value.
      */

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryEnumsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryEnumsSelfTest.java
@@ -255,6 +255,7 @@ public class BinaryEnumsSelfTest extends GridCommonAbstractTest {
 
         BinaryEnumObjectImpl binEnum = new BinaryEnumObjectImpl(binCtx, bytes);
 
+        assertEquals(srcBinEnum.size(), binEnum.size());
         assertEquals(clsName, binEnum.className());
         assertEquals(typeId, binEnum.typeId());
         assertEquals(ord, binEnum.enumOrdinal());

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryFooterOffsetsAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryFooterOffsetsAbstractSelfTest.java
@@ -136,6 +136,8 @@ public abstract class BinaryFooterOffsetsAbstractSelfTest extends GridCommonAbst
 
         BinaryObjectExImpl portObj = toBinary(marsh, obj);
 
+        assertEquals(portObj.size(), portObj.length());
+
         // 1. Test binary object content.
         assert portObj.hasField("field1");
         assert portObj.hasField("field2");

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -2644,6 +2644,7 @@ public class BinaryMarshallerSelfTest extends GridCommonAbstractTest {
                 obj.array().length);
 
             assertTrue(offheapObj.equals(offheapObj));
+            assertEquals(offheapObj.size(), obj.size());
             assertFalse(offheapObj.equals(null));
             assertFalse(offheapObj.equals("str"));
             assertTrue(offheapObj.equals(obj));


### PR DESCRIPTION
This commit introduces a method to BinaryObject interface allowing users to get an estimate of the size
of the object.