### PR TITLE
IGNITE-15388

### DIFF
--- a/modules/azure/pom.xml
+++ b/modules/azure/pom.xml
@@ -28,17 +28,17 @@
     <version>2.12.0-SNAPSHOT</version>
     <url>http://ignite.apache.org</url>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-sdk-bom</artifactId>
-                <version>1.0.2</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+<!--    <dependencyManagement>-->
+<!--        <dependencies>-->
+<!--            <dependency>-->
+<!--                <groupId>com.azure</groupId>-->
+<!--                <artifactId>azure-sdk-bom</artifactId>-->
+<!--                <version>1.0.2</version>-->
+<!--                <type>pom</type>-->
+<!--                <scope>import</scope>-->
+<!--            </dependency>-->
+<!--        </dependencies>-->
+<!--    </dependencyManagement>-->
 
     <dependencies>
         <dependency>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>${azure.sdk.version}</version>
+            <version>12.13.0</version>
         </dependency>
 
         <dependency>
@@ -100,20 +100,18 @@
             <version>12.12.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-security-keyvault-secrets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-identity</artifactId>
         </dependency>
 
         <dependency>
@@ -178,6 +176,13 @@
             <version>${netty.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-codec -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/io.netty/netty-codec-http2 -->
         <dependency>
             <groupId>io.netty</groupId>
@@ -224,6 +229,32 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-resolver-dns -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.39.Final</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-codec-dns -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-dns</artifactId>
             <version>${netty.version}</version>
         </dependency>
 
@@ -281,33 +312,31 @@
             <version>3.4.6</version>
         </dependency>
 
-<!--        &lt;!&ndash; https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-core &ndash;&gt;-->
-<!--        <dependency>-->
-<!--            <groupId>io.projectreactor.netty</groupId>-->
-<!--            <artifactId>reactor-netty-core</artifactId>-->
-<!--            <version>1.0.7</version>-->
-<!--        </dependency>-->
-
-        <!-- https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty -->
+        <!-- https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-core -->
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
-            <artifactId>reactor-netty</artifactId>
+            <artifactId>reactor-netty-core</artifactId>
             <version>1.0.7</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-http</artifactId>
+            <version>1.0.7</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.woodstox/woodstox-core -->
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.2.4</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.codehaus.woodstox/stax2-api -->
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>
             <version>4.2.1</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.reflections/reflections -->

--- a/modules/azure/pom.xml
+++ b/modules/azure/pom.xml
@@ -73,13 +73,19 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-http-netty</artifactId>
-            <version>1.0.0</version>
+            <version>1.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.17.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-internal-avro</artifactId>
+            <version>12.0.5</version>
         </dependency>
 
         <dependency>
@@ -91,7 +97,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-common</artifactId>
-            <version>${azure.sdk.version}</version>
+            <version>12.12.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations -->
@@ -249,6 +255,13 @@
             <version>${netty.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-tcnative -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative</artifactId>
+            <version>2.0.40.Final</version>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -265,15 +278,23 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>3.3.0.RELEASE</version>
+            <version>3.4.6</version>
         </dependency>
+
+<!--        &lt;!&ndash; https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-core &ndash;&gt;-->
+<!--        <dependency>-->
+<!--            <groupId>io.projectreactor.netty</groupId>-->
+<!--            <artifactId>reactor-netty-core</artifactId>-->
+<!--            <version>1.0.7</version>-->
+<!--        </dependency>-->
 
         <!-- https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty -->
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
-            <version>0.9.0.RELEASE</version>
+            <version>1.0.7</version>
         </dependency>
+
 
         <!-- https://mvnrepository.com/artifact/org.codehaus.woodstox/stax2-api -->
         <dependency>

--- a/modules/azure/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinder.java
+++ b/modules/azure/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinder.java
@@ -337,22 +337,6 @@ public class TcpDiscoveryAzureBlobStoreIpFinder extends TcpDiscoveryIpFinderAdap
         return addr.getAddress().getHostAddress() + "#" + addr.getPort();
     }
 
-    /**
-     * Used by TEST SUITES only. Called through reflection.
-     *
-     * @param containerName Container to delete
-     */
-    private void removeContainer(String containerName) {
-        init();
-
-        try {
-            blobServiceClient.getBlobContainerClient(containerName).delete();
-        }
-        catch (Exception e) {
-            throw new IgniteSpiException("Failed to remove the container: " + containerName, e);
-        }
-    }
-
     /** {@inheritDoc} */
     @Override public TcpDiscoveryAzureBlobStoreIpFinder setShared(boolean shared) {
         super.setShared(shared);

--- a/modules/azure/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinder.java
+++ b/modules/azure/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinder.java
@@ -46,7 +46,6 @@ import org.apache.ignite.spi.IgniteSpiConfiguration;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinderAdapter;
 
-
 /**
  * Azure Blob Storage based IP Finder
  * <p>

--- a/modules/azure/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinderSelfTest.java
+++ b/modules/azure/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinderSelfTest.java
@@ -45,7 +45,9 @@ public class TcpDiscoveryAzureBlobStoreIpFinderSelfTest
     }
 
     /** {@inheritDoc} */
-    @Override protected void afterTestsStopped() {
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
         try {
             Method method = TcpDiscoveryAzureBlobStoreIpFinder.class.getDeclaredMethod("removeContainer", String.class);
 

--- a/modules/azure/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinderSelfTest.java
+++ b/modules/azure/src/test/java/org/apache/ignite/spi/discovery/tcp/ipfinder/azure/TcpDiscoveryAzureBlobStoreIpFinderSelfTest.java
@@ -15,11 +15,14 @@ package org.apache.ignite.spi.discovery.tcp.ipfinder.azure;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.lang.reflect.Method;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.spi.discovery.tcp.ipfinder.TcpDiscoveryIpFinderAbstractSelfTest;
 import org.apache.ignite.testsuites.IgniteAzureTestSuite;
@@ -45,15 +48,17 @@ public class TcpDiscoveryAzureBlobStoreIpFinderSelfTest
     }
 
     /** {@inheritDoc} */
-    @Override protected void afterTest() throws Exception {
-        super.afterTest();
+    @Override protected void afterTestsStopped() throws Exception {
+        super.afterTestsStopped();
 
         try {
-            Method method = TcpDiscoveryAzureBlobStoreIpFinder.class.getDeclaredMethod("removeContainer", String.class);
+            BlobContainerClient container =
+                new BlobServiceClientBuilder().endpoint(IgniteAzureTestSuite.getEndpoint()).credential(
+                    new StorageSharedKeyCredential(IgniteAzureTestSuite.getAccountName(),
+                        IgniteAzureTestSuite.getAccountKey())).buildClient().getBlobContainerClient(containerName);
 
-            method.setAccessible(true);
-
-            method.invoke(finder, containerName);
+            if (container.exists())
+                container.delete();
         }
         catch (Exception e) {
             log.warning("Failed to remove bucket on Azure [containerName=" + containerName + ", mes=" + e.getMessage() + ']');

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -54,7 +54,6 @@
         <aspectj.version>1.8.13</aspectj.version>
         <aws.sdk.bundle.version>1.10.12_1</aws.sdk.bundle.version>
         <aws.sdk.version>1.11.75</aws.sdk.version>
-        <azure.sdk.version>12.13.0</azure.sdk.version>
         <netty.version>4.1.66.Final</netty.version>
         <camel.version>2.22.0</camel.version>
         <aws.encryption.sdk.version>1.3.2</aws.encryption.sdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -54,7 +54,7 @@
         <aspectj.version>1.8.13</aspectj.version>
         <aws.sdk.bundle.version>1.10.12_1</aws.sdk.bundle.version>
         <aws.sdk.version>1.11.75</aws.sdk.version>
-        <azure.sdk.version>12.0.0</azure.sdk.version>
+        <azure.sdk.version>12.13.0</azure.sdk.version>
         <netty.version>4.1.66.Final</netty.version>
         <camel.version>2.22.0</camel.version>
         <aws.encryption.sdk.version>1.3.2</aws.encryption.sdk.version>


### PR DESCRIPTION
This patch includes the following changes: 

* Azure-storage-blob version update (to 12.13.0) and its dependencies (considering the dependency graph).
* Removed "removeContainer" method - it is never called because "afterTestsStopped" is called on a separate instance and ipfinder is always null there.
* Removed unnecessary imports (com.nimbusds.oauth2.sdk.util.URLUtils.CHARSET) and reworked the bunch of code in which it was involved.
* Fixed incorrect comparison of error codes in the "unregisterAddresses" method.

The test was checked in a separate (from Ignite) project to make sure all required dependencies were included.