### PR TITLE
IGNITE-14607: Regex Based Filtering For IP Addresses During Discovery

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
@@ -536,9 +536,6 @@ public class IgniteConfiguration {
     /** SSL connection factory. */
     private Factory<SSLContext> sslCtxFactory;
 
-    /** Address filter */
-    private IgnitePredicate<InetSocketAddress> addressFilter;
-
     /** Platform configuration. */
     private PlatformConfiguration platformCfg;
 
@@ -658,7 +655,6 @@ public class IgniteConfiguration {
          */
         activeOnStart = cfg.isActiveOnStart();
         activeOnStartPropSetFlag = cfg.activeOnStartPropSetFlag;
-        addressFilter = cfg.getAddressFilter();
         addrRslvr = cfg.getAddressResolver();
         allResolversPassReq = cfg.isAllSegmentationResolversPassRequired();
         atomicCfg = cfg.getAtomicConfiguration();
@@ -1945,17 +1941,6 @@ public class IgniteConfiguration {
     }
 
     /**
-     * Sets address filter which will allow filtering addresses
-     *
-     * @param addressFilter Address filter
-     */
-    public IgniteConfiguration setAddressFilter(IgnitePredicate<InetSocketAddress> addressFilter) {
-        this.addressFilter = addressFilter;
-
-        return this;
-    }
-
-    /**
      * Returns SSL context factory that will be used for creating a secure socket layer.
      *
      * @return SSL connection factory.
@@ -1963,16 +1948,6 @@ public class IgniteConfiguration {
      */
     public Factory<SSLContext> getSslContextFactory() {
         return sslCtxFactory;
-    }
-
-    /**
-     * Returns address filter used to filter addresses
-     *
-     * @return Address filter predicate
-     * @see SslContextFactory
-     */
-    public IgnitePredicate<InetSocketAddress> getAddressFilter() {
-        return addressFilter;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
@@ -19,7 +19,6 @@ package org.apache.ignite.configuration;
 
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
-import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;

--- a/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.ignite.configuration;
 
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
+import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -31,6 +32,7 @@ import javax.cache.integration.CacheLoader;
 import javax.cache.processor.EntryProcessor;
 import javax.management.MBeanServer;
 import javax.net.ssl.SSLContext;
+
 import org.apache.ignite.IgniteCompute;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.IgniteSystemProperties;
@@ -534,6 +536,9 @@ public class IgniteConfiguration {
     /** SSL connection factory. */
     private Factory<SSLContext> sslCtxFactory;
 
+    /** Address filter */
+    private IgnitePredicate<InetSocketAddress> addressFilter;
+
     /** Platform configuration. */
     private PlatformConfiguration platformCfg;
 
@@ -653,6 +658,7 @@ public class IgniteConfiguration {
          */
         activeOnStart = cfg.isActiveOnStart();
         activeOnStartPropSetFlag = cfg.activeOnStartPropSetFlag;
+        addressFilter = cfg.getAddressFilter();
         addrRslvr = cfg.getAddressResolver();
         allResolversPassReq = cfg.isAllSegmentationResolversPassRequired();
         atomicCfg = cfg.getAtomicConfiguration();
@@ -1939,6 +1945,17 @@ public class IgniteConfiguration {
     }
 
     /**
+     * Sets address filter which will allow filtering addresses
+     *
+     * @param addressFilter Address filter
+     */
+    public IgniteConfiguration setAddressFilter(IgnitePredicate<InetSocketAddress> addressFilter) {
+        this.addressFilter = addressFilter;
+
+        return this;
+    }
+
+    /**
      * Returns SSL context factory that will be used for creating a secure socket layer.
      *
      * @return SSL connection factory.
@@ -1946,6 +1963,16 @@ public class IgniteConfiguration {
      */
     public Factory<SSLContext> getSslContextFactory() {
         return sslCtxFactory;
+    }
+
+    /**
+     * Returns address filter used to filter addresses
+     *
+     * @return Address filter predicate
+     * @see SslContextFactory
+     */
+    public IgnitePredicate<InetSocketAddress> getAddressFilter() {
+        return addressFilter;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -320,6 +320,9 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
     /** IP finder. */
     protected TcpDiscoveryIpFinder ipFinder;
 
+    /** Address filter */
+    private IgnitePredicate<InetSocketAddress> addressFilter;
+
     /** Socket operations timeout. */
     private long sockTimeout; // Must be initialized in the constructor of child class.
 
@@ -461,9 +464,6 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
 
     /** */
     private IgniteDiscoverySpiInternalListener internalLsnr;
-
-    /** Allow specifying an address filter when getting registered nodes */
-    private IgnitePredicate<InetSocketAddress> addressFilter;
 
     /** For test purposes. */
     private boolean skipAddrsRandomization = false;
@@ -925,6 +925,19 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
     @IgniteSpiConfiguration(optional = true)
     public TcpDiscoverySpi setIpFinder(TcpDiscoveryIpFinder ipFinder) {
         this.ipFinder = ipFinder;
+
+        return this;
+    }
+
+    /**
+     * Sets address filter for IP addresses
+     *
+     * @param addressFilter Address filter to use
+     * @return {@code this} for chaining.
+     */
+    @IgniteSpiConfiguration(optional = true)
+    public TcpDiscoverySpi setAddressFilter(IgnitePredicate<InetSocketAddress> addressFilter) {
+        this.addressFilter = addressFilter;
 
         return this;
     }
@@ -2197,8 +2210,6 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
             return;
 
         sslEnable = ignite().configuration().getSslContextFactory() != null;
-
-        addressFilter = ignite().configuration().getAddressFilter();
 
         initFailureDetectionTimeout();
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -72,6 +72,7 @@ import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteInClosure;
+import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.lang.IgniteProductVersion;
 import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.marshaller.Marshaller;
@@ -460,6 +461,9 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
 
     /** */
     private IgniteDiscoverySpiInternalListener internalLsnr;
+
+    /** Allow specifying an address filter when getting registered nodes */
+    private IgnitePredicate<InetSocketAddress> addressFilter;
 
     /** For test purposes. */
     private boolean skipAddrsRandomization = false;
@@ -1994,6 +1998,9 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
             assert addr != null;
 
             try {
+                if (addressFilter != null && !addressFilter.apply(addr))
+                    continue;
+
                 InetSocketAddress resolved = addr.isUnresolved() ?
                         new InetSocketAddress(InetAddress.getByName(addr.getHostName()), addr.getPort()) : addr;
 
@@ -2190,6 +2197,8 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
             return;
 
         sslEnable = ignite().configuration().getSslContextFactory() != null;
+
+        addressFilter = ignite().configuration().getAddressFilter();
 
         initFailureDetectionTimeout();
 

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithAddressFilterTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithAddressFilterTest.java
@@ -34,7 +34,8 @@ import org.junit.Test;
  */
 public class TcpDiscoveryWithAddressFilterTest extends TcpDiscoveryWithWrongServerTest {
 
-    IgnitePredicate<InetSocketAddress> addressFilter = new P1<InetSocketAddress>() {
+    /** Address filter predicate which allows filtering IP addresses duringd discovery */
+    private IgnitePredicate<InetSocketAddress> addressFilter = new P1<InetSocketAddress>() {
         @Override public boolean apply(InetSocketAddress address) {
             // Compile regular expression
             Pattern pattern = Pattern.compile("^/127\\.0\\.0\\.1:47503$", Pattern.CASE_INSENSITIVE);
@@ -54,9 +55,8 @@ public class TcpDiscoveryWithAddressFilterTest extends TcpDiscoveryWithWrongServ
         ipFinder.setAddresses(Collections.singleton("127.0.0.1:" + Integer.toString(SERVER_PORT) + ".." +
                 Integer.toString(LAST_SERVER_PORT)));
 
-        cfg.setAddressFilter(addressFilter);
-
-        cfg.setDiscoverySpi(new TcpDiscoveryWithAddressFilter().setIpFinder(ipFinder));
+        cfg.setDiscoverySpi(new TcpDiscoveryWithAddressFilter().setIpFinder(ipFinder)
+                .setAddressFilter(addressFilter));
 
         return cfg;
     }
@@ -75,14 +75,13 @@ public class TcpDiscoveryWithAddressFilterTest extends TcpDiscoveryWithWrongServ
     /**
      * Check for incoming addresses and check that the filter was applied
      */
-    class TcpDiscoveryWithAddressFilter extends TcpDiscoverySpi {
+    private class TcpDiscoveryWithAddressFilter extends TcpDiscoverySpi {
         /** {@inheritDoc} */
         @Override protected Collection<InetSocketAddress> resolvedAddresses() throws IgniteSpiException {
             Collection<InetSocketAddress> res = super.resolvedAddresses();
 
-            for (InetSocketAddress addr : res) {
+            for (InetSocketAddress addr : res)
                 assertFalse(addr.getHostName().matches("^/127\\.0\\.0\\.1:47503$"));
-            }
 
             return res;
         }

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithAddressFilterTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithAddressFilterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.spi.discovery.tcp;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.typedef.P1;
+import org.apache.ignite.lang.IgnitePredicate;
+import org.apache.ignite.spi.IgniteSpiException;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
+import org.junit.Test;
+
+/**
+ * Test discovery SPI with address filter present
+ */
+public class TcpDiscoveryWithAddressFilterTest extends TcpDiscoveryWithWrongServerTest {
+
+    IgnitePredicate<InetSocketAddress> addressFilter = new P1<InetSocketAddress>() {
+        @Override public boolean apply(InetSocketAddress address) {
+            // Compile regular expression
+            Pattern pattern = Pattern.compile("^/127\\.0\\.0\\.1:47503$", Pattern.CASE_INSENSITIVE);
+            // Match regex against input
+            Matcher matcher = pattern.matcher(address.toString());
+            // Use results...
+            return !(matcher.matches());
+        }
+    };
+
+    /** {@inheritDoc} */
+   @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        TcpDiscoveryVmIpFinder ipFinder = new TcpDiscoveryVmIpFinder();
+
+        ipFinder.setAddresses(Collections.singleton("127.0.0.1:" + Integer.toString(SERVER_PORT) + ".." +
+                Integer.toString(LAST_SERVER_PORT)));
+
+        cfg.setAddressFilter(addressFilter);
+
+        cfg.setDiscoverySpi(new TcpDiscoveryWithAddressFilter().setIpFinder(ipFinder));
+
+        return cfg;
+    }
+
+    /**
+     * Basic test
+     */
+    @Test
+    public void testBasic() throws Exception {
+        startTcpThread(new NoResponseWorker(), SERVER_PORT);
+        startTcpThread(new NoResponseWorker(), LAST_SERVER_PORT);
+
+        simpleTest();
+    }
+
+    /**
+     * Check for incoming addresses and check that the filter was applied
+     */
+    class TcpDiscoveryWithAddressFilter extends TcpDiscoverySpi {
+        /** {@inheritDoc} */
+        @Override protected Collection<InetSocketAddress> resolvedAddresses() throws IgniteSpiException {
+            Collection<InetSocketAddress> res = super.resolvedAddresses();
+
+            for (InetSocketAddress addr : res) {
+                assertFalse(addr.getHostName().matches("^/127\\.0\\.0\\.1:47503$"));
+            }
+
+            return res;
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithWrongServerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithWrongServerTest.java
@@ -43,16 +43,16 @@ import org.junit.Test;
  */
 public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /** Non-Ignite Server port #1. */
-    static final int SERVER_PORT = 47500;
+    protected static final int SERVER_PORT = 47500;
 
     /** Non-Ignite Server port #2. */
-    static final int LAST_SERVER_PORT = SERVER_PORT + 5;
+    protected static final int LAST_SERVER_PORT = SERVER_PORT + 5;
 
     /** Non-Ignite Server sockets. */
-    List<ServerSocket> srvSocks = new ArrayList<>();
+    protected List<ServerSocket> srvSocks = new ArrayList<>();
 
     /** Count of accepted connections to non-Ignite Server. */
-    AtomicInteger connCnt = new AtomicInteger(0);
+    protected AtomicInteger connCnt = new AtomicInteger(0);
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
@@ -81,7 +81,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
      * Starts tcp test thread
      * @param workerFactory one of WorkerFactory
      */
-    void startTcpThread(final WorkerFactory workerFactory, final int port) throws Exception {
+     protected void startTcpThread(final WorkerFactory workerFactory, final int port) throws Exception {
         final ServerSocket srvSock = new ServerSocket(port, 10, InetAddress.getByName("127.0.0.1"));
 
         srvSocks.add(srvSock);
@@ -173,7 +173,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
      * It is expected that both client and server could successfully perform Discovery Procedure when there is
      * unknown (test) server in the ipFinder list.
      */
-    void simpleTest() {
+    protected void simpleTest() {
         try {
             Ignite srv = startGrid("server");
             Ignite client = startClientGrid("client");
@@ -196,7 +196,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /**
      * Just a factory for runnable workers
      */
-    interface WorkerFactory {
+    protected interface WorkerFactory {
         /**
          * Creates a new worker for socket
          * @param clientSock socket for worker
@@ -248,7 +248,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /**
      * SomeResponseWorker.
      */
-    class SomeResponseWorker implements WorkerFactory {
+    protected class SomeResponseWorker implements WorkerFactory {
         /** {@inheritDoc} */
         @Override public Runnable newWorker(Socket clientSock) {
             return new SocketWorker(clientSock) {
@@ -264,7 +264,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /**
      * NoResponseWorker.
      */
-    class NoResponseWorker implements WorkerFactory {
+    protected class NoResponseWorker implements WorkerFactory {
         /** {@inheritDoc} */
         @Override public Runnable newWorker(Socket clientSock) {
             return new SocketWorker(clientSock) {
@@ -320,7 +320,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
      * TcpDiscoverySpi with non-shuffled resolved IP addresses. We should ensure that in this test non-Ignite server
      * is the first element of the addresses list
      */
-    class TcpDiscoverySpiWithOrderedIps extends TcpDiscoverySpi {
+    protected class TcpDiscoverySpiWithOrderedIps extends TcpDiscoverySpi {
         /** {@inheritDoc} */
         @Override protected Collection<InetSocketAddress> resolvedAddresses() throws IgniteSpiException {
             Collection<InetSocketAddress> shuffled = super.resolvedAddresses();

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithWrongServerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryWithWrongServerTest.java
@@ -43,16 +43,16 @@ import org.junit.Test;
  */
 public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /** Non-Ignite Server port #1. */
-    private static final int SERVER_PORT = 47500;
+    static final int SERVER_PORT = 47500;
 
     /** Non-Ignite Server port #2. */
-    private static final int LAST_SERVER_PORT = SERVER_PORT + 5;
+    static final int LAST_SERVER_PORT = SERVER_PORT + 5;
 
     /** Non-Ignite Server sockets. */
-    private List<ServerSocket> srvSocks = new ArrayList<>();
+    List<ServerSocket> srvSocks = new ArrayList<>();
 
     /** Count of accepted connections to non-Ignite Server. */
-    private AtomicInteger connCnt = new AtomicInteger(0);
+    AtomicInteger connCnt = new AtomicInteger(0);
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
@@ -81,7 +81,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
      * Starts tcp test thread
      * @param workerFactory one of WorkerFactory
      */
-    private void startTcpThread(final WorkerFactory workerFactory, final int port) throws Exception {
+    void startTcpThread(final WorkerFactory workerFactory, final int port) throws Exception {
         final ServerSocket srvSock = new ServerSocket(port, 10, InetAddress.getByName("127.0.0.1"));
 
         srvSocks.add(srvSock);
@@ -173,7 +173,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
      * It is expected that both client and server could successfully perform Discovery Procedure when there is
      * unknown (test) server in the ipFinder list.
      */
-    private void simpleTest() {
+    void simpleTest() {
         try {
             Ignite srv = startGrid("server");
             Ignite client = startClientGrid("client");
@@ -196,7 +196,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /**
      * Just a factory for runnable workers
      */
-    private interface WorkerFactory {
+    interface WorkerFactory {
         /**
          * Creates a new worker for socket
          * @param clientSock socket for worker
@@ -248,7 +248,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /**
      * SomeResponseWorker.
      */
-    private class SomeResponseWorker implements WorkerFactory {
+    class SomeResponseWorker implements WorkerFactory {
         /** {@inheritDoc} */
         @Override public Runnable newWorker(Socket clientSock) {
             return new SocketWorker(clientSock) {
@@ -264,7 +264,7 @@ public class TcpDiscoveryWithWrongServerTest extends GridCommonAbstractTest {
     /**
      * NoResponseWorker.
      */
-    private class NoResponseWorker implements WorkerFactory {
+    class NoResponseWorker implements WorkerFactory {
         /** {@inheritDoc} */
         @Override public Runnable newWorker(Socket clientSock) {
             return new SocketWorker(clientSock) {

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteSpiDiscoverySelfTestSuite.java
@@ -72,6 +72,7 @@ import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslSecuredUnsecuredTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslTrustedSelfTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySslTrustedUntrustedTest;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryWithAddressFilterTest;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoveryWithWrongServerTest;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.jdbc.TcpDiscoveryJdbcIpFinderSelfTest;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinderSelfTest;
@@ -135,6 +136,8 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_OVERRIDE_MCAST_GRP
     AuthenticationRestartTest.class,
 
     TcpDiscoveryWithWrongServerTest.class,
+
+    TcpDiscoveryWithAddressFilterTest.class,
 
     TcpDiscoverySpiReconnectDelayTest.class,
 


### PR DESCRIPTION
This commit introduces functionality to filter IP addresses during IP discovery using regexes.