### PR TITLE
IGNITE-15302 Add support of precision parameter for varbinary type

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/annotations/QuerySqlField.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/annotations/QuerySqlField.java
@@ -64,9 +64,9 @@ public @interface QuerySqlField {
     boolean notNull() default false;
 
     /**
-     * Specifies precision for a decimal field.
+     * Specifies field precision for variable length types - decimal, string and byte array.
      *
-     * @return precision for a decimal field.
+     * @return field precision for variable length types - decimal, string and byte array.
      */
     int precision() default -1;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
@@ -647,8 +647,8 @@ public class QueryTypeDescriptorImpl implements GridQueryTypeDescriptor {
                 continue;
 
             if (String.class == propVal.getClass() || byte[].class == propVal.getClass()) {
-                int propValLen = propVal.getClass() == String.class ? ((String) propVal).length()
-                    : ((byte[]) propVal).length;
+                int propValLen = String.class == propVal.getClass() ? ((String)propVal).length()
+                    : ((byte[])propVal).length;
 
                 if (propValLen > prop.precision()) {
                     throw new IgniteSQLException("Value for a column '" + prop.name() + "' is too long. " +

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
@@ -646,11 +646,15 @@ public class QueryTypeDescriptorImpl implements GridQueryTypeDescriptor {
             if (propVal == null || prop.precision() == -1)
                 continue;
 
-            if (String.class == propVal.getClass() &&
-                ((String)propVal).length() > prop.precision()) {
-                throw new IgniteSQLException("Value for a column '" + prop.name() + "' is too long. " + 
-                    "Maximum length: " + prop.precision() + ", actual length: " + ((CharSequence)propVal).length(),
-                    isKey ? TOO_LONG_KEY : TOO_LONG_VALUE);
+            if (String.class == propVal.getClass() || byte[].class == propVal.getClass()) {
+                int propValLen = propVal.getClass() == String.class ? ((String) propVal).length()
+                    : ((byte[]) propVal).length;
+
+                if (propValLen > prop.precision()) {
+                    throw new IgniteSQLException("Value for a column '" + prop.name() + "' is too long. " +
+                        "Maximum length: " + prop.precision() + ", actual length: " + propValLen,
+                        isKey ? TOO_LONG_KEY : TOO_LONG_VALUE);
+                }
             }
             else if (BigDecimal.class == propVal.getClass()) {
                 BigDecimal dec = (BigDecimal)propVal;

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
@@ -1173,7 +1173,8 @@ public class CommandProcessor {
 
             if (col.getType() == Value.STRING ||
                 col.getType() == Value.STRING_FIXED ||
-                col.getType() == Value.STRING_IGNORECASE)
+                col.getType() == Value.STRING_IGNORECASE ||
+                col.getType() == Value.BYTES)
                 if (col.getPrecision() < H2Utils.STRING_DEFAULT_PRECISION)
                     precision.put(e.getKey(), (int)col.getPrecision());
         }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2Utils.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2Utils.java
@@ -694,7 +694,8 @@ public class H2Utils {
 
         if (precision != -1 && (
                 dbType.equalsIgnoreCase(H2DatabaseType.VARCHAR.dBTypeAsString())
-                        || dbType.equalsIgnoreCase(H2DatabaseType.DECIMAL.dBTypeAsString())))
+                        || dbType.equalsIgnoreCase(H2DatabaseType.DECIMAL.dBTypeAsString())
+                        || dbType.equalsIgnoreCase(H2DatabaseType.BINARY.dBTypeAsString())))
             return dbType + '(' + precision + ')';
 
         return dbType;

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/FieldsPrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/FieldsPrecisionTest.java
@@ -35,7 +35,7 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
 /** */
-public class PrecisionTest extends GridCommonAbstractTest {
+public class FieldsPrecisionTest extends GridCommonAbstractTest {
     /** */
     private static final String PERSON_CACHE = "PERSON";
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/FieldsPrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/FieldsPrecisionTest.java
@@ -105,7 +105,7 @@ public class FieldsPrecisionTest extends GridCommonAbstractTest {
     }
 
     /** */
-    private void assertPrecision(IgniteCache cache, Callable<Object> clo, String colName) {
+    private void assertPrecision(IgniteCache<Integer, Person> cache, Callable<Object> clo, String colName) {
         GridTestUtils.assertThrows(null, clo, CacheException.class,
             "Value for a column '" + colName + "' is too long. Maximum length: 5, actual length: 6");
 
@@ -120,7 +120,7 @@ public class FieldsPrecisionTest extends GridCommonAbstractTest {
     }
 
     /** */
-    private IgniteCache startSqlPersonCache() {
+    private IgniteCache<Integer, Person> startSqlPersonCache() {
         ignite.context().query().querySqlFields(new SqlFieldsQuery(
             "create table " + PERSON_CACHE + "(" +
             "   id int PRIMARY KEY," +

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.processors.cache;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 import javax.cache.CacheException;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.QueryEntity;
@@ -77,7 +78,7 @@ public class PrecisionTest extends GridCommonAbstractTest {
         cache.put(KEY + 1, new Person(VALID_STR));
         assertNotNull(cache.get(KEY + 1));
 
-        cache.put(KEY + 2, new Person(VALID_STR));
+        cache.put(KEY + 2, new Person(VALID_STR.getBytes(StandardCharsets.UTF_8)));
         assertNotNull(cache.get(KEY + 2));
 
         cache.query(sqlInsertQuery(KEY + 3, "str", VALID_STR));

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
@@ -18,7 +18,9 @@
 package org.apache.ignite.internal.processors.cache;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 import javax.cache.CacheException;
@@ -76,13 +78,15 @@ public class PrecisionTest extends GridCommonAbstractTest {
     /** */
     private void checkCachePutInsert(IgniteCache<Integer, Person> cache) {
         Stream.of("str", "bin").forEach(fld -> {
-            cache.put(KEY, Person.newPerson(fld, true));
-            assertNotNull(cache.get(KEY));
+            Person validPerson = Person.newPerson(fld, true);
+
+            cache.put(KEY, validPerson);
+            assertEquals(validPerson, cache.get(KEY));
 
             cache.clear();
 
             cache.query(sqlInsertQuery(fld, VALID_STR));
-            assertNotNull(cache.get(KEY));
+            assertEquals(validPerson, cache.get(KEY));
 
             cache.clear();
 
@@ -173,6 +177,26 @@ public class PrecisionTest extends GridCommonAbstractTest {
             String s = valid ? VALID_STR : INVALID_STR;
 
             return "bin".equals(fld) ? new Person(s.getBytes(StandardCharsets.UTF_8)) : new Person(s);
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Person person = (Person)o;
+
+            return id == person.id && Objects.equals(str, person.str) && Arrays.equals(bin, person.bin);
+        }
+
+        /** {@inheritDoc} */
+        @Override public int hashCode() {
+            int result = Objects.hash(id, str);
+            result = 31 * result + Arrays.hashCode(bin);
+            return result;
         }
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
@@ -141,8 +141,11 @@ public class PrecisionTest extends GridCommonAbstractTest {
 
     /** */
     private QueryEntity personQueryEntity() {
-        return new QueryEntity(Integer.class, Person.class)
-            .setKeyType(Integer.class.getName());
+        QueryEntity entity = new QueryEntity(Integer.class, Person.class);
+        entity.setKeyFieldName("id");
+        entity.addQueryField("id", Integer.class.getName(), "ID");
+
+        return entity;
     }
 
     /** */

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import javax.cache.CacheException;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.cache.query.annotations.QuerySqlField;
+import org.apache.ignite.client.ClientCache;
+import org.apache.ignite.client.ClientException;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/** */
+public class PrecisionTest extends GridCommonAbstractTest {
+    /** */
+    private IgniteCache<Integer, Person> cache;
+
+    /** */
+    private static final int KEY = 0;
+
+    /** */
+    private static final int CNT = 10;
+
+
+    /** {@inheritDoc} */
+    @Override public IgniteConfiguration getConfiguration(String instanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(instanceName);
+
+        CacheConfiguration<Integer, Person> ccfg = new CacheConfiguration<Integer, Person>("PERSON")
+            .setIndexedTypes(Integer.class, Person.class);
+
+        cfg.setCacheConfiguration(ccfg);
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        Ignite ignite = startGrids(2);
+
+        cache = ignite.cache("PERSON");
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+    }
+
+    /** */
+    @Test
+    public void testInsertTableVarColumns() {
+        cache.query(new SqlFieldsQuery("" +
+            "create table TABLE(" +
+            "   id int PRIMARY KEY," +
+            "   str varchar(5)," +
+            "   bin binary(5)" +
+            ") with \"CACHE_NAME=SQL,VALUE_TYPE=SQL_TYPE\""));
+
+        StringBuilder validStr = new StringBuilder("12345");
+
+        SqlFieldsQuery strQry = new SqlFieldsQuery("insert into TABLE(id, str) values (?, ?)");
+        SqlFieldsQuery binQry = new SqlFieldsQuery("insert into TABLE(id, bin) values (?, ?)");
+
+        IgniteCache tblCache = ignite(0).cache("SQL");
+
+        for (int i = 1; i < CNT; i++) {
+            validStr.append("0");
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    cache.query(strQry.setArgs(KEY, validStr.toString()));
+
+                    return null;
+                } }, "STR", 5 + i);
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    cache.query(binQry.setArgs(KEY, validStr.toString().getBytes(StandardCharsets.UTF_8)));
+
+                    return null;
+                } }, "BIN", 5 + i);
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    BinaryObject bo = ignite(0).binary().builder("SQL_TYPE")
+                        .setField("id", KEY)
+                        .setField("str", validStr.toString())
+                        .build();
+
+                    tblCache.put(0, bo);
+
+                    return null;
+                } }, "STR", 5 + i);
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    BinaryObject bo = ignite(0).binary().builder("SQL_TYPE")
+                        .setField("id", KEY)
+                        .setField("bin", validStr.toString().getBytes(StandardCharsets.UTF_8))
+                        .build();
+
+                    tblCache.put(0, bo);
+
+                    return null;
+                } }, "BIN", 5 + i);
+        }
+    }
+
+    /** */
+    @Test
+    public void testInsertValueVarColumns() {
+        StringBuilder validStr = new StringBuilder("12345");
+
+        SqlFieldsQuery strQry = new SqlFieldsQuery("insert into PERSON(_KEY, name) values (?, ?)");
+        SqlFieldsQuery binQry = new SqlFieldsQuery("insert into PERSON(_KEY, arr) values (?, ?)");
+
+        for (int i = 1; i < CNT; i++) {
+            String v = validStr.append("0").toString();
+            int len = 5 + i;
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    cache.put(KEY, new Person(v));
+
+                    return null;
+                } }, "NAME", len);
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    cache.put(KEY, new Person(v.getBytes(StandardCharsets.UTF_8)));
+
+                    return null;
+                } }, "ARR", len);
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    cache.query(strQry.setArgs(KEY, v));
+
+                    return null;
+                } }, "NAME", len);
+
+            assertPrecision(new Callable<Object>() {
+                @Override public Object call() {
+                    cache.query(binQry.setArgs(KEY, v.getBytes(StandardCharsets.UTF_8)));
+
+                    return null;
+                } }, "ARR", len);
+        }
+    }
+
+    /** */
+    @Test
+    public void testClientInsertTableVarColumns() throws Exception {
+        cache.query(new SqlFieldsQuery("" +
+            "create table TABLE(" +
+            "   id int PRIMARY KEY," +
+            "   str varchar(5)," +
+            "   bin binary(5)" +
+            ") with \"CACHE_NAME=SQL,VALUE_TYPE=SQL_TYPE\""));
+
+        StringBuilder validStr = new StringBuilder("12345");
+
+        SqlFieldsQuery strQry = new SqlFieldsQuery("insert into TABLE(id, str) values (?, ?)");
+        SqlFieldsQuery binQry = new SqlFieldsQuery("insert into TABLE(id, bin) values (?, ?)");
+
+        try (IgniteClient client = Ignition.startClient(new ClientConfiguration().setAddresses("127.0.0.1"))) {
+            ClientCache cc = client.cache("SQL");
+
+            for (int i = 1; i < CNT; i++) {
+                validStr.append("0");
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        cc.query(strQry.setArgs(KEY, validStr.toString())).getAll();
+
+                        return null;
+                    } }, "STR", 5 + i);
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        cc.query(binQry.setArgs(KEY, validStr.toString().getBytes(StandardCharsets.UTF_8))).getAll();
+
+                        return null;
+                    } }, "BIN", 5 + i);
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        BinaryObject bo = ignite(0).binary().builder("SQL_TYPE")
+                            .setField("id", KEY)
+                            .setField("str", validStr.toString())
+                            .build();
+
+                        cc.put(0, bo);
+
+                        return null;
+                    } }, "STR", 5 + i);
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        BinaryObject bo = ignite(0).binary().builder("SQL_TYPE")
+                            .setField("id", KEY)
+                            .setField("bin", validStr.toString().getBytes(StandardCharsets.UTF_8))
+                            .build();
+
+                        cc.put(0, bo);
+
+                        return null;
+                    } }, "BIN", 5 + i);
+            }
+        }
+    }
+
+    /** */
+    @Test
+    public void testClientInsertValueVarColumns() throws Exception {
+        try (IgniteClient client = Ignition.startClient(new ClientConfiguration().setAddresses("127.0.0.1"))) {
+            ClientCache cc = client.cache("PERSON");
+
+            StringBuilder validStr = new StringBuilder("12345");
+
+            SqlFieldsQuery strQry = new SqlFieldsQuery("insert into PERSON(_KEY, name) values (?, ?)");
+            SqlFieldsQuery binQry = new SqlFieldsQuery("insert into PERSON(_KEY, arr) values (?, ?)");
+
+            for (int i = 1; i < CNT; i++) {
+                String v = validStr.append("0").toString();
+                int len = 5 + i;
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        cc.put(KEY, new Person(v));
+
+                        return null;
+                    } }, "NAME", len);
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        cc.put(KEY, new Person(v.getBytes(StandardCharsets.UTF_8)));
+
+                        return null;
+                    } }, "ARR", len);
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        cc.query(strQry.setArgs(KEY, v)).getAll();
+
+                        return null;
+                    } }, "NAME", len);
+
+                assertClientPrecision(new Callable<Object>() {
+                    @Override public Object call() {
+                        cc.query(binQry.setArgs(KEY, v.getBytes(StandardCharsets.UTF_8))).getAll();
+
+                        return null;
+                    } }, "ARR", len);
+            }
+        }
+    }
+
+    /** */
+    private void assertPrecision(Callable<Object> clo, String colName, int len) {
+        GridTestUtils.assertThrows(null, clo, CacheException.class,
+            "Value for a column '" + colName + "' is too long. Maximum length: 5, actual length: " + len);
+
+        assertNull(cache.get(0));
+    }
+
+    /** */
+    private void assertClientPrecision(Callable<Object> clo, String colName, int len) {
+        GridTestUtils.assertThrows(null, clo, ClientException.class,
+            "Value for a column '" + colName + "' is too long. Maximum length: 5, actual length: " + len);
+
+        assertNull(cache.get(0));
+    }
+
+    /** */
+    static class Person {
+        /** */
+        @QuerySqlField(precision = 5)
+        private final String name;
+
+        @QuerySqlField(precision = 5)
+        private final byte[] arr;
+
+        /** */
+        Person(String name) {
+            this.name = name;
+            this.arr = null;
+        }
+
+        /** */
+        Person(byte[] arr) {
+            this.name = null;
+            this.arr = arr;
+        }
+
+        /** {@inheritDoc} */
+        @Override public int hashCode() {
+            if (name != null)
+                return name.hashCode();
+            else
+                return Arrays.hashCode(arr);
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Person person = (Person)o;
+
+            return java.util.Objects.equals(name, person.name) && Arrays.equals(arr, person.arr);
+        }
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/PrecisionTest.java
@@ -142,16 +142,11 @@ public class PrecisionTest extends GridCommonAbstractTest {
     /** */
     private QueryEntity personQueryEntity() {
         return new QueryEntity(Integer.class, Person.class)
-            .setKeyType(Integer.class.getName())
-            .setKeyFieldName("id");
+            .setKeyType(Integer.class.getName());
     }
 
     /** */
     static class Person {
-        /** */
-        @QuerySqlField
-        private int id;
-
         /** */
         @QuerySqlField(precision = 5)
         private final String str;
@@ -189,12 +184,12 @@ public class PrecisionTest extends GridCommonAbstractTest {
 
             Person person = (Person)o;
 
-            return id == person.id && Objects.equals(str, person.str) && Arrays.equals(bin, person.bin);
+            return Objects.equals(str, person.str) && Arrays.equals(bin, person.bin);
         }
 
         /** {@inheritDoc} */
         @Override public int hashCode() {
-            int result = Objects.hash(id, str);
+            int result = Objects.hash(str);
             result = 31 * result + Arrays.hashCode(bin);
             return result;
         }

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
@@ -33,6 +33,7 @@ import org.apache.ignite.internal.processors.cache.CacheRegisterMetadataLocallyT
 import org.apache.ignite.internal.processors.cache.ClientReconnectAfterClusterRestartTest;
 import org.apache.ignite.internal.processors.cache.ClusterReadOnlyModeDoesNotBreakSqlSelectTest;
 import org.apache.ignite.internal.processors.cache.ClusterReadOnlyModeSqlTest;
+import org.apache.ignite.internal.processors.cache.FieldsPrecisionTest;
 import org.apache.ignite.internal.processors.cache.GridCacheOffHeapSelfTest;
 import org.apache.ignite.internal.processors.cache.GridCacheOffheapIndexEntryEvictTest;
 import org.apache.ignite.internal.processors.cache.GridCacheOffheapIndexGetSelfTest;
@@ -42,7 +43,6 @@ import org.apache.ignite.internal.processors.cache.IgniteCacheConfigurationPrimi
 import org.apache.ignite.internal.processors.cache.IgniteCacheGroupsSqlTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheStarvationOnRebalanceTest;
 import org.apache.ignite.internal.processors.cache.IgniteClientReconnectQueriesTest;
-import org.apache.ignite.internal.processors.cache.FieldsPrecisionTest;
 import org.apache.ignite.internal.processors.cache.WrongIndexedTypesTest;
 import org.apache.ignite.internal.processors.cache.index.H2TreeCorruptedTreeExceptionTest;
 import org.apache.ignite.internal.processors.cache.persistence.RebuildIndexLogMessageTest;

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
@@ -42,6 +42,7 @@ import org.apache.ignite.internal.processors.cache.IgniteCacheConfigurationPrimi
 import org.apache.ignite.internal.processors.cache.IgniteCacheGroupsSqlTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheStarvationOnRebalanceTest;
 import org.apache.ignite.internal.processors.cache.IgniteClientReconnectQueriesTest;
+import org.apache.ignite.internal.processors.cache.PrecisionTest;
 import org.apache.ignite.internal.processors.cache.WrongIndexedTypesTest;
 import org.apache.ignite.internal.processors.cache.index.H2TreeCorruptedTreeExceptionTest;
 import org.apache.ignite.internal.processors.cache.persistence.RebuildIndexLogMessageTest;
@@ -115,7 +116,9 @@ import org.junit.runners.Suite;
 
     WrongIndexedTypesTest.class,
 
-    IndexPagesMetricsInMemoryTest.class
+    IndexPagesMetricsInMemoryTest.class,
+
+    PrecisionTest.class
 })
 public class IgniteCacheWithIndexingTestSuite {
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
@@ -42,7 +42,7 @@ import org.apache.ignite.internal.processors.cache.IgniteCacheConfigurationPrimi
 import org.apache.ignite.internal.processors.cache.IgniteCacheGroupsSqlTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheStarvationOnRebalanceTest;
 import org.apache.ignite.internal.processors.cache.IgniteClientReconnectQueriesTest;
-import org.apache.ignite.internal.processors.cache.PrecisionTest;
+import org.apache.ignite.internal.processors.cache.FieldsPrecisionTest;
 import org.apache.ignite.internal.processors.cache.WrongIndexedTypesTest;
 import org.apache.ignite.internal.processors.cache.index.H2TreeCorruptedTreeExceptionTest;
 import org.apache.ignite.internal.processors.cache.persistence.RebuildIndexLogMessageTest;
@@ -118,7 +118,7 @@ import org.junit.runners.Suite;
 
     IndexPagesMetricsInMemoryTest.class,
 
-    PrecisionTest.class
+    FieldsPrecisionTest.class
 })
 public class IgniteCacheWithIndexingTestSuite {
 }


### PR DESCRIPTION
1. Document QuerySqlField.precision for String (varchar).
2. Enable precision for byte[] (binary, varbinary).