### PR TITLE
fix: libs directory name in documentation

### DIFF
--- a/docs/_docs/setup.adoc
+++ b/docs/_docs/setup.adoc
@@ -138,7 +138,7 @@ functionality. You can enable modules one by one, as required.
 
 All modules are included in the binary distribution, but by default they
 are disabled (except for the `ignite-core`, `ignite-spring`, and
-`ignite-indexing` modules). Modules can be found in the `lib/optional`
+`ignite-indexing` modules). Modules can be found in the `libs/optional`
 directory of the distribution package (each module is located in a
 separate sub-directory).
 
@@ -146,9 +146,9 @@ Depending on how you use Ignite, you can enable modules using one of
 the following methods:
 
 * If you use the binary distribution, move the
-`lib/optional/{module-dir}` to the `lib` directory before starting the
+`libs/optional/{module-dir}` to the `libs` directory before starting the
 node.
-* Add libraries from `lib/optional/{module-dir}` to the classpath of
+* Add libraries from `libs/optional/{module-dir}` to the classpath of
 your application.
 * Add a module as a Maven dependency to your project.
 +


### PR DESCRIPTION
In the latest stable release of 2.10.0 library folder is named as "libs" and not "lib" mentioned in the documentation.
Here's the link for the above-mentioned release - https://apachemirror.wuchna.com//ignite/2.10.0/apache-ignite-2.10.0-bin.zip
