### PR TITLE
IGNITE-14753 Fix builds with maven 3.8.1+

### DIFF
--- a/modules/azure/pom.xml
+++ b/modules/azure/pom.xml
@@ -242,13 +242,6 @@
             <version>${azure.netty.version}</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/io.netty/netty-transport-native-kqueue -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-kqueue</artifactId>
-            <version>${azure.netty.version}</version>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/io.netty/netty-transport-native-unix-common -->
         <dependency>
             <groupId>io.netty</groupId>

--- a/modules/extdata/uri/pom.xml
+++ b/modules/extdata/uri/pom.xml
@@ -64,7 +64,27 @@
         <module>modules/uri-dependency</module>
     </modules>
 
+    <properties>
+
+        <uri.fn>uri</uri.fn>
+        <uri.jar>${uri.fn}.jar</uri.jar>
+
+        <plain.fn>deployfile</plain.fn>
+        <plain.clr>plain</plain.clr>
+        <plain.jar>${plain.fn}-${plain.clr}.jar</plain.jar>
+
+        <well-signed.fn>deployfile</well-signed.fn>
+        <well-signed.clr>well-signed</well-signed.clr>
+        <well-signed.jar>${well-signed.fn}-${well-signed.clr}.jar</well-signed.jar>
+
+        <bad-signed.fn>deployfile</bad-signed.fn>
+        <bad-signed.clr>bad-signed</bad-signed.clr>
+        <bad-signed.jar>${bad-signed.fn}-${bad-signed.clr}.jar</bad-signed.jar>
+
+    </properties>
+
     <build>
+
         <resources>
             <resource>
                 <directory>src/main/java</directory>
@@ -115,13 +135,29 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>jar-file</id>
+                        <id>jar-uri</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <finalName>deployfile</finalName>
+                            <finalName>${uri.fn}</finalName>
+                            <outputDirectory>${basedir}/target/deploy</outputDirectory>
+                            <includes>
+                                <include>**/GridUriDeploymentTestTask8.class</include>
+                                <include>**/GridUriDeploymentTestWithNameTask8.class</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jar-plain</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${plain.fn}</finalName>
+                            <classifier>${plain.clr}</classifier>
                             <outputDirectory>${basedir}/target/file</outputDirectory>
                             <includes>
                                 <include>**/GridUriDeploymentTestTask8.class</include>
@@ -134,28 +170,14 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>jar-uri</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <finalName>uri</finalName>
-                            <outputDirectory>${basedir}/target/deploy</outputDirectory>
-                            <includes>
-                                <include>**/GridUriDeploymentTestTask8.class</include>
-                                <include>**/GridUriDeploymentTestWithNameTask8.class</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>jar-well-signed</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <finalName>well-signed-deployfile</finalName>
+                            <finalName>${well-signed.fn}</finalName>
+                            <classifier>${well-signed.clr}</classifier>
                             <outputDirectory>${basedir}/target/file</outputDirectory>
                             <includes>
                                 <include>**/GridUriDeploymentTestTask10.class</include>
@@ -170,7 +192,8 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <finalName>bad-signed-deployfile</finalName>
+                            <finalName>${bad-signed.fn}</finalName>
+                            <classifier>${bad-signed.clr}</classifier>
                             <outputDirectory>${basedir}/target/file</outputDirectory>
                             <includes>
                                 <include>**/GridUriDeploymentTestTask11.class</include>
@@ -184,6 +207,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jarsigner-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>sign-well</id>
@@ -192,7 +216,7 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
-                            <archive>${basedir}/target/file/well-signed-deployfile.jar</archive>
+                            <archive>${basedir}/target/file/${well-signed.jar}</archive>
                             <keystore>${basedir}/config/signeddeploy/keystore</keystore>
                             <alias>business</alias>
                             <storepass>abc123</storepass>
@@ -212,7 +236,6 @@
                         <artifactId>ignite-tools</artifactId>
                         <version>${project.version}</version>
                     </dependency>
-
                     <dependency>
                         <groupId>com.sun.mail</groupId>
                         <artifactId>javax.mail</artifactId>
@@ -232,15 +255,15 @@
                                 <copy file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestTask11.class" todir="${basedir}/target/file_tmp/classes/org/apache/ignite/spi/deployment/uri/tasks/" />
                                 <copy file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestTask11.class" tofile="${basedir}/target/file_tmp/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" />
 
-                                <jar destfile="${basedir}/target/file/bad-signed-deployfile.jar" basedir="${basedir}/target/file_tmp/classes" />
+                                <jar destfile="${basedir}/target/file/${bad-signed.jar}" basedir="${basedir}/target/file_tmp/classes" />
 
-                                <signjar jar="${basedir}/target/file/bad-signed-deployfile.jar" keystore="${basedir}/config/signeddeploy/keystore" storepass="abc123" keypass="abc123" alias="business" />
+                                <signjar jar="${basedir}/target/file/${bad-signed.jar}" keystore="${basedir}/config/signeddeploy/keystore" storepass="abc123" keypass="abc123" alias="business" />
 
                                 <sleep seconds="2" />
 
                                 <touch file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" />
 
-                                <zip destfile="${basedir}/target/file/bad-signed-deployfile.jar" basedir="${basedir}/target/classes/" includes="org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" update="yes" />
+                                <zip destfile="${basedir}/target/file/${bad-signed.jar}" basedir="${basedir}/target/classes/" includes="org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" update="yes" />
 
                                 <delete dir="${basedir}/target/file_tmp/"/>
                             </target>
@@ -269,7 +292,7 @@
                                 <!--uri-classes.gar-->
                                 <gar destfile="${basedir}/target/deploy2/uri-classes.gar" basedir="${basedir}/target/classes" />
 
-                                <!--Copy libs.-->
+                                <!--Copy libs-->
                                 <zip destfile="${basedir}/target/classes/lib/depend.jar" encoding="UTF-8">
                                     <zipfileset dir="modules/uri-dependency/target/classes" />
                                 </zip>

--- a/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -36,6 +36,7 @@ import org.hibernate.service.jta.platform.internal.AbstractJtaPlatform;
 import org.hibernate.service.jta.platform.spi.JtaPlatform;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 /**
  *
@@ -75,7 +76,7 @@ public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfT
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -36,6 +36,7 @@ import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 /**
  *
@@ -75,7 +76,7 @@ public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfT
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -36,6 +36,7 @@ import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 /**
  *
@@ -75,7 +76,7 @@ public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfT
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
 
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.ow2.jotm</groupId>
             <artifactId>jotm-core</artifactId>
             <version>${jotm.version}</version>

--- a/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/GridJtaTransactionManagerSelfTest.java
+++ b/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/GridJtaTransactionManagerSelfTest.java
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.objectweb.jotm.Current;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.transactions.TransactionConcurrency.OPTIMISTIC;
@@ -76,7 +77,7 @@ public class GridJtaTransactionManagerSelfTest extends GridCommonAbstractTest {
     @Override protected void beforeTestsStarted() throws Exception {
         super.beforeTestsStarted();
 
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         Current.setAppServer(false);
 

--- a/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/jta/AbstractCacheJtaSelfTest.java
+++ b/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/jta/AbstractCacheJtaSelfTest.java
@@ -31,6 +31,7 @@ import org.apache.ignite.testframework.GridTestSafeThreadFactory;
 import org.apache.ignite.transactions.Transaction;
 import org.junit.Test;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.transactions.TransactionConcurrency.PESSIMISTIC;
@@ -49,7 +50,7 @@ public abstract class AbstractCacheJtaSelfTest extends GridCacheAbstractSelfTest
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/kubernetes/pom.xml
+++ b/modules/kubernetes/pom.xml
@@ -109,13 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>5.11.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/modules/urideploy/pom.xml
+++ b/modules/urideploy/pom.xml
@@ -112,13 +112,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.ignite</groupId>
-            <artifactId>ignite-tools</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
             <version>${jetty.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>16</version>
+        <version>23</version>
     </parent>
 
     <properties>
@@ -95,7 +95,7 @@
         <jms.spec.version>1.1.1</jms.spec.version>
         <jna.version>4.5.2</jna.version>
         <jnr.posix.version>3.0.50</jnr.posix.version>
-        <jotm.version>2.2.3</jotm.version>
+        <jotm.version>2.3.1-M1</jotm.version>
         <jsch.bundle.version>0.1.54_1</jsch.bundle.version>
         <jsch.version>0.1.54</jsch.version>
         <jsonlib.bundle.version>2.4_1</jsonlib.bundle.version>
@@ -293,9 +293,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <configuration>
-                        <useDefaultManifestFile>true</useDefaultManifestFile>
-                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Update versions (migrate from http repositories):
  - apache parent
  - jotm (several tests broke after update, fixed)
  - spark-core_2.11

Fix broken configuration for jar plugin (due to versions upgrade in apache parent):
  - Remove 'useDefaultManifestFile' option from ignite parent pom (due to deprecation)
  - Add classifiers for artifacts in modules/extdata/uri

Remove duplicated dependencies definitions from several modules (maven complained to this during builds with warnings)
