### PR TITLE
IGNITE-15270  Fix rebalance test

### DIFF
--- a/modules/ducktests/tests/ignitetest/tests/rebalance/persistent_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/rebalance/persistent_test.py
@@ -74,7 +74,7 @@ class RebalancePersistentTest(IgniteTest):
 
         nodes.append(new_node.nodes[0])
 
-        result = get_result(rebalance_nodes, preload_time, cache_count, entry_count, entry_size)
+        result = get_result(new_node.nodes, preload_time, cache_count, entry_count, entry_size)
 
         control_utility.deactivate()
 
@@ -120,7 +120,7 @@ class RebalancePersistentTest(IgniteTest):
 
         await_and_check_rebalance(ignites)
 
-        result = get_result(rebalance_nodes, preload_time, cache_count, entry_count, entry_size)
+        result = get_result(ignites.nodes[:-1], preload_time, cache_count, entry_count, entry_size)
 
         control_utility.deactivate()
 

--- a/modules/ducktests/tests/ignitetest/tests/rebalance/persistent_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/rebalance/persistent_test.py
@@ -70,8 +70,6 @@ class RebalancePersistentTest(IgniteTest):
 
         await_and_check_rebalance(new_node)
 
-        control_utility.deactivate()
-
         nodes = ignites.nodes.copy()
 
         nodes.append(new_node.nodes[0])
@@ -117,8 +115,6 @@ class RebalancePersistentTest(IgniteTest):
         control_utility.remove_from_baseline([node])
 
         await_and_check_rebalance(ignites)
-
-        control_utility.deactivate()
 
         self.logger.debug(f'DB size after rebalance: {get_database_size_mb(ignites.nodes, ignites.database_dir)}')
 
@@ -185,8 +181,6 @@ class RebalancePersistentTest(IgniteTest):
         rebalance_nodes = [node]
 
         await_and_check_rebalance(ignites, rebalance_nodes, False)
-
-        control_utility.deactivate()
 
         self.logger.debug(f'DB size after rebalance: {get_database_size_mb(ignites.nodes, ignites.database_dir)}')
 

--- a/modules/ducktests/tests/ignitetest/tests/rebalance/persistent_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/rebalance/persistent_test.py
@@ -74,9 +74,13 @@ class RebalancePersistentTest(IgniteTest):
 
         nodes.append(new_node.nodes[0])
 
+        result = get_result(rebalance_nodes, preload_time, cache_count, entry_count, entry_size)
+
+        control_utility.deactivate()
+
         self.logger.debug(f'DB size after rebalance: {get_database_size_mb(nodes, ignites.database_dir)}')
 
-        return get_result(new_node.nodes, preload_time, cache_count, entry_count, entry_size)
+        return result
 
     # pylint: disable=too-many-arguments, too-many-locals
     @cluster(num_nodes=NUM_NODES)
@@ -116,9 +120,13 @@ class RebalancePersistentTest(IgniteTest):
 
         await_and_check_rebalance(ignites)
 
+        result = get_result(rebalance_nodes, preload_time, cache_count, entry_count, entry_size)
+
+        control_utility.deactivate()
+
         self.logger.debug(f'DB size after rebalance: {get_database_size_mb(ignites.nodes, ignites.database_dir)}')
 
-        return get_result(ignites.nodes[:-1], preload_time, cache_count, entry_count, entry_size)
+        return result
 
     @cluster(num_nodes=NUM_NODES)
     @ignite_versions(str(DEV_BRANCH), str(LATEST))
@@ -182,9 +190,13 @@ class RebalancePersistentTest(IgniteTest):
 
         await_and_check_rebalance(ignites, rebalance_nodes, False)
 
+        result = get_result(rebalance_nodes, preload_time, cache_count, entry_count, entry_size)
+
+        control_utility.deactivate()
+
         self.logger.debug(f'DB size after rebalance: {get_database_size_mb(ignites.nodes, ignites.database_dir)}')
 
-        return get_result(rebalance_nodes, preload_time, cache_count, entry_count, entry_size)
+        return result
 
 
 def await_and_check_rebalance(service: IgniteService, rebalance_nodes: list = None, is_full: bool = True):


### PR DESCRIPTION
Thank you for submitting the pull request to the Apache Ignite.

DuctTape rebalance test dont work on dev version because it tries to read cache statistics on deactivated cluster. 
Easy fix is to remove unneeded? deactivation in this test

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
