### PR TITLE
IGNITE-15078 Remove SimpleDateTimeFormat usages

### DIFF
--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/IgnitePersistentStoreTest.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/IgnitePersistentStoreTest.java
@@ -19,8 +19,8 @@ package org.apache.ignite.tests;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
@@ -617,7 +617,7 @@ public class IgnitePersistentStoreTest {
         Map<Long, ProductOrder> ordersMap = TestsHelper.generateOrdersMap(5);
         Map<Long, ProductOrder> ordersMap1;
         Product product = TestsHelper.generateRandomProduct(-1L);
-        ProductOrder order = TestsHelper.generateRandomOrder(-1L, -1L, new Date());
+        ProductOrder order = TestsHelper.generateRandomOrder(-1L, -1L, Instant.now());
 
         IgniteTransactions txs = ignite.transactions();
 

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/load/Worker.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/load/Worker.java
@@ -17,7 +17,7 @@
 
 package org.apache.ignite.tests.load;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,6 +29,7 @@ import org.apache.ignite.cache.store.CacheStore;
 import org.apache.ignite.cache.store.cassandra.common.SystemHelper;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.internal.processors.cache.CacheEntryImpl;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.tests.utils.TestsHelper;
 import org.apache.log4j.Logger;
 
@@ -36,9 +37,6 @@ import org.apache.log4j.Logger;
  * Worker thread abstraction to be inherited by specific load test implementation
  */
 public abstract class Worker extends Thread {
-    /** */
-    private static final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("hh:mm:ss");
-
     /** */
     private long testStartTime;
 
@@ -403,8 +401,12 @@ public abstract class Worker extends Thread {
             builder.append("Test execution successfully completed. ");
 
         builder.append("Statistics: ").append(SystemHelper.LINE_SEPARATOR);
-        builder.append("Start time: ").append(TIME_FORMATTER.format(testStartTime)).append(SystemHelper.LINE_SEPARATOR);
-        builder.append("Finish time: ").append(TIME_FORMATTER.format(finishTime)).append(SystemHelper.LINE_SEPARATOR);
+        builder.append("Start time: ")
+            .append(IgniteUtils.SHORT_DATE_FMT.format(Instant.ofEpochMilli(testStartTime)))
+            .append(SystemHelper.LINE_SEPARATOR);
+        builder.append("Finish time: ")
+            .append(IgniteUtils.SHORT_DATE_FMT.format(Instant.ofEpochMilli(finishTime)))
+            .append(SystemHelper.LINE_SEPARATOR);
         builder.append("Duration: ").append((finishTime - testStartTime) / 1000).append(" sec")
             .append(SystemHelper.LINE_SEPARATOR);
 

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/pojos/ProductOrder.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/pojos/ProductOrder.java
@@ -17,19 +17,21 @@
 
 package org.apache.ignite.tests.pojos;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Simple POJO to store information about product order
  */
 public class ProductOrder {
     /** */
-    private static final DateFormat FORMAT = new SimpleDateFormat("MM/dd/yyyy/S");
+    private static final DateTimeFormatter FORMAT =
+        DateTimeFormatter.ofPattern("MM/dd/yyyy/S").withZone(ZoneId.systemDefault());
 
     /** */
-    private static final DateFormat FULL_FORMAT = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss:S");
+    private static final DateTimeFormatter FULL_FORMAT =
+        DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss:S").withZone(ZoneId.systemDefault());
 
     /** */
     private long id;
@@ -38,7 +40,7 @@ public class ProductOrder {
     private long productId;
 
     /** */
-    private Date date;
+    private Instant date;
 
     /** */
     private int amount;
@@ -51,12 +53,12 @@ public class ProductOrder {
     }
 
     /** */
-    public ProductOrder(long id, Product product, Date date, int amount) {
+    public ProductOrder(long id, Product product, Instant date, int amount) {
         this(id, product.getId(), product.getPrice(), date, amount);
     }
 
     /** */
-    public ProductOrder(long id, long productId, float productPrice, Date date, int amount) {
+    public ProductOrder(long id, long productId, float productPrice, Instant date, int amount) {
         this.id = id;
         this.productId = productId;
         this.date = date;
@@ -104,12 +106,12 @@ public class ProductOrder {
     }
 
     /** */
-    public void setDate(Date date) {
+    public void setDate(Instant date) {
         this.date = date;
     }
 
     /** */
-    public Date getDate() {
+    public Instant getDate() {
         return date;
     }
 

--- a/modules/cassandra/store/src/test/java/org/apache/ignite/tests/utils/TestsHelper.java
+++ b/modules/cassandra/store/src/test/java/org/apache/ignite/tests/utils/TestsHelper.java
@@ -17,7 +17,9 @@
 
 package org.apache.ignite.tests.utils;
 
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -115,16 +117,16 @@ public class TestsHelper {
 
             HOST_PREFIX = prefix;
 
-            Calendar cl = Calendar.getInstance();
+            LocalDate date = LocalDate.now();
 
             String year = TESTS_SETTINGS.getString("orders.year");
-            ORDERS_YEAR = !year.trim().isEmpty() ? Integer.parseInt(year) : cl.get(Calendar.YEAR);
+            ORDERS_YEAR = !year.trim().isEmpty() ? Integer.parseInt(year) : date.getYear();
 
             String month = TESTS_SETTINGS.getString("orders.month");
-            ORDERS_MONTH = !month.trim().isEmpty() ? Integer.parseInt(month) : cl.get(Calendar.MONTH);
+            ORDERS_MONTH = !month.trim().isEmpty() ? (Integer.parseInt(month) + 1) : date.getMonthValue();
 
             String day = TESTS_SETTINGS.getString("orders.day");
-            ORDERS_DAY = !day.trim().isEmpty() ? Integer.parseInt(day) : cl.get(Calendar.DAY_OF_MONTH);
+            ORDERS_DAY = !day.trim().isEmpty() ? Integer.parseInt(day) : date.getDayOfMonth();
         }
         catch (Throwable e) {
             throw new RuntimeException("Failed to initialize TestsHelper", e);
@@ -526,18 +528,15 @@ public class TestsHelper {
 
     /** */
     private static ProductOrder generateRandomOrder(long productId, int saltedNumber) {
-        Calendar cl = Calendar.getInstance();
-        cl.set(Calendar.YEAR, ORDERS_YEAR);
-        cl.set(Calendar.MONTH, ORDERS_MONTH);
-        cl.set(Calendar.DAY_OF_MONTH, ORDERS_DAY);
+        LocalDate date = LocalDate.of(ORDERS_YEAR, ORDERS_MONTH, ORDERS_DAY);
 
         long id = Long.parseLong(productId + System.currentTimeMillis() + HOST_PREFIX + saltedNumber);
 
-        return generateRandomOrder(id, productId, cl.getTime());
+        return generateRandomOrder(id, productId, date.atStartOfDay().toInstant(ZoneOffset.UTC));
     }
 
     /** */
-    public static ProductOrder generateRandomOrder(long id, long productId, Date date) {
+    public static ProductOrder generateRandomOrder(long id, long productId, Instant date) {
         return new ProductOrder(id, productId, generateProductPrice(productId), date, 1 + RANDOM.nextInt(20));
     }
 

--- a/modules/clients/src/test/java/org/apache/ignite/loadtests/client/ClientCacheBenchmark.java
+++ b/modules/clients/src/test/java/org/apache/ignite/loadtests/client/ClientCacheBenchmark.java
@@ -18,10 +18,10 @@
 package org.apache.ignite.loadtests.client;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Random;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.internal.client.GridClient;
@@ -31,6 +31,7 @@ import org.apache.ignite.internal.client.GridClientDataConfiguration;
 import org.apache.ignite.internal.client.GridClientException;
 import org.apache.ignite.internal.client.GridClientFactory;
 import org.apache.ignite.internal.client.GridClientPartitionAffinity;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.GridFileLock;
@@ -252,7 +253,7 @@ public class ClientCacheBenchmark {
                         GridLoadTestUtils.appendLineToFile(
                             outputFileName,
                             "%s,%d",
-                            GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                            IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                             Math.round(benchmark.getItersPerSec()));
                     }
                     catch (IOException e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteDiagnosticMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteDiagnosticMessage.java
@@ -19,11 +19,9 @@ package org.apache.ignite.internal;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
@@ -38,6 +36,7 @@ import org.apache.ignite.internal.processors.cache.distributed.dht.GridDhtTopolo
 import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionsExchangeFuture;
 import org.apache.ignite.internal.processors.cache.transactions.IgniteInternalTx;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
 import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.T3;
@@ -61,13 +60,6 @@ public class IgniteDiagnosticMessage implements Message {
 
     /** */
     private static final int REQUEST_FLAG_MASK = 0x01;
-
-    /** */
-    private static final ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
-        @Override protected DateFormat initialValue() {
-            return new SimpleDateFormat("HH:mm:ss.SSS");
-        }
-    };
 
     /** */
     private byte flags;
@@ -483,7 +475,7 @@ public class IgniteDiagnosticMessage implements Message {
      * @return Time string.
      */
     private static String formatTime(long time) {
-        return dateFormat.get().format(new Date(time));
+        return IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(time));
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteVersionUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteVersionUtils.java
@@ -17,9 +17,11 @@
 
 package org.apache.ignite.internal;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import org.apache.ignite.lang.IgniteProductVersion;
 
 /**
@@ -33,7 +35,7 @@ public class IgniteVersionUtils {
     public static final IgniteProductVersion VER;
 
     /** UTC build date formatter. */
-    private static final SimpleDateFormat BUILD_TSTAMP_DATE_FORMATTER;
+    private static final DateTimeFormatter BUILD_TSTAMP_DATE_FORMATTER;
 
     /** Formatted build date. */
     public static final String BUILD_TSTAMP_STR;
@@ -48,7 +50,7 @@ public class IgniteVersionUtils {
     public static final String REV_HASH_STR;
 
     /** Release date. */
-    public static final String RELEASE_DATE_STR;
+    public static final LocalDate RELEASE_DATE;
 
     /** Compound version. */
     public static final String ACK_VER_STR;
@@ -71,9 +73,7 @@ public class IgniteVersionUtils {
         BUILD_TSTAMP = !BUILD_TSTAMP_FROM_PROPERTY.isEmpty() && Long.parseLong(BUILD_TSTAMP_FROM_PROPERTY) != 0
             ? Long.parseLong(BUILD_TSTAMP_FROM_PROPERTY) : System.currentTimeMillis() / 1000;
 
-        BUILD_TSTAMP_DATE_FORMATTER = new SimpleDateFormat("yyyyMMdd");
-
-        BUILD_TSTAMP_DATE_FORMATTER.setTimeZone(TimeZone.getTimeZone("UTC"));
+        BUILD_TSTAMP_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneId.of("UTC"));
 
         BUILD_TSTAMP_STR = formatBuildTimeStamp(BUILD_TSTAMP * 1000);
 
@@ -81,7 +81,11 @@ public class IgniteVersionUtils {
 
         REV_HASH_STR = IgniteProperties.get("ignite.revision");
 
-        RELEASE_DATE_STR = IgniteProperties.get("ignite.rel.date");
+        String releaseDateStr = IgniteProperties.get("ignite.rel.date");
+
+        DateTimeFormatter releaseDateFormatter = DateTimeFormatter.ofPattern("ddMMyyyy", Locale.US);
+
+        RELEASE_DATE = LocalDate.parse(releaseDateStr, releaseDateFormatter);
 
         String rev = REV_HASH_STR.length() > 8 ? REV_HASH_STR.substring(0, 8) : REV_HASH_STR;
 
@@ -92,13 +96,12 @@ public class IgniteVersionUtils {
 
     /**
      * Builds string date representation in "yyyyMMdd" format.
-     * "synchronized" because it uses {@link SimpleDateFormat} which is not threadsafe.
      *
      * @param ts Timestamp.
      * @return Timestamp date in UTC timezone.
      */
-    public static synchronized String formatBuildTimeStamp(long ts) {
-        return BUILD_TSTAMP_DATE_FORMATTER.format(new Date(ts));
+    public static String formatBuildTimeStamp(long ts) {
+        return BUILD_TSTAMP_DATE_FORMATTER.format(Instant.ofEpochMilli(ts));
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
@@ -34,11 +34,10 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.WritableByteChannel;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -110,6 +109,7 @@ import org.apache.ignite.internal.processors.tracing.MTC.TraceSurroundings;
 import org.apache.ignite.internal.processors.tracing.Span;
 import org.apache.ignite.internal.processors.tracing.SpanTags;
 import org.apache.ignite.internal.util.GridBoundedConcurrentLinkedHashSet;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.StripedCompositeReadWriteLock;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
@@ -847,8 +847,6 @@ public class GridIoManager extends GridManagerAdapter<CommunicationSpi<Serializa
             }
         }
 
-        SimpleDateFormat dateFmt = new SimpleDateFormat("HH:mm:ss,SSS");
-
         StringBuilder b = new StringBuilder(U.nl())
             .append("IO test results (round-trip count per each latency bin).")
             .append(U.nl());
@@ -894,25 +892,25 @@ public class GridIoManager extends GridManagerAdapter<CommunicationSpi<Serializa
                 .append(String.format("%15d", e.getValue().totalLatency)).append(U.nl());
 
             b.append(U.nl()).append("Max latencies (ns):").append(U.nl());
-            format(b, e.getValue().maxLatency, dateFmt);
+            format(b, e.getValue().maxLatency);
 
             b.append(U.nl()).append("Max request send queue times (ns):").append(U.nl());
-            format(b, e.getValue().maxReqSendQueueTime, dateFmt);
+            format(b, e.getValue().maxReqSendQueueTime);
 
             b.append(U.nl()).append("Max request receive queue times (ns):").append(U.nl());
-            format(b, e.getValue().maxReqRcvQueueTime, dateFmt);
+            format(b, e.getValue().maxReqRcvQueueTime);
 
             b.append(U.nl()).append("Max response send queue times (ns):").append(U.nl());
-            format(b, e.getValue().maxResSendQueueTime, dateFmt);
+            format(b, e.getValue().maxResSendQueueTime);
 
             b.append(U.nl()).append("Max response receive queue times (ns):").append(U.nl());
-            format(b, e.getValue().maxResRcvQueueTime, dateFmt);
+            format(b, e.getValue().maxResRcvQueueTime);
 
             b.append(U.nl()).append("Max request wire times (millis):").append(U.nl());
-            format(b, e.getValue().maxReqWireTimeMillis, dateFmt);
+            format(b, e.getValue().maxReqWireTimeMillis);
 
             b.append(U.nl()).append("Max response wire times (millis):").append(U.nl());
-            format(b, e.getValue().maxResWireTimeMillis, dateFmt);
+            format(b, e.getValue().maxResWireTimeMillis);
 
             b.append(U.nl());
         }
@@ -924,12 +922,13 @@ public class GridIoManager extends GridManagerAdapter<CommunicationSpi<Serializa
     /**
      * @param b Builder.
      * @param pairs Pairs to format.
-     * @param dateFmt Formatter.
      */
-    private void format(StringBuilder b, Collection<IgnitePair<Long>> pairs, SimpleDateFormat dateFmt) {
+    private static void format(StringBuilder b, Collection<IgnitePair<Long>> pairs) {
         for (IgnitePair<Long> p : pairs) {
-            b.append(String.format("%15d", p.get1())).append(" ")
-                .append(dateFmt.format(new Date(p.get2()))).append(U.nl());
+            b.append(String.format("%15d", p.get1()))
+                .append(" ")
+                .append(IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(p.get2())))
+                .append(U.nl());
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCachePartitionExchangeManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCachePartitionExchangeManager.java
@@ -17,13 +17,11 @@
 
 package org.apache.ignite.internal.processors.cache;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -277,9 +275,6 @@ public class GridCachePartitionExchangeManager<K, V> extends GridCacheSharedMana
 
     /** */
     private int longRunningOpsDumpStep;
-
-    /** */
-    private DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
 
     /** Events received while cluster state transition was in progress. */
     private final List<PendingDiscoveryEvent> pendingEvts = new ArrayList<>();
@@ -2215,7 +2210,7 @@ public class GridCachePartitionExchangeManager<K, V> extends GridCacheSharedMana
      * @param curTime Current timestamp.
      * @return Warning string.
      */
-    private String longRunningTransactionWarning(IgniteInternalTx tx, long curTime) {
+    private static String longRunningTransactionWarning(IgniteInternalTx tx, long curTime) {
         GridStringBuilder warning = new GridStringBuilder()
             .a(">>> Transaction [startTime=")
             .a(formatTime(tx.startTime()))
@@ -2484,8 +2479,8 @@ public class GridCachePartitionExchangeManager<K, V> extends GridCacheSharedMana
      * @param time Time.
      * @return Time string.
      */
-    private String formatTime(long time) {
-        return dateFormat.format(new Date(time));
+    private static String formatTime(long time) {
+        return IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(time));
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxLocal.java
@@ -17,11 +17,10 @@
 
 package org.apache.ignite.internal.processors.cache.distributed.near;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -146,10 +145,6 @@ import static org.apache.ignite.transactions.TransactionState.UNKNOWN;
  */
 @SuppressWarnings("unchecked")
 public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeoutObject, AutoCloseable, MvccCoordinatorChangeAware {
-    /** */
-    private static final ThreadLocal<SimpleDateFormat> TIME_FORMAT =
-        ThreadLocal.withInitial(() -> new SimpleDateFormat("HH:mm:ss.SSS"));
-
     /** Prepare future updater. */
     private static final AtomicReferenceFieldUpdater<GridNearTxLocal, IgniteInternalFuture> PREP_FUT_UPD =
         AtomicReferenceFieldUpdater.newUpdater(GridNearTxLocal.class, IgniteInternalFuture.class, "prepFut");
@@ -163,7 +158,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
         "SQL queries and cache operations may not be used in the same transaction.";
 
     /** DHT mappings. */
-    private IgniteTxMappings mappings;
+    private final IgniteTxMappings mappings;
 
     /** Prepare future. */
     @GridToStringExclude
@@ -227,7 +222,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
 
     /** */
     @GridToStringExclude
-    private IgniteTxManager.TxDumpsThrottling txDumpsThrottling;
+    private final IgniteTxManager.TxDumpsThrottling txDumpsThrottling;
 
     /** */
     @GridToStringExclude
@@ -238,7 +233,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
     private TransactionProxyImpl rollbackOnlyProxy;
 
     /** Tx label. */
-    @Nullable private String lb;
+    @Nullable private final String lb;
 
     /** Whether this is Mvcc transaction or not.<p>
      * {@code null} means there haven't been any calls made on this transaction, and first operation will give this
@@ -827,7 +822,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
 
             return updateAsync(cacheCtx, new UpdateSourceIterator<IgniteBiTuple<KeyCacheObject, Object>>() {
 
-                private Iterator<Map.Entry<KeyCacheObject, Object>> it = enlisted.entrySet().iterator();
+                private final Iterator<Map.Entry<KeyCacheObject, Object>> it = enlisted.entrySet().iterator();
 
                 @Override public EnlistOperation operation() {
                     return transform ? EnlistOperation.TRANSFORM : EnlistOperation.UPSERT;
@@ -2034,7 +2029,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
 
         return updateAsync(cacheCtx, new UpdateSourceIterator<KeyCacheObject>() {
 
-            private Iterator<KeyCacheObject> it = enlisted.iterator();
+            private final Iterator<KeyCacheObject> it = enlisted.iterator();
 
             @Override public EnlistOperation operation() {
                 return EnlistOperation.DELETE;
@@ -4045,7 +4040,7 @@ public class GridNearTxLocal extends GridDhtTxLocalAdapter implements GridTimeou
 
         GridStringBuilder warning = new GridStringBuilder(isLong ? "Long transaction time dump " : "Transaction time dump ")
             .a("[startTime=")
-            .a(TIME_FORMAT.get().format(new Date(startTime)))
+            .a(IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(startTime)))
             .a(", totalTime=")
             .a(systemTimeMillis + userTimeMillis)
             .a(", systemTime=")

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/RecoveryDebug.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/RecoveryDebug.java
@@ -22,10 +22,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
-import java.util.TimeZone;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.pagemem.wal.record.DataEntry;
@@ -44,16 +44,8 @@ import static java.nio.file.StandardOpenOption.WRITE;
  */
 public class RecoveryDebug implements AutoCloseable {
     /** */
-    private static final ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<SimpleDateFormat>() {
-        /** {@inheritDoc} */
-        @Override protected SimpleDateFormat initialValue() {
-            SimpleDateFormat f = new SimpleDateFormat("dd-MM-yyyy-HH-mm-ss-SSS");
-
-            f.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-            return f;
-        }
-    };
+    private static final DateTimeFormatter DATE_FORMATTER =
+        DateTimeFormatter.ofPattern("dd-MM-yyyy-HH-mm-ss-SSS").withZone(ZoneId.of("UTC"));
 
     /** */
     @Nullable private final IgniteLogger log;
@@ -85,7 +77,7 @@ public class RecoveryDebug implements AutoCloseable {
                     return;
 
             File f = new File(tmpDir, "recovery-" +
-                sdf.get().format(new Date(time)) + "-" + constId + ".log");
+                DATE_FORMATTER.format(Instant.ofEpochMilli(time)) + "-" + constId + ".log");
 
             f.createNewFile();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/filename/PdsFolderResolver.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/filename/PdsFolderResolver.java
@@ -21,7 +21,9 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.Serializable;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -272,9 +274,11 @@ public class PdsFolderResolver<L extends FileLockHolder> {
 
         res.a(params.size);
         res.a(" bytes, modified ");
-        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM/dd/yyyy hh:mm a");
 
-        res.a(simpleDateFormat.format(params.lastModified));
+        DateTimeFormatter formatter =
+            DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a").withZone(ZoneId.systemDefault());
+
+        res.a(formatter.format(Instant.ofEpochMilli(params.lastModified)));
         res.a(" ");
 
         return res.toString();

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridDebug.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridDebug.java
@@ -24,12 +24,13 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
-import java.nio.charset.Charset;
-import java.text.SimpleDateFormat;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.management.MBeanServer;
@@ -47,16 +48,10 @@ import org.jetbrains.annotations.Nullable;
 public class GridDebug {
     /** */
     private static final AtomicReference<ConcurrentLinkedQueue<Item>> que =
-        new AtomicReference<>(new ConcurrentLinkedQueue<Item>());
-
-    /** */
-    private static final SimpleDateFormat DEBUG_DATE_FMT = new SimpleDateFormat("HH:mm:ss,SSS");
+        new AtomicReference<>(new ConcurrentLinkedQueue<>());
 
     /** */
     private static final FileOutputStream out;
-
-    /** */
-    private static final Charset charset = Charset.forName("UTF-8");
 
     /** */
     private static volatile long start;
@@ -86,7 +81,10 @@ public class GridDebug {
     /* */
     static {
         if (LOGS_PATH != null) {
-            File log = new File(new File(LOGS_PATH), new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss-").format(new Date()) +
+            DateTimeFormatter formatter =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-").withZone(ZoneId.systemDefault());
+
+            File log = new File(new File(LOGS_PATH), formatter.format(Instant.now()) +
                     ManagementFactory.getRuntimeMXBean().getName() + ".log");
 
             assert !log.exists();
@@ -130,7 +128,7 @@ public class GridDebug {
         Thread th = Thread.currentThread();
 
         try {
-            out.write((formatEntry(System.currentTimeMillis(), th.getName(), th.getId(), x) + "\n").getBytes(charset));
+            out.write((formatEntry(System.currentTimeMillis(), th.getName(), th.getId(), x) + "\n").getBytes(StandardCharsets.UTF_8));
             out.flush();
         }
         catch (IOException e) {
@@ -252,7 +250,7 @@ public class GridDebug {
      * @return Empty string (useful for assertions like {@code assert x == 0 : D.dumpWithReset();} ).
      */
     public static String dumpWithReset() {
-        return dumpWithReset(new ConcurrentLinkedQueue<Item>(), null);
+        return dumpWithReset(new ConcurrentLinkedQueue<>(), null);
     }
 
     /**
@@ -301,7 +299,7 @@ public class GridDebug {
         ConcurrentLinkedQueue<Item> old = que.get();
 
         if (old != null) // Was not stopped.
-            que.compareAndSet(old, new ConcurrentLinkedQueue<Item>());
+            que.compareAndSet(old, new ConcurrentLinkedQueue<>());
     }
 
     /**
@@ -314,8 +312,8 @@ public class GridDebug {
      * @return String.
      */
     private static String formatEntry(long ts, String threadName, long threadId, Object... data) {
-        return "<" + DEBUG_DATE_FMT.format(new Date(ts)) + "><~DBG~><" + threadName + " id:" + threadId + "> " +
-            Arrays.deepToString(data);
+        return "<" + IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(ts)) + "><~DBG~><" + threadName + " id:" +
+            threadId + "> " + Arrays.deepToString(data);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridTimer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridTimer.java
@@ -17,8 +17,7 @@
 
 package org.apache.ignite.internal.util;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 
@@ -26,9 +25,6 @@ import org.apache.ignite.internal.util.typedef.internal.U;
  * Timer to use mostly for debugging purposes.
  */
 public class GridTimer {
-    /** Debug date format. */
-    private static final SimpleDateFormat DEBUG_DATE_FMT = new SimpleDateFormat("HH:mm:ss,SS");
-
     /** Timer name. */
     private final String name;
 
@@ -143,8 +139,8 @@ public class GridTimer {
      * @param msg Message to debug.
      */
     private void debug(String msg) {
-        System.out.println('<' + DEBUG_DATE_FMT.format(new Date(U.currentTimeMillis())) + "><DEBUG><" +
-            Thread.currentThread().getName() + "> " + msg);
+        System.out.println('<' + IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(U.currentTimeMillis()))
+            + "><DEBUG><" + Thread.currentThread().getName() + "> " + msg);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -97,13 +97,14 @@ import java.security.ProtectionDomain;
 import java.security.cert.X509Certificate;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -387,10 +388,10 @@ public abstract class IgniteUtils {
     private static volatile GridTuple<String> ggHome;
 
     /** OS JDK string. */
-    private static String osJdkStr;
+    private static final String osJdkStr;
 
     /** OS string. */
-    private static String osStr;
+    private static final String osStr;
 
     /** JDK string. */
     private static String jdkStr;
@@ -447,7 +448,7 @@ public abstract class IgniteUtils {
     private static boolean mac;
 
     /** Indicates whether current OS is of RedHat family. */
-    private static boolean redHat;
+    private static final boolean redHat;
 
     /** Indicates whether current OS architecture is Sun Sparc. */
     private static boolean sparc;
@@ -492,7 +493,7 @@ public abstract class IgniteUtils {
     private static String jvmImplName;
 
     /** Will be set to {@code true} if detected a 32-bit JVM. */
-    private static boolean jvm32Bit;
+    private static final boolean jvm32Bit;
 
     /** JMX domain as 'xxx.apache.ignite'. */
     public static final String JMX_DOMAIN = IgniteUtils.class.getName().substring(0, IgniteUtils.class.getName().
@@ -508,17 +509,24 @@ public abstract class IgniteUtils {
     private static final int MASK = 0xf;
 
     /** Long date format pattern for log messages. */
-    private static final SimpleDateFormat LONG_DATE_FMT = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
+    public static final DateTimeFormatter LONG_DATE_FMT =
+        DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss").withZone(ZoneId.systemDefault());
 
     /**
      * Short date format pattern for log messages in "quiet" mode.
      * Only time is included since we don't expect "quiet" mode to be used
      * for longer runs.
      */
-    private static final SimpleDateFormat SHORT_DATE_FMT = new SimpleDateFormat("HH:mm:ss");
+    public static final DateTimeFormatter SHORT_DATE_FMT =
+        DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
 
     /** Debug date format. */
-    private static final SimpleDateFormat DEBUG_DATE_FMT = new SimpleDateFormat("HH:mm:ss,SSS");
+    public static final DateTimeFormatter DEBUG_DATE_FMT =
+        DateTimeFormatter.ofPattern("HH:mm:ss,SSS").withZone(ZoneId.systemDefault());
+
+    /** Date format for thread dumps. */
+    private static final DateTimeFormatter THREAD_DUMP_FMT =
+        DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss z").withZone(ZoneId.systemDefault());
 
     /** Cached local host address to make sure that every time the same local host is returned. */
     private static InetAddress locHost;
@@ -623,7 +631,7 @@ public abstract class IgniteUtils {
     private static final Field urlClsLdrField = urlClassLoaderField();
 
     /** Dev only logging disabled. */
-    private static boolean devOnlyLogDisabled =
+    private static final boolean devOnlyLogDisabled =
         IgniteSystemProperties.getBoolean(IgniteSystemProperties.IGNITE_DEV_ONLY_LOGGING_DISABLED);
 
     /** JDK9: jdk.internal.loader.URLClassPath. */
@@ -633,7 +641,7 @@ public abstract class IgniteUtils {
     private static Method mthdURLClassPathGetUrls;
 
     /** Byte count prefixes. */
-    private static String BYTE_CNT_PREFIXES = " KMGTPE";
+    private static final String BYTE_CNT_PREFIXES = " KMGTPE";
 
     /*
      * Initializes enterprise check.
@@ -1330,7 +1338,7 @@ public abstract class IgniteUtils {
      * @return Common prefix for debug messages.
      */
     private static String debugPrefix() {
-        return '<' + DEBUG_DATE_FMT.format(new Date(System.currentTimeMillis())) + "><DEBUG><" +
+        return '<' + DEBUG_DATE_FMT.format(Instant.now()) + "><DEBUG><" +
             Thread.currentThread().getName() + '>' + ' ';
     }
 
@@ -1342,7 +1350,7 @@ public abstract class IgniteUtils {
 
         Runtime runtime = Runtime.getRuntime();
 
-        X.println('<' + DEBUG_DATE_FMT.format(new Date(System.currentTimeMillis())) + "><DEBUG><" +
+        X.println('<' + DEBUG_DATE_FMT.format(Instant.now()) + "><DEBUG><" +
             Thread.currentThread().getName() + "> Heap stats [free=" + runtime.freeMemory() / (1024 * 1024) +
             "M, total=" + runtime.totalMemory() / (1024 * 1024) + "M]");
     }
@@ -1474,7 +1482,7 @@ public abstract class IgniteUtils {
             mxBean.dumpAllThreads(mxBean.isObjectMonitorUsageSupported(), mxBean.isSynchronizerUsageSupported());
 
         GridStringBuilder sb = new GridStringBuilder(THREAD_DUMP_MSG)
-            .a(new SimpleDateFormat("yyyy/MM/dd HH:mm:ss z").format(new Date(U.currentTimeMillis()))).a(NL);
+            .a(THREAD_DUMP_FMT.format(Instant.ofEpochMilli(U.currentTimeMillis()))).a(NL);
 
         for (ThreadInfo info : threadInfos) {
             printThreadInfo(info, sb, deadlockedThreadsIds);
@@ -3360,7 +3368,7 @@ public abstract class IgniteUtils {
      * @return Formatted time string.
      */
     public static String format(long sysTime) {
-        return LONG_DATE_FMT.format(new java.util.Date(sysTime));
+        return LONG_DATE_FMT.format(Instant.ofEpochMilli(sysTime));
     }
 
     /**
@@ -4483,7 +4491,7 @@ public abstract class IgniteUtils {
         if (log != null)
             log.getLogger(IgniteConfiguration.COURTESY_LOGGER_NAME).warning(compact(longMsg.toString()));
         else
-            X.println("[" + SHORT_DATE_FMT.format(new java.util.Date()) + "] (courtesy) " +
+            X.println("[" + SHORT_DATE_FMT.format(Instant.now()) + "] (courtesy) " +
                 compact(shortMsg.toString()));
     }
 
@@ -4579,7 +4587,7 @@ public abstract class IgniteUtils {
         if (log != null)
             log.warning(compact(msg.toString()), e);
         else {
-            X.println("[" + SHORT_DATE_FMT.format(new java.util.Date()) + "] (wrn) " +
+            X.println("[" + SHORT_DATE_FMT.format(Instant.now()) + "] (wrn) " +
                     compact(msg.toString()));
 
             if (e != null)
@@ -4609,7 +4617,7 @@ public abstract class IgniteUtils {
         if (log != null)
             log.warning(IgniteLogger.DEV_ONLY, compact(msg.toString()), null);
         else
-            X.println("[" + SHORT_DATE_FMT.format(new java.util.Date()) + "] (wrn) " +
+            X.println("[" + SHORT_DATE_FMT.format(Instant.now()) + "] (wrn) " +
                 compact(msg.toString()));
     }
 
@@ -4805,7 +4813,7 @@ public abstract class IgniteUtils {
                 log.error(compact(longMsg.toString()), e);
         }
         else {
-            X.printerr("[" + SHORT_DATE_FMT.format(new java.util.Date()) + "] (err) " +
+            X.printerr("[" + SHORT_DATE_FMT.format(Instant.now()) + "] (err) " +
                 compact(shortMsg.toString()));
 
             if (e != null)
@@ -4838,7 +4846,7 @@ public abstract class IgniteUtils {
     public static void quiet(boolean err, Object... objs) {
         assert objs != null;
 
-        String time = SHORT_DATE_FMT.format(new java.util.Date());
+        String time = SHORT_DATE_FMT.format(Instant.now());
 
         SB sb = new SB();
 
@@ -7841,19 +7849,6 @@ public abstract class IgniteUtils {
                 }
             }
         }
-    }
-
-    /**
-     * Formats passed date with specified pattern.
-     *
-     * @param date Date to format.
-     * @param ptrn Pattern.
-     * @return Formatted date.
-     */
-    public static String format(Date date, String ptrn) {
-        java.text.DateFormat format = new java.text.SimpleDateFormat(ptrn);
-
-        return format.format(date);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/util/VisorTaskUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/util/VisorTaskUtils.java
@@ -35,7 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,6 +59,7 @@ import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
 import org.apache.ignite.internal.processors.cache.IgniteCacheProxy;
 import org.apache.ignite.internal.processors.cache.IgniteCacheProxyImpl;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.SB;
@@ -155,14 +156,6 @@ public class VisorTaskUtils {
     private static final Comparator<VisorLogFile> LAST_MODIFIED = new Comparator<VisorLogFile>() {
         @Override public int compare(VisorLogFile f1, VisorLogFile f2) {
             return Long.compare(f2.getLastModified(), f1.getLastModified());
-        }
-    };
-
-    /** Debug date format. */
-    private static final ThreadLocal<SimpleDateFormat> DEBUG_DATE_FMT = new ThreadLocal<SimpleDateFormat>() {
-        /** {@inheritDoc} */
-        @Override protected SimpleDateFormat initialValue() {
-            return new SimpleDateFormat("HH:mm:ss,SSS");
         }
     };
 
@@ -806,8 +799,12 @@ public class VisorTaskUtils {
                 log.warning(msg);
         }
         else
-            X.println(String.format("[%s][%s]%s",
-                DEBUG_DATE_FMT.get().format(time), Thread.currentThread().getName(), msg));
+            X.println(String.format(
+                "[%s][%s]%s",
+                IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(time)),
+                Thread.currentThread().getName(),
+                msg
+            ));
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLoggerFormatter.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLoggerFormatter.java
@@ -19,10 +19,10 @@ package org.apache.ignite.logger.java;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.internal.S;
 
 /**
@@ -31,14 +31,6 @@ import org.apache.ignite.internal.util.typedef.internal.S;
 public class JavaLoggerFormatter extends Formatter {
     /** Name for anonymous loggers. */
     public static final String ANONYMOUS_LOGGER_NAME = "UNKNOWN";
-
-    /** */
-    private static final ThreadLocal<SimpleDateFormat> DATE_FORMATTER = new ThreadLocal<SimpleDateFormat>() {
-        /** {@inheritDoc} */
-        @Override protected SimpleDateFormat initialValue() {
-            return new SimpleDateFormat("HH:mm:ss,SSS");
-        }
-    };
 
     /** {@inheritDoc} */
     @Override public String format(LogRecord record) {
@@ -63,7 +55,7 @@ public class JavaLoggerFormatter extends Formatter {
             ex = "\n" + stackTrace;
         }
 
-        return "[" + DATE_FORMATTER.get().format(new Date(record.getMillis())) + "][" +
+        return "[" + IgniteUtils.DEBUG_DATE_FMT.format(Instant.ofEpochMilli(record.getMillis())) + "][" +
             record.getLevel() + "][" +
             threadName + "][" +
             logName + "] " +

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoveryImpl.java
@@ -18,11 +18,12 @@
 package org.apache.ignite.spi.discovery.tcp;
 
 import java.net.InetSocketAddress;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -73,6 +74,10 @@ abstract class TcpDiscoveryImpl {
 
     /** How often the warning message should occur in logs to prevent log spam. */
     public static final long LOG_WARN_MSG_TIMEOUT = 60 * 60 * 1000L;
+
+    /** Debug log date formatter. */
+    private static final DateTimeFormatter DEBUG_FORMATTER =
+        DateTimeFormatter.ofPattern("[HH:mm:ss,SSS]").withZone(ZoneId.systemDefault());
 
     /** */
     protected final TcpDiscoverySpi spi;
@@ -178,7 +183,7 @@ abstract class TcpDiscoveryImpl {
     protected void debugLog(@Nullable TcpDiscoveryAbstractMessage discoMsg, String msg) {
         assert debugMode;
 
-        String msg0 = new SimpleDateFormat("[HH:mm:ss,SSS]").format(new Date(System.currentTimeMillis())) +
+        String msg0 = DEBUG_FORMATTER.format(Instant.now()) +
             '[' + Thread.currentThread().getName() + "][" + getLocalNodeId() +
             "-" + locNode.internalOrder() + "] " +
             msg;

--- a/modules/core/src/main/java/org/apache/ignite/startup/BasicWarmupClosure.java
+++ b/modules/core/src/main/java/org/apache/ignite/startup/BasicWarmupClosure.java
@@ -17,10 +17,9 @@
 
 package org.apache.ignite.startup;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -37,6 +36,7 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.processors.cache.IgniteCacheProxy;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.CU;
@@ -66,9 +66,6 @@ public class BasicWarmupClosure implements IgniteInClosure<IgniteConfiguration> 
 
     /** Grid count. */
     private int gridCnt = DFLT_GRID_CNT;
-
-    /** Warmup date format. */
-    private static final SimpleDateFormat WARMUP_DATE_FMT = new SimpleDateFormat("HH:mm:ss");
 
     /** Warmup thread count. */
     private int threadCnt = Runtime.getRuntime().availableProcessors() * 2;
@@ -343,7 +340,7 @@ public class BasicWarmupClosure implements IgniteInClosure<IgniteConfiguration> 
      * @param msg Format message.
      */
     private static void out(String msg) {
-        System.out.println('[' + WARMUP_DATE_FMT.format(new Date(System.currentTimeMillis())) + "][WARMUP][" +
+        System.out.println('[' + IgniteUtils.SHORT_DATE_FMT.format(Instant.now()) + "][WARMUP][" +
             Thread.currentThread().getName() + ']' + ' ' + msg);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/startup/cmdline/AboutDialog.java
+++ b/modules/core/src/main/java/org/apache/ignite/startup/cmdline/AboutDialog.java
@@ -29,8 +29,8 @@ import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URL;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -57,6 +57,9 @@ public class AboutDialog extends JDialog {
     /** Border color. */
     private static final Color VALUE_BORDER_COLOR = new Color(0xcdcdcd);
 
+    /** Release date formatter. */
+    private static final DateTimeFormatter RELEASE_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd MMM yyyy");
+
     /** Global reference to about dialog to prevent double open. */
     private static AboutDialog aboutDlg;
 
@@ -70,7 +73,7 @@ public class AboutDialog extends JDialog {
     private final String ver;
 
     /** Release date. */
-    private final Date release;
+    private final LocalDate release;
 
     /** Copyright. */
     private final String copyright;
@@ -85,7 +88,7 @@ public class AboutDialog extends JDialog {
      * @param release Release date.
      * @param copyright Copyright.
      */
-    AboutDialog(String appName, String bannerSpec, String ver, Date release, String copyright) {
+    AboutDialog(String appName, String bannerSpec, String ver, LocalDate release, String copyright) {
         this.appName = appName;
 
         this.bannerSpec = bannerSpec;
@@ -101,7 +104,7 @@ public class AboutDialog extends JDialog {
     }
 
     /** Close action. */
-    private Action closeAct = new AbstractAction("Close") {
+    private final Action closeAct = new AbstractAction("Close") {
         @Override public void actionPerformed(ActionEvent e) {
             assert SwingUtilities.isEventDispatchThread();
 
@@ -110,7 +113,7 @@ public class AboutDialog extends JDialog {
     };
 
     /** Close button. */
-    private JButton closeBtn = new JButton(closeAct);
+    private final JButton closeBtn = new JButton(closeAct);
 
     /**
      * Create and initialize dialog controls.
@@ -224,7 +227,7 @@ public class AboutDialog extends JDialog {
         licPanel.add(Box.createVerticalGlue(), gbcStrut());
 
         addAboutItem(licPanel, "Version:", ver);
-        addAboutItem(licPanel, "Release Date:", new SimpleDateFormat("dd MMM yyyy").format(release));
+        addAboutItem(licPanel, "Release Date:", RELEASE_DATE_FORMATTER.format(release));
         addAboutItem(licPanel, "Copyright:", copyright);
 
         return licPanel;
@@ -325,8 +328,8 @@ public class AboutDialog extends JDialog {
      * @param release Release date.
      * @param copyright Copyright blurb.
      */
-    public static void centerShow(final String appName, final String bannerSpec,
-        final String ver, final Date release, final String copyright) {
+    public static void centerShow(String appName, String bannerSpec,
+        String ver, LocalDate release, String copyright) {
         SwingUtilities.invokeLater(new Runnable() {
             @Override public void run() {
                 if (aboutDlg == null) {

--- a/modules/core/src/main/java/org/apache/ignite/startup/cmdline/CommandLineStartup.java
+++ b/modules/core/src/main/java/org/apache/ignite/startup/cmdline/CommandLineStartup.java
@@ -27,12 +27,9 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URL;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
@@ -67,7 +64,7 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_PROG_NAME;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_RESTART_CODE;
 import static org.apache.ignite.internal.IgniteVersionUtils.ACK_VER_STR;
 import static org.apache.ignite.internal.IgniteVersionUtils.COPYRIGHT;
-import static org.apache.ignite.internal.IgniteVersionUtils.RELEASE_DATE_STR;
+import static org.apache.ignite.internal.IgniteVersionUtils.RELEASE_DATE;
 import static org.apache.ignite.internal.IgniteVersionUtils.VER_STR;
 
 /**
@@ -127,9 +124,6 @@ public final class CommandLineStartup {
     /** @see IgniteSystemProperties#IGNITE_PROG_NAME */
     public static final String DFLT_PROG_NAME = "ignite.{sh|bat}";
 
-    /** Build date. */
-    private static Date releaseDate;
-
     /**
      * Static initializer.
      */
@@ -157,8 +151,6 @@ public final class CommandLineStartup {
 
         // Mac OS specific customizations: app icon and about dialog.
         try {
-            releaseDate = new SimpleDateFormat("ddMMyyyy", Locale.US).parse(RELEASE_DATE_STR);
-
             Class<?> appCls = Class.forName("com.apple.eawt.Application");
 
             Object osxApp = appCls.getDeclaredMethod("getApplication").invoke(null);
@@ -184,7 +176,7 @@ public final class CommandLineStartup {
                 new InvocationHandler() {
                     @Override public Object invoke(Object proxy, Method mtd, Object[] args) throws Throwable {
                         AboutDialog.centerShow("Ignite Node", bannerUrl.toExternalForm(), VER_STR,
-                            releaseDate, COPYRIGHT);
+                            RELEASE_DATE, COPYRIGHT);
 
                         return null;
                     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/AbstractDataTypesCoverageTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/AbstractDataTypesCoverageTest.java
@@ -20,10 +20,12 @@ package org.apache.ignite.internal.processors.cache;
 import java.io.Serializable;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -287,13 +289,13 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
      */
     private static class TestPolicy implements ExpiryPolicy, Serializable {
         /** */
-        private Long create;
+        private final Long create;
 
         /** */
-        private Long access;
+        private final Long access;
 
         /** */
-        private Long update;
+        private final Long update;
 
         /**
          * @param create TTL for creation.
@@ -567,10 +569,10 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
         private static final long serialVersionUID = 0L;
 
         /** Original value. */
-        private Object val;
+        private final Object val;
 
         /** Converted value. */
-        private String sqlStrVal;
+        private final String sqlStrVal;
 
         /**
          * Constructor.
@@ -604,13 +606,14 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
         private static final String PATTERN = "HH:mm:ss.SSS";
 
         /** */
-        private static final SimpleDateFormat TIME_DATE_FORMAT = new SimpleDateFormat(PATTERN);
+        private static final DateTimeFormatter TIME_DATE_FORMAT =
+            DateTimeFormatter.ofPattern(PATTERN).withZone(ZoneId.systemDefault());
 
         /** Original value. */
-        private Object val;
+        private final Object val;
 
         /** Converted value. */
-        private String sqlStrVal;
+        private final String sqlStrVal;
 
         /**
          * Constructor.
@@ -619,7 +622,11 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
          */
         public Timed(Time time) {
             val = time;
-            sqlStrVal = "PARSEDATETIME('" + TIME_DATE_FORMAT.format(time) + "', '" + PATTERN + "')";
+            sqlStrVal = String.format(
+                "PARSEDATETIME('%s', '%s')",
+                TIME_DATE_FORMAT.format(Instant.ofEpochMilli(time.getTime())),
+                PATTERN
+            );
         }
 
         /**
@@ -629,8 +636,11 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
          */
         public Timed(LocalTime time) {
             val = time;
-            sqlStrVal = "PARSEDATETIME('" + TIME_DATE_FORMAT.format(
-                java.sql.Time.valueOf(time)) + "', '" + PATTERN + "')";
+            sqlStrVal = String.format(
+                "PARSEDATETIME('%s', '%s')",
+                TIME_DATE_FORMAT.format(time),
+                PATTERN
+            );
         }
 
         /** @inheritDoc */
@@ -655,13 +665,14 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
         private static final String PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";
 
         /** */
-        private static final SimpleDateFormat DATE_TIME_DATE_FORMAT = new SimpleDateFormat(PATTERN);
+        private static final DateTimeFormatter DATE_TIME_DATE_FORMAT =
+            DateTimeFormatter.ofPattern(PATTERN).withZone(ZoneId.systemDefault());
 
         /** Original value. */
-        private Object val;
+        private final Object val;
 
         /** Converted value. */
-        private String sqlStrVal;
+        private final String sqlStrVal;
 
         /**
          * Constructor.
@@ -670,7 +681,7 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
          */
         public Dated(Date date) {
             val = date;
-            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(date) + "', '" + PATTERN + "')";
+            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(date.toInstant()) + "', '" + PATTERN + "')";
         }
 
         /**
@@ -680,8 +691,7 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
          */
         public Dated(LocalDateTime date) {
             val = date;
-            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(
-                java.sql.Timestamp.valueOf(date)) + "', '" + PATTERN + "')";
+            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(date) + "', '" + PATTERN + "')";
         }
 
         /**
@@ -691,7 +701,7 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
          */
         public Dated(Timestamp ts, String ptrn) {
             val = ts;
-            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(ts) + "', '" + ptrn + "')";
+            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(ts.toLocalDateTime()) + "', '" + ptrn + "')";
         }
 
         /**
@@ -701,8 +711,7 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
          */
         public Dated(LocalDate date) {
             val = date;
-            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(
-                java.sql.Timestamp.valueOf(date.atStartOfDay())) + "', '" + PATTERN + "')";
+            sqlStrVal = "PARSEDATETIME('" + DATE_TIME_DATE_FORMAT.format(date.atStartOfDay()) + "', '" + PATTERN + "')";
         }
 
         /** @inheritDoc */
@@ -724,10 +733,10 @@ public abstract class AbstractDataTypesCoverageTest extends GridCommonAbstractTe
         private static final long serialVersionUID = 0L;
 
         /** Original value. */
-        private Object val;
+        private final Object val;
 
         /** Converted value. */
-        private String sqlStrVal;
+        private final String sqlStrVal;
 
         /**
          * Constructor.

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/cache/GridCacheBenchmark.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/cache/GridCacheBenchmark.java
@@ -17,11 +17,12 @@
 
 package org.apache.ignite.loadtests.cache;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.testframework.GridFileLock;
@@ -190,7 +191,7 @@ public class GridCacheBenchmark {
                     GridLoadTestUtils.appendLineToFile(
                         outputFileName,
                         "%s,%d,%d",
-                        GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                        IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                         durPutx,
                         durGet);
             }

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/communication/GridIoManagerBenchmark.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/communication/GridIoManagerBenchmark.java
@@ -18,9 +18,9 @@
 package org.apache.ignite.loadtests.communication;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -36,13 +36,13 @@ import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.managers.communication.GridIoManager;
 import org.apache.ignite.internal.managers.communication.GridMessageListener;
 import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.loadtests.util.GridCumulativeAverage;
-import org.apache.ignite.testframework.GridLoadTestUtils;
 import org.jetbrains.annotations.Nullable;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -194,8 +194,8 @@ public class GridIoManagerBenchmark {
                     try {
                         X.println("Saving results to output file: " + outputFilename);
 
-                        appendLineToFile(outputFilename, "%s,%d", GridLoadTestUtils.DATE_TIME_FORMAT.format(
-                            new Date()), qpsAvg.get());
+                        appendLineToFile(outputFilename, "%s,%d", IgniteUtils.LONG_DATE_FMT.format(
+                            Instant.now()), qpsAvg.get());
                     }
                     catch (IOException e) {
                         X.println("Failed to record results to a file: " + e.getMessage());

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/dsi/GridDsiClient.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/dsi/GridDsiClient.java
@@ -18,9 +18,9 @@
 package org.apache.ignite.loadtests.dsi;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -36,6 +36,7 @@ import org.apache.ignite.Ignition;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.compute.ComputeTaskFuture;
 import org.apache.ignite.internal.util.GridAtomicLong;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.T3;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.lang.IgnitePredicate;
@@ -371,7 +372,7 @@ public class GridDsiClient implements Callable {
                                 GridLoadTestUtils.appendLineToFile(
                                     outputFileName,
                                     "%s,%d,%d,%d",
-                                    GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                                    IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                                     txPerSecond,
                                     avgLatency,
                                     maxSubmitTime);
@@ -389,7 +390,7 @@ public class GridDsiClient implements Callable {
                                     GridLoadTestUtils.appendLineToFile(
                                         srvOutputFileName,
                                         "%s,%d,%d,%d",
-                                        GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                                        IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                                         sst.get1(),
                                         sst.get2(),
                                         sst.get3());

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionLoadTestClient.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionLoadTestClient.java
@@ -18,9 +18,9 @@
 package org.apache.ignite.loadtests.job;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.LongAdder;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCompute;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.lang.GridAbsClosure;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.X;
@@ -125,7 +126,7 @@ public class GridJobExecutionLoadTestClient implements Callable<Object> {
                             GridLoadTestUtils.appendLineToFile(
                                 outputFileName,
                                 "%s,%d",
-                                GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                                IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                                 avgTxPerSec.get()
                             );
                         }

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionLoadTestClientSemaphore.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionLoadTestClientSemaphore.java
@@ -18,9 +18,9 @@
 package org.apache.ignite.loadtests.job;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -30,6 +30,7 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCompute;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.cluster.ClusterGroup;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.lang.GridAbsClosure;
 import org.apache.ignite.internal.util.typedef.CI1;
 import org.apache.ignite.internal.util.typedef.G;
@@ -141,7 +142,7 @@ public class GridJobExecutionLoadTestClientSemaphore implements Callable<Object>
                             GridLoadTestUtils.appendLineToFile(
                                 outputFileName,
                                 "%s,%d",
-                                GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                                IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                                 avgTxPerSec.get()
                             );
                         }

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionSingleNodeLoadTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionSingleNodeLoadTest.java
@@ -18,9 +18,9 @@
 package org.apache.ignite.loadtests.job;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -36,6 +36,7 @@ import org.apache.ignite.compute.ComputeJobResult;
 import org.apache.ignite.compute.ComputeJobResultPolicy;
 import org.apache.ignite.compute.ComputeTask;
 import org.apache.ignite.compute.ComputeTaskCancelledException;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.X;
@@ -162,7 +163,7 @@ public class GridJobExecutionSingleNodeLoadTest {
                                 GridLoadTestUtils.appendLineToFile(
                                     outputFileName,
                                     "%s,%d",
-                                    GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                                    IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                                     avgTasksPerSec.get());
                             }
                             catch (IOException e) {

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionSingleNodeSemaphoreLoadTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/job/GridJobExecutionSingleNodeSemaphoreLoadTest.java
@@ -18,7 +18,7 @@
 package org.apache.ignite.loadtests.job;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -32,6 +32,7 @@ import org.apache.ignite.compute.ComputeJobResultPolicy;
 import org.apache.ignite.compute.ComputeTask;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.CI1;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.G;
@@ -137,7 +138,7 @@ public class GridJobExecutionSingleNodeSemaphoreLoadTest {
                                 GridLoadTestUtils.appendLineToFile(
                                     outputFileName,
                                     "%s,%d",
-                                    GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                                    IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                                     avgTasksPerSec.get());
                             }
                             catch (IOException e) {

--- a/modules/core/src/test/java/org/apache/ignite/loadtests/mergesort/GridMergeSortLoadTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/loadtests/mergesort/GridMergeSortLoadTest.java
@@ -18,10 +18,11 @@
 package org.apache.ignite.loadtests.mergesort;
 
 import java.io.IOException;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Random;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.lang.GridAbsClosure;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.X;
@@ -94,7 +95,7 @@ public class GridMergeSortLoadTest {
                     GridLoadTestUtils.appendLineToFile(
                         outputFileName,
                         "%s,%d",
-                        GridLoadTestUtils.DATE_TIME_FORMAT.format(new Date()),
+                        IgniteUtils.LONG_DATE_FMT.format(Instant.now()),
                         execTime / 1000);
             }
         }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/GridLoadTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/GridLoadTestUtils.java
@@ -23,7 +23,6 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.text.SimpleDateFormat;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -35,9 +34,6 @@ import org.jetbrains.annotations.Nullable;
  * Utility class for load tests.
  */
 public class GridLoadTestUtils {
-    /** Date and time format. */
-    public static final SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
-
     /** Lock file. */
     public static final File LOCK_FILE = new File(System.getProperty("user.home"), ".gg-loadtest-lock");
 

--- a/modules/ducktests/src/main/java/org/apache/ignite/internal/ducktest/tests/cellular_affinity_test/CellularTxStreamer.java
+++ b/modules/ducktests/src/main/java/org/apache/ignite/internal/ducktest/tests/cellular_affinity_test/CellularTxStreamer.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.ducktest.tests.cellular_affinity_test;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,6 +30,7 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.affinity.Affinity;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.internal.ducktest.utils.IgniteAwareApplication;
+import org.apache.ignite.internal.util.IgniteUtils;
 
 /**
  * Streams transactions to specified cell.
@@ -121,10 +121,10 @@ public class CellularTxStreamer extends IgniteAwareApplication {
         }
 
         List<String> result = new ArrayList<>();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
         for (int i = 0; i < precision; i++)
-            result.add(Duration.ofNanos(latencies[i]).toMillis() + " ms at " + formatter.format(opStartTimes[i]));
+            result.add(Duration.ofNanos(latencies[i]).toMillis() + " ms at " +
+                IgniteUtils.DEBUG_DATE_FMT.format(opStartTimes[i]));
 
         recordResult("WORST_LATENCY", result.toString());
         recordResult("STREAMED", cnt - warmup);

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/stat/StatisticsTypesAbstractTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/stat/StatisticsTypesAbstractTest.java
@@ -17,12 +17,11 @@
 
 package org.apache.ignite.internal.processors.query.stat;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
-
 import org.apache.ignite.Ignite;
 
 /**
@@ -40,34 +39,20 @@ public abstract class StatisticsTypesAbstractTest extends StatisticsAbstractTest
     private static final String START_DATE = "1970.01.01 12:00:00 UTC";
 
     /** Start time. */
-    protected static final long TIMESTART;
+    protected static final Instant TIMESTART = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss z")
+        .parse(START_DATE, Instant::from);
 
     /** Time format. */
-    private static final SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("HH:mm:ss");
+    private static final DateTimeFormatter TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.of("UTC"));
 
     /** Date format. */
-    private static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd");
+    private static final DateTimeFormatter DATE_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.of("UTC"));
 
-    /** Timestam format. */
-    private static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
-    static {
-        TimeZone tz = TimeZone.getTimeZone("UTC");
-        SimpleDateFormat SDF = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z");
-        SDF.setTimeZone(tz);
-        Calendar cal = Calendar.getInstance();
-        try {
-            cal.setTime(SDF.parse(START_DATE));
-        }
-        catch (ParseException e) {
-            // No-op.
-        }
-        TIMESTART = cal.getTimeInMillis();
-
-        TIME_FORMATTER.setTimeZone(tz);
-        DATE_FORMATTER.setTimeZone(tz);
-        TIMESTAMP_FORMATTER.setTimeZone(tz);
-    }
+    /** Timestamp format. */
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"));
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -132,22 +117,13 @@ public abstract class StatisticsTypesAbstractTest extends StatisticsAbstractTest
                 return String.valueOf((double) cntr / 100);
 
             case "TIME":
-                Calendar timeCalendar = Calendar.getInstance();
-                timeCalendar.setTimeInMillis(TIMESTART);
-                timeCalendar.add(Calendar.SECOND, (int) cntr);
-                return "'" + TIME_FORMATTER.format(timeCalendar.getTime()) + "'";
+                return "'" + TIME_FORMATTER.format(TIMESTART.plus(cntr, ChronoUnit.SECONDS)) + "'";
 
             case "DATE":
-                Calendar dateCalendar = Calendar.getInstance();
-                dateCalendar.setTimeInMillis(TIMESTART);
-                dateCalendar.add(Calendar.DATE, (int) cntr);
-                return "'" + DATE_FORMATTER.format(dateCalendar.getTime()) + "'";
+                return "'" + DATE_FORMATTER.format(TIMESTART.plus(cntr, ChronoUnit.DAYS)) + "'";
 
             case "TIMESTAMP":
-                Calendar tsCalendar = Calendar.getInstance();
-                tsCalendar.setTimeInMillis(TIMESTART);
-                tsCalendar.add(Calendar.SECOND, (int) cntr);
-                return "'" + TIMESTAMP_FORMATTER.format(tsCalendar.getTime()) + "'";
+                return "'" + TIMESTAMP_FORMATTER.format(TIMESTART.plus(cntr, ChronoUnit.SECONDS)) + "'";
 
             case "VARCHAR":
                 return "'varchar" + cntr + "'";

--- a/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
+++ b/modules/ssh/src/main/java/org/apache/ignite/internal/util/nodestart/StartNodeCallableImpl.java
@@ -23,8 +23,9 @@ import java.io.InputStreamReader;
 import java.io.InterruptedIOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import com.jcraft.jsch.ChannelExec;
@@ -71,7 +72,8 @@ public class StartNodeCallableImpl implements StartNodeCallable {
     private static final String DFLT_SCRIPT_LINUX = "bin/ignite.sh -v";
 
     /** Date format for log file name. */
-    private static final SimpleDateFormat FILE_NAME_DATE_FORMAT = new SimpleDateFormat("MM-dd-yyyy--HH-mm-ss");
+    private static final DateTimeFormatter FILE_NAME_DATE_FORMAT =
+        DateTimeFormatter.ofPattern("MM-dd-yyyy--HH-mm-ss").withZone(ZoneId.systemDefault());
 
     /** Used to register successful node start in log */
     private static final String SUCCESSFUL_START_MSG = "Successfully bound to TCP port";
@@ -171,7 +173,8 @@ public class StartNodeCallableImpl implements StartNodeCallable {
             if (cfg == null)
                 cfg = "";
 
-            String id = FILE_NAME_DATE_FORMAT.format(new Date()) + '-' + UUID.randomUUID().toString().substring(0, 8);
+            String id = FILE_NAME_DATE_FORMAT.format(Instant.now()) + '-' +
+                UUID.randomUUID().toString().substring(0, 8);
 
             String scriptOutputFileName = id + ".log";
 

--- a/modules/visor-console/src/main/scala/org/apache/ignite/visor/commands/VisorConsole.scala
+++ b/modules/visor-console/src/main/scala/org/apache/ignite/visor/commands/VisorConsole.scala
@@ -48,9 +48,6 @@ class VisorConsole {
     /** Copyright. */
     protected def copyright() = COPYRIGHT
 
-    /** Release date. */
-    protected def releaseDate() = new SimpleDateFormat("ddMMyyyy").parse(RELEASE_DATE_STR)
-
     /** Program name. */
     protected val progName = sys.props.getOrElse(IGNITE_PROG_NAME, "ignitevisorcmd")
 
@@ -326,7 +323,7 @@ class VisorConsole {
                 new java.lang.reflect.InvocationHandler {
                     def invoke(proxy: Any, mth: java.lang.reflect.Method, args: Array[Object]) = {
                         AboutDialog.centerShow("Visor - Ignite Shell Console", bannerIconUrl.toExternalForm,
-                            version(), releaseDate(), copyright())
+                            version(), RELEASE_DATE, copyright())
 
                         null
                     }


### PR DESCRIPTION
### Description

https://issues.apache.org/jira/browse/IGNITE-15078

This PR removes all usages of `SimpleDateFormat` in the production code, which is not thread-safe and is superseded by Java 8 Time API.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
