### PR TITLE
IGNITE-14324 EVT_CLIENT_NODE_DISCONNECTED is not triggered in k8s

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryIpFinderFailureTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryIpFinderFailureTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryIpFinderFailureTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryIpFinderFailureTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.spi.discovery.tcp;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.util.typedef.X;
+import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.events.EventType.EVT_CLIENT_NODE_DISCONNECTED;
+import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
+
+/**
+ * Check different disconnections scenarios in respect to {@link TcpDiscoverySpi#joinTimeout} cfg
+ * alongside possible failures in IpResolver.
+ */
+public class TcpDiscoveryIpFinderFailureTest extends GridCommonAbstractTest {
+
+    /**  */
+    private TestDynamicIpFinder dynamicIpFinder;
+
+    /** Listening test logger. */
+    private ListeningTestLogger listeningLog;
+
+    /** */
+    @Before
+    public void initDynamicIpFinder() {
+        dynamicIpFinder = new TestDynamicIpFinder();
+        listeningLog = new ListeningTestLogger(log);
+    }
+
+    /** */
+    @After
+    public void tearDown() {
+        stopAllGrids();
+    }
+
+    /**
+     * Tests shared client node disconnection should use {@link TcpDiscoverySpi#netTimeout).
+     */
+    @Test
+    public void testClientNodeSharedIpFinderFailure() throws Exception {
+        dynamicIpFinder.setAddresses(Collections.singleton("127.0.0.1:47500"));
+
+        runClientNodeIpFinderFailureTest(TcpDiscoverySpi.DFLT_RECONNECT_DELAY);
+    }
+
+    /**
+     * Tests static client node disconnection should use {@link TcpDiscoverySpi#netTimeout).
+     */
+    @Test
+    public void testClientNodeStaticIpFinderFailure() throws Exception {
+        dynamicIpFinder.setAddresses(Collections.singleton("127.0.0.1:47500"));
+        dynamicIpFinder.setShared(false);
+        runClientNodeIpFinderFailureTest(TcpDiscoverySpi.DFLT_RECONNECT_DELAY);
+    }
+
+    /**
+     * Tests client node disconnection works with {@link TcpDiscoverySpi#getReconnectDelay()} ) set to zero.
+     */
+    @Test
+    public void testClientNodeIpFinderFailureWithZeroReconnectDelay() throws Exception {
+        dynamicIpFinder.setAddresses(Collections.singleton("127.0.0.1:47500"));
+
+        runClientNodeIpFinderFailureTest(0);
+    }
+
+    /** */
+    private void runClientNodeIpFinderFailureTest(long reconnectDelay) throws Exception {
+        List<LogListener> listeners = new ArrayList<>();
+
+        listeners.add(LogListener.matches(
+                "Failed to get registered addresses from IP " +
+                        "finder (retrying every " + reconnectDelay + "ms; change 'reconnectDelay' to configure " +
+                        "the frequency of retries) [maxTimeout=4000]").build());
+
+        listeners.add(LogListener.matches(
+                "Unable to get registered addresses from IP finder," +
+                        " timeout is reached (consider increasing 'joinTimeout' for join process or " +
+                        "'netTimeout' for reconnection) [joinTimeout=10000, netTimeout=4000]").build());
+
+        listeners.forEach(listeningLog::registerListener);
+
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server", false);
+
+        TcpDiscoverySpi discoverySpi = new TcpDiscoverySpi();
+        discoverySpi.setJoinTimeout(10000);
+        discoverySpi.setNetworkTimeout(4000);
+        discoverySpi.setReconnectDelay((int) reconnectDelay);
+        discoverySpi.setIpFinder(dynamicIpFinder);
+
+        IgniteConfiguration cfgClient = getConfigurationDynamicIpFinder("Client", true, discoverySpi);
+
+        IgniteEx crd = startGrid(cfgSrv);
+        IgniteEx client = startGrid(cfgClient);
+
+        waitForTopology(2);
+
+        dynamicIpFinder.breakService();
+
+        Ignition.stop(crd.name(), true);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        client.events().localListen(event -> {
+            listeners.forEach(lsnr -> assertTrue(lsnr.check()));
+
+            latch.countDown();
+
+            return true;
+        }, EVT_CLIENT_NODE_DISCONNECTED);
+
+        assertTrue("Failed to wait for client node disconnected.", latch.await(6, SECONDS));
+    }
+
+    /**
+     * Tests server node disconnection with dynamic IP finder.
+     * Server node should catch NODE_LEFT event, no calls to IP resolver.
+     */
+    @Test
+    public void testServerNodeDynamicIpFinderFailureInTheMiddle() throws Exception {
+        dynamicIpFinder.setAddresses(Collections.singleton("127.0.0.1:47500"));
+
+        runServerNodeDisconnectionITest();
+    }
+
+    /**
+     * Tests server node disconnection with static IP finder.
+     * Server node should catch NODE_LEFT event, no calls to IP resolver.
+     */
+    @Test
+    public void testServerNodeStaticIpFinderFailureInTheMiddle() throws Exception {
+        dynamicIpFinder.setAddresses(Collections.singleton("127.0.0.1:47500"));
+        dynamicIpFinder.setShared(false);
+
+        runServerNodeDisconnectionITest();
+    }
+
+    /** */
+    private void runServerNodeDisconnectionITest() throws Exception {
+        dynamicIpFinder.setAddresses(Collections.singleton("127.0.0.1:47500"));
+
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server1", false);
+        IgniteConfiguration cfgSrv2 = getConfigurationDynamicIpFinder("Server2", false);
+
+        IgniteEx crd = startGrid(cfgSrv);
+        IgniteEx srv = startGrid(cfgSrv2);
+
+        waitForTopology(2);
+
+        dynamicIpFinder.breakService();
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        srv.events().localListen(event -> {
+            latch.countDown();
+            return true;
+        }, EVT_NODE_LEFT);
+
+        Ignition.stop(crd.name(), true);
+
+        assertTrue("Failed to wait for server node disconnected.", latch.await(10, SECONDS));
+    }
+
+    /**
+     * Tests that dynamic IP finder doesn't allow server node to join topology if IpResolver is unavailable
+     * and joinTimeout is not specified.
+     * Server node should be constantly trying to obtain IP addresses.
+     */
+    @Test
+    public void testServerNodeBrokenDynamicIpFinderFromTheStartNoJoinTimeout() throws Exception {
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server1", false, 0);
+
+        dynamicIpFinder.breakService();
+
+        AtomicBoolean done = new AtomicBoolean();
+
+        IgniteInternalFuture<Boolean> fut = GridTestUtils.runAsync(() -> {
+            try {
+                startGrid(cfgSrv);
+
+                fail("Server node should not join a cluster if dynamic service is not working");
+            }
+            catch (IgniteCheckedException e) {
+                if (X.hasCause(e, IgniteSpiException.class))
+                    return true;
+            }
+            catch (Exception e) {
+                return false;
+            }
+            finally {
+                done.set(true);
+            }
+
+            return false;
+        });
+
+        if (!GridTestUtils.waitForCondition(done::get, 10_000)) {
+            fut.cancel();
+
+            Assert.assertEquals("Node was not failed", fut.get(), true);
+        } else {
+            String nodeState = fut.get() ? "Connected" : "Failed";
+
+            fail("Node should be still trying to join topology. State=" + nodeState);
+        }
+    }
+
+    /**
+     * Tests that static IP finder doesn't allow server node to join topology if IpResolver is unavailable
+     * and joinTimeout is set to 0
+     * Server node should be constantly trying to obtain IP addresses.
+     */
+    @Test
+    public void testServerNodeBrokenStaticIpFinderZeroJoinTimeout() throws Exception {
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server1", false, 0);
+        dynamicIpFinder.setShared(false);
+        dynamicIpFinder.breakService();
+
+        AtomicBoolean done = new AtomicBoolean();
+
+        IgniteInternalFuture<Boolean> fut = GridTestUtils.runAsync(() -> {
+            try {
+                startGrid(cfgSrv);
+
+                fail("Server node should not join a cluster if static ip finder is not working");
+            }
+            catch (IgniteCheckedException e) {
+                if (X.hasCause(e, IgniteSpiException.class))
+                    return true;
+            }
+            catch (Exception e) {
+                return false;
+            }
+            finally {
+                done.set(true);
+            }
+
+            return false;
+        });
+
+        if (!GridTestUtils.waitForCondition(() -> done.get(), 5_000)) fut.cancel();
+
+        Assert.assertEquals("Node should be stuck in a joining loop", fut.get(), true);
+    }
+
+    /**
+     * Tests that broken static IP finder allows server node to join topology
+     * when joinTimeout expires.
+     */
+    @Test
+    public void testServerNodeBrokenStaticIpFinderWithJoinTimeout() throws Exception {
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server1", false, 2000);
+
+        dynamicIpFinder.breakService();
+
+        List<LogListener> listeners = new ArrayList<>();
+
+        listeners.add(LogListener.matches(
+                "Failed to get registered addresses from IP " +
+                        "finder (retrying every 2000ms; change 'reconnectDelay' to configure " +
+                        "the frequency of retries) [maxTimeout=2000]").build());
+
+        listeners.add(LogListener.matches(
+                "Unable to get registered addresses from IP finder," +
+                        " timeout is reached (consider increasing 'joinTimeout' for join process or " +
+                        "'netTimeout' for reconnection) [joinTimeout=2000, netTimeout=5000]").build());
+
+        listeners.add(LogListener.matches(
+                "Topology snapshot [ver=1").build());
+
+        listeners.forEach(listeningLog::registerListener);
+
+        startGrid(cfgSrv);
+
+        listeners.forEach(lsnr -> assertTrue(lsnr.check()));
+    }
+
+    /**
+     * Tests shared IP finder with empty list allows server to start.
+     */
+    @Test
+    public void testServerNodeStartupWithEmptySharedIpFinder() throws Exception {
+        dynamicIpFinder.setAddresses(null);
+
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server", false);
+
+        IgniteEx grid = startGrid(cfgSrv);
+
+        assertEquals(1, grid.cluster().topologyVersion());
+    }
+
+    /**
+     * Tests non shared IP finder with empty list is not allowed.
+     */
+    @Test
+    public void testServerNodeDynamicIpFinderWithEmptyAddresses() throws Exception {
+        dynamicIpFinder.setShared(false);
+        dynamicIpFinder.setAddresses(null);
+
+        setRootLoggerDebugLevel();
+
+        IgniteConfiguration cfgSrv = getConfigurationDynamicIpFinder("Server1", false);
+
+        boolean isSpiExThrown = false;
+
+        try {
+            startGrid(cfgSrv);
+
+            fail("Server node must fail if non-shared ip finder returns empty list");
+        }
+        catch (IgniteCheckedException e) {
+            if (e.getCause() != null && e.getCause() instanceof IgniteCheckedException) {
+                Throwable cause = e.getCause();
+                if (cause.getCause() != null && cause.getCause() instanceof IgniteSpiException)
+                    isSpiExThrown = true;
+            }
+        }
+
+        assertTrue("Server node must fail if nonshared dynamic service returns empty list", isSpiExThrown);
+    }
+
+    /**
+     * Gets node configuration with dynamic IP finder.
+     */
+    private IgniteConfiguration getConfigurationDynamicIpFinder(String instanceName, boolean clientMode) throws Exception {
+        TcpDiscoverySpi discoverySpi = new TcpDiscoverySpi();
+        discoverySpi.setIpFinder(dynamicIpFinder);
+
+        return getConfigurationDynamicIpFinder(instanceName, clientMode, discoverySpi);
+    }
+
+    /**
+     * Gets node configuration with dynamic IP finder.
+     */
+    private IgniteConfiguration getConfigurationDynamicIpFinder(String instanceName, boolean clientMode, int joinTimeout) throws Exception {
+        TcpDiscoverySpi discoverySpi = new TcpDiscoverySpi();
+        discoverySpi.setJoinTimeout(joinTimeout);
+        discoverySpi.setNetworkTimeout(5000);
+        discoverySpi.setIpFinder(dynamicIpFinder);
+
+        return getConfigurationDynamicIpFinder(instanceName, clientMode, discoverySpi);
+    }
+
+    /**
+     * Gets node configuration with dynamic IP finder.
+     */
+    private IgniteConfiguration getConfigurationDynamicIpFinder(String instanceName, boolean clientMode, TcpDiscoverySpi discoverySpi) throws Exception {
+        IgniteConfiguration cfg = getConfiguration();
+        cfg.setNodeId(null);
+        cfg.setLocalHost("127.0.0.1");
+
+        cfg.setDiscoverySpi(discoverySpi);
+
+        cfg.setGridLogger(listeningLog);
+
+        cfg.setIgniteInstanceName(instanceName);
+        cfg.setClientMode(clientMode);
+
+        return cfg;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryIpFinderFailureTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryIpFinderFailureTest.java
@@ -17,6 +17,12 @@
 
 package org.apache.ignite.spi.discovery.tcp;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;
@@ -32,12 +38,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.ignite.events.EventType.EVT_CLIENT_NODE_DISCONNECTED;

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestDynamicIpFinder.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestDynamicIpFinder.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestDynamicIpFinder.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestDynamicIpFinder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.spi.discovery.tcp;
+
+import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+
+/**
+ * Shared IpFinder implementation for testing purposes.
+ */
+public class TestDynamicIpFinder extends TcpDiscoveryVmIpFinder {
+
+    /** */
+    private boolean isAvailable = true;
+
+    /**
+     * Ctor.
+     */
+    public TestDynamicIpFinder() {
+        setShared(true);
+    }
+
+    /** {@inheritDoc} */
+    @Override public Collection<InetSocketAddress> getRegisteredAddresses() throws IgniteSpiException {
+        if (isAvailable)
+            return super.getRegisteredAddresses();
+
+        throw new IgniteSpiException("Service is unavailable");
+    }
+
+    /**
+     * Simulates service fail.
+     */
+    public void breakService() {
+        isAvailable = false;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestDynamicIpFinder.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestDynamicIpFinder.java
@@ -17,11 +17,11 @@
 
 package org.apache.ignite.spi.discovery.tcp;
 
-import org.apache.ignite.spi.IgniteSpiException;
-import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
-
 import java.net.InetSocketAddress;
 import java.util.Collection;
+
+import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
 
 /**
  * Shared IpFinder implementation for testing purposes.

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
@@ -44,6 +44,7 @@ import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryConcurrentStartTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryCoordinatorFailureTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryFailedJoinTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryIpFinderCleanerTest;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryIpFinderFailureTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryMarshallerCheckSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryMetricsWarnLogTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryMultiThreadedTest;
@@ -173,6 +174,12 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_OVERRIDE_MCAST_GRP
     DiscoveryClientSocketTest.class,
 
     DiscoverySpiDataExchangeTest.class
+    IgniteMetricsOverflowTest.class,
+    MetricsCompactionTest.class,
+
+    GridDiscoveryManagerChangeCoordinatorTest.class,
+
+    TcpDiscoveryIpFinderFailureTest.class
 })
 public class IgniteSpiDiscoverySelfTestSuite {
     /** */

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
@@ -173,11 +173,7 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_OVERRIDE_MCAST_GRP
 
     DiscoveryClientSocketTest.class,
 
-    DiscoverySpiDataExchangeTest.class
-    IgniteMetricsOverflowTest.class,
-    MetricsCompactionTest.class,
-
-    GridDiscoveryManagerChangeCoordinatorTest.class,
+    DiscoverySpiDataExchangeTest.class,
 
     TcpDiscoveryIpFinderFailureTest.class
 })

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/KubernetesDiscoveryAbstractTest.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/KubernetesDiscoveryAbstractTest.java
@@ -15,17 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.client;
+package org.apache.ignite.kubernetes.discovery;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.stream.Collectors;
-import org.apache.ignite.Ignition;
-import org.apache.ignite.configuration.ClientConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
-import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.kubernetes.configuration.KubernetesConnectionConfiguration;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.kubernetes.TcpDiscoveryKubernetesIpFinder;
@@ -33,16 +25,21 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-/** Test that thin client connects to cluster with {@link ThinClientKubernetesAddressFinder}. */
-public class TestClusterClientConnection extends GridCommonAbstractTest {
+/** Super class for Kubernetes discovery tests. */
+public abstract class KubernetesDiscoveryAbstractTest extends GridCommonAbstractTest {
     /** Mock of kubernetes API. */
     private static ClientAndServer mockServer;
 
@@ -71,28 +68,8 @@ public class TestClusterClientConnection extends GridCommonAbstractTest {
     }
 
     /** */
-    @Test
-    public void testClientConnectsToCluster() throws Exception {
-        mockServerResponse();
-
-        IgniteEx crd = startGrid(getConfiguration());
-        String crdAddr = crd.localNode().addresses().iterator().next();
-
-        mockServerResponse(crdAddr);
-
-        ClientConfiguration ccfg = new ClientConfiguration();
-        ccfg.setAddressesFinder(new ThinClientKubernetesAddressFinder(prepareConfiguration()));
-
-        IgniteClient client = Ignition.startClient(ccfg);
-
-        ClientCache cache = client.createCache("cache");
-        cache.put(1, 2);
-        assertEquals(2, cache.get(1));
-    }
-
-    /** {@inheritDoc} */
-    @Override protected IgniteConfiguration getConfiguration() throws Exception {
-        IgniteConfiguration cfg = super.getConfiguration();
+    protected IgniteConfiguration getConfiguration(String instanceName, Boolean clientMode) throws Exception {
+        IgniteConfiguration cfg = getConfiguration();
 
         KubernetesConnectionConfiguration kccfg = prepareConfiguration();
         TcpDiscoveryKubernetesIpFinder ipFinder = new TcpDiscoveryKubernetesIpFinder(kccfg);
@@ -102,13 +79,30 @@ public class TestClusterClientConnection extends GridCommonAbstractTest {
 
         cfg.setDiscoverySpi(discoverySpi);
 
-        cfg.setIgniteInstanceName(getTestIgniteInstanceName());
+        cfg.setGridLogger(log);
+
+        cfg.setIgniteInstanceName(instanceName);
+        cfg.setClientMode(clientMode);
 
         return cfg;
     }
 
-    /** */
-    private void mockServerResponse(String... addrs) {
+    /**
+     * Mocks HTTP server response.
+     *
+     * @param addrs Address list to return.
+     */
+    protected final void mockServerResponse(String... addrs) {
+        mockServerResponse(1, addrs);
+    }
+
+    /**
+     * Mocks HTTP server response.
+     *
+     * @param times How many times mock should return value.
+     * @param addrs Address list to return.
+     */
+    protected final void mockServerResponse(int times, String... addrs) {
         String ipAddrs = Arrays.stream(addrs)
             .map(addr -> String.format("{\"ip\":\"%s\"}", addr))
             .collect(Collectors.joining(","));
@@ -118,7 +112,7 @@ public class TestClusterClientConnection extends GridCommonAbstractTest {
                 request()
                     .withMethod("GET")
                     .withPath(String.format("/api/v1/namespaces/%s/endpoints/%s", namespace, service)),
-                Times.exactly(1)
+                Times.exactly(times)
             )
             .respond(
                 response()
@@ -136,8 +130,8 @@ public class TestClusterClientConnection extends GridCommonAbstractTest {
     }
 
     /** */
-    private KubernetesConnectionConfiguration prepareConfiguration()
-        throws IOException
+    protected final KubernetesConnectionConfiguration prepareConfiguration()
+            throws IOException
     {
         File account = File.createTempFile("kubernetes-test-account", "");
         FileWriter fw = new FileWriter(account);

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/KubernetesDiscoveryAbstractTest.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/KubernetesDiscoveryAbstractTest.java
@@ -17,6 +17,12 @@
 
 package org.apache.ignite.kubernetes.discovery;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.kubernetes.configuration.KubernetesConnectionConfiguration;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
@@ -27,12 +33,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestClusterClientConnection.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestClusterClientConnection.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestClusterClientConnection.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestClusterClientConnection.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.kubernetes.discovery;
+
+import org.apache.ignite.Ignition;
+import org.apache.ignite.client.ClientCache;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.client.ThinClientKubernetesAddressFinder;
+import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.junit.Test;
+
+/** Test that thin client connects to cluster with {@link ThinClientKubernetesAddressFinder}. */
+public class TestClusterClientConnection extends KubernetesDiscoveryAbstractTest {
+    /** */
+    @Test
+    public void testClientConnectsToCluster() throws Exception {
+        mockServerResponse();
+
+        IgniteConfiguration cfg = getConfiguration(getTestIgniteInstanceName(), false);
+
+        IgniteEx crd = startGrid(cfg);
+        String crdAddr = crd.localNode().addresses().iterator().next();
+
+        mockServerResponse(crdAddr);
+
+        ClientConfiguration ccfg = new ClientConfiguration();
+        ccfg.setAddressesFinder(new ThinClientKubernetesAddressFinder(prepareConfiguration()));
+
+        IgniteClient client = Ignition.startClient(ccfg);
+
+        ClientCache cache = client.createCache("cache");
+        cache.put(1, 2);
+        assertEquals(2, cache.get(1));
+    }
+}

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestKubernetesIpFinderDisconnection.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestKubernetesIpFinderDisconnection.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the GridGain Community Edition License (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestKubernetesIpFinderDisconnection.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestKubernetesIpFinderDisconnection.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.kubernetes.discovery;
+
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.events.EventType.EVT_CLIENT_NODE_DISCONNECTED;
+
+/**
+ * Test that client node is disconnected from a cluster if KubernetesIpFinder fails.
+ */
+public class TestKubernetesIpFinderDisconnection extends KubernetesDiscoveryAbstractTest {
+
+    /** Tests that client is disconnected if {@link TcpDiscoverySpi#setNetworkTimeout(long)} ()} ) is set.  */
+    @Test
+    public void testClientNodeDisconnectsWithMaxRetries() throws Exception {
+        IgniteConfiguration cfgSrv = getConfiguration(getTestIgniteInstanceName(), false);
+
+        IgniteConfiguration cfgClient = getConfiguration("client", true);
+        ((TcpDiscoverySpi) cfgClient.getDiscoverySpi()).setNetworkTimeout(1000);
+
+        runSuccessfulDisconnectionTest(cfgSrv, cfgClient);
+    }
+
+    /** Tests that client is still trying to connect
+     * if {@link TcpDiscoverySpi#setNetworkTimeout(long)} ()} ) is big. */
+    @Test
+    public void testClientNodeIsNotDisconnectedWithBigNetworkTimeout() throws Exception {
+        IgniteConfiguration cfgSrv = getConfiguration(getTestIgniteInstanceName(), false);
+
+        IgniteConfiguration cfgClient = getConfiguration("client", true);
+        ((TcpDiscoverySpi) cfgClient.getDiscoverySpi()).setNetworkTimeout(6000);
+
+        runFailureDisconnectionTest(cfgSrv, cfgClient);
+    }
+
+    /** Tests that client is disconnected with default settings. */
+    @Test
+    public void testClientNodeDisconnectsWithDefaultSettings() throws Exception {
+        IgniteConfiguration cfgSrv = getConfiguration(getTestIgniteInstanceName(), false);
+        IgniteConfiguration cfgClient = getConfiguration("client", true);
+
+        runSuccessfulDisconnectionTest(cfgSrv, cfgClient);
+    }
+
+    /**
+     * Runs disconnection test and check that a client is disconnected from the grid.
+     */
+    private void runSuccessfulDisconnectionTest(IgniteConfiguration cfgNode1, IgniteConfiguration cfgNode2) throws Exception {
+        mockServerResponse();
+
+        IgniteEx crd = startGrid(cfgNode1);
+        String crdAddr = crd.localNode().addresses().iterator().next();
+
+        mockServerResponse(crdAddr);
+
+        IgniteEx client = startGrid(cfgNode2);
+
+        waitForTopology(2);
+
+        Ignition.stop(crd.name(), true);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        client.events().localListen(event -> {
+            latch.countDown();
+
+            return true;
+        }, EVT_CLIENT_NODE_DISCONNECTED);
+
+        assertTrue("Failed to wait for client node disconnected.", latch.await(8, SECONDS));
+    }
+
+    /**
+     * Runs disconnection test and check that a client is connected to the grid.
+     */
+    private void runFailureDisconnectionTest(IgniteConfiguration cfgNode1, IgniteConfiguration cfgNode2) throws Exception {
+        mockServerResponse();
+
+        IgniteEx crd = startGrid(cfgNode1);
+        String crdAddr = crd.localNode().addresses().iterator().next();
+
+        mockServerResponse(crdAddr);
+
+        IgniteEx client = startGrid(cfgNode2);
+
+        waitForTopology(2);
+
+        Ignition.stop(crd.name(), true);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        client.events().localListen(event -> {
+            latch.countDown();
+
+            return true;
+        }, EVT_CLIENT_NODE_DISCONNECTED);
+
+        assertFalse("A client should not be disconnected.", latch.await(5, SECONDS));
+    }
+}

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestKubernetesIpFinderDisconnection.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestKubernetesIpFinderDisconnection.java
@@ -17,13 +17,13 @@
 
 package org.apache.ignite.kubernetes.discovery;
 
+import java.util.concurrent.CountDownLatch;
+
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.junit.Test;
-
-import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.ignite.events.EventType.EVT_CLIENT_NODE_DISCONNECTED;

--- a/modules/kubernetes/src/test/java/org/apache/ignite/testsuites/IgniteKubernetesTestSuite.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/testsuites/IgniteKubernetesTestSuite.java
@@ -17,7 +17,8 @@
 
 package org.apache.ignite.testsuites;
 
-import org.apache.ignite.client.TestClusterClientConnection;
+import org.apache.ignite.kubernetes.discovery.TestClusterClientConnection;
+import org.apache.ignite.kubernetes.discovery.TestKubernetesIpFinderDisconnection;
 import org.apache.ignite.internal.kubernetes.connection.KubernetesServiceAddressResolverTest;
 import org.apache.ignite.kubernetes.configuration.KubernetesConnectionConfigurationTest;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.kubernetes.TcpDiscoveryKubernetesIpFinderSelfTest;
@@ -32,6 +33,7 @@ import org.junit.runners.Suite;
     KubernetesConnectionConfigurationTest.class,
     TcpDiscoveryKubernetesIpFinderSelfTest.class,
     TestClusterClientConnection.class,
+    TestKubernetesIpFinderDisconnection.class,
     KubernetesServiceAddressResolverTest.class
 })
 public class IgniteKubernetesTestSuite {

--- a/modules/kubernetes/src/test/java/org/apache/ignite/testsuites/IgniteKubernetesTestSuite.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/testsuites/IgniteKubernetesTestSuite.java
@@ -17,10 +17,10 @@
 
 package org.apache.ignite.testsuites;
 
-import org.apache.ignite.kubernetes.discovery.TestClusterClientConnection;
-import org.apache.ignite.kubernetes.discovery.TestKubernetesIpFinderDisconnection;
 import org.apache.ignite.internal.kubernetes.connection.KubernetesServiceAddressResolverTest;
 import org.apache.ignite.kubernetes.configuration.KubernetesConnectionConfigurationTest;
+import org.apache.ignite.kubernetes.discovery.TestClusterClientConnection;
+import org.apache.ignite.kubernetes.discovery.TestKubernetesIpFinderDisconnection;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.kubernetes.TcpDiscoveryKubernetesIpFinderSelfTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;


### PR DESCRIPTION
* Fixed TcpDiscoverySpi might be stuck infinitely resolving IP addresses, now the process is configurable either using netTimeout or joinTimeout depending on a process.

(cherry picked from commit b6735e14e8f47bed7ef478e02c6f78d732d353e0)

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
