### PR TITLE
IGNITE-14990 Incorrect values of cache, cache group, data region metrics after cluster re-activation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupContext.java
@@ -1305,12 +1305,14 @@ public class CacheGroupContext {
 
     /**
      * Removes statistics metrics registries.
+     *
+     * @param destroy Group destroy flag.
      */
-    public void removeIOStatistic() {
+    public void removeIOStatistic(boolean destroy) {
         if (statHolderData != IoStatisticsHolderNoOp.INSTANCE)
-            ctx.kernalContext().metric().remove(statHolderData.metricRegistryName());
+            ctx.kernalContext().metric().remove(statHolderData.metricRegistryName(), destroy);
 
         if (statHolderIdx != IoStatisticsHolderNoOp.INSTANCE)
-            ctx.kernalContext().metric().remove(statHolderIdx.metricRegistryName());
+            ctx.kernalContext().metric().remove(statHolderIdx.metricRegistryName(), destroy);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupMetricsImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheGroupMetricsImpl.java
@@ -493,17 +493,21 @@ public class CacheGroupMetricsImpl {
         return sparseStorageSize == null ? 0 : sparseStorageSize.value();
     }
 
-    /** Removes all metric for cache group. */
-    public void remove() {
+    /**
+     * Removes all metric for cache group.
+     *
+     * @param destroy Group destroy flag.
+     */
+    public void remove(boolean destroy) {
         if (ctx.shared().kernalContext().isStopping())
             return;
 
         if (ctx.config().getNearConfiguration() != null)
-            ctx.shared().kernalContext().metric().remove(cacheMetricsRegistryName(ctx.config().getName(), true));
+            ctx.shared().kernalContext().metric().remove(cacheMetricsRegistryName(ctx.config().getName(), true), destroy);
 
-        ctx.shared().kernalContext().metric().remove(cacheMetricsRegistryName(ctx.config().getName(), false));
+        ctx.shared().kernalContext().metric().remove(cacheMetricsRegistryName(ctx.config().getName(), false), destroy);
 
-        ctx.shared().kernalContext().metric().remove(metricGroupName());
+        ctx.shared().kernalContext().metric().remove(metricGroupName(), destroy);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
@@ -650,10 +650,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
         lastFut = null;
     }
 
-    /** Remove cache metrics. */
-    public void removeMetrics() {
+    /**
+     * Remove cache metrics.
+     *
+     * @param destroy Group destroy flag.
+     */
+    public void removeMetrics(boolean destroy) {
         if (!ctx.kernalContext().isStopping())
-            ctx.kernalContext().metric().remove(cacheMetricsRegistryName(ctx.name(), isNear()));
+            ctx.kernalContext().metric().remove(cacheMetricsRegistryName(ctx.name(), isNear()), destroy);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -560,11 +560,9 @@ public class GridCacheProcessor extends GridProcessorAdapter {
             }
         }
 
-        if (destroy) {
-            grp.metrics().remove();
+        grp.metrics().remove(destroy);
 
-            grp.removeIOStatistic();
-        }
+        grp.removeIOStatistic(destroy);
 
         sharedCtx.evict().cleanupRemovedGroup(grp.groupId());
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -1037,8 +1037,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
 
             cache.stop();
 
-            if (destroy)
-                cache.removeMetrics();
+            cache.removeMetrics(destroy);
 
             GridCacheContextInfo cacheInfo = new GridCacheContextInfo(ctx, false);
 
@@ -1054,8 +1053,7 @@ public class GridCacheProcessor extends GridProcessorAdapter {
                 if (dht != null) {
                     dht.stop();
 
-                    if (destroy)
-                        dht.removeMetrics();
+                    dht.removeMetrics(destroy);
 
                     GridCacheContext<?, ?> dhtCtx = dht.context();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataRegionMetricsImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/DataRegionMetricsImpl.java
@@ -726,6 +726,11 @@ public class DataRegionMetricsImpl implements DataRegionMetrics {
             metrics.reset();
     }
 
+    /** Removes all metric for data region. */
+    public void remove() {
+        kernalCtx.metric().remove(metricRegistry().name(), false);
+    }
+
     /** @param time Time to add to {@code totalThrottlingTime} metric in milliseconds. */
     public void addThrottlingTime(long time) {
         if (kernalCtx.performanceStatistics().enabled())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IgniteCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IgniteCacheDatabaseSharedManager.java
@@ -1473,6 +1473,8 @@ public class IgniteCacheDatabaseSharedManager extends GridCacheSharedManagerAdap
                 MBEAN_GROUP_NAME,
                 region.metrics().getName()
             );
+
+            region.metrics().remove();
         }
 
         dataRegionMap.clear();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/GridMetricManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/metric/GridMetricManager.java
@@ -410,10 +410,23 @@ public class GridMetricManager extends GridManagerAdapter<MetricExporterSpi> imp
      * @param regName Metric registry name.
      */
     public void remove(String regName) {
+        remove(regName, true);
+    }
+
+    /**
+     * Removes metric registry.
+     *
+     * @param regName Metric registry name.
+     * @param removeCfg {@code True} if remove metric configurations.
+     */
+    public void remove(String regName, boolean removeCfg) {
         GridCompoundFuture opsFut = new GridCompoundFuture<>();
 
         registries.computeIfPresent(regName, (key, mreg) -> {
             notifyListeners(mreg, metricRegRemoveLsnrs, log);
+
+            if (!removeCfg)
+                return null;
 
             DistributedMetaStorage metastorage0 = metastorage;
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/CacheMetricsAddRemoveTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/CacheMetricsAddRemoveTest.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.metric;
 
 import java.util.Arrays;
+import com.google.common.collect.Iterators;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cluster.ClusterState;
 import org.apache.ignite.configuration.CacheConfiguration;
@@ -249,18 +250,12 @@ public class CacheMetricsAddRemoveTest extends GridCommonAbstractTest {
         for (int i = 0; i < 3; i++) {
             GridMetricManager mmgr = metricManager(i);
 
-            MetricRegistry mreg = mmgr.registry(cachePrefix);
-
-            assertNull(mreg.findMetric(metricName(cachePrefix, CACHE_GETS)));
-            assertNull(mreg.findMetric(metricName(cachePrefix, CACHE_PUTS)));
-            assertNull(mreg.findMetric(GET_TIME));
+            assertFalse(Iterators.tryFind(mmgr.iterator(), reg -> cachePrefix.equals(reg.name())).isPresent());
 
             if (nearEnabled) {
-                mreg = mmgr.registry(metricName(cachePrefix, "near"));
+                String regName = metricName(cachePrefix, "near");
 
-                assertNull(mreg.findMetric(CACHE_GETS));
-                assertNull(mreg.findMetric(CACHE_PUTS));
-                assertNull(mreg.findMetric(GET_TIME));
+                assertFalse(Iterators.tryFind(mmgr.iterator(), reg -> regName.equals(reg.name())).isPresent());
             }
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/CacheMetricsAddRemoveTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/CacheMetricsAddRemoveTest.java
@@ -114,7 +114,7 @@ public class CacheMetricsAddRemoveTest extends GridCommonAbstractTest {
         //Cache will be stopped during deactivation.
         grid("client").cluster().state(ClusterState.INACTIVE);
 
-        checkMetricsNotEmpty(cachePrefix);
+        checkMetricsEmpty(cachePrefix);
 
         grid("client").cluster().state(ClusterState.ACTIVE);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/CacheMetricsAddRemoveTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/CacheMetricsAddRemoveTest.java
@@ -253,7 +253,7 @@ public class CacheMetricsAddRemoveTest extends GridCommonAbstractTest {
 
             assertNull(mreg.findMetric(metricName(cachePrefix, CACHE_GETS)));
             assertNull(mreg.findMetric(metricName(cachePrefix, CACHE_PUTS)));
-            assertNull(mreg.findMetric(metricName(cachePrefix, GET_TIME)));
+            assertNull(mreg.findMetric(GET_TIME));
 
             if (nearEnabled) {
                 mreg = mmgr.registry(metricName(cachePrefix, "near"));

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsClusterActivationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsClusterActivationTest.java
@@ -32,6 +32,7 @@ import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.processors.cache.persistence.DataRegion;
 import org.apache.ignite.internal.processors.metric.MetricRegistry;
 import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.spi.metric.IntMetric;
 import org.apache.ignite.spi.metric.LongMetric;
 import org.apache.ignite.spi.metric.ObjectMetric;
@@ -120,26 +121,28 @@ public class MetricsClusterActivationTest extends GridCommonAbstractTest {
         grid(1).rebalanceEnabled(false);
         stopGrid(2);
 
-        checkMetrics(ignite, true);
+        checkMetrics(true);
 
         for (int i = 0; i < 3; i++) {
             ignite.cluster().state(ClusterState.INACTIVE);
 
-            checkMetrics(ignite, false);
+            checkMetrics(false);
 
             ignite.cluster().state(ClusterState.ACTIVE);
 
-            checkMetrics(ignite, isPersistenceEnabled);
+            checkMetrics(isPersistenceEnabled);
         }
     }
 
     /** Checks metrics. */
-    private void checkMetrics(IgniteEx ignite, boolean expEntries) throws IgniteCheckedException {
-        checkDataRegionMetrics(ignite);
+    private void checkMetrics(boolean expEntries) throws IgniteCheckedException {
+        for (IgniteEx ignite : F.transform(G.allGrids(), ignite -> (IgniteEx)ignite)) {
+            checkDataRegionMetrics(ignite);
 
-        checkCacheGroupsMetrics(ignite);
+            checkCacheGroupsMetrics(ignite);
 
-        checkCacheMetrics(ignite, expEntries);
+            checkCacheMetrics(ignite, expEntries);
+        }
     }
 
     /** Checks data region metrics. */

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsClusterActivationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsClusterActivationTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ignite.internal.metric;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.cache.CacheWriteSynchronizationMode;
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.cache.persistence.DataRegion;
+import org.apache.ignite.internal.processors.metric.MetricRegistry;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.spi.metric.IntMetric;
+import org.apache.ignite.spi.metric.LongMetric;
+import org.apache.ignite.spi.metric.ObjectMetric;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.ignite.configuration.DataStorageConfiguration.DFLT_DATA_REG_DEFAULT_NAME;
+import static org.apache.ignite.internal.processors.cache.CacheGroupMetricsImpl.CACHE_GROUP_METRICS_PREFIX;
+import static org.apache.ignite.internal.processors.cache.persistence.DataRegionMetricsImpl.DATAREGION_METRICS_PREFIX;
+import static org.apache.ignite.internal.processors.metric.impl.MetricUtils.cacheMetricsRegistryName;
+import static org.apache.ignite.internal.processors.metric.impl.MetricUtils.metricName;
+
+/**
+ * Tests metrics on a cluster activation.
+ */
+@RunWith(Parameterized.class)
+public class MetricsClusterActivationTest extends GridCommonAbstractTest {
+    /** */
+    public static final int ENTRY_CNT = 50;
+
+    /** */
+    public static final int BACKUPS = 2;
+
+    /** Persistence enabled flag. */
+    @Parameterized.Parameter
+    public boolean isPersistenceEnabled;
+
+    /** @return Test parameters. */
+    @Parameterized.Parameters(name = "isPersistenceEnabled={0}")
+    public static Collection<?> parameters() {
+        return Arrays.asList(new Object[][] {{false}, {true}});
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setDataStorageConfiguration(
+            new DataStorageConfiguration().setDefaultDataRegionConfiguration(
+                new DataRegionConfiguration()
+                    .setPersistenceEnabled(isPersistenceEnabled)
+                    .setMetricsEnabled(true))
+        );
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        if (isPersistenceEnabled)
+            cleanPersistenceDir();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids();
+
+        if (isPersistenceEnabled)
+            cleanPersistenceDir();
+    }
+
+    /** @throws Exception If failed. */
+    @Test
+    public void testReActivate() throws Exception {
+        IgniteEx ignite = startGrids(3);
+
+        ignite.cluster().state(ClusterState.ACTIVE);
+
+        IgniteCache<Object, Object> cache = ignite.getOrCreateCache(
+            new CacheConfiguration<>(DEFAULT_CACHE_NAME)
+                .setStatisticsEnabled(true)
+                .setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC)
+                .setBackups(BACKUPS));
+
+        for (int i = 0; i < ENTRY_CNT; i++)
+            cache.put(i, i);
+
+        // Pause rebalance to check instant partitions states.
+        grid(0).rebalanceEnabled(false);
+        grid(1).rebalanceEnabled(false);
+        stopGrid(2);
+
+        checkMetrics(ignite, true);
+
+        for (int i = 0; i < 3; i++) {
+            ignite.cluster().state(ClusterState.INACTIVE);
+
+            checkMetrics(ignite, false);
+
+            ignite.cluster().state(ClusterState.ACTIVE);
+
+            checkMetrics(ignite, isPersistenceEnabled);
+        }
+    }
+
+    /** Checks metrics. */
+    private void checkMetrics(IgniteEx ignite, boolean expEntries) throws IgniteCheckedException {
+        checkDataRegionMetrics(ignite);
+
+        checkCacheGroupsMetrics(ignite);
+
+        checkCacheMetrics(ignite, expEntries);
+    }
+
+    /** Checks data region metrics. */
+    private void checkDataRegionMetrics(IgniteEx ignite) throws IgniteCheckedException {
+        DataRegion region = ignite.context().cache().context().database().dataRegion(DFLT_DATA_REG_DEFAULT_NAME);
+
+        MetricRegistry mreg = ignite.context().metric().registry(metricName(DATAREGION_METRICS_PREFIX,
+            DFLT_DATA_REG_DEFAULT_NAME));
+
+        if (!ignite.cluster().state().active()) {
+            assertEquals(0, F.size(mreg.iterator()));
+
+            return;
+        }
+
+        long offHeapSize = mreg.<LongMetric>findMetric("OffHeapSize").value();
+        long initialSize = mreg.<LongMetric>findMetric("InitialSize").value();
+        long maxSize = mreg.<LongMetric>findMetric("MaxSize").value();
+
+        assertTrue(offHeapSize > 0);
+        assertTrue(offHeapSize <= region.config().getMaxSize());
+        assertEquals(region.config().getInitialSize(), initialSize);
+        assertEquals(region.config().getMaxSize(), maxSize);
+    }
+
+    /** Checks cache groups metrics. */
+    private void checkCacheGroupsMetrics(IgniteEx ignite) {
+        MetricRegistry mreg = ignite.context().metric().registry(metricName(CACHE_GROUP_METRICS_PREFIX,
+            DEFAULT_CACHE_NAME));
+
+        if (!ignite.cluster().state().active()) {
+            assertEquals(0, F.size(mreg.iterator()));
+
+            return;
+        }
+
+        int minimumNumberOfPartitionCopies = mreg.<IntMetric>findMetric("MinimumNumberOfPartitionCopies").value();
+        int maximumNumberOfPartitionCopies = mreg.<IntMetric>findMetric("MaximumNumberOfPartitionCopies").value();
+        Map<Integer, List<String>> owningPartitionsAllocationMap = mreg.
+            <ObjectMetric<Map<Integer, List<String>>>>findMetric("OwningPartitionsAllocationMap").value();
+        Map<Integer, List<String>> movingPartitionsAllocationMap = mreg.
+            <ObjectMetric<Map<Integer, List<String>>>>findMetric("MovingPartitionsAllocationMap").value();
+
+        assertEquals(BACKUPS, minimumNumberOfPartitionCopies);
+        assertEquals(BACKUPS, maximumNumberOfPartitionCopies);
+        assertFalse(owningPartitionsAllocationMap.isEmpty());
+        assertFalse(movingPartitionsAllocationMap.isEmpty());
+    }
+
+    /** Checks cache groups metrics. */
+    private void checkCacheMetrics(IgniteEx ignite, boolean expEntries) {
+        MetricRegistry mreg = ignite.context().metric().registry(cacheMetricsRegistryName(DEFAULT_CACHE_NAME, false));
+
+        if (!ignite.cluster().state().active()) {
+            assertEquals(0, F.size(mreg.iterator()));
+
+            return;
+        }
+
+        long offHeapEntriesCount = mreg.<LongMetric>findMetric("OffHeapEntriesCount").value();
+        long offHeapPrimaryEntriesCount = mreg.<LongMetric>findMetric("OffHeapPrimaryEntriesCount").value();
+        long offHeapBackupEntriesCount = mreg.<LongMetric>findMetric("OffHeapBackupEntriesCount").value();
+
+        if (expEntries) {
+            assertEquals(ENTRY_CNT, offHeapEntriesCount);
+            assertTrue(offHeapPrimaryEntriesCount > 0);
+            assertTrue(offHeapBackupEntriesCount > 0);
+        }
+        else {
+            assertEquals(0, offHeapEntriesCount);
+            assertEquals(0, offHeapPrimaryEntriesCount);
+            assertEquals(0, offHeapBackupEntriesCount);
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsClusterActivationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/MetricsClusterActivationTest.java
@@ -189,7 +189,7 @@ public class MetricsClusterActivationTest extends GridCommonAbstractTest {
         assertFalse(movingPartitionsAllocationMap.isEmpty());
     }
 
-    /** Checks cache groups metrics. */
+    /** Checks cache metrics. */
     private void checkCacheMetrics(IgniteEx ignite, boolean expEntries) {
         MetricRegistry mreg = ignite.context().metric().registry(cacheMetricsRegistryName(DEFAULT_CACHE_NAME, false));
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/IgniteSequenceInternalCleanupTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/IgniteSequenceInternalCleanupTest.java
@@ -113,11 +113,9 @@ public class IgniteSequenceInternalCleanupTest extends GridCommonAbstractTest {
 
             ignite.cluster().active(true);
 
-            doSleep(500);
-
             long putsAfter = ignite.cache("test0").metrics().getCachePuts();
 
-            assertEquals(1, putsAfter);
+            assertEquals(0, putsAfter);
         }
         finally {
             stopAllGrids();

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -99,6 +99,7 @@ import org.apache.ignite.internal.processors.database.BPlusTreeFakeReuseSelfTest
 import org.apache.ignite.internal.processors.database.BPlusTreeReuseSelfTest;
 import org.apache.ignite.internal.processors.database.BPlusTreeSelfTest;
 import org.apache.ignite.internal.processors.database.CacheFreeListSelfTest;
+import org.apache.ignite.internal.metric.MetricsClusterActivationTest;
 import org.apache.ignite.internal.processors.database.DataRegionMetricsSelfTest;
 import org.apache.ignite.internal.processors.database.IndexStorageSelfTest;
 import org.apache.ignite.internal.processors.database.SwapPathConstructionSelfTest;
@@ -236,6 +237,7 @@ import org.junit.runners.Suite;
     IndexStorageSelfTest.class,
     CacheFreeListSelfTest.class,
     DataRegionMetricsSelfTest.class,
+    MetricsClusterActivationTest.class,
     SwapPathConstructionSelfTest.class,
     BitSetIntSetTest.class,
     ImmutableIntSetTest.class,

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -56,6 +56,7 @@ import org.apache.ignite.internal.managers.IgniteDiagnosticMessagesMultipleConne
 import org.apache.ignite.internal.managers.IgniteDiagnosticMessagesTest;
 import org.apache.ignite.internal.managers.communication.GridIoManagerFileTransmissionSelfTest;
 import org.apache.ignite.internal.managers.discovery.IncompleteDeserializationExceptionTest;
+import org.apache.ignite.internal.metric.MetricsClusterActivationTest;
 import org.apache.ignite.internal.mxbean.IgniteStandardMXBeanTest;
 import org.apache.ignite.internal.pagemem.wal.record.WALRecordSerializationTest;
 import org.apache.ignite.internal.pagemem.wal.record.WALRecordTest;
@@ -99,7 +100,6 @@ import org.apache.ignite.internal.processors.database.BPlusTreeFakeReuseSelfTest
 import org.apache.ignite.internal.processors.database.BPlusTreeReuseSelfTest;
 import org.apache.ignite.internal.processors.database.BPlusTreeSelfTest;
 import org.apache.ignite.internal.processors.database.CacheFreeListSelfTest;
-import org.apache.ignite.internal.metric.MetricsClusterActivationTest;
 import org.apache.ignite.internal.processors.database.DataRegionMetricsSelfTest;
 import org.apache.ignite.internal.processors.database.IndexStorageSelfTest;
 import org.apache.ignite.internal.processors.database.SwapPathConstructionSelfTest;


### PR DESCRIPTION
Remove data region/cache/cache group metrics on deactivation without removing metrics configuration.