### PR TITLE
removing MULTI_THREADED from H2 options

### DIFF
--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/ConnectionManager.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/ConnectionManager.java
@@ -47,7 +47,7 @@ import static org.apache.ignite.internal.processors.query.h2.H2Utils.setter;
  */
 public class ConnectionManager {
     /** Default DB options. */
-    private static final String DEFAULT_DB_OPTIONS = ";LOCK_MODE=3;MULTI_THREADED=1;DB_CLOSE_ON_EXIT=FALSE" +
+    private static final String DEFAULT_DB_OPTIONS = ";LOCK_MODE=3;DB_CLOSE_ON_EXIT=FALSE" +
         ";DEFAULT_LOCK_TIMEOUT=10000;FUNCTIONS_IN_SCHEMA=true;OPTIMIZE_REUSE_RESULTS=0;QUERY_CACHE_SIZE=0" +
         ";MAX_OPERATION_MEMORY=0;BATCH_JOINS=1" +
         ";ROW_FACTORY=\"" + H2PlainRowFactory.class.getName() + "\"" +


### PR DESCRIPTION
The support for MULTI_THREADED has been removed in H2 v1.4.200:
https://github.com/h2database/h2database/releases/tag/version-1.4.200

If a H2 v1.4.200 is on classpath, it will crash Ignite:
Caused by: org.h2.jdbc.JdbcSQLNonTransientConnectionException: Unsupported connection setting "MULTI_THREADED" [90113-200]

It's due to hardcoded DB_OPTIONS:
https://github.com/andyglick/apache-ignite/blob/master/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java#L202

The fix is to either remove MULTI_THREADED argument or to add IGNORE_UNKNOWN_SETTINGS=TRUE
