### PR TITLE
IGNITE-13582 WAL force rollover timeout introduced

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
@@ -1026,6 +1026,7 @@ public class DataStorageConfiguration implements Serializable {
      * negative  value disables auto archiving.
      * @return current configuration instance for chaining
      */
+    @IgniteExperimental
     public DataStorageConfiguration setWalForceArchiveTimeout(long walForceArchiveTimeout) {
         this.walForceArchiveTimeout = walForceArchiveTimeout;
 

--- a/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteExperimental;
 import org.apache.ignite.mxbean.MetricsMxBean;
 import org.jetbrains.annotations.Nullable;
 
@@ -289,6 +290,7 @@ public class DataStorageConfiguration implements Serializable {
     private long walAutoArchiveAfterInactivity = -1;
 
     /** Time interval (in milliseconds) for force archiving of incompletely WAL segment. */
+    @IgniteExperimental
     private long walForceArchiveTimeout = -1;
 
     /**
@@ -1033,6 +1035,7 @@ public class DataStorageConfiguration implements Serializable {
     /**
      * @return time in millis to run auto archiving WAL segment (even if incomplete) after last record log
      */
+    @IgniteExperimental
     public long getWalForceArchiveTimeout() {
         return walForceArchiveTimeout;
     }

--- a/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
@@ -288,6 +288,9 @@ public class DataStorageConfiguration implements Serializable {
      */
     private long walAutoArchiveAfterInactivity = -1;
 
+    /** Time interval (in milliseconds) for force archiving of incompletely WAL segment. */
+    private long walForceArchiveTimeout = -1;
+
     /**
      * If true, threads that generate dirty pages too fast during ongoing checkpoint will be throttled.
      */
@@ -1013,6 +1016,25 @@ public class DataStorageConfiguration implements Serializable {
      */
     public long getWalAutoArchiveAfterInactivity() {
         return walAutoArchiveAfterInactivity;
+    }
+
+    /**
+     * @param walForceArchiveTimeout time in millis to run auto archiving segment (even if incomplete) after last
+     * record logging.<br> Positive value enables incomplete segment archiving after timeout (inactivity).<br> Zero or
+     * negative  value disables auto archiving.
+     * @return current configuration instance for chaining
+     */
+    public DataStorageConfiguration setWalForceArchiveTimeout(long walForceArchiveTimeout) {
+        this.walForceArchiveTimeout = walForceArchiveTimeout;
+
+        return this;
+    }
+
+    /**
+     * @return time in millis to run auto archiving WAL segment (even if incomplete) after last record log
+     */
+    public long getWalForceArchiveTimeout() {
+        return walForceArchiveTimeout;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/FileWriteAheadLogManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/FileWriteAheadLogManager.java
@@ -326,6 +326,9 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
      */
     private final long walAutoArchiveAfterInactivity;
 
+    /** Positive (non-0) value indicates WAL must be archived even if not complete. */
+    private final long walForceArchiveTimeout;
+
     /**
      * Container with last WAL record logged timestamp.<br> Zero value means there was no records logged to current
      * segment, skip possible archiving for this case<br> Value is filled only for case {@link
@@ -401,6 +404,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
         ioFactory = mode == WALMode.FSYNC ? dsCfg.getFileIOFactory() : new RandomAccessFileIOFactory();
         segmentFileInputFactory = new SimpleSegmentFileInputFactory();
         walAutoArchiveAfterInactivity = dsCfg.getWalAutoArchiveAfterInactivity();
+        walForceArchiveTimeout = dsCfg.getWalForceArchiveTimeout();
 
         double thresholdWalArchiveSizePercentage = IgniteSystemProperties.getDouble(
             IGNITE_THRESHOLD_WAL_ARCHIVE_SIZE_PERCENTAGE, DFLT_THRESHOLD_WAL_ARCHIVE_SIZE_PERCENTAGE);
@@ -749,20 +753,32 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
         if (mode == WALMode.BACKGROUND)
             backgroundFlushSchedule = cctx.time().schedule(this::doFlush, flushFreq, flushFreq);
 
-        if (walAutoArchiveAfterInactivity > 0)
-            scheduleNextInactivityPeriodElapsedCheck();
+        if (walAutoArchiveAfterInactivity > 0 || walForceArchiveTimeout > 0)
+            scheduleNextRollover();
     }
 
     /**
-     * Schedules next check of inactivity period expired. Based on current record update timestamp. At timeout method
-     * does check of inactivity period and schedules new launch.
+     * Schedules next rollover check.
+     * If {@link DataStorageConfiguration#getWalForceArchiveTimeout()} configured rollover happens forcefully.
+     * Else check based on current record update timestamp and at timeout method does check of inactivity period and schedules new launch.
      */
-    private void scheduleNextInactivityPeriodElapsedCheck() {
-        final long lastRecMs = lastRecordLoggedMs.get();
-        final long nextPossibleAutoArchive = (lastRecMs <= 0 ? U.currentTimeMillis() : lastRecMs) + walAutoArchiveAfterInactivity;
+    private void scheduleNextRollover() {
+        final long nextPossibleAutoArchive;
 
-        if (log.isDebugEnabled())
-            log.debug("Schedule WAL rollover check at " + new Time(nextPossibleAutoArchive).toString());
+        if (walForceArchiveTimeout > 0) {
+            nextPossibleAutoArchive = U.currentTimeMillis() + walForceArchiveTimeout;
+
+            if (log.isDebugEnabled())
+                log.debug("Schedule WAL rollover at " + new Time(nextPossibleAutoArchive).toString());
+        }
+        else {
+            final long lastRecMs = lastRecordLoggedMs.get();
+
+            nextPossibleAutoArchive = (lastRecMs <= 0 ? U.currentTimeMillis() : lastRecMs) + walAutoArchiveAfterInactivity;
+
+            if (log.isDebugEnabled())
+                log.debug("Schedule WAL rollover check at " + new Time(nextPossibleAutoArchive).toString());
+        }
 
         nextAutoArchiveTimeoutObj = new GridTimeoutObject() {
             private final IgniteUuid id = IgniteUuid.randomUuid();
@@ -779,9 +795,9 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
                 if (log.isDebugEnabled())
                     log.debug("Checking if WAL rollover required (" + new Time(U.currentTimeMillis()).toString() + ")");
 
-                checkWalRolloverRequiredDuringInactivityPeriod();
+                checkWalRolloverRequired();
 
-                scheduleNextInactivityPeriodElapsedCheck();
+                scheduleNextRollover();
             }
         };
         cctx.time().addTimeoutObject(nextAutoArchiveTimeoutObj);
@@ -793,11 +809,12 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
     }
 
     /**
-     * Checks if there was elapsed significant period of inactivity. If WAL auto-archive is enabled using
-     * {@link #walAutoArchiveAfterInactivity} > 0 this method will activate roll over by timeout.<br>
+     * Checks if there was elapsed significant period of inactivity or force archive timeout.
+     * If WAL auto-archive is enabled using {@link #walAutoArchiveAfterInactivity} > 0 or {@link #walForceArchiveTimeout}
+     * this method will activate roll over by timeout.
      */
-    private void checkWalRolloverRequiredDuringInactivityPeriod() {
-        if (walAutoArchiveAfterInactivity <= 0)
+    private void checkWalRolloverRequired() {
+        if (walAutoArchiveAfterInactivity <= 0 && walForceArchiveTimeout <= 0)
             return; // feature not configured, nothing to do
 
         final long lastRecMs = lastRecordLoggedMs.get();
@@ -805,13 +822,15 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
         if (lastRecMs == 0)
             return; //no records were logged to current segment, does not consider inactivity
 
-        final long elapsedMs = U.currentTimeMillis() - lastRecMs;
+        if (walForceArchiveTimeout <= 0) {
+            final long elapsedMs = U.currentTimeMillis() - lastRecMs;
 
-        if (elapsedMs <= walAutoArchiveAfterInactivity)
-            return; // not enough time elapsed since last write
+            if (elapsedMs <= walAutoArchiveAfterInactivity)
+                return; // not enough time elapsed since last write
 
-        if (!lastRecordLoggedMs.compareAndSet(lastRecMs, 0))
-            return; // record write occurred concurrently
+            if (!lastRecordLoggedMs.compareAndSet(lastRecMs, 0))
+                return; // record write occurred concurrently
+        }
 
         final FileWriteHandle handle = currentHandle();
 
@@ -900,7 +919,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
             if (ptr != null) {
                 metrics.onWalRecordLogged(rec.size());
 
-                if (walAutoArchiveAfterInactivity > 0)
+                if (walAutoArchiveAfterInactivity > 0 || walForceArchiveTimeout > 0)
                     lastRecordLoggedMs.set(U.currentTimeMillis());
 
                 return ptr;
@@ -1324,7 +1343,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
 
             assert updated : "Concurrent updates on rollover are not allowed";
 
-            if (walAutoArchiveAfterInactivity > 0)
+            if (walAutoArchiveAfterInactivity > 0 || walForceArchiveTimeout > 0)
                 lastRecordLoggedMs.set(0);
 
             // Let other threads to proceed with new segment.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/FileWriteAheadLogManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/FileWriteAheadLogManager.java
@@ -336,9 +336,7 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
      */
     private final AtomicLong lastRecordLoggedMs = new AtomicLong();
 
-    /**
-     *  Last rollover time.
-     */
+    /** Last rollover time. */
     private AtomicLong lastRolloverMs;
 
     /**
@@ -801,31 +799,31 @@ public class FileWriteAheadLogManager extends GridCacheSharedManagerAdapter impl
      */
     private void checkWalRolloverRequired() {
         if (walAutoArchiveAfterInactivity <= 0 && walForceArchiveTimeout <= 0)
-            return; // feature not configured, nothing to do
+            return; // feature not configured, nothing to do.
 
         final long lastRecMs = lastRecordLoggedMs.get();
 
         if (lastRecMs == 0)
-            return; //no records were logged to current segment, does not consider inactivity
+            return; //no records were logged to current segment, does not consider inactivity.
 
         if (walForceArchiveTimeout > 0) {
             final long lastRollover = lastRolloverMs.get();
             final long elapsedMs = U.currentTimeMillis() - lastRollover;
 
             if (elapsedMs < walForceArchiveTimeout)
-                return;
+                return; // not enough time elapsed since last rollover.
 
             if (!lastRolloverMs.compareAndSet(lastRollover, 0))
-                return; // record write occurred concurrently
+                return; // record write occurred concurrently.
         }
         else {
             final long elapsedMs = U.currentTimeMillis() - lastRecMs;
 
             if (elapsedMs <= walAutoArchiveAfterInactivity)
-                return; // not enough time elapsed since last write
+                return; // not enough time elapsed since last write.
 
             if (!lastRecordLoggedMs.compareAndSet(lastRecMs, 0))
-                return; // record write occurred concurrently
+                return; // record write occurred concurrently.
         }
 
         final FileWriteHandle handle = currentHandle();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
@@ -2055,7 +2055,8 @@ public class PlatformConfigurationUtils {
                 .setSystemRegionMaxSize(in.readLong())
                 .setPageSize(in.readInt())
                 .setConcurrencyLevel(in.readInt())
-                .setWalAutoArchiveAfterInactivity(in.readLong());
+                .setWalAutoArchiveAfterInactivity(in.readLong())
+                .setWalForceArchiveTimeout(in.readLong());
 
         if (in.readBoolean())
             res.setCheckpointReadLockTimeout(in.readLong());
@@ -2191,6 +2192,7 @@ public class PlatformConfigurationUtils {
             w.writeInt(cfg.getPageSize());
             w.writeInt(cfg.getConcurrencyLevel());
             w.writeLong(cfg.getWalAutoArchiveAfterInactivity());
+            w.writeLong(cfg.getWalForceArchiveTimeout());
 
             if (cfg.getCheckpointReadLockTimeout() != null) {
                 w.writeBoolean(true);

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorDataStorageConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/node/VisorDataStorageConfiguration.java
@@ -116,8 +116,11 @@ public class VisorDataStorageConfiguration extends VisorDataTransferObject {
     /** Time interval (in milliseconds) for rate-based metrics. */
     private long metricsRateTimeInterval;
 
-    /** Time interval (in milliseconds) for running auto archiving for incompletely WAL segment */
+    /** Time interval (in milliseconds) for running auto archiving for incompletely WAL segment. */
     private long walAutoArchiveAfterInactivity;
+
+    /** Time interval (in milliseconds) for running auto archiving for incompletely WAL segment. */
+    private long walForceArchiveTimeout;
 
     /** If true, threads that generate dirty pages too fast during ongoing checkpoint will be throttled. */
     private boolean writeThrottlingEnabled;
@@ -177,6 +180,7 @@ public class VisorDataStorageConfiguration extends VisorDataTransferObject {
         metricsSubIntervalCount = cfg.getMetricsSubIntervalCount();
         metricsRateTimeInterval = cfg.getMetricsRateTimeInterval();
         walAutoArchiveAfterInactivity = cfg.getWalAutoArchiveAfterInactivity();
+        walForceArchiveTimeout = cfg.getWalForceArchiveTimeout();
         writeThrottlingEnabled = cfg.isWriteThrottlingEnabled();
         walCompactionEnabled = cfg.isWalCompactionEnabled();
     }
@@ -371,6 +375,13 @@ public class VisorDataStorageConfiguration extends VisorDataTransferObject {
     }
 
     /**
+     * @return Time in millis.
+     */
+    public long getWalForceArchiveTimeout() {
+        return walForceArchiveTimeout;
+    }
+
+    /**
      * @return Flag indicating whether write throttling is enabled.
      */
     public boolean isWriteThrottlingEnabled() {
@@ -425,6 +436,7 @@ public class VisorDataStorageConfiguration extends VisorDataTransferObject {
         out.writeInt(metricsSubIntervalCount);
         out.writeLong(metricsRateTimeInterval);
         out.writeLong(walAutoArchiveAfterInactivity);
+        out.writeLong(walForceArchiveTimeout);
         out.writeBoolean(writeThrottlingEnabled);
         out.writeInt(walBufSize);
         out.writeBoolean(walCompactionEnabled);
@@ -460,6 +472,7 @@ public class VisorDataStorageConfiguration extends VisorDataTransferObject {
         metricsSubIntervalCount = in.readInt();
         metricsRateTimeInterval = in.readLong();
         walAutoArchiveAfterInactivity = in.readLong();
+        walForceArchiveTimeout = in.readLong();
         writeThrottlingEnabled = in.readBoolean();
 
         if (protoVer > V1) {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/full-config.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/full-config.xml
@@ -168,6 +168,7 @@
                               walArchivePath="abc" walFlushFrequency="00:00:12" walFsyncDelayNanos="13" walHistorySize="14"
                               walMode="Background" walRecordIteratorBufferSize="15" walSegments="16" walSegmentSize="17"
                               walPath="wal-store" writeThrottlingEnabled="true" walAutoArchiveAfterInactivity="00:00:18"
+                              walForceArchiveTimeout="00:00:19"
                               walPageCompression="Zstd">
         <dataRegionConfigurations>
             <dataRegionConfiguration emptyPagesPoolSize="1" evictionThreshold="2" initialSize="3" metricsEnabled="true"

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationSerializerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationSerializerTest.cs
@@ -344,6 +344,7 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreEqual(17, ds.WalSegmentSize);
             Assert.AreEqual("wal-store", ds.WalPath);
             Assert.AreEqual(TimeSpan.FromSeconds(18), ds.WalAutoArchiveAfterInactivity);
+            Assert.AreEqual(TimeSpan.FromSeconds(19), ds.WalForceArchiveTimeout);
             Assert.IsTrue(ds.WriteThrottlingEnabled);
             Assert.AreEqual(DiskPageCompression.Zstd, ds.WalPageCompression);
 
@@ -1031,6 +1032,7 @@ namespace Apache.Ignite.Core.Tests
                     ConcurrencyLevel = 1,
                     PageSize = 5 * 1024,
                     WalAutoArchiveAfterInactivity = TimeSpan.FromSeconds(19),
+                    WalForceArchiveTimeout = TimeSpan.FromSeconds(20),
                     WalPageCompression = DiskPageCompression.Lz4,
                     WalPageCompressionLevel = 10,
                     DefaultDataRegionConfiguration = new DataRegionConfiguration

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -628,6 +628,8 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreEqual(DataStorageConfiguration.DefaultConcurrencyLevel, cfg.ConcurrencyLevel);
             Assert.AreEqual(DataStorageConfiguration.DefaultWalAutoArchiveAfterInactivity,
                 cfg.WalAutoArchiveAfterInactivity);
+            Assert.AreEqual(DataStorageConfiguration.DefaultWalAutoArchiveAfterInactivity,
+                cfg.WalForceArchiveTimeout);
         }
 
         /// <summary>
@@ -887,6 +889,7 @@ namespace Apache.Ignite.Core.Tests
                     ConcurrencyLevel = 1,
                     PageSize = 8 * 1024,
                     WalAutoArchiveAfterInactivity = TimeSpan.FromMinutes(5),
+                    WalForceArchiveTimeout = TimeSpan.FromMinutes(6),
                     CheckpointReadLockTimeout = TimeSpan.FromSeconds(9.5),
                     DefaultDataRegionConfiguration = new DataRegionConfiguration
                     {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataStorageConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataStorageConfiguration.cs
@@ -200,6 +200,7 @@ namespace Apache.Ignite.Core.Configuration
             SystemRegionMaxSize = DefaultSystemRegionMaxSize;
             PageSize = DefaultPageSize;
             WalAutoArchiveAfterInactivity = DefaultWalAutoArchiveAfterInactivity;
+            WalForceArchiveTimeout = DefaultWalAutoArchiveAfterInactivity;
             MaxWalArchiveSize = DefaultMaxWalArchiveSize;
             WalPageCompression = DefaultWalPageCompression;
             ConcurrencyLevel = DefaultConcurrencyLevel;
@@ -241,6 +242,7 @@ namespace Apache.Ignite.Core.Configuration
             PageSize = reader.ReadInt();
             ConcurrencyLevel = reader.ReadInt();
             WalAutoArchiveAfterInactivity = reader.ReadLongAsTimespan();
+            WalForceArchiveTimeout = reader.ReadLongAsTimespan();
             CheckpointReadLockTimeout = reader.ReadTimeSpanNullable();
             WalPageCompression = (DiskPageCompression)reader.ReadInt();
             WalPageCompressionLevel = reader.ReadIntNullable();
@@ -296,6 +298,7 @@ namespace Apache.Ignite.Core.Configuration
             writer.WriteInt(PageSize);
             writer.WriteInt(ConcurrencyLevel);
             writer.WriteTimeSpanAsLong(WalAutoArchiveAfterInactivity);
+            writer.WriteTimeSpanAsLong(WalForceArchiveTimeout);
             writer.WriteTimeSpanAsLongNullable(CheckpointReadLockTimeout);
             writer.WriteInt((int)WalPageCompression);
             writer.WriteIntNullable(WalPageCompressionLevel);
@@ -499,6 +502,12 @@ namespace Apache.Ignite.Core.Configuration
         /// </summary>
         [DefaultValue(typeof(TimeSpan), "-00:00:00.001")]
         public TimeSpan WalAutoArchiveAfterInactivity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time for running auto archiving for incompletely WAL segment.
+        /// </summary>
+        [DefaultValue(typeof(TimeSpan), "-00:00:00.001")]
+        public TimeSpan WalForceArchiveTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets the timeout for checkpoint read lock acquisition.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfigurationSection.xsd
@@ -2053,6 +2053,11 @@
                                 <xs:documentation>Inactivity time after which to run WAL segment auto archiving.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="walForceArchiveTimeout" type="xs:string">
+                            <xs:annotation>
+                                <xs:documentation>Time interval (in milliseconds) for force archiving of incompletely WAL segment.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                         <xs:attribute name="checkpointReadLockTimeout" type="xs:string">
                             <xs:annotation>
                                 <xs:documentation>


### PR DESCRIPTION
This PR introduces new `DataStorageConfiguration` parameter `walForceArchiveTimeout`.
If this parameter set then Ignite will execute WAL segment rollover each `walForceArchiveTimeout` milliseconds.

This change required to successfully implement [Ignite CDC feature](https://cwiki.apache.org/confluence/display/IGNITE/IEP-59+CDC+-+Capture+Data+Change)



### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
