### PR TITLE
IGNITE-12920 Static hierarchy in jmx tree

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/GridManagerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/GridManagerAdapter.java
@@ -275,7 +275,7 @@ public abstract class GridManagerAdapter<T extends IgniteSpi> implements GridMan
             onBeforeSpiStart();
 
             try {
-                spi.spiStart(ctx.igniteInstanceName());
+                spi.spiStart(U.getInstanceNameFromContext(ctx));
             }
             catch (IgniteSpiException e) {
                 throw new IgniteCheckedException("Failed to start SPI: " + spi, e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/IgniteMBeansManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/IgniteMBeansManager.java
@@ -305,7 +305,7 @@ public class IgniteMBeansManager {
         try {
             ObjectName objName = U.registerMBean(
                 ctx.config().getMBeanServer(),
-                ctx.config().getIgniteInstanceName(),
+                U.getInstanceNameFromContext(ctx),
                 grp, name, impl, itf);
 
             if (log.isDebugEnabled())

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/JmxSystemViewExporterSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/systemview/JmxSystemViewExporterSpi.java
@@ -23,6 +23,7 @@ import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.systemview.view.SystemView;
@@ -58,7 +59,7 @@ public class JmxSystemViewExporterSpi extends AbstractSystemViewExporterSpi {
 
             ObjectName mbean = U.registerMBean(
                 ignite().configuration().getMBeanServer(),
-                igniteInstanceName,
+                U.getInstanceNameFromContext(((IgniteEx)ignite).context()),
                 VIEWS,
                 sysView.name(),
                 mlBean,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheDiagnosticManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheDiagnosticManager.java
@@ -91,7 +91,7 @@ public class CacheDiagnosticManager extends GridCacheSharedManagerAdapter {
         try {
             U.registerMBean(
                 cfg.getMBeanServer(),
-                cfg.getIgniteInstanceName(),
+                U.getInstanceNameFromContext(cctx.kernalContext()),
                 groupName,
                 mbeanName,
                 impl,
@@ -120,7 +120,7 @@ public class CacheDiagnosticManager extends GridCacheSharedManagerAdapter {
         try {
             cfg.getMBeanServer().unregisterMBean(
                 U.makeMBeanName(
-                    cfg.getIgniteInstanceName(),
+                    U.getInstanceNameFromContext(cctx.kernalContext()),
                     groupName,
                     name
                 ));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IgniteCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IgniteCacheDatabaseSharedManager.java
@@ -219,7 +219,7 @@ public class IgniteCacheDatabaseSharedManager extends GridCacheSharedManagerAdap
         try {
             U.registerMBean(
                 cfg.getMBeanServer(),
-                cfg.getIgniteInstanceName(),
+                U.getInstanceNameFromContext(cctx.kernalContext()),
                 groupName,
                 dataRegionName,
                 impl,
@@ -248,7 +248,7 @@ public class IgniteCacheDatabaseSharedManager extends GridCacheSharedManagerAdap
         try {
             cfg.getMBeanServer().unregisterMBean(
                 U.makeMBeanName(
-                    cfg.getIgniteInstanceName(),
+                    U.getInstanceNameFromContext(cctx.kernalContext()),
                     groupName,
                     name
                 ));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/ClusterProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/ClusterProcessor.java
@@ -616,7 +616,7 @@ public class ClusterProcessor extends GridProcessorAdapter implements Distribute
             try {
                 mBean = U.registerMBean(
                     ctx.config().getMBeanServer(),
-                    ctx.igniteInstanceName(),
+                    U.getInstanceNameFromContext(ctx),
                     M_BEAN_NAME,
                     mxBeanImpl.getClass().getSimpleName(),
                     mxBeanImpl,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
@@ -236,7 +236,7 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
         try {
             ObjectName objName = U.registerMBean(
                 ctx.config().getMBeanServer(),
-                ctx.config().getIgniteInstanceName(),
+                U.getInstanceNameFromContext(ctx),
                 "Clients", name, new ClientProcessorMXBeanImpl(), ClientProcessorMXBean.class);
 
             if (log.isDebugEnabled())
@@ -256,7 +256,7 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
         String name = getClass().getSimpleName();
 
         try {
-            ObjectName objName = U.makeMBeanName(ctx.config().getIgniteInstanceName(), "Clients", name);
+            ObjectName objName = U.makeMBeanName(U.getInstanceNameFromContext(ctx), "Clients", name);
 
             ctx.config().getMBeanServer().unregisterMBean(objName);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -329,7 +329,7 @@ public abstract class IgniteUtils {
     public static final Long DFLT_MAX_CHECKPOINTING_PAGE_BUFFER_SIZE = 2 * GB;
 
     /** @see IgniteSystemProperties#IGNITE_MBEAN_APPEND_CLASS_LOADER_ID */
-    public static final boolean DFLT_MBEAN_APPEND_CLASS_LOADER_ID = true;
+    public static final boolean DFLT_MBEAN_APPEND_CLASS_LOADER_ID = false;
 
     /** {@code True} if {@code unsafe} should be used for array copy. */
     private static final boolean UNSAFE_BYTE_ARR_CP = unsafeByteArrayCopyAvailable();
@@ -4760,6 +4760,27 @@ public abstract class IgniteUtils {
             catch (SQLException ignored) {
                 // No-op.
             }
+    }
+
+    /**
+     * Get String name of instance from GridKernakContext.
+     *
+     * @param ctx Ignte kernal context.
+     * @return value for instance name..
+     */
+    public static @Nullable String getInstanceNameFromContext(GridKernalContext ctx) {
+        String igniteInstanceName = null;
+        if (ctx != null) {
+            igniteInstanceName = ctx.igniteInstanceName();
+
+            if (igniteInstanceName == null && ctx.config() != null) {
+                if (ctx.config().getConsistentId() != null)
+                    igniteInstanceName = ctx.config().getConsistentId().toString();
+                else if (ctx.config().getNodeId() != null)
+                    igniteInstanceName = ctx.config().getNodeId().toString();
+            }
+        }
+        return igniteInstanceName;
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/util/mbeans/GridMBeanSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/util/mbeans/GridMBeanSelfTest.java
@@ -21,7 +21,13 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 import javax.management.StandardMBean;
+
+import static java.util.stream.Collectors.toSet;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.mxbean.IgniteStandardMXBean;
 import org.apache.ignite.mxbean.IgniteMXBean;
@@ -30,6 +36,8 @@ import org.apache.ignite.mxbean.MXBeanParametersDescriptions;
 import org.apache.ignite.mxbean.MXBeanParametersNames;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+
+import java.util.Set;
 
 /**
  * MBean test.
@@ -330,6 +338,53 @@ public class GridMBeanSelfTest extends GridCommonAbstractTest {
         @MXBeanParametersNames({"ignored", "someData"})
         @MXBeanParametersDescriptions({"MBeanOperationParameter1."})
         public String doSomethingBadAgain(boolean ignored, String someData);
+    }
+
+    /**
+     * Test MBean interface creation
+     *
+     * @throws Exception Thrown if test fails.
+     */
+    @Test
+    public void testMbeanCreation() throws Exception {
+        checkIfMbeanHaveInstanceName(null,null);
+        checkIfMbeanHaveInstanceName("testInstanceName",null);
+        checkIfMbeanHaveInstanceName(null,"testConsistanceId");
+        checkIfMbeanHaveInstanceName("testInstanceName","testConsistanceId");
+
+    }
+
+
+    private void checkIfMbeanHaveInstanceName(String instanceName, String consistanceId) throws Exception {
+        IgniteEx ignite = (IgniteEx) startGrid(instanceName, new IgniteConfiguration()
+            .setConsistentId(consistanceId)
+        );
+
+        MBeanServer srv = ignite.configuration().getMBeanServer();
+
+        Set<String> beans = srv.queryMBeans(new ObjectName("org.apache:*"), null)
+            .stream()
+            .map(ObjectInstance::getObjectName)
+            .map(ObjectName::toString)
+            .filter(o -> (!o.contains("igniteInstanceName=")))
+            .filter(o -> (!"org.apache:group=Kernal,name=Ignition".equals(o)))
+            .collect(toSet());
+
+        assertTrue("There are mbeans without instanceName for case when instanceName="
+                + instanceName + " and consistanceId="
+                + consistanceId + ":"
+                + String.join("\n", beans)
+            , beans.isEmpty());
+
+        stopGrid(instanceName, false);
+
+        Set<String> mbeans = srv.queryMBeans(new ObjectName("org.apache:*"), null)
+            .stream()
+            .map(ObjectInstance::getObjectName)
+            .map(ObjectName::toString)
+            .collect(toSet());
+
+        assertTrue("There are " + mbeans.size() + " beans after node stopped" + String.join("\n", mbeans), mbeans.isEmpty());
     }
 
     /**


### PR DESCRIPTION
JMX hierarchy became more static, IGNITE_MBEAN_APPEND_CLASS_LOADER_ID is false by default and igniteInstanceName will exist in any cases when igniteInstanceName is not specified as null or emtyString by default