### PR TITLE
IGNITE-14609 Document old and new async continuation behavior

### DIFF
--- a/docs/_data/toc.yaml
+++ b/docs/_data/toc.yaml
@@ -380,6 +380,8 @@
       url: net-specific/net-deployment-options
     - title: Standalone Nodes
       url: net-specific/net-standalone-nodes
+    - title: Asynchronous APIs
+      url: net-specific/net-async
     - title: Logging
       url: net-specific/net-logging
     - title: LINQ

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -260,7 +260,7 @@ If an asynchronous operation is completed by the time the callback is passed to 
 Otherwise, the callback is executed asynchronously when the operation is completed.
 
 Callbacks for asynchronous compute operations are invoked by threads from the /perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
-Therefore, you should avoid calling synchronous cache and compute operations from inside the callback, because it may lead to a deadlock due to pools starvation.
+Calling synchronous cache and compute operations from inside the callback may lead to a deadlock due to pools starvation.
 To achieve nested execution of asynchronous compute operations, you can take advantage of /perf-and-troubleshooting/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 
 Callbacks for asynchronous cache operations are invoked using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -259,9 +259,9 @@ This is java specific
 If an asynchronous operation is completed by the time the callback is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the callback is executed synchronously by the calling thread.
 Otherwise, the callback is executed asynchronously when the operation is completed.
 
-Callbacks for asynchronous compute operations are invoked by threads from the /perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
+Callbacks for asynchronous compute operations are invoked by threads from the link:perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
 Calling synchronous cache and compute operations from inside the callback may lead to a deadlock due to pools starvation.
-To achieve nested execution of asynchronous compute operations, you can take advantage of /perf-and-troubleshooting/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
+To achieve nested execution of asynchronous compute operations, you can take advantage of link:perf-and-troubleshooting/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 
 Callbacks for asynchronous cache operations are invoked using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
 

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -266,9 +266,9 @@ To achieve nested execution of asynchronous compute operations, you can take adv
 Callbacks for asynchronous cache operations are invoked by using `ForkJoinPool#commonPool`, unless a different executor is configured with `IgniteConfiguration#asyncContinuationExecutor`.
 
 * This default executor is safe for any operations inside the callback.
-* Default behavior has changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
+* Default behavior was changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
 * To restore the previous behavior, use `IgniteConfiguration.setAsyncContinuationExecutor(Runnable::run)`.
-** Can provide a small performance improvement in some situations, because callbacks are executed without any indirection or scheduling.
+** Previous behavior can provide a small performance improvement, because callbacks are executed without any indirection or scheduling.
 ** UNSAFE: cache operations can't proceed while system threads execute callbacks, and deadlocks are possible if other cache operations are invoked from the callback.
 
 

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -267,7 +267,7 @@ Callbacks for asynchronous cache operations are invoked by using `ForkJoinPool#c
 
 * This default executor is safe for any operations inside the callback.
 * Default behavior was changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
-* To restore the previous behavior, use `IgniteConfiguration.setAsyncContinuationExecutor(Runnable::run)`.
+* To restore previous behavior, use `IgniteConfiguration.setAsyncContinuationExecutor(Runnable::run)`.
 ** Previous behavior can provide a small performance improvement, because callbacks are executed without any indirection or scheduling.
 ** UNSAFE: cache operations cannot proceed while system threads execute callbacks, and deadlocks are possible if other cache operations are invoked from the callback.
 

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -263,7 +263,7 @@ Callbacks for asynchronous compute operations are invoked by threads from the li
 Calling synchronous cache and compute operations from inside the callback may lead to a deadlock due to pools starvation.
 To achieve nested execution of asynchronous compute operations, you can take advantage of link:perf-and-troubleshooting/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 
-Callbacks for asynchronous cache operations are invoked using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
+Callbacks for asynchronous cache operations are invoked by using `ForkJoinPool#commonPool`, unless a different executor is configured with `IgniteConfiguration#asyncContinuationExecutor`.
 
 * This default executor is safe for any operations inside the callback.
 * Default behavior has changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -259,11 +259,11 @@ This is java specific
 If an asynchronous operation is completed by the time the callback is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the callback is executed synchronously by the calling thread.
 Otherwise, the callback is executed asynchronously when the operation is completed.
 
-Callbacks for asynchronous compute operations are called by threads from the /perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
+Callbacks for asynchronous compute operations are invoked by threads from the /perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
 Therefore, you should avoid calling synchronous cache and compute operations from inside the callback, because it may lead to a deadlock due to pools starvation.
 To achieve nested execution of asynchronous compute operations, you can take advantage of /perf-and-troubleshooting/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 
-Callbacks for asynchronous cache operations are called using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
+Callbacks for asynchronous cache operations are invoked using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
 
 * This default executor is safe for any operations inside the callback.
 * Default behavior has changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -269,7 +269,7 @@ Callbacks for asynchronous cache operations are invoked by using `ForkJoinPool#c
 * Default behavior was changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
 * To restore the previous behavior, use `IgniteConfiguration.setAsyncContinuationExecutor(Runnable::run)`.
 ** Previous behavior can provide a small performance improvement, because callbacks are executed without any indirection or scheduling.
-** UNSAFE: cache operations can't proceed while system threads execute callbacks, and deadlocks are possible if other cache operations are invoked from the callback.
+** UNSAFE: cache operations cannot proceed while system threads execute callbacks, and deadlocks are possible if other cache operations are invoked from the callback.
 
 
 ====

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -266,6 +266,10 @@ To achieve nested execution of asynchronous compute operations, you can take adv
 Callbacks for asynchronous cache operations are called using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
 * This default executor is safe for any operations inside the callback.
 * Default behavior has changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
+* To restore the previous behavior, use `IgniteConfiguration.setAsyncContinuationExecutor(Runnable::run)`.
+** Can provide a small performance improvement in some situations, because callbacks are executed without any indirection or scheduling.
+** UNSAFE: cache operations can't proceed while system threads execute callbacks, and deadlocks are possible if other cache operations are invoked from the callback.
+
 
 ====
 

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -259,9 +259,9 @@ This is java specific
 If an asynchronous operation is completed by the time the callback is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the callback is executed synchronously by the calling thread.
 Otherwise, the callback is executed asynchronously when the operation is completed.
 
-Callbacks for asynchronous compute operations are called by threads from the link:perf-troubleshooting-guide/thread-pools-tuning[Ignite public pool].
+Callbacks for asynchronous compute operations are called by threads from the /perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
 Therefore, you should avoid calling synchronous cache and compute operations from inside the callback, because it may lead to a deadlock due to pools starvation.
-To achieve nested execution of asynchronous compute operations, you can take advantage of link:perf-troubleshooting-guide/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
+To achieve nested execution of asynchronous compute operations, you can take advantage of /perf-and-troubleshooting/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 
 Callbacks for asynchronous cache operations are called using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
 

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -264,6 +264,7 @@ Therefore, you should avoid calling synchronous cache and compute operations fro
 To achieve nested execution of asynchronous compute operations, you can take advantage of link:perf-troubleshooting-guide/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 
 Callbacks for asynchronous cache operations are called using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
+
 * This default executor is safe for any operations inside the callback.
 * Default behavior has changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
 * To restore the previous behavior, use `IgniteConfiguration.setAsyncContinuationExecutor(Runnable::run)`.

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -218,9 +218,13 @@ The asynchronous operations return an object that represents the result of the o
 *ALSO, do we need to explain what a "closure" is?*
 
 Blocking and closure are basic notions a java developer should know. We also expect that users know/can learn themselves how to use the Feature class. We can elaborate on this if we get relevant feedback.
+
+NOTE: Closure is not a technically correct term here. Closure is something that captures (encloses) context: https://en.wikipedia.org/wiki/Closure_(computer_programming).
+We don't know if the user code which is passed as a listener is a closure or not.
+Callback seems to be a better fit.
 ////
 
-To wait for the results in a non-blocking fashion, register a closure using the `IgniteFuture.listen()` or `IgniteFuture.chain()` method. The closure is called when the operation is completed.
+To wait for the results in a non-blocking fashion, register a callback using the `IgniteFuture.listen()` or `IgniteFuture.chain()` method. The callback is called when the operation is completed.
 
 [tabs]
 --
@@ -245,16 +249,16 @@ include::code-snippets/cpp/src/cache_asynchronous_execution.cpp[tag=cache-asynch
 [NOTE]
 ====
 [discrete]
-=== Closures Execution and Thread Pools
+=== Callbacks Execution and Thread Pools
 
 ////////////////////////////////////////////////////////////////////////////////
 This is java specific
 ////////////////////////////////////////////////////////////////////////////////
 
 
-If an asynchronous operation is completed by the time the closure is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the closure is executed synchronously by the calling thread. Otherwise, the closure is executed asynchronously when the operation is completed.
+If an asynchronous operation is completed by the time the callback is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the callback is executed synchronously by the calling thread. Otherwise, the callback is executed asynchronously when the operation is completed.
 
-Depending on the type of operation, the closure might be called by a thread from the system pool (asynchronous cache operations) or by a thread from the public pool (asynchronous compute operations). Therefore, you should avoid calling synchronous cache and compute operations from inside the closure, because it may lead to a deadlock due to pools starvation.
+Depending on the type of operation, the callback might be called by a thread from the system pool (asynchronous cache operations) or by a thread from the public pool (asynchronous compute operations). Therefore, you should avoid calling synchronous cache and compute operations from inside the callback, because it may lead to a deadlock due to pools starvation.
 
 To achieve nested execution of asynchronous compute operations, you can take advantage of link:perf-troubleshooting-guide/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
 ====

--- a/docs/_docs/key-value-api/basic-cache-operations.adoc
+++ b/docs/_docs/key-value-api/basic-cache-operations.adoc
@@ -256,11 +256,17 @@ This is java specific
 ////////////////////////////////////////////////////////////////////////////////
 
 
-If an asynchronous operation is completed by the time the callback is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the callback is executed synchronously by the calling thread. Otherwise, the callback is executed asynchronously when the operation is completed.
+If an asynchronous operation is completed by the time the callback is passed to either the `IgniteFuture.listen()` or `IgniteFuture.chain()` method, then the callback is executed synchronously by the calling thread.
+Otherwise, the callback is executed asynchronously when the operation is completed.
 
-Depending on the type of operation, the callback might be called by a thread from the system pool (asynchronous cache operations) or by a thread from the public pool (asynchronous compute operations). Therefore, you should avoid calling synchronous cache and compute operations from inside the callback, because it may lead to a deadlock due to pools starvation.
-
+Callbacks for asynchronous compute operations are called by threads from the link:perf-troubleshooting-guide/thread-pools-tuning[Ignite public pool].
+Therefore, you should avoid calling synchronous cache and compute operations from inside the callback, because it may lead to a deadlock due to pools starvation.
 To achieve nested execution of asynchronous compute operations, you can take advantage of link:perf-troubleshooting-guide/thread-pools-tuning#creating-custom-thread-pool[custom thread pools].
+
+Callbacks for asynchronous cache operations are called using `IgniteConfiguration#asyncContinuationExecutor`, which defaults to `ForkJoinPool#commonPool`.
+* This default executor is safe for any operations inside the callback.
+* Default behavior has changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
+
 ====
 
 
@@ -272,7 +278,7 @@ To achieve nested execution of asynchronous compute operations, you can take adv
 
 == Resource Injection
 
-Ignite allows dependency injection of pre-defined Ignite resources, and supports field-based as well as method-based injection. Resources with proper annotations will be injected into the corresponding task, job, closure, or SPI before it is initialized.
+Ignite allows dependency injection of pre-defined Ignite resources, and supports field-based as well as method-based injection. Resources with proper annotations will be injected into the corresponding task, job, callback, or SPI before it is initialized.
 
 
 You can inject resources by annotating either a field or a method. When you annotate a field, Ignite simply sets the value of the field at injection time (disregarding an access modifier of the field). If you annotate a method with a resource annotation, it should accept an input parameter of the type corresponding to the injected resource. If it does, then the method is invoked at injection time with the appropriate resource passed as an input argument.

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -33,7 +33,7 @@ string hello = await cache.GetAsync(1);
 ----
 
 With async APIs, current thread is not blocked while we wait for the cache operation to complete;
-it is returned to the thread pool and can perform other work.
+the thread is returned to the thread pool and can perform other work.
 
 When the async operation completes, our method resumes execution - either on the same thread, or on a different one -
 depending on the environment and the configuration. This is called "async continuation".

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -50,12 +50,13 @@ All thin client async APIs use link:https://docs.microsoft.com/en-us/dotnet/stan
 
 === Thick Cache
 
-Server and thick client async cache APIs handle async continuations in a special way:
+Callbacks for asynchronous cache operations on server and thick client nodes are invoked by using Java `ForkJoinPool#commonPool`, unless a different executor is configured with `IgniteConfiguration.AsyncContinuationExecutor`.
 
-* In Ignite 2.11 and later, the behavior is controlled by `IgniteConfiguration.AsyncContinuationExecutor` property. A common thread pool is used by default, and no special care is required.
+* This default executor is safe for any operations inside the callback.
+* Default behavior was changed in Ignite 2.11. Before that, async cache operation callbacks were called from an Ignite system pool (so-called "striped pool").
 * To restore the previous behavior, use `IgniteConfiguration.AsyncContinuationExecutor = AsyncContinuationExecutor.UnsafeSynchronous`.
-** Can provide a small performance improvement in some situations, because callbacks are executed without any indirection or scheduling.
-** UNSAFE: cache operations cannot proceed while system threads execute continuations (callbacks), and deadlocks are possible if other cache operations are invoked from the callback.
+** Previous behavior can provide a small performance improvement, because callbacks are executed without any indirection or scheduling.
+** UNSAFE: cache operations cannot proceed while system threads execute callbacks, and deadlocks are possible if other cache operations are invoked from the callback.
 
 [IMPORTANT]
 ====

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -94,7 +94,7 @@ Tip: use an extension method to reduce verbosity.
 
 *Ignite 2.11 and later*: all `ICompute` async APIs use .NET Thread Pool to run async continuations.
 
-*Ignite 2.10 and before*: Compute async continuations are executed on link:/perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
+*Ignite 2.10 and before*: Compute async continuations are executed on link:perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
 To reduce the load on the public pool, it is recommended to use the same `ContinueWith` approach as above:
 
 [source,csharp]

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -68,7 +68,7 @@ which means that `GetAsync` call in the code above is executed by the system thr
 This can lead to deadlocks if user code blocks the thread, or cause starvation because system thread is busy
 running user code instead of performing cache operations.
 
-To enable safe behavior, move continuations to the .NET Thread Pool manually:
+To enable safe behavior, move continuations to .NET Thread Pool manually:
 
 [source,csharp]
 ----

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -16,7 +16,7 @@
 
 == Overview
 
-Many Ignite APIs have asynchronous versions, for example, `void ICache.Put` and `Task ICache.PutAsync`.
+Many Ignite APIs have asynchronous variants, for example, `void ICache.Put` and `Task ICache.PutAsync`.
 Async APIs allow us to write link:https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/[efficient non-blocking code]:
 
 [source,csharp]

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -55,7 +55,7 @@ Server and thick client async cache APIs handle async continuations in a special
 * In Ignite 2.11 and later, the behavior is controlled by `IgniteConfiguration.AsyncContinuationExecutor` property. A common thread pool is used by default, and no special care is required.
 * To restore the previous behavior, use `IgniteConfiguration.AsyncContinuationExecutor = AsyncContinuationExecutor.UnsafeSynchronous`.
 ** Can provide a small performance improvement in some situations, because callbacks are executed without any indirection or scheduling.
-** UNSAFE: cache operations can't proceed while system threads execute continuations (callbacks), and deadlocks are possible if other cache operations are invoked from the callback.
+** UNSAFE: cache operations cannot proceed while system threads execute continuations (callbacks), and deadlocks are possible if other cache operations are invoked from the callback.
 
 [IMPORTANT]
 ====

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+= Asynchronous APIs
+
+== Overview
+
+Many Ignite APIs have asynchronous versions, for example, `void ICache.Put` and `Task ICache.PutAsync`.
+Async APIs allow us to write link:https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/async/[efficient non-blocking code]:
+
+[source,csharp]
+----
+ICache<int, string> cache = ignite.GetOrCreateCache<int, string>("my-cache");
+
+// Sync, blocks thread on every call.
+cache.Put(1, "Hello");
+string hello = cache.Get(1);
+
+// Async, does not block threads.
+await cache.PutAsync(1, "Hello");
+string hello = await cache.GetAsync(1);
+----
+
+With async APIs, current thread is not blocked while we wait for cache operation to complete;
+it is returned to the thread pool and can perform other work.
+
+When the async operation completes, our method resumes execution - either on the same thread, or on a different one -
+depending on the environment and the configuration. This is called "async continuation".
+
+
+== Async Continuations
+
+== ConfigureAwait
+
+TODO
+
+
+
+
+== Cache
+
+Consider the following code:
+
+[source,csharp]
+----
+// Print Hello World on all cluster nodes.
+ignite.GetCompute().Broadcast(new HelloAction());
+
+class HelloAction : IComputeAction
+{
+  public void Invoke()
+  {
+    Console.WriteLine("Hello World!");
+  }
+}
+----
+
+
+== Compute

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -41,7 +41,8 @@ depending on the environment and the configuration. This is called "async contin
 
 == Async Continuations
 
-Unless specified otherwise, Ignite executes async continuations on the link:https://docs.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool[.NET Thread Pool.]
+Unless specified otherwise, Ignite executes async continuations on the link:https://docs.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool[.NET Thread Pool], which is safe and does not require any special care.
+
 
 === Thin Client
 
@@ -55,6 +56,39 @@ Server and thick client async cache APIs handle async continuations in a special
 * To restore the previous behavior, use `IgniteConfiguration.AsyncContinuationExecutor = AsyncContinuationExecutor.UnsafeSynchronous`.
 ** Can provide a small performance improvement in some situations, because callbacks are executed without any indirection or scheduling.
 ** UNSAFE: cache operations can't proceed while system threads execute continuations (callbacks), and deadlocks are possible if other cache operations are invoked from the callback.
+
+[IMPORTANT]
+====
+[discrete]
+=== *Ignite 2.10 and before*: danger of deadlocks and system pool starvation
+
+In Ignite versions 2.10 and before, system pool is used to run async continuations,
+which means that `GetAsync` call in the code above is executed by the system thread.
+
+This can lead to deadlocks if user code blocks the thread, or cause starvation because system thread is busy
+running user code instead of performing cache operations.
+
+To enable safe behavior, move continuations to the .NET Thread Pool manually:
+
+[source,csharp]
+----
+await cache.PutAsync(1, "Hello").ContinueWith(
+                t => {},
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+
+string hello = await cache.GetAsync(1).ContinueWith(
+                t => t.Result,
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+----
+
+This is rather verbose, but can be simplified with an extension method.
+
+====
+
 
 === Compute
 

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -94,7 +94,20 @@ Tip: use an extension method to reduce verbosity.
 
 *Ignite 2.11 and later*: all `ICompute` async APIs use .NET Thread Pool to run async continuations.
 
-*Ignite 2.10 and before*: Compute async continuations are executed on link:/perf-and-troubleshooting/thread-pools-tuning[Ignite public pool]
+*Ignite 2.10 and before*: Compute async continuations are executed on link:/perf-and-troubleshooting/thread-pools-tuning[Ignite public pool].
+To reduce the load on the public pool, it is recommended to use the same `ContinueWith` approach as above:
+
+[source,csharp]
+----
+await compute.CallAsync(new MyAction()).ContinueWith(
+                t => t.Result,
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+----
+
+This will move the continuation from Ignite public pool (reserved for Compute functionality) to the .NET thread pool (`TaskScheduler.Default`).
+
 
 == ConfigureAwait
 

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -98,7 +98,9 @@ Tip: use an extension method to reduce verbosity.
 
 == ConfigureAwait
 
-TODO
+`Task.ConfigureAwait` method can be used as usual with all Ignite async APIs.
+
+See link:https://devblogs.microsoft.com/dotnet/configureawait-faq/[ConfigureAwait FAQ] for more details.
 
 
 

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -60,7 +60,7 @@ Server and thick client async cache APIs handle async continuations in a special
 [IMPORTANT]
 ====
 [discrete]
-=== *Ignite 2.10 and before*: danger of deadlocks and system pool starvation
+=== *Ignite 2.10 and before*: possibility of deadlocks and system pool starvation
 
 In Ignite versions 2.10 and before, system pool is used to run async continuations,
 which means that `GetAsync` call in the code above is executed by the system thread.
@@ -85,14 +85,16 @@ string hello = await cache.GetAsync(1).ContinueWith(
                 TaskScheduler.Default);
 ----
 
-This is rather verbose, but can be simplified with an extension method.
+Tip: use an extension method to reduce verbosity.
 
 ====
 
 
 === Compute
 
-TODO
+*Ignite 2.11 and later*: all `ICompute` async APIs use .NET Thread Pool to run async continuations.
+
+*Ignite 2.10 and before*: Compute async continuations are executed on link:/perf-and-troubleshooting/thread-pools-tuning[Ignite public pool]
 
 == ConfigureAwait
 

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -21,7 +21,7 @@ Async APIs allow us to write link:https://docs.microsoft.com/en-us/dotnet/csharp
 
 [source,csharp]
 ----
-ICache<int, string> cache = ignite.GetOrCreateCache<int, string>("my-cache");
+ICache<int, string> cache = ignite.GetOrCreateCache<int, string>("name");
 
 // Sync, blocks thread on every call.
 cache.Put(1, "Hello");
@@ -32,7 +32,7 @@ await cache.PutAsync(1, "Hello");
 string hello = await cache.GetAsync(1);
 ----
 
-With async APIs, current thread is not blocked while we wait for cache operation to complete;
+With async APIs, current thread is not blocked while we wait for the cache operation to complete;
 it is returned to the thread pool and can perform other work.
 
 When the async operation completes, our method resumes execution - either on the same thread, or on a different one -
@@ -41,9 +41,20 @@ depending on the environment and the configuration. This is called "async contin
 
 == Async Continuations
 
-=== Cache
+Unless specified otherwise, Ignite executes async continuations on the link:https://docs.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool[.NET Thread Pool.]
 
-TODO
+=== Thin Client
+
+All thin client async APIs use link:https://docs.microsoft.com/en-us/dotnet/standard/threading/the-managed-thread-pool[.NET Thread Pool.] for async continuations.
+
+=== Thick Cache
+
+Server and thick client async cache APIs handle async continuations in a special way:
+
+* In Ignite 2.11 and later, the behavior is controlled by `IgniteConfiguration.AsyncContinuationExecutor` property. A common thread pool is used by default, and no special care is required.
+* To restore the previous behavior, use `IgniteConfiguration.AsyncContinuationExecutor = AsyncContinuationExecutor.UnsafeSynchronous`.
+** Can provide a small performance improvement in some situations, because callbacks are executed without any indirection or scheduling.
+** UNSAFE: cache operations can't proceed while system threads execute continuations (callbacks), and deadlocks are possible if other cache operations are invoked from the callback.
 
 === Compute
 

--- a/docs/_docs/net-specific/net-async.adoc
+++ b/docs/_docs/net-specific/net-async.adoc
@@ -41,6 +41,14 @@ depending on the environment and the configuration. This is called "async contin
 
 == Async Continuations
 
+=== Cache
+
+TODO
+
+=== Compute
+
+TODO
+
 == ConfigureAwait
 
 TODO
@@ -48,23 +56,3 @@ TODO
 
 
 
-== Cache
-
-Consider the following code:
-
-[source,csharp]
-----
-// Print Hello World on all cluster nodes.
-ignite.GetCompute().Broadcast(new HelloAction());
-
-class HelloAction : IComputeAction
-{
-  public void Invoke()
-  {
-    Console.WriteLine("Hello World!");
-  }
-}
-----
-
-
-== Compute

--- a/modules/core/src/main/java/org/apache/ignite/lang/IgniteFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/lang/IgniteFuture.java
@@ -96,20 +96,18 @@ public interface IgniteFuture<V> {
     public boolean isDone();
 
     /**
-     * Registers listener closure to be asynchronously notified whenever future completes.
-     * Closure will be processed in thread that completes this future or (if future already
-     * completed) immediately in current thread.
+     * Registers a callback to be invoked when the future completes.
+     * If the future is already completed, callback will be invoked immediately in the current thread.
      *
      * @param lsnr Listener closure to register. Cannot be {@code null}.
      */
     public void listen(IgniteInClosure<? super IgniteFuture<V>> lsnr);
 
     /**
-     * Registers listener closure to be asynchronously notified whenever future completes.
-     * Closure will be processed in specified executor.
+     * Registers a callback to be invoked with the specified executor when the future completes.
      *
      * @param lsnr Listener closure to register. Cannot be {@code null}.
-     * @param exec Executor to run listener. Cannot be {@code null}.
+     * @param exec Executor to invoke the listener. Cannot be {@code null}.
      */
     public void listenAsync(IgniteInClosure<? super IgniteFuture<V>> lsnr, Executor exec);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/ThinClient/ThinClientPutAsyncBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/ThinClient/ThinClientPutAsyncBenchmark.cs
@@ -18,8 +18,6 @@
 namespace Apache.Ignite.Benchmarks.ThinClient
 {
     using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Apache.Ignite.Benchmarks.Interop;
     using Apache.Ignite.Core.Client.Cache;
 
@@ -47,7 +45,7 @@ namespace Apache.Ignite.Benchmarks.ThinClient
         {
             descs.Add(BenchmarkOperationDescriptor.Create("ThinClientPutAsync", PutAsync, 1));
         }
-
+        
         /// <summary>
         /// Cache put.
         /// </summary>
@@ -55,11 +53,7 @@ namespace Apache.Ignite.Benchmarks.ThinClient
         {
             int idx = BenchmarkUtils.GetRandomInt(Dataset);
 
-            _cache.PutAsync(idx, Emps[idx]).ContinueWith(
-                t => {},
-                CancellationToken.None,
-                TaskContinuationOptions.None,
-                TaskScheduler.Default);
+            _cache.PutAsync(idx, Emps[idx]).Wait();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/ThinClient/ThinClientPutAsyncBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/ThinClient/ThinClientPutAsyncBenchmark.cs
@@ -18,6 +18,8 @@
 namespace Apache.Ignite.Benchmarks.ThinClient
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Apache.Ignite.Benchmarks.Interop;
     using Apache.Ignite.Core.Client.Cache;
 
@@ -45,7 +47,7 @@ namespace Apache.Ignite.Benchmarks.ThinClient
         {
             descs.Add(BenchmarkOperationDescriptor.Create("ThinClientPutAsync", PutAsync, 1));
         }
-        
+
         /// <summary>
         /// Cache put.
         /// </summary>
@@ -53,7 +55,11 @@ namespace Apache.Ignite.Benchmarks.ThinClient
         {
             int idx = BenchmarkUtils.GetRandomInt(Dataset);
 
-            _cache.PutAsync(idx, Emps[idx]).Wait();
+            _cache.PutAsync(idx, Emps[idx]).ContinueWith(
+                t => {},
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
         }
     }
 }


### PR DESCRIPTION
Java:
* Update "Asynchronous Execution" section on "Basic Cache Operations" page
* Fix IgniteFuture javadoc (listen methods)

.NET:
* Add dedicated async page to ".NET Specific" section
* Document Cache and Compute async continuation behavior in different versions
