### PR TITLE
IGNITE-14644 .NET: Log a warning about COMPlus_EnableAlternateStackCheck

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteStartStopTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteStartStopTest.cs
@@ -60,8 +60,6 @@ namespace Apache.Ignite.Core.Tests
         [Test]
         public void TestStartWithConfigPath()
         {
-            Environment.SetEnvironmentVariable("COMPlus_EnableAlternateStackCheck", "0");
-            
             var cfg = new IgniteConfiguration
             {
                 SpringConfigUrl = Path.Combine("Config", "spring-test.xml"),

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteStartStopTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteStartStopTest.cs
@@ -60,6 +60,8 @@ namespace Apache.Ignite.Core.Tests
         [Test]
         public void TestStartWithConfigPath()
         {
+            Environment.SetEnvironmentVariable("COMPlus_EnableAlternateStackCheck", "0");
+            
             var cfg = new IgniteConfiguration
             {
                 SpringConfigUrl = Path.Combine("Config", "spring-test.xml"),

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
@@ -66,6 +66,13 @@ namespace Apache.Ignite.Core
         /// </summary>
         public const string ClientConfigurationSectionName = "igniteClientConfiguration";
 
+        /// <summary>
+        /// Environment variable name to enable alternate stack checks on .NET Core 3+ and .NET 5+.
+        /// This is required to fix "Stack smashing detected" errors that occur instead of NullReferenceException
+        /// on Linux and macOS when Java overwrites SIGSEGV handler installed by .NET in thick client or server mode.
+        /// </summary>
+        private const string EnvEnableAlternateStackCheck = "COMPlus_EnableAlternateStackCheck";
+
         /** */
         private static readonly object SyncRoot = new object();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
@@ -357,7 +357,13 @@ namespace Apache.Ignite.Core
                 {
                     log.Warn("GC server mode is not enabled, this could lead to less " +
                              "than optimal performance on multi-core machines (to enable see " +
-                             "http://msdn.microsoft.com/en-us/library/ms229357(v=vs.110).aspx).");
+                             "https://docs.microsoft.com/en-us/dotnet/core/run-time-config/garbage-collector).");
+                }
+
+                if ((Os.IsLinux || Os.IsMacOs) &&
+                    string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvEnableAlternateStackCheck)))
+                {
+                    log.Warn("TODO");
                 }
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
@@ -361,10 +361,10 @@ namespace Apache.Ignite.Core
                 }
 
                 if ((Os.IsLinux || Os.IsMacOs) &&
-                    string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvEnableAlternateStackCheck)))
+                    Environment.GetEnvironmentVariable(EnvEnableAlternateStackCheck) != "1")
                 {
-                    log.Warn("Alternate stack check is not enabled, this will cause 'Stack smashing detected'" +
-                             "error when NullReferenceException occurs on .NET Core on Linux and macOS." +
+                    log.Warn("Alternate stack check is not enabled, this will cause 'Stack smashing detected' " +
+                             "error when NullReferenceException occurs on .NET Core on Linux and macOS. " +
                              "To enable alternate stack check on .NET Core 3+ and .NET 5+, " +
                              "set {0} environment variable to 1.", EnvEnableAlternateStackCheck);
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
@@ -363,7 +363,10 @@ namespace Apache.Ignite.Core
                 if ((Os.IsLinux || Os.IsMacOs) &&
                     string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvEnableAlternateStackCheck)))
                 {
-                    log.Warn("TODO");
+                    log.Warn("Alternate stack check is not enabled, this will cause 'Stack smashing detected'" +
+                             "error when NullReferenceException occurs on .NET Core on Linux and macOS." +
+                             "To enable alternate stack check on .NET Core 3+ and .NET 5+, " +
+                             "set {0} environment variable to 1.", EnvEnableAlternateStackCheck);
                 }
             }
         }


### PR DESCRIPTION
On Linux, Java overwrites SIGSEGV handler installed by .NET, so NullReferenceException causes a confusing "Stack smashing detected" error. This can be fixed by setting COMPlus_EnableAlternateStackCheck environment variable. Log a warning to raise user awareness.