### PR TITLE
IGNITE-14665 Use parent version of surefire for fork-count-1 profile

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1019,7 +1019,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M3</version>
                         <configuration>
                             <forkCount>1</forkCount>
                         </configuration>


### PR DESCRIPTION
Wrong surefire (parent use 3.0.0-M4, profile - 3.0.0-M3) dependency leads to incorrect work. Then some test suites are skipped on TeamCity.