### PR TITLE
IGNITE-15358: Fix client node reconnect with enabled security

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteEventsImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteEventsImpl.java
@@ -191,7 +191,6 @@ public class IgniteEventsImpl extends AsyncSupportAdapter<IgniteEvents> implemen
             final UUID subjId = ctx.security().securityContext().subject().id();
 
             return new SecurityAwarePredicate<>(subjId, res);
-
         }
 
         return res;

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
@@ -2138,10 +2138,8 @@ public class GridIoManager extends GridManagerAdapter<CommunicationSpi<Serializa
         if (ctx.security().enabled()) {
             UUID secSubjId = null;
 
-            UUID curSecSubjId = ctx.security().securityContext().subject().id();
-
-            if (!locNodeId.equals(curSecSubjId))
-                secSubjId = curSecSubjId;
+            if (!ctx.security().isDefaultContext())
+                secSubjId = ctx.security().securityContext().subject().id();
 
             return new GridIoSecurityAwareMessage(secSubjId, plc, topic, topicOrd, msg, ordered, timeout, skipOnTimeout);
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/discovery/GridDiscoveryManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/discovery/GridDiscoveryManager.java
@@ -868,6 +868,8 @@ public class GridDiscoveryManager extends GridManagerAdapter<DiscoverySpi> {
 
                     ctx.service().onLocalJoin(localJoinEvent(), discoCache);
 
+                    ctx.security().onLocalJoin();
+
                     DiscoCache discoCache0 = discoCache;
 
                     ctx.cluster().clientReconnectFuture().listen(new CI1<IgniteFuture<?>>() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/discovery/GridDiscoveryManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/discovery/GridDiscoveryManager.java
@@ -796,6 +796,8 @@ public class GridDiscoveryManager extends GridManagerAdapter<DiscoverySpi> {
                     discoWrk.discoCache = discoCache;
 
                     if (!isLocDaemon && !ctx.clientDisconnected()) {
+                        ctx.security().onLocalJoin();
+
                         ctx.cache().context().versions().onLocalJoin(topVer);
 
                         ctx.cache().context().coordinators().onLocalJoin(discoEvt, discoCache);
@@ -805,8 +807,6 @@ public class GridDiscoveryManager extends GridManagerAdapter<DiscoverySpi> {
                         ctx.service().onLocalJoin(discoEvt, discoCache);
 
                         ctx.encryption().onLocalJoin();
-
-                        ctx.security().onLocalJoin();
 
                         ctx.cluster().onLocalJoin();
                     }
@@ -856,6 +856,8 @@ public class GridDiscoveryManager extends GridManagerAdapter<DiscoverySpi> {
                     assert locNode.isClient() : locNode;
                     assert node.isClient() : node;
 
+                    ctx.security().onLocalJoin();
+
                     boolean clusterRestarted = gridStartTime != getSpi().getGridStartTime();
 
                     gridStartTime = getSpi().getGridStartTime();
@@ -867,8 +869,6 @@ public class GridDiscoveryManager extends GridManagerAdapter<DiscoverySpi> {
                     ctx.cache().context().exchange().onLocalJoin(localJoinEvent(), discoCache);
 
                     ctx.service().onLocalJoin(localJoinEvent(), discoCache);
-
-                    ctx.security().onLocalJoin();
 
                     DiscoCache discoCache0 = discoCache;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurity.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurity.java
@@ -61,6 +61,9 @@ public interface IgniteSecurity {
      */
     public OperationSecurityContext withContext(UUID nodeId);
 
+    /** @return {@code True} if current thread executed in default security context. */
+    public boolean isDefaultContext();
+
     /**
      * @return SecurityContext of holder {@link OperationSecurityContext}.
      */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
@@ -138,7 +138,7 @@ public class IgniteSecurityProcessor implements IgniteSecurity, GridProcessor {
         SecurityContext cur = curSecCtx.get();
 
         boolean isNewCtxDflt = secCtx == dflt;
-        boolean isCurCtxDflt = cur == dflt;
+        boolean isCurCtxDflt = cur == null;
 
         if (isCurCtxDflt && isNewCtxDflt)
             return dfltOpCtx;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
@@ -249,6 +249,8 @@ public class IgniteSecurityProcessor implements IgniteSecurity, GridProcessor {
     @Override public void authorize(String name, SecurityPermission perm) throws SecurityException {
         SecurityContext secCtx = securityContext();
 
+        assert secCtx != null;
+
         secPrc.authorize(name, perm, secCtx);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
@@ -182,13 +182,12 @@ public class IgniteSecurityProcessor implements IgniteSecurity, GridProcessor {
 
             SecurityContext res;
 
-            if (locNodeSecCtx != null && locNodeSecCtx.subject().id().equals(subjId))
+            if (node == null)
+                res = secPrc.securityContext(subjId);
+            else if (locNodeSecCtx.subject().id().equals(subjId))
                 res = locNodeSecCtx;
-            else {
-                res = node != null
-                    ? secCtxs.computeIfAbsent(subjId, uuid -> nodeSecurityContext(marsh, U.resolveClassLoader(ctx.config()), node))
-                    : secPrc.securityContext(subjId);
-            }
+            else
+                res = secCtxs.computeIfAbsent(subjId, uuid -> nodeSecurityContext(marsh, U.resolveClassLoader(ctx.config()), node));
 
             if (res == null) {
                 throw new IllegalStateException("Failed to find security context " +

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
@@ -85,7 +85,7 @@ public class IgniteSecurityProcessor implements IgniteSecurity, GridProcessor {
     }
 
     /** Current security context if differs from {@link #dfltSecCtx}. */
-    private final ThreadLocal<SecurityContext> curSecCtx = ThreadLocal.withInitial(() -> null);
+    private final ThreadLocal<SecurityContext> curSecCtx = new ThreadLocal<>();
 
     /** Grid kernal context. */
     private final GridKernalContext ctx;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/IgniteSecurityProcessor.java
@@ -80,6 +80,7 @@ public class IgniteSecurityProcessor implements IgniteSecurity, GridProcessor {
     /**
      * Dummy instance to use instead of local context.
      * Local context can be changed on local node reconnect.
+     * @see #onLocalJoin()
      */
     public static final SecurityContext DUMMY = new SecurityContext() {
         @Override public SecuritySubject subject() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/NoOpIgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/NoOpIgniteSecurityProcessor.java
@@ -69,6 +69,11 @@ public class NoOpIgniteSecurityProcessor extends GridProcessorAdapter implements
     }
 
     /** {@inheritDoc} */
+    @Override public boolean isDefaultContext() {
+        return true;
+    }
+
+    /** {@inheritDoc} */
     @Override public SecurityContext securityContext() {
         return null;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/NoOpIgniteSecurityProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/NoOpIgniteSecurityProcessor.java
@@ -46,7 +46,11 @@ public class NoOpIgniteSecurityProcessor extends GridProcessorAdapter implements
     public static final String SECURITY_DISABLED_ERROR_MSG = "Operation cannot be performed: Ignite security disabled.";
 
     /** No operation security context. */
-    private final OperationSecurityContext opSecCtx = new OperationSecurityContext(this, null);
+    private final OperationSecurityContext opSecCtx = new OperationSecurityContext(this, null) {
+        @Override public void close() {
+            // No-op.
+        }
+    };
 
     /** Instance of IgniteSandbox. */
     private final IgniteSandbox sandbox = new NoOpSandbox();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/OperationSecurityContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/OperationSecurityContext.java
@@ -32,9 +32,6 @@ public class OperationSecurityContext implements AutoCloseable {
      * @param secCtx Security context.
      */
     OperationSecurityContext(IgniteSecurity proc, SecurityContext secCtx) {
-        assert proc != null;
-        assert secCtx != null || !proc.enabled();
-
         this.proc = proc;
         this.secCtx = secCtx;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/OperationSecurityContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/OperationSecurityContext.java
@@ -39,14 +39,11 @@ public class OperationSecurityContext implements AutoCloseable {
         this.secCtx = secCtx;
     }
 
-    /** Empty constructor. */
-    OperationSecurityContext() {
-        this.proc = null;
-        this.secCtx = null;
-    }
-
     /** {@inheritDoc} */
     @Override public void close() {
-        proc.withContext(secCtx);
+        if (secCtx == null)
+            ((IgniteSecurityProcessor)proc).restoreDefaultContext();
+        else
+            proc.withContext(secCtx);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/OperationSecurityContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/OperationSecurityContext.java
@@ -39,6 +39,12 @@ public class OperationSecurityContext implements AutoCloseable {
         this.secCtx = secCtx;
     }
 
+    /** Empty constructor. */
+    OperationSecurityContext() {
+        this.proc = null;
+        this.secCtx = null;
+    }
+
     /** {@inheritDoc} */
     @Override public void close() {
         proc.withContext(secCtx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareCallable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareCallable.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.processors.security.OperationSecurityContext;
 import org.apache.ignite.internal.processors.security.SecurityContext;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a {@link Callable} wrapper that executes the original {@link Callable} with the security context
@@ -37,7 +36,7 @@ public class SecurityAwareCallable<T> implements Callable<T> {
     private final IgniteSecurity security;
 
     /** */
-    private final @Nullable SecurityContext secCtx;
+    private final SecurityContext secCtx;
 
     /** */
     public SecurityAwareCallable(IgniteSecurity security, Callable<T> delegate) {
@@ -51,6 +50,8 @@ public class SecurityAwareCallable<T> implements Callable<T> {
 
     /** {@inheritDoc} */
     @Override public T call() throws Exception {
+        // `secCtx==null` mean run in context of local node.
+        // `security.securityContext()` can return null in case it invoked before join to the cluster.
         if (secCtx == null)
             return delegate.call();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareCallable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareCallable.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.processors.security.OperationSecurityContext;
 import org.apache.ignite.internal.processors.security.SecurityContext;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a {@link Callable} wrapper that executes the original {@link Callable} with the security context
@@ -36,7 +37,7 @@ public class SecurityAwareCallable<T> implements Callable<T> {
     private final IgniteSecurity security;
 
     /** */
-    private final SecurityContext secCtx;
+    private final @Nullable SecurityContext secCtx;
 
     /** */
     public SecurityAwareCallable(IgniteSecurity security, Callable<T> delegate) {
@@ -50,6 +51,9 @@ public class SecurityAwareCallable<T> implements Callable<T> {
 
     /** {@inheritDoc} */
     @Override public T call() throws Exception {
+        if (secCtx == null)
+            return delegate.call();
+
         try (OperationSecurityContext ignored = security.withContext(secCtx)) {
             return delegate.call();
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareCallable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareCallable.java
@@ -45,13 +45,11 @@ public class SecurityAwareCallable<T> implements Callable<T> {
 
         this.delegate = delegate;
         this.security = security;
-        secCtx = security.securityContext();
+        secCtx = security.isDefaultContext() ? null : security.securityContext();
     }
 
     /** {@inheritDoc} */
     @Override public T call() throws Exception {
-        // `secCtx==null` mean run in context of local node.
-        // `security.securityContext()` can return null in case it invoked before join to the cluster.
         if (secCtx == null)
             return delegate.call();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
@@ -48,6 +48,8 @@ public class SecurityAwareRunnable implements Runnable {
 
     /** {@inheritDoc} */
     @Override public void run() {
+        // `secCtx==null` mean run in context of local node.
+        // `security.securityContext()` can return null in case it invoked before join to the cluster.
         if (secCtx == null) {
             delegate.run();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
@@ -42,13 +42,11 @@ public class SecurityAwareRunnable implements Runnable {
 
         this.delegate = delegate;
         this.security = security;
-        secCtx = security.securityContext();
+        secCtx = security.isDefaultContext() ? null : security.securityContext();
     }
 
     /** {@inheritDoc} */
     @Override public void run() {
-        // `secCtx==null` mean run in context of local node.
-        // `security.securityContext()` can return null in case it invoked before join to the cluster.
         if (secCtx == null) {
             delegate.run();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
@@ -20,6 +20,7 @@ package org.apache.ignite.internal.processors.security.thread;
 import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.processors.security.OperationSecurityContext;
 import org.apache.ignite.internal.processors.security.SecurityContext;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a {@link Runnable} wrapper that executes the original {@link Runnable} with the security context
@@ -33,7 +34,7 @@ public class SecurityAwareRunnable implements Runnable {
     private final IgniteSecurity security;
 
     /** */
-    private final SecurityContext secCtx;
+    private final @Nullable SecurityContext secCtx;
 
     /** */
     public SecurityAwareRunnable(IgniteSecurity security, Runnable delegate) {
@@ -47,6 +48,12 @@ public class SecurityAwareRunnable implements Runnable {
 
     /** {@inheritDoc} */
     @Override public void run() {
+        if (secCtx == null) {
+            delegate.run();
+
+            return;
+        }
+
         try (OperationSecurityContext ignored = security.withContext(secCtx)) {
             delegate.run();
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/security/thread/SecurityAwareRunnable.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.processors.security.thread;
 import org.apache.ignite.internal.processors.security.IgniteSecurity;
 import org.apache.ignite.internal.processors.security.OperationSecurityContext;
 import org.apache.ignite.internal.processors.security.SecurityContext;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a {@link Runnable} wrapper that executes the original {@link Runnable} with the security context
@@ -34,7 +33,7 @@ public class SecurityAwareRunnable implements Runnable {
     private final IgniteSecurity security;
 
     /** */
-    private final @Nullable SecurityContext secCtx;
+    private final SecurityContext secCtx;
 
     /** */
     public SecurityAwareRunnable(IgniteSecurity security, Runnable delegate) {

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNode.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/internal/TcpDiscoveryNode.java
@@ -63,7 +63,7 @@ public class TcpDiscoveryNode extends GridMetadataAwareAdapter implements Ignite
     private static final long serialVersionUID = 0L;
 
     /** Node ID. */
-    private UUID id;
+    private volatile UUID id;
 
     /** Consistent ID. */
     @GridToStringInclude

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.cluster.ClusterNode;
-import org.apache.ignite.cluster.ClusterState;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteEx;
@@ -68,17 +67,13 @@ public class ClientReconnectTest extends GridCommonAbstractTest {
     /** */
     @Test
     public void testClientNodeReconnected() throws Exception {
-        IgniteEx ignite = startGrids(2);
+        startGrids(2);
 
-        ignite.cluster().state(ClusterState.ACTIVE);
-
-        int clientIdx = 2;
-
-        IgniteEx ex = startClientGrid(clientIdx);
+        IgniteEx cli = startClientGrid(2);
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        ex.events().localListen(evt -> {
+        cli.events().localListen(evt -> {
             latch.countDown();
 
             return true;
@@ -86,7 +81,7 @@ public class ClientReconnectTest extends GridCommonAbstractTest {
 
         DiscoverySpi discoverySpi = ignite(0).configuration().getDiscoverySpi();
 
-        discoverySpi.failNode(nodeId(clientIdx), null);
+        discoverySpi.failNode(nodeId(2), null);
 
         assertTrue(latch.await(getTestTimeout(), TimeUnit.MILLISECONDS));
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
@@ -65,13 +65,6 @@ public class ClientReconnectTest extends GridCommonAbstractTest {
         });
     }
 
-    /** {@inheritDoc} */
-    @Override protected void beforeTest() throws Exception {
-        super.beforeTest();
-
-        cleanPersistenceDir();
-    }
-
     /** */
     @Test
     public void testClientNodeReconnected() throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.security.client;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.security.GridSecurityProcessor;
+import org.apache.ignite.internal.processors.security.SecurityContext;
+import org.apache.ignite.plugin.security.SecurityCredentials;
+import org.apache.ignite.spi.discovery.DiscoverySpi;
+import org.apache.ignite.spi.discovery.TestReconnectSecurityPluginProvider;
+import org.apache.ignite.spi.discovery.tcp.TestReconnectProcessor;
+import org.apache.ignite.spi.discovery.tcp.internal.TcpDiscoveryNode;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static org.apache.ignite.events.EventType.EVT_CLIENT_NODE_RECONNECTED;
+
+/**
+ * Tests client node can reconnect cluster based only on node id which changed on disconnect.
+ * @see TcpDiscoveryNode#onClientDisconnected(UUID)
+ */
+public class ClientReconnectTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        return super.getConfiguration(igniteInstanceName).setPluginProviders(new TestReconnectSecurityPluginProvider() {
+            @Override protected GridSecurityProcessor securityProcessor(GridKernalContext ctx) {
+                return new TestReconnectProcessor(ctx) {
+                    @Override public SecurityContext securityContext(UUID subjId) {
+                        if (ctx.localNodeId().equals(subjId))
+                            return ctx.security().securityContext();
+
+                        throw new IgniteException(
+                            "Unexpected subjId[subjId=" + subjId + ",localNodeId=" + ctx.localNodeId() + ']'
+                        );
+                    }
+
+                    @Override public SecurityContext authenticateNode(ClusterNode node, SecurityCredentials cred) {
+                        return new TestSecurityContext(new TestSecuritySubject(node.id()));
+                    }
+                };
+            }
+        });
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        cleanPersistenceDir();
+    }
+
+    /** */
+    @Test
+    public void testClientNodeReconnected() throws Exception {
+        IgniteEx ignite = startGrids(2);
+
+        ignite.cluster().state(ClusterState.ACTIVE);
+
+        int clientIdx = 2;
+
+        IgniteEx ex = startClientGrid(clientIdx);
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ex.events().localListen(evt -> {
+            latch.countDown();
+
+            return true;
+        }, EVT_CLIENT_NODE_RECONNECTED);
+
+        DiscoverySpi discoverySpi = ignite(0).configuration().getDiscoverySpi();
+
+        discoverySpi.failNode(nodeId(clientIdx), null);
+
+        assertTrue(latch.await(getTestTimeout(), TimeUnit.MILLISECONDS));
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/client/ClientReconnectTest.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.processors.security.client;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.apache.ignite.IgniteException;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.GridKernalContext;
@@ -51,9 +50,9 @@ public class ClientReconnectTest extends GridCommonAbstractTest {
                         if (ctx.localNodeId().equals(subjId))
                             return ctx.security().securityContext();
 
-                        throw new IgniteException(
-                            "Unexpected subjId[subjId=" + subjId + ",localNodeId=" + ctx.localNodeId() + ']'
-                        );
+                        fail("Unexpected subjId[subjId=" + subjId + ", localNodeId=" + ctx.localNodeId() + ']');
+
+                        return null;
                     }
 
                     @Override public SecurityContext authenticateNode(ClusterNode node, SecurityCredentials cred) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/security/impl/TestSecurityProcessor.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/security/impl/TestSecurityProcessor.java
@@ -32,7 +32,6 @@ import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteNodeAttributes;
 import org.apache.ignite.internal.processors.GridProcessorAdapter;
 import org.apache.ignite.internal.processors.security.GridSecurityProcessor;
-import org.apache.ignite.internal.processors.security.IgniteSecurityProcessor.DeferredSecurityContext;
 import org.apache.ignite.internal.processors.security.SecurityContext;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.plugin.security.AuthenticationContext;
@@ -153,9 +152,6 @@ public class TestSecurityProcessor extends GridProcessorAdapter implements GridS
     /** {@inheritDoc} */
     @Override public void authorize(String name, SecurityPermission perm, SecurityContext securityCtx)
         throws SecurityException {
-        if (securityCtx instanceof DeferredSecurityContext)
-            securityCtx = ((DeferredSecurityContext)securityCtx).delegate();
-
         if (!((TestSecurityContext)securityCtx).operationAllowed(name, perm))
             throw new SecurityException("Authorization failed [perm=" + perm +
                 ", name=" + name +

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestReconnectProcessor.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TestReconnectProcessor.java
@@ -109,7 +109,7 @@ public class TestReconnectProcessor extends GridProcessorAdapter implements Grid
     /**
      *
      */
-    private static class TestSecuritySubject implements SecuritySubject {
+    public static class TestSecuritySubject implements SecuritySubject {
 
         /** Id. */
         private final UUID id;
@@ -150,7 +150,7 @@ public class TestReconnectProcessor extends GridProcessorAdapter implements Grid
     /**
      *
      */
-    private static class TestSecurityContext implements SecurityContext, Serializable {
+    public static class TestSecurityContext implements SecurityContext, Serializable {
         /** Serial version uid. */
         private static final long serialVersionUID = 0L;
 

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/SecurityTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/SecurityTestSuite.java
@@ -32,6 +32,7 @@ import org.apache.ignite.internal.processors.security.cache.closure.ScanQueryRem
 import org.apache.ignite.internal.processors.security.client.AdditionalSecurityCheckTest;
 import org.apache.ignite.internal.processors.security.client.AdditionalSecurityCheckWithGlobalAuthTest;
 import org.apache.ignite.internal.processors.security.client.AttributeSecurityCheckTest;
+import org.apache.ignite.internal.processors.security.client.ClientReconnectTest;
 import org.apache.ignite.internal.processors.security.client.IgniteClientContainSubjectAddressTest;
 import org.apache.ignite.internal.processors.security.client.ThinClientPermissionCheckSecurityTest;
 import org.apache.ignite.internal.processors.security.client.ThinClientPermissionCheckTest;
@@ -83,6 +84,7 @@ import org.junit.runners.Suite;
     ThinClientPermissionCheckSecurityTest.class,
     ContinuousQueryPermissionCheckTest.class,
     IgniteClientContainSubjectAddressTest.class,
+    ClientReconnectTest.class,
     SnapshotPermissionCheckTest.class,
 
     DistributedClosureRemoteSecurityContextCheckTest.class,

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClusterNode.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperClusterNode.java
@@ -54,7 +54,7 @@ public class ZookeeperClusterNode implements IgniteClusterNode, Externalizable, 
     private static final byte CLIENT_NODE_MASK = 0x01;
 
     /** */
-    private UUID id;
+    private volatile UUID id;
 
     /** */
     private Serializable consistentId;


### PR DESCRIPTION
Reinitialized local security context on client node reconnect, because node id changed on disconnect.

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
