### PR TITLE
IGNITE-14607: Regex Based IP Filtering

### DIFF
--- a/modules/azure/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinder.java
+++ b/modules/azure/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinder.java
@@ -133,6 +133,9 @@ public class TcpDiscoveryAzureBlobStoreIpFinder extends TcpDiscoveryIpFinderAdap
                 break;
             }
 
+            if (!isIpAddressAllowed(blobItem.getName()))
+                continue;
+
             try {
                 if (!blobItem.isDeleted()) {
                     addrs.add(addrFromString(blobItem.getName()));
@@ -371,6 +374,13 @@ public class TcpDiscoveryAzureBlobStoreIpFinder extends TcpDiscoveryIpFinderAdap
     /** {@inheritDoc} */
     @Override public TcpDiscoveryAzureBlobStoreIpFinder setShared(boolean shared) {
         super.setShared(shared);
+
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override public TcpDiscoveryAzureBlobStoreIpFinder setRegex(String regex) {
+        super.setRegex(regex);
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/TcpDiscoveryIpFinder.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/TcpDiscoveryIpFinder.java
@@ -100,6 +100,14 @@ public interface TcpDiscoveryIpFinder {
     public void unregisterAddresses(Collection<InetSocketAddress> addrs) throws IgniteSpiException;
 
     /**
+     * Filters given IP address through filter regexes, if any
+     *
+     * @param ipAddress Address to check
+     * @return true if allowed, false otherwise
+     */
+    public boolean isIpAddressAllowed(String ipAddress);
+
+    /**
      * Closes this IP finder and releases any system resources associated with it.
      */
     public void close();


### PR DESCRIPTION
This commit introduces the notion of regexes which can be registered and used as filters for incoming IPAddresses. A new API is introduced for the same and implemented in Azure Blob Storage IP Finder.