### PR TITLE
IGNITE-15407 Fix PK flag ordering in SQL AST traverse

### DIFF
--- a/modules/indexing/src/test/java/org/apache/ignite/sqltests/CheckWarnJoinPartitionedTables.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/sqltests/CheckWarnJoinPartitionedTables.java
@@ -60,9 +60,12 @@ public class CheckWarnJoinPartitionedTables extends GridCommonAbstractTest {
 
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {
-        stopAllGrids();
-
         crd = startGrid();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
     }
 
     /** */


### PR DESCRIPTION
This patch fixes a bug in the `SqlAstTraverser`. It incorrectly handled info about PK in cases of changing order of tables.