### PR TITLE
IGNITE-15045 .NET: Fix NullPointerException in ContinuousQuery with security enabled

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/SecurityAwareFilter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/SecurityAwareFilter.java
@@ -53,6 +53,11 @@ public class SecurityAwareFilter<K, V> extends AbstractSecurityAwareExternalizab
 
     /** {@inheritDoc} */
     @Override public boolean evaluate(CacheEntryEvent<? extends K, ? extends V> evt) throws CacheEntryListenerException {
+        // Even if there is no custom filter, the platform filter is always present (for proper resource release),
+        // but only the custom filter is serialized.
+        if (original == null)
+            return true;
+
         IgniteSecurity security = ignite.context().security();
 
         try (OperationSecurityContext c = security.withContext(subjectId)) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -142,10 +142,8 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
 
                 qry.setLocalListener(this);
 
-                if (hasFilter || javaFilter != null) {
-                    //noinspection deprecation
-                    qry.setRemoteFilter(this); // Filter must be set always for correct resource release.
-                }
+                //noinspection deprecation
+                qry.setRemoteFilter(this); // Filter must be set always for correct resource release.
 
                 qry.setPageSize(bufSize);
                 qry.setTimeInterval(timeInterval);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -142,8 +142,10 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
 
                 qry.setLocalListener(this);
 
-                //noinspection deprecation
-                qry.setRemoteFilter(this); // Filter must be set always for correct resource release.
+                if (hasFilter || javaFilter != null) {
+                    //noinspection deprecation
+                    qry.setRemoteFilter(this); // Filter must be set always for correct resource release.
+                }
 
                 qry.setPageSize(bufSize);
                 qry.setTimeInterval(timeInterval);


### PR DESCRIPTION
Add null check to `SecurityAwareFilter`, because `PlatformContinuousQueryImpl` always sets itself as a remote filter, but serializes as null when the actual filter is not present.