### PR TITLE
IGNITE-14475: Fix C++ Query Example when run with multiple nodes

### DIFF
--- a/modules/platforms/cpp/examples/include/ignite/examples/person.h
+++ b/modules/platforms/cpp/examples/include/ignite/examples/person.h
@@ -71,7 +71,7 @@ namespace ignite
         // 2) collocation column info (orgId). This is required because of constraint : affinity key must be part of the
         // key.
         struct PersonKey {
-            PersonKey(int64_t _id, int64_t _orgId) : id(_id), orgIdAff(_id)
+            PersonKey(int64_t id, int64_t orgId) : id(id), orgIdAff(orgId)
             {
                 // No-op.
             }

--- a/modules/platforms/cpp/examples/query-example/src/query_example.cpp
+++ b/modules/platforms/cpp/examples/query-example/src/query_example.cpp
@@ -117,8 +117,8 @@ void DoSqlQueryWithJoin()
     // Execute query to get names of all employees.
     std::string sql(
         "select concat(firstName, ' ', lastName), org.name "
-        "from Person, \"Organization\".Organization as org "
-        "where Person.orgId = org._key");
+        "from Person inner join \"Organization\".Organization as org "
+        "on Person.orgId = org._key");
 
     QueryFieldsCursor cursor = cache.Query(SqlFieldsQuery(sql));
 


### PR DESCRIPTION
Fixed constructor for `PersonKey`. Error in it was resulting in wrong affinity for keys.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
