### PR TITLE
IGNITE-14314: GridDhtLockFuture#onComplete Should Be Aware of Cache C…

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtLockFuture.java
@@ -791,7 +791,7 @@ public final class GridDhtLockFuture extends GridCacheCompoundIdentityFuture<Boo
         }
 
         try {
-            if (err == null && !stopping)
+            if (err == null && !stopping && cctx.config() != null)
                 loadMissingFromStore();
         }
         finally {


### PR DESCRIPTION
…leanup

The current structure of the method only considers node stoppage as a parameter when
deciding if cache context methods should be invoked or not. It should also consider if the
cache is cleaned up or not.