### PR TITLE
IGNITE-14353 Ability to specify postfix for IgniteLogger instead of nodeId

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -1571,157 +1571,99 @@ public class IgnitionEx {
      * Grid data container.
      */
     private static final class IgniteNamedInstance {
-        /**
-         * Map of registered MBeans.
-         */
+        /** Map of registered MBeans. */
         private static final Map<MBeanServer, GridMBeanServerData> mbeans =
             new HashMap<>();
 
-        /**
-         *
-         */
+        /** */
         private static final String[] EMPTY_STR_ARR = new String[0];
 
-        /**
-         * Grid name.
-         */
+        /** Grid name. */
         private final String name;
 
-        /**
-         * Grid instance.
-         */
+        /** Grid instance. */
         private volatile IgniteKernal grid;
 
-        /**
-         * Executor service.
-         */
+        /** Executor service. */
         private ThreadPoolExecutor execSvc;
 
-        /**
-         * Executor service for services.
-         */
+        /** Executor service for services. */
         private ThreadPoolExecutor svcExecSvc;
 
-        /**
-         * System executor service.
-         */
+        /** System executor service. */
         private ThreadPoolExecutor sysExecSvc;
 
-        /**
-         *
-         */
+        /** */
         private StripedExecutor stripedExecSvc;
 
-        /**
-         * Management executor service.
-         */
+        /** Management executor service. */
         private ThreadPoolExecutor mgmtExecSvc;
 
-        /**
-         * P2P executor service.
-         */
+        /** P2P executor service. */
         private ThreadPoolExecutor p2pExecSvc;
 
-        /**
-         * Data streamer executor service.
-         */
+        /** Data streamer executor service. */
         private StripedExecutor dataStreamerExecSvc;
 
-        /**
-         * REST requests executor service.
-         */
+        /** REST requests executor service. */
         private ThreadPoolExecutor restExecSvc;
 
-        /**
-         * Utility cache executor service.
-         */
+        /** Utility cache executor service. */
         private ThreadPoolExecutor utilityCacheExecSvc;
 
-        /**
-         * Affinity executor service.
-         */
+        /** Affinity executor service. */
         private ThreadPoolExecutor affExecSvc;
 
-        /**
-         * Indexing pool.
-         */
+        /** Indexing pool. */
         private ThreadPoolExecutor idxExecSvc;
 
-        /**
-         * Thread pool for create/rebuild indexes.
-         */
+        /** Thread pool for create/rebuild indexes. */
         private ThreadPoolExecutor buildIdxExecSvc;
 
-        /**
-         * Continuous query executor service.
-         */
+        /** Continuous query executor service. */
         private IgniteStripedThreadPoolExecutor callbackExecSvc;
 
-        /**
-         * Query executor service.
-         */
+        /** Query executor service. */
         private ThreadPoolExecutor qryExecSvc;
 
-        /**
-         * Query executor service.
-         */
+        /** Query executor service. */
         private ThreadPoolExecutor schemaExecSvc;
 
-        /**
-         * Rebalance executor service.
-         */
+        /** Rebalance executor service. */
         private ThreadPoolExecutor rebalanceExecSvc;
 
-        /**
-         * Rebalance striped executor service.
-         */
+        /** Rebalance striped executor service. */
         private IgniteStripedThreadPoolExecutor rebalanceStripedExecSvc;
 
-        /**
-         * Executor service.
-         */
+        /** Executor service. */
         private Map<String, ThreadPoolExecutor> customExecSvcs;
 
-        /**
-         * Grid state.
-         */
+        /** Grid state. */
         private volatile IgniteState state = STOPPED;
 
-        /**
-         * Shutdown hook.
-         */
+        /** Shutdown hook. */
         private Thread shutdownHook;
 
-        /**
-         * Grid log.
-         */
+        /** Grid log. */
         private IgniteLogger log;
 
-        /**
-         * Start guard.
-         */
+        /** Start guard. */
         private final AtomicBoolean startGuard = new AtomicBoolean();
 
-        /**
-         * Start latch.
-         */
+        /** Start latch. */
         private final CountDownLatch startLatch = new CountDownLatch(1);
 
-        /**
-         * Raised if node is waiting graceful shutdown. Set to false to end wait.
-         */
+        /** Raised if node is waiting graceful shutdown. Set to false to end wait. */
         private volatile boolean delayedShutdown = false;
 
         /**
-         * Thread that starts this named instance. This field can be non-volatile since it makes sense only for thread
-         * where it was originally initialized.
+         * Thread that starts this named instance. This field can be non-volatile since
+         * it makes sense only for thread where it was originally initialized.
          */
         @SuppressWarnings("FieldAccessedSynchronizedAndUnsynchronized")
         private Thread starterThread;
 
-        /**
-         *
-         */
+        /** */
         private boolean starterThreadInterrupted;
 
         /**
@@ -1932,8 +1874,8 @@ public class IgnitionEx {
                 },
                 IgniteSystemProperties.getLong(IGNITE_SYSTEM_WORKER_BLOCKED_TIMEOUT,
                     cfg.getSystemWorkerBlockedTimeout() != null
-                        ? cfg.getSystemWorkerBlockedTimeout()
-                        : cfg.getFailureDetectionTimeout()),
+                    ? cfg.getSystemWorkerBlockedTimeout()
+                    : cfg.getFailureDetectionTimeout()),
                 log);
 
             stripedExecSvc = new StripedExecutor(
@@ -2588,8 +2530,8 @@ public class IgnitionEx {
         }
 
         /**
-         * @param cfgLog  Configured logger.
-         * @param nodeId  Local node ID.
+         * @param cfgLog Configured logger.
+         * @param nodeId Local node ID.
          * @param workDir Work directory.
          * @return Initialized logger.
          * @throws IgniteCheckedException If failed.

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -110,6 +110,7 @@ import org.apache.ignite.lang.IgniteBiInClosure;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteInClosure;
 import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.ignite.logger.java.JavaLogger;
 import org.apache.ignite.marshaller.Marshaller;
 import org.apache.ignite.marshaller.MarshallerUtils;
@@ -1570,99 +1571,157 @@ public class IgnitionEx {
      * Grid data container.
      */
     private static final class IgniteNamedInstance {
-        /** Map of registered MBeans. */
+        /**
+         * Map of registered MBeans.
+         */
         private static final Map<MBeanServer, GridMBeanServerData> mbeans =
             new HashMap<>();
 
-        /** */
+        /**
+         *
+         */
         private static final String[] EMPTY_STR_ARR = new String[0];
 
-        /** Grid name. */
+        /**
+         * Grid name.
+         */
         private final String name;
 
-        /** Grid instance. */
+        /**
+         * Grid instance.
+         */
         private volatile IgniteKernal grid;
 
-        /** Executor service. */
+        /**
+         * Executor service.
+         */
         private ThreadPoolExecutor execSvc;
 
-        /** Executor service for services. */
+        /**
+         * Executor service for services.
+         */
         private ThreadPoolExecutor svcExecSvc;
 
-        /** System executor service. */
+        /**
+         * System executor service.
+         */
         private ThreadPoolExecutor sysExecSvc;
 
-        /** */
+        /**
+         *
+         */
         private StripedExecutor stripedExecSvc;
 
-        /** Management executor service. */
+        /**
+         * Management executor service.
+         */
         private ThreadPoolExecutor mgmtExecSvc;
 
-        /** P2P executor service. */
+        /**
+         * P2P executor service.
+         */
         private ThreadPoolExecutor p2pExecSvc;
 
-        /** Data streamer executor service. */
+        /**
+         * Data streamer executor service.
+         */
         private StripedExecutor dataStreamerExecSvc;
 
-        /** REST requests executor service. */
+        /**
+         * REST requests executor service.
+         */
         private ThreadPoolExecutor restExecSvc;
 
-        /** Utility cache executor service. */
+        /**
+         * Utility cache executor service.
+         */
         private ThreadPoolExecutor utilityCacheExecSvc;
 
-        /** Affinity executor service. */
+        /**
+         * Affinity executor service.
+         */
         private ThreadPoolExecutor affExecSvc;
 
-        /** Indexing pool. */
+        /**
+         * Indexing pool.
+         */
         private ThreadPoolExecutor idxExecSvc;
 
-        /** Thread pool for create/rebuild indexes. */
+        /**
+         * Thread pool for create/rebuild indexes.
+         */
         private ThreadPoolExecutor buildIdxExecSvc;
 
-        /** Continuous query executor service. */
+        /**
+         * Continuous query executor service.
+         */
         private IgniteStripedThreadPoolExecutor callbackExecSvc;
 
-        /** Query executor service. */
+        /**
+         * Query executor service.
+         */
         private ThreadPoolExecutor qryExecSvc;
 
-        /** Query executor service. */
+        /**
+         * Query executor service.
+         */
         private ThreadPoolExecutor schemaExecSvc;
 
-        /** Rebalance executor service. */
+        /**
+         * Rebalance executor service.
+         */
         private ThreadPoolExecutor rebalanceExecSvc;
 
-        /** Rebalance striped executor service. */
+        /**
+         * Rebalance striped executor service.
+         */
         private IgniteStripedThreadPoolExecutor rebalanceStripedExecSvc;
 
-        /** Executor service. */
+        /**
+         * Executor service.
+         */
         private Map<String, ThreadPoolExecutor> customExecSvcs;
 
-        /** Grid state. */
+        /**
+         * Grid state.
+         */
         private volatile IgniteState state = STOPPED;
 
-        /** Shutdown hook. */
+        /**
+         * Shutdown hook.
+         */
         private Thread shutdownHook;
 
-        /** Grid log. */
+        /**
+         * Grid log.
+         */
         private IgniteLogger log;
 
-        /** Start guard. */
+        /**
+         * Start guard.
+         */
         private final AtomicBoolean startGuard = new AtomicBoolean();
 
-        /** Start latch. */
+        /**
+         * Start latch.
+         */
         private final CountDownLatch startLatch = new CountDownLatch(1);
 
-        /** Raised if node is waiting graceful shutdown. Set to false to end wait. */
+        /**
+         * Raised if node is waiting graceful shutdown. Set to false to end wait.
+         */
         private volatile boolean delayedShutdown = false;
 
         /**
-         * Thread that starts this named instance. This field can be non-volatile since
-         * it makes sense only for thread where it was originally initialized.
+         * Thread that starts this named instance. This field can be non-volatile since it makes sense only for thread
+         * where it was originally initialized.
          */
         @SuppressWarnings("FieldAccessedSynchronizedAndUnsynchronized")
         private Thread starterThread;
 
-        /** */
+        /**
+         *
+         */
         private boolean starterThreadInterrupted;
 
         /**
@@ -1873,8 +1932,8 @@ public class IgnitionEx {
                 },
                 IgniteSystemProperties.getLong(IGNITE_SYSTEM_WORKER_BLOCKED_TIMEOUT,
                     cfg.getSystemWorkerBlockedTimeout() != null
-                    ? cfg.getSystemWorkerBlockedTimeout()
-                    : cfg.getFailureDetectionTimeout()),
+                        ? cfg.getSystemWorkerBlockedTimeout()
+                        : cfg.getFailureDetectionTimeout()),
                 log);
 
             stripedExecSvc = new StripedExecutor(
@@ -2529,14 +2588,27 @@ public class IgnitionEx {
         }
 
         /**
+         * @param cfgLog  Configured logger.
+         * @param nodeId  Local node ID.
+         * @param workDir Work directory.
+         * @return Initialized logger.
+         * @throws IgniteCheckedException If failed.
+         */
+        private IgniteLogger initLogger(@Nullable IgniteLogger cfgLog, UUID nodeId, String workDir)
+            throws IgniteCheckedException {
+            return initLogger(cfgLog, nodeId, null, workDir);
+        }
+
+        /**
          * @param cfgLog Configured logger.
          * @param nodeId Local node ID.
+         * @param postfix Log file postfix.
          * @param workDir Work directory.
          * @return Initialized logger.
          * @throws IgniteCheckedException If failed.
          */
         @SuppressWarnings("ErrorNotRethrown")
-        private IgniteLogger initLogger(@Nullable IgniteLogger cfgLog, UUID nodeId, String workDir)
+        public IgniteLogger initLogger(@Nullable IgniteLogger cfgLog, UUID nodeId, String postfix, String workDir)
             throws IgniteCheckedException {
             try {
                 Exception log4jInitErr = null;
@@ -2600,8 +2672,12 @@ public class IgnitionEx {
                     ((JavaLogger)cfgLog).setWorkDirectory(workDir);
 
                 // Set node IDs for all file appenders.
-                if (cfgLog instanceof LoggerNodeIdAware)
-                    ((LoggerNodeIdAware)cfgLog).setNodeId(nodeId);
+                if (cfgLog instanceof LoggerNodeIdAware) {
+                    if (nodeId == null && cfgLog instanceof LoggerPostfixAware)
+                        ((LoggerPostfixAware)cfgLog).setPostfix(postfix);
+                    else
+                        ((LoggerNodeIdAware)cfgLog).setNodeId(nodeId);
+                }
 
                 if (log4jInitErr != null)
                     U.warn(cfgLog, "Failed to initialize Log4JLogger (falling back to standard java logging): "

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -8833,7 +8833,7 @@ public abstract class IgniteUtils {
      * @return File name with node ID.
      */
     @SuppressWarnings("IfMayBeConditional")
-    public static String nodeIdLogFileName(String postfix, String fileName) {
+    public static String logFileName(String postfix, String fileName) {
         assert postfix != null;
         assert fileName != null;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -8826,7 +8826,7 @@ public abstract class IgniteUtils {
     }
 
     /**
-     * Attaches node ID to log file name.
+     * Attaches prefix to log file name.
      *
      * @param postfix Postfix.
      * @param fileName File name.

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -8826,11 +8826,11 @@ public abstract class IgniteUtils {
     }
 
     /**
-     * Attaches prefix to log file name.
+     * Attaches postfix to log file name.
      *
      * @param postfix Postfix.
      * @param fileName File name.
-     * @return File name with prefix.
+     * @return File name with postfix.
      */
     @SuppressWarnings("IfMayBeConditional")
     public static String logFileName(String postfix, String fileName) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -8828,13 +8828,13 @@ public abstract class IgniteUtils {
     /**
      * Attaches node ID to log file name.
      *
-     * @param nodeId Node ID.
+     * @param postfix Postfix.
      * @param fileName File name.
      * @return File name with node ID.
      */
     @SuppressWarnings("IfMayBeConditional")
-    public static String nodeIdLogFileName(UUID nodeId, String fileName) {
-        assert nodeId != null;
+    public static String nodeIdLogFileName(String postfix, String fileName) {
+        assert postfix != null;
         assert fileName != null;
 
         fileName = GridFilenameUtils.separatorsToSystem(fileName);
@@ -8842,9 +8842,9 @@ public abstract class IgniteUtils {
         int dot = fileName.lastIndexOf('.');
 
         if (dot < 0 || dot == fileName.length() - 1)
-            return fileName + '-' + U.id8(nodeId);
+            return fileName + '-' + postfix;
         else
-            return fileName.substring(0, dot) + '-' + U.id8(nodeId) + fileName.substring(dot);
+            return fileName.substring(0, dot) + '-' + postfix + fileName.substring(dot);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -8830,7 +8830,7 @@ public abstract class IgniteUtils {
      *
      * @param postfix Postfix.
      * @param fileName File name.
-     * @return File name with node ID.
+     * @return File name with prefix.
      */
     @SuppressWarnings("IfMayBeConditional")
     public static String logFileName(String postfix, String fileName) {

--- a/modules/core/src/main/java/org/apache/ignite/logger/LoggerPostfixAware.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/LoggerPostfixAware.java
@@ -17,9 +17,6 @@
 
 package org.apache.ignite.logger;
 
-import java.util.UUID;
-import org.apache.ignite.internal.util.typedef.internal.U;
-
 /**
  * Interface for Ignite file appenders to attach postfix to log file names.
  */
@@ -30,19 +27,4 @@ public interface LoggerPostfixAware extends LoggerNodeIdAware {
      * @param postfix Postfix.
      */
     public void setPostfix(String postfix);
-
-    /**
-     * @return postfix.
-     */
-    public String getPostfix();
-
-    /** {@inheritDoc} */
-    @Override public default void setNodeId(UUID nodeId) {
-        setPostfix(U.id8(nodeId));
-    }
-
-    /** {@inheritDoc} */
-    @Override public default UUID getNodeId() {
-        return UUID.fromString(getPostfix());
-    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/logger/LoggerPostfixAware.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/LoggerPostfixAware.java
@@ -20,23 +20,28 @@ package org.apache.ignite.logger;
 import java.util.UUID;
 
 /**
- * Interface for Ignite file appenders to attach node ID to log file names.
- *
- * @deprecated Use {@link LoggerPostfixAware} instead.
+ * Interface for Ignite file appenders to attach postfix to log file names.
  */
-@Deprecated
-public interface LoggerNodeIdAware {
+public interface LoggerPostfixAware extends LoggerNodeIdAware {
     /**
-     * Sets node ID.
+     * Sets postfix.
      *
-     * @param nodeId Node ID.
+     * @param postfix Postfix.
      */
-    public void setNodeId(UUID nodeId);
+    public void setPostfix(String postfix);
 
     /**
-     * Gets node ID.
-     *
-     * @return Node ID.
+     * @return postfix.
      */
-    public UUID getNodeId();
+    public String getPostfix();
+
+    /** {@inheritDoc} */
+    @Override public default void setNodeId(UUID nodeId) {
+        setPostfix(nodeId.toString());
+    }
+
+    /** {@inheritDoc} */
+    @Override public default UUID getNodeId() {
+        return UUID.fromString(getPostfix());
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/logger/LoggerPostfixAware.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/LoggerPostfixAware.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.logger;
 
 import java.util.UUID;
+import org.apache.ignite.internal.util.typedef.internal.U;
 
 /**
  * Interface for Ignite file appenders to attach postfix to log file names.
@@ -37,7 +38,7 @@ public interface LoggerPostfixAware extends LoggerNodeIdAware {
 
     /** {@inheritDoc} */
     @Override public default void setNodeId(UUID nodeId) {
-        setPostfix(nodeId.toString());
+        setPostfix(U.id8(nodeId));
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
@@ -126,6 +126,10 @@ public class JavaLogger implements IgniteLogger, LoggerPostfixAware {
 
     /** Node ID. */
     @GridToStringExclude
+    private volatile UUID nodeId;
+
+    /** Postfix. */
+    @GridToStringExclude
     private volatile String postfix;
 
     /**
@@ -366,13 +370,25 @@ public class JavaLogger implements IgniteLogger, LoggerPostfixAware {
 
     /** {@inheritDoc} */
     @Override public void setNodeId(UUID nodeId) {
-        setPostfix(U.id8(nodeId));
+        A.notNull(nodeId, "nodeId");
+
+        postfix(nodeId, U.id8(nodeId));
     }
 
     /** {@inheritDoc} */
     @Override public void setPostfix(String postfix) {
         A.notNull(postfix, "postfix");
 
+        postfix(null, postfix);
+    }
+
+    /** {@inheritDoc} */
+    @Override public String getPostfix() {
+        return postfix;
+    }
+
+    /** */
+    private void postfix(UUID nodeId, String postfix) {
         if (this.postfix != null)
             return;
 
@@ -382,6 +398,7 @@ public class JavaLogger implements IgniteLogger, LoggerPostfixAware {
                 return;
 
             this.postfix = postfix;
+            this.nodeId = nodeId;
         }
 
         JavaLoggerFileHandler fileHnd = findHandler(impl, JavaLoggerFileHandler.class);
@@ -398,8 +415,8 @@ public class JavaLogger implements IgniteLogger, LoggerPostfixAware {
     }
 
     /** {@inheritDoc} */
-    @Override public String getPostfix() {
-        return postfix;
+    @Override public UUID getNodeId() {
+        return nodeId;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
@@ -382,11 +382,6 @@ public class JavaLogger implements IgniteLogger, LoggerPostfixAware {
         postfix(null, postfix);
     }
 
-    /** {@inheritDoc} */
-    @Override public String getPostfix() {
-        return postfix;
-    }
-
     /** */
     private void postfix(UUID nodeId, String postfix) {
         if (this.postfix != null)

--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLoggerFileHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLoggerFileHandler.java
@@ -80,6 +80,15 @@ public final class JavaLoggerFileHandler extends StreamHandler {
      * @param nodeId Node id.
      */
     public void nodeId(UUID nodeId, String workDir) throws IgniteCheckedException, IOException {
+        postfix(U.id8(nodeId), workDir);
+    }
+
+    /**
+     * Sets Postfix and instantiates {@link FileHandler} delegate.
+     *
+     * @param postfix Postfix.
+     */
+    public void postfix(String postfix, String workDir) throws IgniteCheckedException, IOException {
         if (delegate != null)
             return;
 
@@ -90,7 +99,7 @@ public final class JavaLoggerFileHandler extends StreamHandler {
         if (ptrn == null)
             ptrn = "ignite-%{id8}.%g.log";
 
-        ptrn = new File(logDirectory(workDir), ptrn.replace("%{id8}", U.id8(nodeId))).getAbsolutePath();
+        ptrn = new File(logDirectory(workDir), ptrn.replace("%{id8}", postfix)).getAbsolutePath();
 
         int limit = getIntProperty(clsName + ".limit", 0);
 

--- a/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
@@ -20,7 +20,7 @@ package org.apache.ignite.logger.java;
 import java.util.UUID;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.util.typedef.internal.U;
-import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.ignite.testframework.junits.common.GridCommonTest;
 import org.junit.Test;
 
@@ -43,7 +43,7 @@ public class JavaLoggerTest {
         log = new JavaLogger();
 
         ((JavaLogger)log).setWorkDirectory(U.defaultWorkDirectory());
-        ((LoggerNodeIdAware)log).setNodeId(UUID.fromString("00000000-1111-2222-3333-444444444444"));
+        ((LoggerPostfixAware)log).setNodeId(UUID.fromString("00000000-1111-2222-3333-444444444444"));
 
         System.out.println(log.toString());
 
@@ -67,5 +67,23 @@ public class JavaLoggerTest {
 
         // Ensure we don't get pattern, only actual file name is allowed here.
         assert !log.fileName().contains("%");
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testLogInitializeWithPrefix() throws Exception {
+        log = new JavaLogger();
+
+        ((JavaLogger)log).setWorkDirectory(U.defaultWorkDirectory());
+        ((LoggerPostfixAware)log).setPostfix("myapp");
+
+        assert log.getLogger(JavaLoggerTest.class.getName()) instanceof JavaLogger;
+
+        assert log.fileName() != null;
+
+        // Ensure we don't get pattern, only actual file name is allowed here.
+        assert log.fileName().contains("myapp");
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
@@ -24,6 +24,7 @@ import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.ignite.testframework.junits.common.GridCommonTest;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -43,7 +44,10 @@ public class JavaLoggerTest {
         log = new JavaLogger();
 
         ((JavaLogger)log).setWorkDirectory(U.defaultWorkDirectory());
-        ((LoggerPostfixAware)log).setNodeId(UUID.fromString("00000000-1111-2222-3333-444444444444"));
+        UUID id = UUID.fromString("00000000-1111-2222-3333-444444444444");
+
+        ((LoggerPostfixAware)log).setNodeId(id);
+        assertEquals(id, ((LoggerPostfixAware)log).getNodeId());
 
         System.out.println(log.toString());
 
@@ -67,23 +71,5 @@ public class JavaLoggerTest {
 
         // Ensure we don't get pattern, only actual file name is allowed here.
         assert !log.fileName().contains("%");
-    }
-
-    /**
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testLogInitializeWithPrefix() throws Exception {
-        log = new JavaLogger();
-
-        ((JavaLogger)log).setWorkDirectory(U.defaultWorkDirectory());
-        ((LoggerPostfixAware)log).setPostfix("myapp");
-
-        assert log.getLogger(JavaLoggerTest.class.getName()) instanceof JavaLogger;
-
-        assert log.fileName() != null;
-
-        // Ensure we don't get pattern, only actual file name is allowed here.
-        assert log.fileName().contains("myapp");
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridLog4jRollingFileAppender.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridLog4jRollingFileAppender.java
@@ -19,6 +19,7 @@ package org.apache.ignite.testframework.junits.logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.UUID;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -78,6 +79,11 @@ public class GridLog4jRollingFileAppender extends RollingFileAppender implements
     }
 
     /** {@inheritDoc} */
+    @Override public void setNodeId(UUID nodeId) {
+        setPostfix(U.id8(nodeId));
+    }
+
+    /** {@inheritDoc} */
     @SuppressWarnings("NonPrivateFieldAccessedInSynchronizedContext")
     @Override public synchronized void setPostfix(String postfix) {
         A.notNull(postfix, "postfix");
@@ -102,8 +108,8 @@ public class GridLog4jRollingFileAppender extends RollingFileAppender implements
     }
 
     /** {@inheritDoc} */
-    @Override public String getPostfix() {
-        return postfix;
+    @Override public synchronized UUID getNodeId() {
+        throw new UnsupportedOperationException("getNodeId");
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridLog4jRollingFileAppender.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridLog4jRollingFileAppender.java
@@ -19,20 +19,19 @@ package org.apache.ignite.testframework.junits.logger;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.UUID;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.U;
-import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.log4j.Layout;
 import org.apache.log4j.RollingFileAppender;
 
 /**
  * Log4J {@link org.apache.log4j.RollingFileAppender} with added support for grid node IDs.
  */
-public class GridLog4jRollingFileAppender extends RollingFileAppender implements LoggerNodeIdAware {
-    /** Node ID. */
-    private UUID nodeId;
+public class GridLog4jRollingFileAppender extends RollingFileAppender implements LoggerPostfixAware {
+    /** Postfix. */
+    private String postfix;
 
     /** Basic log file name. */
     private String baseFileName;
@@ -80,16 +79,16 @@ public class GridLog4jRollingFileAppender extends RollingFileAppender implements
 
     /** {@inheritDoc} */
     @SuppressWarnings("NonPrivateFieldAccessedInSynchronizedContext")
-    @Override public synchronized void setNodeId(UUID nodeId) {
-        A.notNull(nodeId, "nodeId");
+    @Override public synchronized void setPostfix(String postfix) {
+        A.notNull(postfix, "postfix");
 
-        this.nodeId = nodeId;
+        this.postfix = postfix;
 
         if (fileName != null) { // fileName could be null if IGNITE_HOME is not defined.
             if (baseFileName == null)
                 baseFileName = fileName;
 
-            fileName = U.nodeIdLogFileName(nodeId, baseFileName);
+            fileName = U.nodeIdLogFileName(postfix, baseFileName);
         }
         else {
             String tmpDir = IgniteSystemProperties.getString("java.io.tmpdir");
@@ -97,20 +96,20 @@ public class GridLog4jRollingFileAppender extends RollingFileAppender implements
             if (tmpDir != null) {
                 baseFileName = new File(tmpDir, "ignite.log").getAbsolutePath();
 
-                fileName = U.nodeIdLogFileName(nodeId, baseFileName);
+                fileName = U.nodeIdLogFileName(postfix, baseFileName);
             }
         }
     }
 
     /** {@inheritDoc} */
-    @Override public synchronized UUID getNodeId() {
-        return nodeId;
+    @Override public String getPostfix() {
+        return postfix;
     }
 
     /** {@inheritDoc} */
     @Override public synchronized void setFile(String fileName, boolean fileAppend, boolean bufIO, int bufSize)
         throws IOException {
-        if (nodeId != null)
+        if (postfix != null)
             super.setFile(fileName, fileAppend, bufIO, bufSize);
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridLog4jRollingFileAppender.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridLog4jRollingFileAppender.java
@@ -94,7 +94,7 @@ public class GridLog4jRollingFileAppender extends RollingFileAppender implements
             if (baseFileName == null)
                 baseFileName = fileName;
 
-            fileName = U.nodeIdLogFileName(postfix, baseFileName);
+            fileName = U.logFileName(postfix, baseFileName);
         }
         else {
             String tmpDir = IgniteSystemProperties.getString("java.io.tmpdir");
@@ -102,7 +102,7 @@ public class GridLog4jRollingFileAppender extends RollingFileAppender implements
             if (tmpDir != null) {
                 baseFileName = new File(tmpDir, "ignite.log").getAbsolutePath();
 
-                fileName = U.nodeIdLogFileName(postfix, baseFileName);
+                fileName = U.logFileName(postfix, baseFileName);
             }
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.util.GridConcurrentHashSet;
@@ -405,6 +406,11 @@ public class GridTestLog4jLogger implements IgniteLogger, LoggerPostfixAware {
     }
 
     /** {@inheritDoc} */
+    @Override public void setNodeId(UUID nodeId) {
+        setPostfix(U.id8(nodeId));
+    }
+
+    /** {@inheritDoc} */
     @Override public void setPostfix(String postfix) {
         A.notNull(postfix, "postfix");
 
@@ -420,8 +426,8 @@ public class GridTestLog4jLogger implements IgniteLogger, LoggerPostfixAware {
     }
 
     /** {@inheritDoc} */
-    @Override public String getPostfix() {
-        return postfix;
+    @Override public UUID getNodeId() {
+        throw new UnsupportedOperationException("getNodeId");
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.util.GridConcurrentHashSet;
@@ -33,7 +32,7 @@ import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteClosure;
-import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Category;
 import org.apache.log4j.ConsoleAppender;
@@ -77,7 +76,7 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
  * logger in your task/job code. See {@link org.apache.ignite.resources.LoggerResource} annotation about logger
  * injection.
  */
-public class GridTestLog4jLogger implements IgniteLogger, LoggerNodeIdAware {
+public class GridTestLog4jLogger implements IgniteLogger, LoggerPostfixAware {
     /** Appenders. */
     private static Collection<FileAppender> fileAppenders = new GridConcurrentHashSet<>();
 
@@ -102,9 +101,9 @@ public class GridTestLog4jLogger implements IgniteLogger, LoggerNodeIdAware {
     /** Quiet flag. */
     private final boolean quiet;
 
-    /** Node ID. */
+    /** Postfix. */
     @GridToStringExclude
-    private UUID nodeId;
+    private String postfix;
 
     /**
      * Creates new logger and automatically detects if root logger already
@@ -406,14 +405,14 @@ public class GridTestLog4jLogger implements IgniteLogger, LoggerNodeIdAware {
     }
 
     /** {@inheritDoc} */
-    @Override public void setNodeId(UUID nodeId) {
-        A.notNull(nodeId, "nodeId");
+    @Override public void setPostfix(String postfix) {
+        A.notNull(postfix, "postfix");
 
-        this.nodeId = nodeId;
+        this.postfix = postfix;
 
         for (FileAppender a : fileAppenders) {
-            if (a instanceof LoggerNodeIdAware) {
-                ((LoggerNodeIdAware)a).setNodeId(nodeId);
+            if (a instanceof LoggerPostfixAware) {
+                ((LoggerPostfixAware)a).setPostfix(postfix);
 
                 a.activateOptions();
             }
@@ -421,8 +420,8 @@ public class GridTestLog4jLogger implements IgniteLogger, LoggerNodeIdAware {
     }
 
     /** {@inheritDoc} */
-    @Override public UUID getNodeId() {
-        return nodeId;
+    @Override public String getPostfix() {
+        return postfix;
     }
 
     /**

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
@@ -108,10 +108,6 @@ public class Log4JLogger implements IgniteLogger, LoggerPostfixAware, Log4jFileA
     @GridToStringExclude
     private UUID nodeId;
 
-    /** Postfix. */
-    @GridToStringExclude
-    private String postfix;
-
     /**
      * Creates new logger and automatically detects if root logger already
      * has appenders configured. If it does not, the root logger will be
@@ -513,7 +509,6 @@ public class Log4JLogger implements IgniteLogger, LoggerPostfixAware, Log4jFileA
     /** */
     private void postfix(UUID nodeId, String postfix) {
         this.nodeId = nodeId;
-        this.postfix = postfix;
 
         updateFilePath(new Log4jNodeIdFilePath(postfix));
     }

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
@@ -530,11 +530,6 @@ public class Log4JLogger implements IgniteLogger, LoggerPostfixAware, Log4jFileA
         postfix(nodeId, postfix);
     }
 
-    /** {@inheritDoc} */
-    @Override public String getPostfix() {
-        return postfix;
-    }
-
     /**
      * Gets files for all registered file appenders.
      *

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
@@ -104,6 +104,10 @@ public class Log4JLogger implements IgniteLogger, LoggerPostfixAware, Log4jFileA
     /** Quiet flag. */
     private final boolean quiet;
 
+    /** Node ID. */
+    @GridToStringExclude
+    private UUID nodeId;
+
     /** Postfix. */
     @GridToStringExclude
     private String postfix;
@@ -501,16 +505,29 @@ public class Log4JLogger implements IgniteLogger, LoggerPostfixAware, Log4jFileA
 
     /** {@inheritDoc} */
     @Override public void setNodeId(UUID nodeId) {
-        setPostfix(U.id8(nodeId));
+        A.notNull(nodeId, "nodeId");
+
+        postfix(nodeId, U.id8(nodeId));
+    }
+
+    /** */
+    private void postfix(UUID nodeId, String postfix) {
+        this.nodeId = nodeId;
+        this.postfix = postfix;
+
+        updateFilePath(new Log4jNodeIdFilePath(postfix));
+    }
+
+    /** {@inheritDoc} */
+    @Override public UUID getNodeId() {
+        return nodeId;
     }
 
     /** {@inheritDoc} */
     @Override public void setPostfix(String postfix) {
         A.notNull(postfix, "postfix");
 
-        this.postfix = postfix;
-
-        updateFilePath(new Log4jNodeIdFilePath(postfix));
+        postfix(nodeId, postfix);
     }
 
     /** {@inheritDoc} */

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4JLogger.java
@@ -33,7 +33,7 @@ import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteClosure;
-import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Category;
 import org.apache.log4j.ConsoleAppender;
@@ -79,7 +79,7 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
  * logger in your task/job code. See {@link org.apache.ignite.resources.LoggerResource} annotation about logger
  * injection.
  */
-public class Log4JLogger implements IgniteLogger, LoggerNodeIdAware, Log4jFileAware {
+public class Log4JLogger implements IgniteLogger, LoggerPostfixAware, Log4jFileAware {
     /** Appenders. */
     private static Collection<FileAppender> fileAppenders = new GridConcurrentHashSet<>();
 
@@ -104,9 +104,9 @@ public class Log4JLogger implements IgniteLogger, LoggerNodeIdAware, Log4jFileAw
     /** Quiet flag. */
     private final boolean quiet;
 
-    /** Node ID. */
+    /** Postfix. */
     @GridToStringExclude
-    private UUID nodeId;
+    private String postfix;
 
     /**
      * Creates new logger and automatically detects if root logger already
@@ -501,16 +501,21 @@ public class Log4JLogger implements IgniteLogger, LoggerNodeIdAware, Log4jFileAw
 
     /** {@inheritDoc} */
     @Override public void setNodeId(UUID nodeId) {
-        A.notNull(nodeId, "nodeId");
-
-        this.nodeId = nodeId;
-
-        updateFilePath(new Log4jNodeIdFilePath(nodeId));
+        setPostfix(U.id8(nodeId));
     }
 
     /** {@inheritDoc} */
-    @Override public UUID getNodeId() {
-        return nodeId;
+    @Override public void setPostfix(String postfix) {
+        A.notNull(postfix, "postfix");
+
+        this.postfix = postfix;
+
+        updateFilePath(new Log4jNodeIdFilePath(postfix));
+    }
+
+    /** {@inheritDoc} */
+    @Override public String getPostfix() {
+        return postfix;
     }
 
     /**

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jNodeIdFilePath.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jNodeIdFilePath.java
@@ -32,29 +32,29 @@ class Log4jNodeIdFilePath implements IgniteClosure<String, String> {
     private static final long serialVersionUID = 0L;
 
     /** Node id. */
-    private final UUID nodeId;
+    private final String postfix;
 
     /**
      * Creates new instance.
      *
-     * @param id Node id.
+     * @param postfix Postfix.
      */
-    Log4jNodeIdFilePath(UUID id) {
-        nodeId = id;
+    Log4jNodeIdFilePath(String postfix) {
+        this.postfix = postfix;
     }
 
     /** {@inheritDoc} */
     @Override public String apply(String oldPath) {
         if (!F.isEmpty(U.IGNITE_LOG_DIR))
-            return U.nodeIdLogFileName(nodeId, new File(U.IGNITE_LOG_DIR, "ignite.log").getAbsolutePath());
+            return U.nodeIdLogFileName(postfix, new File(U.IGNITE_LOG_DIR, "ignite.log").getAbsolutePath());
 
         if (oldPath != null) // fileName could be null if IGNITE_HOME is not defined.
-            return U.nodeIdLogFileName(nodeId, oldPath);
+            return U.nodeIdLogFileName(postfix, oldPath);
 
         String tmpDir = IgniteSystemProperties.getString("java.io.tmpdir");
 
         if (tmpDir != null)
-            return U.nodeIdLogFileName(nodeId, new File(tmpDir, "ignite.log").getAbsolutePath());
+            return U.nodeIdLogFileName(postfix, new File(tmpDir, "ignite.log").getAbsolutePath());
 
         System.err.println("Failed to get tmp directory for log file.");
 

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jNodeIdFilePath.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jNodeIdFilePath.java
@@ -45,15 +45,15 @@ class Log4jNodeIdFilePath implements IgniteClosure<String, String> {
     /** {@inheritDoc} */
     @Override public String apply(String oldPath) {
         if (!F.isEmpty(U.IGNITE_LOG_DIR))
-            return U.nodeIdLogFileName(postfix, new File(U.IGNITE_LOG_DIR, "ignite.log").getAbsolutePath());
+            return U.logFileName(postfix, new File(U.IGNITE_LOG_DIR, "ignite.log").getAbsolutePath());
 
         if (oldPath != null) // fileName could be null if IGNITE_HOME is not defined.
-            return U.nodeIdLogFileName(postfix, oldPath);
+            return U.logFileName(postfix, oldPath);
 
         String tmpDir = IgniteSystemProperties.getString("java.io.tmpdir");
 
         if (tmpDir != null)
-            return U.nodeIdLogFileName(postfix, new File(tmpDir, "ignite.log").getAbsolutePath());
+            return U.logFileName(postfix, new File(tmpDir, "ignite.log").getAbsolutePath());
 
         System.err.println("Failed to get tmp directory for log file.");
 

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jNodeIdFilePath.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jNodeIdFilePath.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.logger.log4j;
 
 import java.io.File;
-import java.util.UUID;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.U;

--- a/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
+++ b/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
@@ -431,11 +431,6 @@ public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
         postfix(null, postfix);
     }
 
-    /** {@inheritDoc} */
-    @Override public String getPostfix() {
-        return postfix;
-    }
-
     /**
      * Gets {@link IgniteLogger} wrapper around log4j logger for the given
      * category. If category is {@code null}, then root logger is returned. If

--- a/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
+++ b/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
@@ -113,10 +113,6 @@ public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
     @GridToStringExclude
     private volatile UUID nodeId;
 
-    /** Postfix. */
-    @GridToStringExclude
-    private volatile String postfix;
-
     /**
      * Creates new logger with given implementation.
      *
@@ -396,7 +392,6 @@ public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
 
     private void postfix(UUID nodeId, String postfix) {
         this.nodeId = nodeId;
-        this.postfix = postfix;
 
         // Set postfix as system variable to be used at configuration.
         System.setProperty(NODE_ID, postfix);

--- a/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
+++ b/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
@@ -109,6 +109,10 @@ public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
     /** Quiet flag. */
     private final boolean quiet;
 
+    /** Node ID. */
+    @GridToStringExclude
+    private volatile UUID nodeId;
+
     /** Postfix. */
     @GridToStringExclude
     private volatile String postfix;
@@ -385,13 +389,13 @@ public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
 
     /** {@inheritDoc} */
     @Override public void setNodeId(UUID nodeId) {
-        setPostfix(U.id8(nodeId));
+        A.notNull(nodeId, "nodeId");
+
+        postfix(nodeId, U.id8(nodeId));
     }
 
-    /** {@inheritDoc} */
-    @Override public void setPostfix(String postfix) {
-        A.notNull(postfix, "nodeId");
-
+    private void postfix(UUID nodeId, String postfix) {
+        this.nodeId = nodeId;
         this.postfix = postfix;
 
         // Set postfix as system variable to be used at configuration.
@@ -413,6 +417,18 @@ public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
                 }
             });
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override public UUID getNodeId() {
+        return nodeId;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void setPostfix(String postfix) {
+        A.notNull(postfix, "nodeId");
+
+        postfix(null, postfix);
     }
 
     /** {@inheritDoc} */

--- a/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
+++ b/modules/log4j2/src/main/java/org/apache/ignite/logger/log4j2/Log4J2Logger.java
@@ -31,7 +31,7 @@ import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteClosure;
-import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
@@ -81,7 +81,7 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
  * logger in your task/job code. See {@link org.apache.ignite.resources.LoggerResource} annotation about logger
  * injection.
  */
-public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
+public class Log4J2Logger implements IgniteLogger, LoggerPostfixAware {
     /** */
     private static final String NODE_ID = "nodeId";
 
@@ -109,9 +109,9 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
     /** Quiet flag. */
     private final boolean quiet;
 
-    /** Node ID. */
+    /** Postfix. */
     @GridToStringExclude
-    private volatile UUID nodeId;
+    private volatile String postfix;
 
     /**
      * Creates new logger with given implementation.
@@ -385,12 +385,17 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
 
     /** {@inheritDoc} */
     @Override public void setNodeId(UUID nodeId) {
-        A.notNull(nodeId, "nodeId");
+        setPostfix(U.id8(nodeId));
+    }
 
-        this.nodeId = nodeId;
+    /** {@inheritDoc} */
+    @Override public void setPostfix(String postfix) {
+        A.notNull(postfix, "nodeId");
 
-        // Set nodeId as system variable to be used at configuration.
-        System.setProperty(NODE_ID, U.id8(nodeId));
+        this.postfix = postfix;
+
+        // Set postfix as system variable to be used at configuration.
+        System.setProperty(NODE_ID, postfix);
 
         if (inited) {
             final LoggerContext ctx = impl.getContext();
@@ -411,8 +416,8 @@ public class Log4J2Logger implements IgniteLogger, LoggerNodeIdAware {
     }
 
     /** {@inheritDoc} */
-    @Override public UUID getNodeId() {
-        return nodeId;
+    @Override public String getPostfix() {
+        return postfix;
     }
 
     /**

--- a/modules/log4j2/src/test/java/org/apache/ignite/logger/log4j2/Log4j2LoggerSelfTest.java
+++ b/modules/log4j2/src/test/java/org/apache/ignite/logger/log4j2/Log4j2LoggerSelfTest.java
@@ -70,7 +70,9 @@ public class Log4j2LoggerSelfTest {
         assertTrue(log.toString().contains("Log4J2Logger"));
         assertTrue(log.toString().contains(xml.getPath()));
 
-        ((LoggerPostfixAware)log).setNodeId(UUID.randomUUID());
+        UUID id = UUID.randomUUID();
+        ((LoggerPostfixAware)log).setNodeId(id);
+        assertEquals(id, ((LoggerPostfixAware)log).getNodeId());
 
         checkLog(log);
     }
@@ -93,7 +95,9 @@ public class Log4j2LoggerSelfTest {
         assertTrue(log.toString().contains("Log4J2Logger"));
         assertTrue(log.toString().contains(url.getPath()));
 
-        ((LoggerPostfixAware)log).setNodeId(UUID.randomUUID());
+        UUID id = UUID.randomUUID();
+        ((LoggerPostfixAware)log).setNodeId(id);
+        assertEquals(id, ((LoggerPostfixAware)log).getNodeId());
 
         checkLog(log);
     }
@@ -110,7 +114,9 @@ public class Log4j2LoggerSelfTest {
         assertTrue(log.toString().contains("Log4J2Logger"));
         assertTrue(log.toString().contains(LOG_PATH_TEST));
 
-        ((LoggerPostfixAware)log).setNodeId(UUID.randomUUID());
+        UUID id = UUID.randomUUID();
+        ((LoggerPostfixAware)log).setNodeId(id);
+        assertEquals(id, ((LoggerPostfixAware)log).getNodeId());
 
         checkLog(log);
     }

--- a/modules/log4j2/src/test/java/org/apache/ignite/logger/log4j2/Log4j2LoggerSelfTest.java
+++ b/modules/log4j2/src/test/java/org/apache/ignite/logger/log4j2/Log4j2LoggerSelfTest.java
@@ -26,7 +26,7 @@ import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.internal.U;
-import org.apache.ignite.logger.LoggerNodeIdAware;
+import org.apache.ignite.logger.LoggerPostfixAware;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
 import org.apache.ignite.testframework.GridTestUtils;
@@ -70,7 +70,7 @@ public class Log4j2LoggerSelfTest {
         assertTrue(log.toString().contains("Log4J2Logger"));
         assertTrue(log.toString().contains(xml.getPath()));
 
-        ((LoggerNodeIdAware)log).setNodeId(UUID.randomUUID());
+        ((LoggerPostfixAware)log).setNodeId(UUID.randomUUID());
 
         checkLog(log);
     }
@@ -93,7 +93,7 @@ public class Log4j2LoggerSelfTest {
         assertTrue(log.toString().contains("Log4J2Logger"));
         assertTrue(log.toString().contains(url.getPath()));
 
-        ((LoggerNodeIdAware)log).setNodeId(UUID.randomUUID());
+        ((LoggerPostfixAware)log).setNodeId(UUID.randomUUID());
 
         checkLog(log);
     }
@@ -110,7 +110,7 @@ public class Log4j2LoggerSelfTest {
         assertTrue(log.toString().contains("Log4J2Logger"));
         assertTrue(log.toString().contains(LOG_PATH_TEST));
 
-        ((LoggerNodeIdAware)log).setNodeId(UUID.randomUUID());
+        ((LoggerPostfixAware)log).setNodeId(UUID.randomUUID());
 
         checkLog(log);
     }
@@ -140,6 +140,10 @@ public class Log4j2LoggerSelfTest {
         new Log4J2Logger(LOG_PATH_TEST).setNodeId(id);
 
         assertEquals(U.id8(id), System.getProperty("nodeId"));
+
+        new Log4J2Logger(LOG_PATH_TEST).setPostfix("myapp");
+
+        assertEquals("myapp", System.getProperty("nodeId"));
     }
 
     /**


### PR DESCRIPTION
This PR adds an ability for Ignite-related application to specify string log file postfix instead of `UUID` nodeId.
It will allow those applications to store their own log files near ignite logs.

* LoggerPostfixAware interface introduced
* LoggerNodeIdAware interface deprecated

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
