### PR TITLE
IGNITE-14311 .NET: ServiceTest refactoring

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
@@ -374,7 +374,7 @@ namespace Apache.Ignite.Core.Tests.Services
         /** <inheritDoc /> */
         public void testUTCDateFromCache()
         {
-            _svc.testDateFromCache();
+            _svc.testUTCDateFromCache();
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1115,6 +1115,24 @@ namespace Apache.Ignite.Core.Tests.Services
         }
 
         /// <summary>
+        /// Tests Java service invocation with dynamic proxy.
+        /// </summary>
+        [Test]
+        public void TestCallJavaServiceDynamicProxy()
+        {
+            // Deploy Java service
+            var javaSvcName = TestUtils.DeployJavaService(Grid1);
+
+            var svc = new JavaServiceDynamicProxy(Grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true));
+
+            DoTestService(
+                svc,
+                new JavaServiceDynamicProxy(Services.WithKeepBinary().WithServerKeepBinary()
+                    .GetDynamicServiceProxy(javaSvcName))
+            );
+        }
+
+        /// <summary>
         /// Tets binary methods in services.
         /// </summary>
         private void DoTestBinary(IJavaService svc, IJavaService binSvc)
@@ -1148,24 +1166,6 @@ namespace Apache.Ignite.Core.Tests.Services
             var binObjs = binSvc.testBinaryObjectArray(binArr);
 
             Assert.AreEqual(new[] {11, 12, 13}, binObjs.Select(x => x.GetField<int>("Field")));
-        }
-
-        /// <summary>
-        /// Tests Java service invocation with dynamic proxy.
-        /// </summary>
-        [Test]
-        public void TestCallJavaServiceDynamicProxy()
-        {
-            // Deploy Java service
-            var javaSvcName = TestUtils.DeployJavaService(Grid1);
-
-            var svc = new JavaServiceDynamicProxy(Grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true));
-
-            DoTestService(
-                svc,
-                new JavaServiceDynamicProxy(Services.WithKeepBinary().WithServerKeepBinary()
-                    .GetDynamicServiceProxy(javaSvcName))
-            );
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -367,7 +367,7 @@ namespace Apache.Ignite.Core.Tests.Services
             // Exception in service.
             ex = Assert.Throws<ServiceInvocationException>(() => prx.ErrMethod(123));
             Assert.AreEqual("ExpectedException", (ex.InnerException ?? ex).Message.Substring(0, 17));
- 
+
             Assert.AreEqual(42, svc.TestOverload(2, ServicesTypeAutoResolveTest.Emps));
             Assert.AreEqual(3, svc.TestOverload(1, 2));
             Assert.AreEqual(5, svc.TestOverload(3, 2));
@@ -876,7 +876,7 @@ namespace Apache.Ignite.Core.Tests.Services
             var binSvc = _client.GetServices().WithKeepBinary().WithServerKeepBinary()
                 .GetServiceProxy<IJavaService>(javaSvcName, false);
 
-            DoTestService(svc, binSvc);
+            DoTestService(svc, binSvc, true);
 
             DoTestBinary(svc, binSvc);
 
@@ -902,8 +902,6 @@ namespace Apache.Ignite.Core.Tests.Services
 
             DoTestService(svc, binSvc);
 
-            DoTestJavaServiceExceptions(svc);
-
             DoTestBinary(svc, binSvc);
 
             Services.Cancel(javaSvcName);
@@ -925,14 +923,12 @@ namespace Apache.Ignite.Core.Tests.Services
                 new JavaServiceDynamicProxy(Services.WithKeepBinary().WithServerKeepBinary()
                     .GetDynamicServiceProxy(javaSvcName))
             );
-
-            DoTestJavaServiceExceptions(svc);
         }
 
         /// <summary>
         /// Tests service methods.
         /// </summary>
-        private void DoTestService(IJavaService svc, IJavaService binSvc)
+        private void DoTestService(IJavaService svc, IJavaService binSvc, bool isClient = false)
         {
             // Basics
             Assert.IsTrue(svc.isInitialized());
@@ -967,7 +963,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(new byte[] {2, 3, 4}, bytes);
 
             var shorts = svc.testArray(new short[] {1, 2, 3});
-            
+
             Assert.AreEqual(shorts.GetType(), typeof(short[]));
             Assert.AreEqual(new short[] {2, 3, 4}, shorts);
 
@@ -992,7 +988,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(new double[] {2, 3, 4}, doubles);
 
             var strs = svc.testArray(new [] {"a", "b"});
-            
+
             Assert.AreEqual(strs.GetType(), typeof(string[]));
             Assert.AreEqual(new[] {"a1", "b1"}, strs);
 
@@ -1026,7 +1022,7 @@ namespace Apache.Ignite.Core.Tests.Services
                 binSvc.testBinaryObject(
                     Grid1.GetBinary().ToBinary<IBinaryObject>(new PlatformComputeBinarizable {Field = 6}))
                     .GetField<int>("Field"));
-            
+
             DateTime dt = new DateTime(1992, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
             Assert.AreEqual(dt, svc.test(dt));
@@ -1066,6 +1062,53 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(dt1, cache.Get(3));
             Assert.AreEqual(dt2, cache.Get(4));
 
+            // Test standard java checked exception.
+            Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
+            ex = ex.InnerException;
+            Assert.IsNotNull(ex);
+            Assert.IsInstanceOf<ThreadInterruptedException>(ex);
+            Assert.AreEqual("Test", ex.Message);
+
+            // Test standard java unchecked exception.
+            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
+            ex = ex.InnerException;
+            Assert.IsNotNull(ex);
+            Assert.IsInstanceOf<ArgumentException>(ex);
+            Assert.AreEqual("Test", ex.Message);
+
+            // Test user defined exception mapping by pattern.
+            ((IIgniteInternal) Grid1).PluginProcessor.RegisterExceptionMapping(
+                "org.apache.ignite.platform.PlatformDeployServiceTask$TestMapped*",
+                (c, m, e, i) => new TestServiceException(m, e));
+
+            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
+            ex = ex.InnerException;
+            Assert.IsNotNull(ex);
+            if (isClient)
+                Assert.IsInstanceOf<IgniteException>(ex);
+            else
+                Assert.IsInstanceOf<TestServiceException>(ex);
+            Assert.IsTrue(ex.Message.Contains("Test"));
+
+            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
+            ex = ex.InnerException;
+            Assert.IsNotNull(ex);
+            if (isClient)
+                Assert.IsInstanceOf<IgniteException>(ex);
+            else
+                Assert.IsInstanceOf<TestServiceException>(ex);
+            Assert.IsTrue(ex.Message.Contains("Test"));
+
+            // Test user defined unmapped exception.
+            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
+            ex = ex.InnerException;
+            Assert.IsNotNull(ex);
+            Assert.IsInstanceOf<IgniteException>(ex);
+            var javaEx = ex.InnerException as JavaException;
+            Assert.IsNotNull(javaEx);
+            Assert.AreEqual("Test", javaEx.JavaMessage);
+            Assert.AreEqual("org.apache.ignite.platform.PlatformDeployServiceTask$TestUnmappedException", javaEx.JavaClassName);
+
 #if NETCOREAPP
             //This Date in Europe/Moscow have offset +4.
             DateTime dt3 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local);
@@ -1090,53 +1133,6 @@ namespace Apache.Ignite.Core.Tests.Services
         }
 
         /// <summary>
-        /// Tests exceptions from Java service.
-        /// </summary>
-        private void DoTestJavaServiceExceptions(IJavaService svc)
-        {
-            // Test standard java checked exception.
-            Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<ThreadInterruptedException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            // Test standard java unchecked exception.
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<ArgumentException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            // Test user defined exception mapping by pattern.
-            ((IIgniteInternal) Grid1).PluginProcessor.RegisterExceptionMapping(
-                "org.apache.ignite.platform.PlatformDeployServiceTask$TestMapped*",
-                (c, m, e, i) => new TestServiceException(m, e));
-
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<TestServiceException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<TestServiceException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            // Test user defined unmapped exception.
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<IgniteException>(ex);
-            var javaEx = ex.InnerException as JavaException;
-            Assert.IsNotNull(javaEx);
-            Assert.AreEqual("Test", javaEx.JavaMessage);
-            Assert.AreEqual("org.apache.ignite.platform.PlatformDeployServiceTask$TestUnmappedException", javaEx.JavaClassName);
-        }
-
-        /// <summary>
         /// Tets binary methods in services.
         /// </summary>
         private void DoTestBinary(IJavaService svc, IJavaService binSvc)
@@ -1152,7 +1148,7 @@ namespace Apache.Ignite.Core.Tests.Services
             var binarizableObjs = svc.testBinarizableArrayOfObjects(arrOfObj);
 
             Assert.AreEqual(typeof(object[]), binarizableObjs.GetType());
-            Assert.AreEqual(new[] {11, 12, 13},binarizableObjs 
+            Assert.AreEqual(new[] {11, 12, 13},binarizableObjs
                 .OfType<PlatformComputeBinarizable>().Select(x => x.Field));
 
             Assert.IsNull(svc.testBinarizableArrayOfObjects(null));
@@ -1198,7 +1194,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Grid2 = Ignition.Start(GetConfiguration(path + "2.xml"));
 
             var cfg = GetConfiguration(path + "3.xml");
-            
+
             Grid3 = Ignition.Start(cfg);
 
             cfg.ClientMode = true;
@@ -1721,7 +1717,7 @@ namespace Apache.Ignite.Core.Tests.Services
                 // No-op.
             }
         }
-        
+
 #if NETCOREAPP
         /// <summary>
         /// Adds support of the local dates to the Ignite timestamp serialization.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -56,6 +56,9 @@ namespace Apache.Ignite.Core.Tests.Services
         protected IIgnite Grid3;
 
         /** */
+        private IIgnite _client;
+
+        /** */
         protected IIgnite[] Grids;
 
         [TestFixtureTearDown]
@@ -364,7 +367,7 @@ namespace Apache.Ignite.Core.Tests.Services
             // Exception in service.
             ex = Assert.Throws<ServiceInvocationException>(() => prx.ErrMethod(123));
             Assert.AreEqual("ExpectedException", (ex.InnerException ?? ex).Message.Substring(0, 17));
-
+ 
             Assert.AreEqual(42, svc.TestOverload(2, ServicesTypeAutoResolveTest.Emps));
             Assert.AreEqual(3, svc.TestOverload(1, 2));
             Assert.AreEqual(5, svc.TestOverload(3, 2));
@@ -860,7 +863,31 @@ namespace Apache.Ignite.Core.Tests.Services
         /// Tests Java service invocation.
         /// </summary>
         [Test]
-        public void TestCallJavaService()
+        public void TestCallJavaServiceRemote()
+        {
+            // Deploy Java service
+            var javaSvcName = TestUtils.DeployJavaService(Grid1);
+
+            // Verify descriptor
+            var descriptor = _client.GetServices().GetServiceDescriptors().Single(x => x.Name == javaSvcName);
+            Assert.AreEqual(javaSvcName, descriptor.Name);
+
+            var svc = _client.GetServices().GetServiceProxy<IJavaService>(javaSvcName, false);
+            var binSvc = _client.GetServices().WithKeepBinary().WithServerKeepBinary()
+                .GetServiceProxy<IJavaService>(javaSvcName, false);
+
+            DoTestService(svc, binSvc);
+
+            DoTestBinary(svc, binSvc);
+
+            Services.Cancel(javaSvcName);
+        }
+
+        /// <summary>
+        /// Tests Java service invocation.
+        /// </summary>
+        [Test]
+        public void TestCallJavaServiceLocal()
         {
             // Deploy Java service
             var javaSvcName = TestUtils.DeployJavaService(Grid1);
@@ -873,6 +900,40 @@ namespace Apache.Ignite.Core.Tests.Services
             var binSvc = Services.WithKeepBinary().WithServerKeepBinary()
                 .GetServiceProxy<IJavaService>(javaSvcName, false);
 
+            DoTestService(svc, binSvc);
+
+            DoTestJavaServiceExceptions(svc);
+
+            DoTestBinary(svc, binSvc);
+
+            Services.Cancel(javaSvcName);
+        }
+
+        /// <summary>
+        /// Tests Java service invocation with dynamic proxy.
+        /// </summary>
+        [Test]
+        public void TestCallJavaServiceDynamicProxy()
+        {
+            // Deploy Java service
+            var javaSvcName = TestUtils.DeployJavaService(Grid1);
+
+            var svc = new JavaServiceDynamicProxy(Grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true));
+
+            DoTestService(
+                svc,
+                new JavaServiceDynamicProxy(Services.WithKeepBinary().WithServerKeepBinary()
+                    .GetDynamicServiceProxy(javaSvcName))
+            );
+
+            DoTestJavaServiceExceptions(svc);
+        }
+
+        /// <summary>
+        /// Tests service methods.
+        /// </summary>
+        private void DoTestService(IJavaService svc, IJavaService binSvc)
+        {
             // Basics
             Assert.IsTrue(svc.isInitialized());
             Assert.IsTrue(TestUtils.WaitForCondition(() => svc.isExecuted(), 500));
@@ -899,24 +960,59 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(false, svc.testWrapper(true));
             Assert.AreEqual('b', svc.testWrapper('a'));
 
+            // params / varargs
+            Assert.AreEqual(5, svc.testParams(1, 2, 3, 4, "5"));
+            Assert.AreEqual(0, svc.testParams());
+
             // Arrays
-            Assert.AreEqual(new byte[] {2, 3, 4}, svc.testArray(new byte[] {1, 2, 3}));
-            Assert.AreEqual(new short[] {2, 3, 4}, svc.testArray(new short[] {1, 2, 3}));
-            Assert.AreEqual(new[] {2, 3, 4}, svc.testArray(new[] {1, 2, 3}));
-            Assert.AreEqual(new long[] {2, 3, 4}, svc.testArray(new long[] {1, 2, 3}));
-            Assert.AreEqual(new float[] {2, 3, 4}, svc.testArray(new float[] {1, 2, 3}));
-            Assert.AreEqual(new double[] {2, 3, 4}, svc.testArray(new double[] {1, 2, 3}));
-            Assert.AreEqual(new[] {"a1", "b1"}, svc.testArray(new [] {"a", "b"}));
-            Assert.AreEqual(new[] {'c', 'd'}, svc.testArray(new[] {'b', 'c'}));
-            Assert.AreEqual(new[] {false, true, false}, svc.testArray(new[] {true, false, true}));
+            var bytes = svc.testArray(new byte[] {1, 2, 3});
+
+            Assert.AreEqual(bytes.GetType(), typeof(byte[]));
+            Assert.AreEqual(new byte[] {2, 3, 4}, bytes);
+
+            var shorts = svc.testArray(new short[] {1, 2, 3});
+            
+            Assert.AreEqual(shorts.GetType(), typeof(short[]));
+            Assert.AreEqual(new short[] {2, 3, 4}, shorts);
+
+            var ints = svc.testArray(new[] {1, 2, 3});
+
+            Assert.AreEqual(ints.GetType(), typeof(int[]));
+            Assert.AreEqual(new[] {2, 3, 4}, ints);
+
+            var longs = svc.testArray(new long[] {1, 2, 3});
+
+            Assert.AreEqual(longs.GetType(), typeof(long[]));
+            Assert.AreEqual(new long[] {2, 3, 4}, longs);
+
+            var floats = svc.testArray(new float[] {1, 2, 3});
+
+            Assert.AreEqual(floats.GetType(), typeof(float[]));
+            Assert.AreEqual(new float[] {2, 3, 4}, floats);
+
+            var doubles = svc.testArray(new double[] {1, 2, 3});
+
+            Assert.AreEqual(doubles.GetType(), typeof(double[]));
+            Assert.AreEqual(new double[] {2, 3, 4}, doubles);
+
+            var strs = svc.testArray(new [] {"a", "b"});
+            
+            Assert.AreEqual(strs.GetType(), typeof(string[]));
+            Assert.AreEqual(new[] {"a1", "b1"}, strs);
+
+            var chars = svc.testArray(new[] {'b', 'c'});
+
+            Assert.AreEqual(chars.GetType(), typeof(char[]));
+            Assert.AreEqual(new[] {'c', 'd'}, chars);
+
+            var bools = svc.testArray(new[] {true, false, true});
+
+            Assert.AreEqual(bools.GetType(), typeof(bool[]));
+            Assert.AreEqual(new[] {false, true, false}, bools);
 
             // Nulls
             Assert.AreEqual(9, svc.testNull(8));
             Assert.IsNull(svc.testNull(null));
-
-            // params / varargs
-            Assert.AreEqual(5, svc.testParams(1, 2, 3, 4, "5"));
-            Assert.AreEqual(0, svc.testParams());
 
             // Overloads
             Assert.AreEqual(3, svc.test(2, "1"));
@@ -925,49 +1021,33 @@ namespace Apache.Ignite.Core.Tests.Services
             // Binary
             Assert.AreEqual(7, svc.testBinarizable(new PlatformComputeBinarizable {Field = 6}).Field);
 
-            // Binary collections
-            var arr  = new[] {10, 11, 12}.Select(
-                x => new PlatformComputeBinarizable {Field = x}).ToArray();
-            var arrOfObj = arr.ToArray<object>();
-
-            Assert.AreEqual(new[] {11, 12, 13}, svc.testBinarizableCollection(arr)
-                .OfType<PlatformComputeBinarizable>().Select(x => x.Field));
-
-            Assert.AreEqual(new[] {11, 12, 13}, svc.testBinarizableArrayOfObjects(arrOfObj)
-                .OfType<PlatformComputeBinarizable>().Select(x => x.Field));
-
-            Assert.IsNull(svc.testBinarizableArrayOfObjects(null));
-
-            Assert.AreEqual(new[] {11, 12, 13}, svc.testBinarizableArray(arr)
-                .Select(x => x.Field));
-
-            Assert.IsNull(svc.testBinarizableArray(null));
-
             // Binary object
             Assert.AreEqual(15,
                 binSvc.testBinaryObject(
                     Grid1.GetBinary().ToBinary<IBinaryObject>(new PlatformComputeBinarizable {Field = 6}))
                     .GetField<int>("Field"));
-
+            
             DateTime dt = new DateTime(1992, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
             Assert.AreEqual(dt, svc.test(dt));
             Assert.AreEqual(dt, svc.testNullTimestamp(dt));
             Assert.IsNull(svc.testNullTimestamp(null));
-            Assert.AreEqual(dt, svc.testArray(new DateTime?[] {dt})[0]);
+
+            var dates = svc.testArray(new DateTime?[] {dt});
+
+            Assert.AreEqual(dates.GetType(), typeof(DateTime?[]));
+            Assert.AreEqual(dt, dates[0]);
 
             Guid guid = Guid.NewGuid();
 
             Assert.AreEqual(guid, svc.test(guid));
             Assert.AreEqual(guid, svc.testNullUUID(guid));
             Assert.IsNull(svc.testNullUUID(null));
-            Assert.AreEqual(guid, svc.testArray(new Guid?[] {guid})[0]);
 
-            // Binary object array.
-            var binArr = arr.Select(Grid1.GetBinary().ToBinary<IBinaryObject>).ToArray();
+            var guids = svc.testArray(new Guid?[] {guid});
 
-            Assert.AreEqual(new[] {11, 12, 13}, binSvc.testBinaryObjectArray(binArr)
-                .Select(x => x.GetField<int>("Field")));
+            Assert.AreEqual(guids.GetType(), typeof(Guid?[]));
+            Assert.AreEqual(guid, guids[0]);
 
             DateTime dt1 = new DateTime(1982, 4, 1, 0, 0, 0, 0, DateTimeKind.Utc);
             DateTime dt2 = new DateTime(1991, 10, 1, 0, 0, 0, 0, DateTimeKind.Utc);
@@ -985,47 +1065,6 @@ namespace Apache.Ignite.Core.Tests.Services
 
             Assert.AreEqual(dt1, cache.Get(3));
             Assert.AreEqual(dt2, cache.Get(4));
-
-            // Test standard java checked exception.
-            Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<ThreadInterruptedException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            // Test standard java unchecked exception.
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<ArgumentException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            // Test user defined exception mapping by pattern.
-            ((IIgniteInternal)Grid1).PluginProcessor.RegisterExceptionMapping(
-                "org.apache.ignite.platform.PlatformDeployServiceTask$TestMapped*",
-                (c, m, e, i) => new TestServiceException(m, e));
-
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<TestServiceException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<TestServiceException>(ex);
-            Assert.AreEqual("Test", ex.Message);
-
-            // Test user defined unmapped exception.
-            ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
-            ex = ex.InnerException;
-            Assert.IsNotNull(ex);
-            Assert.IsInstanceOf<IgniteException>(ex);
-            var javaEx = ex.InnerException as JavaException;
-            Assert.IsNotNull(javaEx);
-            Assert.AreEqual("Test", javaEx.JavaMessage);
-            Assert.AreEqual("org.apache.ignite.platform.PlatformDeployServiceTask$TestUnmappedException", javaEx.JavaClassName);
 
 #if NETCOREAPP
             //This Date in Europe/Moscow have offset +4.
@@ -1048,105 +1087,13 @@ namespace Apache.Ignite.Core.Tests.Services
             cache.Put(9, now);
             Assert.AreEqual(now.ToUniversalTime(), cache.Get(9).ToUniversalTime());
 #endif
-
-            Services.Cancel(javaSvcName);
         }
 
         /// <summary>
-        /// Tests Java service invocation with dynamic proxy.
+        /// Tests exceptions from Java service.
         /// </summary>
-        [Test]
-        public void TestCallJavaServiceDynamicProxy()
+        private void DoTestJavaServiceExceptions(IJavaService svc)
         {
-            // Deploy Java service
-            var javaSvcName = TestUtils.DeployJavaService(Grid1);
-            var svc = Grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true);
-
-            // Basics
-            Assert.IsTrue(svc.isInitialized());
-            Assert.IsTrue(TestUtils.WaitForCondition(() => svc.isExecuted(), 500));
-            Assert.IsFalse(svc.isCancelled());
-
-            // Primitives
-            Assert.AreEqual(4, svc.test((byte)3));
-            Assert.AreEqual(5, svc.test((short)4));
-            Assert.AreEqual(6, svc.test(5));
-            Assert.AreEqual(6, svc.test((long)5));
-            Assert.AreEqual(3.8f, svc.test(2.3f));
-            Assert.AreEqual(5.8, svc.test(3.3));
-            Assert.IsFalse(svc.test(true));
-            Assert.AreEqual('b', svc.test('a'));
-            Assert.AreEqual("Foo!", svc.test("Foo"));
-
-            // Nullables (Java wrapper types)
-            Assert.AreEqual(4, svc.testWrapper(3));
-            Assert.AreEqual(5, svc.testWrapper((short?)4));
-            Assert.AreEqual(6, svc.testWrapper((int?)5));
-            Assert.AreEqual(6, svc.testWrapper((long?)5));
-            Assert.AreEqual(3.8f, svc.testWrapper(2.3f));
-            Assert.AreEqual(5.8, svc.testWrapper(3.3));
-            Assert.AreEqual(false, svc.testWrapper(true));
-            Assert.AreEqual('b', svc.testWrapper('a'));
-
-            // Arrays
-            Assert.AreEqual(new byte[] { 2, 3, 4 }, svc.testArray(new byte[] { 1, 2, 3 }));
-            Assert.AreEqual(new short[] { 2, 3, 4 }, svc.testArray(new short[] { 1, 2, 3 }));
-            Assert.AreEqual(new[] { 2, 3, 4 }, svc.testArray(new[] { 1, 2, 3 }));
-            Assert.AreEqual(new long[] { 2, 3, 4 }, svc.testArray(new long[] { 1, 2, 3 }));
-            Assert.AreEqual(new float[] { 2, 3, 4 }, svc.testArray(new float[] { 1, 2, 3 }));
-            Assert.AreEqual(new double[] { 2, 3, 4 }, svc.testArray(new double[] { 1, 2, 3 }));
-            Assert.AreEqual(new[] { "a1", "b1" }, svc.testArray(new[] { "a", "b" }));
-            Assert.AreEqual(new[] { 'c', 'd' }, svc.testArray(new[] { 'b', 'c' }));
-            Assert.AreEqual(new[] { false, true, false }, svc.testArray(new[] { true, false, true }));
-
-            // Nulls
-            Assert.AreEqual(9, svc.testNull(8));
-            Assert.IsNull(svc.testNull(null));
-
-            // Overloads
-            Assert.AreEqual(3, svc.test(2, "1"));
-            Assert.AreEqual(3, svc.test("1", 2));
-
-            // Binary
-            Assert.AreEqual(7, svc.testBinarizable(new PlatformComputeBinarizable { Field = 6 }).Field);
-
-            // Binary object
-            var binSvc = Services.WithKeepBinary().WithServerKeepBinary().GetDynamicServiceProxy(javaSvcName);
-
-            Assert.AreEqual(15,
-                binSvc.testBinaryObject(
-                    Grid1.GetBinary().ToBinary<IBinaryObject>(new PlatformComputeBinarizable { Field = 6 }))
-                    .GetField<int>("Field"));
-
-            DateTime dt = new DateTime(1992, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-
-            Assert.AreEqual(dt, svc.test(dt));
-            Assert.AreEqual(dt, svc.testNullTimestamp(dt));
-            Assert.IsNull(svc.testNullTimestamp(null));
-            Assert.AreEqual(dt, svc.testArray(new DateTime?[] { dt })[0]);
-
-            Guid guid = Guid.NewGuid();
-
-            Assert.AreEqual(guid, svc.test(guid));
-            Assert.AreEqual(guid, svc.testNullUUID(guid));
-            Assert.IsNull(svc.testNullUUID(null));
-            Assert.AreEqual(guid, svc.testArray(new Guid?[] { guid })[0]);
-
-            DateTime dt1 = new DateTime(1982, 4, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            DateTime dt2 = new DateTime(1991, 10, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-
-            Assert.AreEqual(dt2, svc.testDate(dt1));
-
-            var cache = Grid1.GetOrCreateCache<int, DateTime>("net-dates");
-
-            cache.Put(1, dt1);
-            cache.Put(2, dt2);
-
-            svc.testUTCDateFromCache();
-
-            Assert.AreEqual(dt1, cache.Get(3));
-            Assert.AreEqual(dt2, cache.Get(4));
-
             // Test standard java checked exception.
             Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
             ex = ex.InnerException;
@@ -1162,7 +1109,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual("Test", ex.Message);
 
             // Test user defined exception mapping by pattern.
-            ((IIgniteInternal)Grid1).PluginProcessor.RegisterExceptionMapping(
+            ((IIgniteInternal) Grid1).PluginProcessor.RegisterExceptionMapping(
                 "org.apache.ignite.platform.PlatformDeployServiceTask$TestMapped*",
                 (c, m, e, i) => new TestServiceException(m, e));
 
@@ -1187,6 +1134,42 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.IsNotNull(javaEx);
             Assert.AreEqual("Test", javaEx.JavaMessage);
             Assert.AreEqual("org.apache.ignite.platform.PlatformDeployServiceTask$TestUnmappedException", javaEx.JavaClassName);
+        }
+
+        /// <summary>
+        /// Tets binary methods in services.
+        /// </summary>
+        private void DoTestBinary(IJavaService svc, IJavaService binSvc)
+        {
+            // Binary collections
+            var arr = new[] {10, 11, 12}.Select(
+                x => new PlatformComputeBinarizable {Field = x}).ToArray();
+            var arrOfObj = arr.ToArray<object>();
+
+            Assert.AreEqual(new[] {11, 12, 13}, svc.testBinarizableCollection(arr)
+                .OfType<PlatformComputeBinarizable>().Select(x => x.Field));
+
+            var binarizableObjs = svc.testBinarizableArrayOfObjects(arrOfObj);
+
+            Assert.AreEqual(typeof(object[]), binarizableObjs.GetType());
+            Assert.AreEqual(new[] {11, 12, 13},binarizableObjs 
+                .OfType<PlatformComputeBinarizable>().Select(x => x.Field));
+
+            Assert.IsNull(svc.testBinarizableArrayOfObjects(null));
+
+            var bins = svc.testBinarizableArray(arr);
+
+            Assert.AreEqual(typeof(PlatformComputeBinarizable[]), bins.GetType());
+            Assert.AreEqual(new[] {11, 12, 13},bins.Select(x => x.Field));
+
+            Assert.IsNull(svc.testBinarizableArray(null));
+
+            // Binary object array.
+            var binArr = arr.Select(Grid1.GetBinary().ToBinary<IBinaryObject>).ToArray();
+
+            var binObjs = binSvc.testBinaryObjectArray(binArr);
+
+            Assert.AreEqual(new[] {11, 12, 13}, binObjs.Select(x => x.GetField<int>("Field")));
         }
 
         /// <summary>
@@ -1213,9 +1196,17 @@ namespace Apache.Ignite.Core.Tests.Services
             var path = Path.Combine("Config", "Compute", "compute-grid");
             Grid1 = Ignition.Start(GetConfiguration(path + "1.xml"));
             Grid2 = Ignition.Start(GetConfiguration(path + "2.xml"));
-            Grid3 = Ignition.Start(GetConfiguration(path + "3.xml"));
 
-            Grids = new[] { Grid1, Grid2, Grid3 };
+            var cfg = GetConfiguration(path + "3.xml");
+            
+            Grid3 = Ignition.Start(cfg);
+
+            cfg.ClientMode = true;
+            cfg.IgniteInstanceName = "client";
+
+            _client = Ignition.Start(cfg);
+
+            Grids = new[] { Grid1, Grid2, Grid3, _client };
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -908,24 +908,6 @@ namespace Apache.Ignite.Core.Tests.Services
         }
 
         /// <summary>
-        /// Tests Java service invocation with dynamic proxy.
-        /// </summary>
-        [Test]
-        public void TestCallJavaServiceDynamicProxy()
-        {
-            // Deploy Java service
-            var javaSvcName = TestUtils.DeployJavaService(Grid1);
-
-            var svc = new JavaServiceDynamicProxy(Grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true));
-
-            DoTestService(
-                svc,
-                new JavaServiceDynamicProxy(Services.WithKeepBinary().WithServerKeepBinary()
-                    .GetDynamicServiceProxy(javaSvcName))
-            );
-        }
-
-        /// <summary>
         /// Tests service methods.
         /// </summary>
         private void DoTestService(IJavaService svc, IJavaService binSvc, bool isClient = false)
@@ -1166,6 +1148,24 @@ namespace Apache.Ignite.Core.Tests.Services
             var binObjs = binSvc.testBinaryObjectArray(binArr);
 
             Assert.AreEqual(new[] {11, 12, 13}, binObjs.Select(x => x.GetField<int>("Field")));
+        }
+
+        /// <summary>
+        /// Tests Java service invocation with dynamic proxy.
+        /// </summary>
+        [Test]
+        public void TestCallJavaServiceDynamicProxy()
+        {
+            // Deploy Java service
+            var javaSvcName = TestUtils.DeployJavaService(Grid1);
+
+            var svc = new JavaServiceDynamicProxy(Grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true));
+
+            DoTestService(
+                svc,
+                new JavaServiceDynamicProxy(Services.WithKeepBinary().WithServerKeepBinary()
+                    .GetDynamicServiceProxy(javaSvcName))
+            );
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -960,10 +960,6 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(false, svc.testWrapper(true));
             Assert.AreEqual('b', svc.testWrapper('a'));
 
-            // params / varargs
-            Assert.AreEqual(5, svc.testParams(1, 2, 3, 4, "5"));
-            Assert.AreEqual(0, svc.testParams());
-
             // Arrays
             var bytes = svc.testArray(new byte[] {1, 2, 3});
 
@@ -1013,6 +1009,10 @@ namespace Apache.Ignite.Core.Tests.Services
             // Nulls
             Assert.AreEqual(9, svc.testNull(8));
             Assert.IsNull(svc.testNull(null));
+
+            // params / varargs
+            Assert.AreEqual(5, svc.testParams(1, 2, 3, 4, "5"));
+            Assert.AreEqual(0, svc.testParams());
 
             // Overloads
             Assert.AreEqual(3, svc.test(2, "1"));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTypeAutoResolveTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTypeAutoResolveTest.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Core.Tests.Services
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using Apache.Ignite.Core.Binary;
     using NUnit.Framework;
     using Apache.Ignite.Platform.Model;
@@ -39,7 +40,7 @@ namespace Apache.Ignite.Core.Tests.Services
         };
 
         /** */
-        protected internal static readonly Parameter[] Param = new[] 
+        protected internal static readonly Parameter[] Param = new[]
         {
             new Parameter()
                 {Id = 1, Values = new[] {new ParamValue() {Id = 1, Val = 42}, new ParamValue() {Id = 2, Val = 43}}},
@@ -49,6 +50,9 @@ namespace Apache.Ignite.Core.Tests.Services
 
         /** */
         private IIgnite _grid1;
+
+        /** */
+        private IIgnite _client;
 
         [TestFixtureTearDown]
         public void FixtureTearDown()
@@ -96,7 +100,7 @@ namespace Apache.Ignite.Core.Tests.Services
         /// Types should be resolved implicitly.
         /// </summary>
         [Test]
-        public void TestCallJavaServiceDynamicProxy() 
+        public void TestCallJavaServiceDynamicProxy()
         {
             // Deploy Java service
             var javaSvcName = TestUtils.DeployJavaService(_grid1);
@@ -106,11 +110,11 @@ namespace Apache.Ignite.Core.Tests.Services
         }
 
         /// <summary>
-        /// Tests Java service invocation.
+        /// Tests Java service invocation on local.
         /// Types should be resolved implicitly.
         /// </summary>
         [Test]
-        public void TestCallJavaService()
+        public void TestCallJavaServiceLocal()
         {
             // Deploy Java service
             var javaSvcName = TestUtils.DeployJavaService(_grid1);
@@ -119,17 +123,44 @@ namespace Apache.Ignite.Core.Tests.Services
 
             DoTestService(svc);
 
+            DoTestDepartments(svc);
+
+            _grid1.GetServices().Cancel(javaSvcName);
+        }
+
+        /// <summary>
+        /// Tests Java service invocation on remote node..
+        /// Types should be resolved implicitly.
+        /// </summary>
+        [Test]
+        public void TestCallJavaServiceRemote()
+        {
+            // Deploy Java service
+            var javaSvcName = TestUtils.DeployJavaService(_grid1);
+
+            var svc = _client.GetServices().GetServiceProxy<IJavaService>(javaSvcName, false);
+
+            DoTestService(svc);
+
+            DoTestDepartments(svc);
+
+            _grid1.GetServices().Cancel(javaSvcName);
+        }
+
+        /// <summary>
+        /// Tests departments call.
+        /// </summary>
+        private void DoTestDepartments(IJavaService svc)
+        {
             Assert.IsNull(svc.testDepartments(null));
 
-            var arr  = new[] {"HR", "IT"}.Select(x => new Department() {Name = x}).ToArray();
+            var arr = new[] {"HR", "IT"}.Select(x => new Department() {Name = x}).ToArray();
 
             ICollection deps = svc.testDepartments(arr);
 
             Assert.NotNull(deps);
             Assert.AreEqual(1, deps.Count);
             Assert.AreEqual("Executive", deps.OfType<Department>().Select(d => d.Name).ToArray()[0]);
-
-            _grid1.GetServices().Cancel(javaSvcName);
         }
 
         /// <summary>
@@ -202,7 +233,17 @@ namespace Apache.Ignite.Core.Tests.Services
                 return;
 
             var path = Path.Combine("Config", "Compute", "compute-grid");
-            _grid1 = Ignition.Start(GetConfiguration(path + "1.xml"));
+
+            var cfg = GetConfiguration(path + "1.xml");
+
+            _grid1 = Ignition.Start(cfg);
+
+            cfg.ClientMode = true;
+            cfg.IgniteInstanceName = "client";
+            cfg.WorkDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "client_work");
+
+            _client = Ignition.Start(cfg);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTypeAutoResolveTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTypeAutoResolveTest.cs
@@ -102,7 +102,7 @@ namespace Apache.Ignite.Core.Tests.Services
             var javaSvcName = TestUtils.DeployJavaService(_grid1);
             var svc = _grid1.GetServices().GetDynamicServiceProxy(javaSvcName, true);
 
-            doTestService(new JavaServiceDynamicProxy(svc));
+            DoTestService(new JavaServiceDynamicProxy(svc));
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Apache.Ignite.Core.Tests.Services
 
             var svc = _grid1.GetServices().GetServiceProxy<IJavaService>(javaSvcName, false);
 
-            doTestService(svc);
+            DoTestService(svc);
 
             Assert.IsNull(svc.testDepartments(null));
 
@@ -135,7 +135,7 @@ namespace Apache.Ignite.Core.Tests.Services
         /// <summary>
         /// Tests java service instance.
         /// </summary>
-        private void doTestService(IJavaService svc)
+        private static void DoTestService(IJavaService svc)
         {
             Assert.IsNull(svc.testAddress(null));
 


### PR DESCRIPTION
This patch improves .NET `ServicesTest` by 

* removing code duplication
* adding checks for a return array type
* adding case when service deployed on the server node and .Net call it via the client one.

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
