### PR TITLE
IGNITE-13399 Fix access right issues in computation of system metrics.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/GridMetricManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/GridMetricManager.java
@@ -781,7 +781,8 @@ public class GridMetricManager extends GridManagerAdapter<MetricExporterSpi> imp
      */
     private long totalSysMemory() {
         try {
-            return U.<Long>property(os, "totalPhysicalMemorySize");
+            com.sun.management.OperatingSystemMXBean sunOs = (com.sun.management.OperatingSystemMXBean) os;
+            return sunOs.getTotalPhysicalMemorySize();
         }
         catch (RuntimeException ignored) {
             return -1;
@@ -840,9 +841,10 @@ public class GridMetricManager extends GridManagerAdapter<MetricExporterSpi> imp
             long cpuTime;
 
             try {
-                cpuTime = U.<Long>property(os, "processCpuTime");
+                com.sun.management.OperatingSystemMXBean sunOs = (com.sun.management.OperatingSystemMXBean) os;
+                cpuTime = sunOs.getProcessCpuTime();
             }
-            catch (IgniteException ignored) {
+            catch (ClassCastException ignored) {
                 return -1;
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/GridMetricManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/GridMetricManager.java
@@ -844,7 +844,7 @@ public class GridMetricManager extends GridManagerAdapter<MetricExporterSpi> imp
                 com.sun.management.OperatingSystemMXBean sunOs = (com.sun.management.OperatingSystemMXBean) os;
                 cpuTime = sunOs.getProcessCpuTime();
             }
-            catch (ClassCastException ignored) {
+            catch (RuntimeException ignored) {
                 return -1;
             }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/SystemMetricsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/SystemMetricsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.metric;
+
+import org.apache.ignite.internal.IgniteNodeAttributes;
+import org.apache.ignite.internal.processors.metric.GridMetricManager;
+import org.apache.ignite.internal.processors.metric.MetricRegistry;
+import org.apache.ignite.spi.metric.DoubleMetric;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/** */
+public class SystemMetricsTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        super.beforeTestsStarted();
+        startGrid(0);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        super.afterTestsStopped();
+        stopAllGrids();
+    }
+
+    /**
+     * Checks that the process CPU load metric is positive.
+     */
+    @Test
+    public void testCpuLoadMetric() {
+        MetricRegistry sysReg = grid(0).context().metric().registry(GridMetricManager.SYS_METRICS);
+
+        DoubleMetric cpuLoad = sysReg.doubleMetric(GridMetricManager.CPU_LOAD, GridMetricManager.CPU_LOAD_DESCRIPTION);
+        double loadVal = cpuLoad.value();
+        assertTrue("CPU Load is negative: " + loadVal, loadVal >= 0);
+    }
+
+    /**
+     * Checks that the total physical memory node attribute has a positive value.
+     */
+    @Test
+    public void testTotalSystemMemory() {
+        long phyMem = (long)grid(0).context().nodeAttribute(IgniteNodeAttributes.ATTR_PHY_RAM);
+        assertTrue("Total system memory size is negative: " + phyMem, phyMem >= 0);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite9.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteCacheTestSuite9.java
@@ -30,6 +30,7 @@ import org.apache.ignite.internal.metric.LogExporterSpiTest;
 import org.apache.ignite.internal.metric.MetricsConfigurationTest;
 import org.apache.ignite.internal.metric.MetricsSelfTest;
 import org.apache.ignite.internal.metric.ReadMetricsOnNodeStartupTest;
+import org.apache.ignite.internal.metric.SystemMetricsTest;
 import org.apache.ignite.internal.metric.SystemViewComputeJobTest;
 import org.apache.ignite.internal.metric.SystemViewSelfTest;
 import org.apache.ignite.internal.processors.cache.CachePutIfAbsentTest;
@@ -123,6 +124,7 @@ public class IgniteCacheTestSuite9 {
         GridTestUtils.addTestIfNeeded(suite, IoStatisticsSelfTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, IoStatisticsMetricsLocalMXBeanImplSelfTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, MetricsSelfTest.class, ignoredTests);
+        GridTestUtils.addTestIfNeeded(suite, SystemMetricsTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, MetricsConfigurationTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, SystemViewSelfTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, SystemViewComputeJobTest.class, ignoredTests);


### PR DESCRIPTION
Previously certain Ignite metrics were calculated based on private fields of some internal JVM MBeans. These private fields were accessed via reflection, which lead to errors on Java 9+, thus making the metrics have negative values.
This patch changes the way the required values are retrieved, so that no reflection is used.