### PR TITLE
IGNITE-15391 Add support for creating IndexQuery without index name

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQuery.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import javax.cache.Cache;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.lang.IgniteExperimental;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Index query runs over internal index structure and returns cache entries for index rows that match specified criteria.
@@ -41,8 +42,26 @@ public final class IndexQuery<K, V> extends Query<Cache.Entry<K, V>> {
     /** Cache Value type. Describes a table within a cache that runs a query. */
     private final String valType;
 
-    /** Index name. */
-    private final String idxName;
+    /** Index name. If {@code null} then Ignite tries to find an index by {@link #criteria} fields. */
+    private final @Nullable String idxName;
+
+    /**
+     * Specify index with cache value class.
+     *
+     * @param valCls Cache value class.
+     */
+    public IndexQuery(Class<?> valCls) {
+        this(valCls, null);
+    }
+
+    /**
+     * Specify index with cache value type.
+     *
+     * @param valType Cache value type.
+     */
+    public IndexQuery(String valType) {
+        this(valType, null);
+    }
 
     /**
      * Specify index with cache value class and index name.
@@ -50,7 +69,7 @@ public final class IndexQuery<K, V> extends Query<Cache.Entry<K, V>> {
      * @param valCls Cache value class.
      * @param idxName Index name.
      */
-    public IndexQuery(Class<?> valCls, String idxName) {
+    public IndexQuery(Class<?> valCls, @Nullable String idxName) {
         this(valCls.getName(), idxName);
     }
 
@@ -60,9 +79,9 @@ public final class IndexQuery<K, V> extends Query<Cache.Entry<K, V>> {
      * @param valType Cache value type.
      * @param idxName Index name.
      */
-    public IndexQuery(String valType, String idxName) {
+    public IndexQuery(String valType, @Nullable String idxName) {
         A.notEmpty(valType, "valType");
-        A.notEmpty(idxName, "idxName");
+        A.nullableNotEmpty(idxName, "idxName");
 
         this.valType = valType;
         this.idxName = idxName;

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
@@ -173,14 +173,14 @@ public class IndexQueryProcessor {
             .flatMap(f -> Stream.of(f, QueryUtils.normalizeObjectName(f, false)))
             .collect(Collectors.toSet());
 
-        for (Index i: idxs) {
-            IndexDefinition idxDef = idxProc.indexDefinition(i.id());
+        for (Index idx: idxs) {
+            IndexDefinition idxDef = idxProc.indexDefinition(idx.id());
 
             if (!tableName.equals(idxDef.idxName().tableName()))
                 continue;
 
             if (checkIndex(idxDef, idxQryDesc.criteria().size(), critFields))
-                return i;
+                return idx;
         }
 
         return null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridArgumentCheck.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridArgumentCheck.java
@@ -189,6 +189,20 @@ public class GridArgumentCheck {
     }
 
     /**
+     * Checks that given String is nullable but not empty.
+     *
+     * @param str String.
+     * @param name Argument name.
+     */
+    public static void nullableNotEmpty(String str, String name) {
+        if (str == null)
+            return;
+
+        if (str.isEmpty())
+            throw new IllegalArgumentException(INVALID_ARG_MSG_PREFIX + name + NOT_EMPTY_SUFFIX);
+    }
+
+    /**
      * Checks that a String is not null or empty.
      *
      * @param value Value to check.

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryAliasTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryAliasTest.java
@@ -36,10 +36,13 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
 
 /** */
+@RunWith(Parameterized.class)
 public class IndexQueryAliasTest extends GridCommonAbstractTest {
     /** */
     private static final String CACHE = "TEST_CACHE";
@@ -52,6 +55,23 @@ public class IndexQueryAliasTest extends GridCommonAbstractTest {
 
     /** */
     private static final int CNT = 10_000;
+
+    /** Query index, {@code null} or index name. */
+    @Parameterized.Parameter
+    public String qryIdx;
+
+    /** Query desc index, {@code null} or index name. */
+    @Parameterized.Parameter(1)
+    public String qryDescIdx;
+
+    /** */
+    @Parameterized.Parameters(name = "qryIdx={0}")
+    public static List<Object[]> params() {
+        return F.asList(
+            new Object[] {null, null},
+            new Object[] {ID_IDX, DESC_ID_IDX}
+        );
+    }
 
     /** */
     private static IgniteCache<Long, Person> cache;
@@ -95,13 +115,13 @@ public class IndexQueryAliasTest extends GridCommonAbstractTest {
         int pivot = new Random().nextInt(CNT);
 
         // Lt.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("asId", pivot));
 
         check(cache.query(qry), 0, pivot);
 
         // Lt, desc index.
-        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("asDescId", pivot));
 
         check(cache.query(descQry), 0, pivot);
@@ -112,14 +132,18 @@ public class IndexQueryAliasTest extends GridCommonAbstractTest {
     public void testAliasCaseRangeQueries() {
         int pivot = new Random().nextInt(CNT);
 
+        String idIdx = qryIdx != null ? qryIdx.toLowerCase() : null;
+
         // Lt.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, ID_IDX.toLowerCase())
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, idIdx)
             .setCriteria(lt("ASID", pivot));
 
         check(cache.query(qry), 0, pivot);
 
+        String idDescIdx = qryDescIdx != null ? qryDescIdx.toLowerCase() : null;
+
         // Lt, desc index.
-        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX.toLowerCase())
+        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, idDescIdx)
             .setCriteria(lt("ASDESCID", pivot));
 
         check(cache.query(descQry), 0, pivot);

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryAliasTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryAliasTest.java
@@ -65,7 +65,7 @@ public class IndexQueryAliasTest extends GridCommonAbstractTest {
     public String qryDescIdx;
 
     /** */
-    @Parameterized.Parameters(name = "qryIdx={0}")
+    @Parameterized.Parameters(name = "qryIdx={0}, qryDescIdx={1}")
     public static List<Object[]> params() {
         return F.asList(
             new Object[] {null, null},

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryAllTypesTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryAllTypesTest.java
@@ -41,8 +41,11 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.query.annotations.QuerySqlField;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.gt;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.gte;
@@ -50,6 +53,7 @@ import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lte;
 
 /** */
+@RunWith(Parameterized.class)
 public class IndexQueryAllTypesTest extends GridCommonAbstractTest {
     /** */
     private static final String CACHE = "TEST_CACHE";
@@ -59,6 +63,16 @@ public class IndexQueryAllTypesTest extends GridCommonAbstractTest {
 
     /** */
     private static IgniteCache<Long, Person> cache;
+
+    /** Whether to specify index name in IndexQuery. */
+    @Parameterized.Parameter
+    public boolean useIdxName;
+
+    /** */
+    @Parameterized.Parameters(name = "useIdxName={0}")
+    public static List<Boolean> params() {
+        return F.asList(false, true);
+    }
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -301,8 +315,7 @@ public class IndexQueryAllTypesTest extends GridCommonAbstractTest {
 
     /** */
     private String idxName(String field) {
-        // TODO: test case for escaping (true / false) separately.
-        return ("Person_" + field + "_idx").toUpperCase();
+        return useIdxName ? ("Person_" + field + "_idx").toUpperCase() : null;
     }
 
     /** */

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryQueryEntityTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryQueryEntityTest.java
@@ -38,11 +38,13 @@ import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
 
 /** */
+@RunWith(Parameterized.class)
 public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
     /** */
     private static final String CACHE = "TEST_CACHE";
@@ -71,7 +73,7 @@ public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
     public String qryDescIdx;
 
     /** */
-    @Parameterized.Parameters(name = "qryIdx={0}")
+    @Parameterized.Parameters(name = "qryIdx={0}, qryDescIdx={1}")
     public static List<Object[]> params() {
         return F.asList(
             new Object[] {null, null},

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryQueryEntityTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryQueryEntityTest.java
@@ -38,6 +38,7 @@ import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
 
@@ -60,6 +61,23 @@ public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
 
     /** */
     private static final int CNT = 10_000;
+
+    /** Query index, {@code null} or index name. */
+    @Parameterized.Parameter
+    public String qryIdx;
+
+    /** Query desc index, {@code null} or index name. */
+    @Parameterized.Parameter(1)
+    public String qryDescIdx;
+
+    /** */
+    @Parameterized.Parameters(name = "qryIdx={0}")
+    public static List<Object[]> params() {
+        return F.asList(
+            new Object[] {null, null},
+            new Object[] {ID_IDX, DESC_ID_IDX}
+        );
+    }
 
     /** */
     private static IgniteCache<Long, Person> cache;
@@ -113,44 +131,46 @@ public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
     /** */
     @Test
     public void testEmptyCache() {
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", Integer.MAX_VALUE));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("descId", Integer.MAX_VALUE));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
-        // Wrong fields in query.
-        GridTestUtils.assertThrows(null, () -> {
-            IndexQuery<Long, Person> wrongQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
-                .setCriteria(lt("id", Integer.MAX_VALUE));
+        if (qryIdx != null) {
+            // Wrong fields in query.
+            GridTestUtils.assertThrows(null, () -> {
+                IndexQuery<Long, Person> wrongQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+                    .setCriteria(lt("id", Integer.MAX_VALUE));
 
-            cache.query(wrongQry).getAll();
-        }, IgniteException.class, null);
+                cache.query(wrongQry).getAll();
+            }, IgniteException.class, null);
+        }
     }
 
     /** */
     @Test
     public void testEmptyCacheTableName() {
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", Integer.MAX_VALUE));
 
         assertTrue(cacheTblName.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("descId", Integer.MAX_VALUE));
 
         assertTrue(cacheTblName.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, ID_IDX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", Integer.MAX_VALUE));
 
         assertTrue(cacheTblName.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("descId", Integer.MAX_VALUE));
 
         assertTrue(cacheTblName.query(qry).getAll().isEmpty());
@@ -164,13 +184,13 @@ public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
         int pivot = new Random().nextInt(CNT);
 
         // Lt.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", pivot));
 
         check(cache.query(qry), 0, pivot);
 
         // Lt, desc index.
-        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("descId", pivot));
 
         check(cache.query(descQry), 0, pivot);
@@ -184,13 +204,13 @@ public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
         int pivot = new Random().nextInt(CNT);
 
         // Lt.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", pivot));
 
         check(cacheTblName.query(qry), 0, pivot);
 
         // Lt, desc index.
-        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
+        IndexQuery<Long, Person> descQry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("descId", pivot));
 
         check(cacheTblName.query(descQry), 0, pivot);

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryQueryEntityTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryQueryEntityTest.java
@@ -29,13 +29,11 @@ import java.util.stream.LongStream;
 import javax.cache.Cache;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.IgniteException;
 import org.apache.ignite.cache.QueryEntity;
 import org.apache.ignite.cache.QueryIndex;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.typedef.F;
-import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -142,16 +140,6 @@ public class IndexQueryQueryEntityTest extends GridCommonAbstractTest {
             .setCriteria(lt("descId", Integer.MAX_VALUE));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
-
-        if (qryIdx != null) {
-            // Wrong fields in query.
-            GridTestUtils.assertThrows(null, () -> {
-                IndexQuery<Long, Person> wrongQry = new IndexQuery<Long, Person>(Person.class, DESC_ID_IDX)
-                    .setCriteria(lt("id", Integer.MAX_VALUE));
-
-                cache.query(wrongQry).getAll();
-            }, IgniteException.class, null);
-        }
     }
 
     /** */

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryRangeTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryRangeTest.java
@@ -253,8 +253,8 @@ public class IndexQueryRangeTest extends GridCommonAbstractTest {
     /** */
     public void checkRangeDescQueries() {
         // Query empty cache.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, IDX)
-            .setCriteria(lt("id", Integer.MAX_VALUE));
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, DESC_IDX)
+            .setCriteria(lt("descId", Integer.MAX_VALUE));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQuerySqlIndexTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQuerySqlIndexTest.java
@@ -64,7 +64,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
     /** Query index, {@code null} of index name. */
     @Parameterized.Parameter()
-    public String qryIdxName;
+    public String qryDescIdxName;
 
     /** */
     @Parameterized.Parameters(name = "qryIdxName={0}")
@@ -100,7 +100,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Object> qry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+        IndexQuery<Long, Object> qry = new IndexQuery<Long, Object>(Person.class.getName(), qryDescIdxName)
             .setCriteria(lte("descId", Integer.MAX_VALUE));
 
         assertTrue(tblCache.query(qry).getAll().isEmpty());
@@ -114,9 +114,9 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
         tblCache = crd.cache(CACHE_TABLE);
 
         // Wrong fields in query.
-        if (qryIdxName != null) {
+        if (qryDescIdxName != null) {
             GridTestUtils.assertThrowsAnyCause(null, () -> {
-                IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+                IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryDescIdxName)
                     .setCriteria(lt("id", Integer.MAX_VALUE));
 
                 return tblCache.query(wrongQry).getAll();
@@ -126,7 +126,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         // Wrong cache.
         GridTestUtils.assertThrowsAnyCause(null, () -> {
-            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryDescIdxName)
                 .setCriteria(lt("descId", Integer.MAX_VALUE));
 
             return cache.query(wrongQry).getAll();
@@ -143,12 +143,12 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryDescIdxName)
             .setCriteria(lt("descId", pivot));
 
         check(tblCache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
+        qry = new IndexQuery<Long, Person>(Person.class.getName(), qryDescIdxName)
             .setCriteria(lt("DESCID", pivot));
 
         check(tblCache.query(qry), 0, pivot);
@@ -163,15 +163,15 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryDescIdxName)
             .setCriteria(lt("descId", pivot));
 
         check(tblCache.query(qry), 0, pivot);
 
-        String errMsg = qryIdxName != null ? "Index doesn't match query." : "No index found for criteria.";
+        String errMsg = qryDescIdxName != null ? "Index doesn't match query." : "No index found for criteria.";
 
         GridTestUtils.assertThrowsAnyCause(null, () -> {
-            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryDescIdxName)
                 .setCriteria(lt("DESCID", Integer.MAX_VALUE));
 
             return tblCache.query(wrongQry).getAll();
@@ -188,16 +188,16 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        String idx = qryIdxName == null ? qryIdxName : qryIdxName.toLowerCase();
+        String idx = qryDescIdxName == null ? qryDescIdxName : qryDescIdxName.toLowerCase();
 
         IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), idx)
             .setCriteria(lt("descId", pivot));
 
         check(tblCache.query(qry), 0, pivot);
 
-        if (qryIdxName != null) {
+        if (qryDescIdxName != null) {
             GridTestUtils.assertThrowsAnyCause(null, () -> {
-                IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+                IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryDescIdxName)
                     .setCriteria(lt("descId", Integer.MAX_VALUE));
 
                 return tblCache.query(wrongQry).getAll();
@@ -215,7 +215,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE).withKeepBinary();
 
-        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(Person.class.getName(), qryIdxName)
+        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(Person.class.getName(), qryDescIdxName)
             .setCriteria(lt("descId", pivot));
 
         checkBinary(tblCache.query(qry), 0, pivot);
@@ -230,7 +230,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE).withKeepBinary();
 
-        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(VALUE_TYPE, qryIdxName)
+        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(VALUE_TYPE, qryDescIdxName)
             .setCriteria(lt("descId", pivot));
 
         checkBinary(tblCache.query(qry), 0, pivot);
@@ -245,7 +245,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryDescIdxName)
             .setCriteria(eq("_KEY", (long) pivot), lte("descId", pivot));
 
         check(tblCache.query(qry), pivot, pivot + 1);

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQuerySqlIndexTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQuerySqlIndexTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.cache.query;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
@@ -32,12 +34,15 @@ import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.eq;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lte;
 
 /** */
+@RunWith(Parameterized.class)
 public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
     /** */
     private static final String CACHE = "TEST_CACHE";
@@ -56,6 +61,16 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
     /** */
     private static final int CNT = 10_000;
+
+    /** Query index, {@code null} of index name. */
+    @Parameterized.Parameter()
+    public String qryIdxName;
+
+    /** */
+    @Parameterized.Parameters(name = "qryIdxName={0}")
+    public static Collection<?> testParams() {
+        return Arrays.asList(null, DESC_ID_IDX);
+    }
 
     /** */
     private IgniteCache<Object, Object> cache;
@@ -85,7 +100,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Object> qry = new IndexQuery<Long, Object>(Person.class.getName(), DESC_ID_IDX)
+        IndexQuery<Long, Object> qry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
             .setCriteria(lte("descId", Integer.MAX_VALUE));
 
         assertTrue(tblCache.query(qry).getAll().isEmpty());
@@ -99,17 +114,19 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
         tblCache = crd.cache(CACHE_TABLE);
 
         // Wrong fields in query.
-        GridTestUtils.assertThrowsAnyCause(null, () -> {
-            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), DESC_ID_IDX)
-                .setCriteria(lt("id", Integer.MAX_VALUE));
+        if (qryIdxName != null) {
+            GridTestUtils.assertThrowsAnyCause(null, () -> {
+                IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+                    .setCriteria(lt("id", Integer.MAX_VALUE));
 
-            return tblCache.query(wrongQry).getAll();
+                return tblCache.query(wrongQry).getAll();
 
-        }, IgniteCheckedException.class, "Index doesn't match query.");
+            }, IgniteCheckedException.class, "Index doesn't match query.");
+        }
 
         // Wrong cache.
         GridTestUtils.assertThrowsAnyCause(null, () -> {
-            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), DESC_ID_IDX)
+            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
                 .setCriteria(lt("descId", Integer.MAX_VALUE));
 
             return cache.query(wrongQry).getAll();
@@ -126,12 +143,12 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), DESC_ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
             .setCriteria(lt("descId", pivot));
 
         check(tblCache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class.getName(), DESC_ID_IDX)
+        qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
             .setCriteria(lt("DESCID", pivot));
 
         check(tblCache.query(qry), 0, pivot);
@@ -146,18 +163,20 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), DESC_ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
             .setCriteria(lt("descId", pivot));
 
         check(tblCache.query(qry), 0, pivot);
 
+        String errMsg = qryIdxName != null ? "Index doesn't match query." : "No index found for criteria.";
+
         GridTestUtils.assertThrowsAnyCause(null, () -> {
-            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), DESC_ID_IDX)
+            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
                 .setCriteria(lt("DESCID", Integer.MAX_VALUE));
 
             return tblCache.query(wrongQry).getAll();
 
-        }, IgniteCheckedException.class, "Index doesn't match query.");
+        }, IgniteCheckedException.class, errMsg);
     }
 
     /** Should support only original field. */
@@ -169,18 +188,22 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), DESC_ID_IDX.toLowerCase())
+        String idx = qryIdxName == null ? qryIdxName : qryIdxName.toLowerCase();
+
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), idx)
             .setCriteria(lt("descId", pivot));
 
         check(tblCache.query(qry), 0, pivot);
 
-        GridTestUtils.assertThrowsAnyCause(null, () -> {
-            IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), DESC_ID_IDX)
-                .setCriteria(lt("descId", Integer.MAX_VALUE));
+        if (qryIdxName != null) {
+            GridTestUtils.assertThrowsAnyCause(null, () -> {
+                IndexQuery<Long, Object> wrongQry = new IndexQuery<Long, Object>(Person.class.getName(), qryIdxName)
+                    .setCriteria(lt("descId", Integer.MAX_VALUE));
 
-            return tblCache.query(wrongQry).getAll();
+                return tblCache.query(wrongQry).getAll();
 
-        }, IgniteCheckedException.class, "No index found");
+            }, IgniteCheckedException.class, "No index found");
+        }
     }
 
     /** */
@@ -192,7 +215,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE).withKeepBinary();
 
-        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(Person.class.getName(), DESC_ID_IDX)
+        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(Person.class.getName(), qryIdxName)
             .setCriteria(lt("descId", pivot));
 
         checkBinary(tblCache.query(qry), 0, pivot);
@@ -207,7 +230,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE).withKeepBinary();
 
-        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(VALUE_TYPE, DESC_ID_IDX)
+        IndexQuery<Long, BinaryObject> qry = new IndexQuery<Long, BinaryObject>(VALUE_TYPE, qryIdxName)
             .setCriteria(lt("descId", pivot));
 
         checkBinary(tblCache.query(qry), 0, pivot);
@@ -222,7 +245,7 @@ public class IndexQuerySqlIndexTest extends GridCommonAbstractTest {
 
         tblCache = crd.cache(CACHE_TABLE);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), DESC_ID_IDX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class.getName(), qryIdxName)
             .setCriteria(eq("_KEY", (long) pivot), lte("descId", pivot));
 
         check(tblCache.query(qry), pivot, pivot + 1);

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryTestSuite.java
@@ -33,6 +33,7 @@ import org.junit.runners.Suite;
     IndexQueryAliasTest.class,
     IndexQuerySqlIndexTest.class,
     IndexQueryRangeTest.class,
+    IndexQueryWrongIndexTest.class,
     MultifieldIndexQueryTest.class,
     MultiTableIndexQuery.class
 })

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryWrongIndexTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryWrongIndexTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.query;
+
+import javax.cache.CacheException;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.query.annotations.QuerySqlField;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
+
+/** */
+public class IndexQueryWrongIndexTest extends GridCommonAbstractTest {
+    /** */
+    private static final String ID_IDX = "ID_IDX";
+
+    /** */
+    private static final String DESC_ID_IDX = "DESC_ID_IDX";
+
+    /** */
+    @Test
+    public void testWrongIndexAndFieldsMatching() throws Exception {
+        Ignite crd = startGrids(2);
+
+        IgniteCache<Integer, Person> cache = crd.getOrCreateCache(new CacheConfiguration<Integer, Person>()
+            .setName("CACHE")
+            .setIndexedTypes(Integer.class, Person.class));
+
+        // Wrong fields in query.
+        GridTestUtils.assertThrows(null, () -> {
+            IndexQuery<Integer, Person> wrongQry = new IndexQuery<Integer, Person>(Person.class, DESC_ID_IDX)
+                .setCriteria(lt("id", Integer.MAX_VALUE));
+
+                cache.query(wrongQry).getAll();
+
+                return null;
+        }, CacheException.class, null);
+
+        // Wrong fields in query.
+        GridTestUtils.assertThrows(null, () -> {
+            IndexQuery<Integer, Person> wrongQry = new IndexQuery<Integer, Person>(Person.class, ID_IDX)
+                .setCriteria(lt("descId", Integer.MAX_VALUE));
+
+            cache.query(wrongQry).getAll();
+
+            return null;
+        }, CacheException.class, null);
+    }
+
+    /** */
+    private static class Person {
+        /** */
+        @QuerySqlField(orderedGroups = @QuerySqlField.Group(name = ID_IDX, order = 0))
+        final int id;
+
+        /** */
+        @QuerySqlField(orderedGroups = @QuerySqlField.Group(name = DESC_ID_IDX, order = 0))
+        final int descId;
+
+        /** */
+        Person(int id) {
+            this.id = id;
+            descId = id;
+        }
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/MultifieldIndexQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/MultifieldIndexQueryTest.java
@@ -66,6 +66,18 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
     @Parameterized.Parameter()
     public int nodesCnt;
 
+    /** Query index, {@code null} or index name. */
+    @Parameterized.Parameter(1)
+    public String qryIdx;
+
+    /** Query desc index, {@code null} or index name. */
+    @Parameterized.Parameter(2)
+    public String qryDescIdx;
+
+    /** Query key PK index, {@code null} or index name. */
+    @Parameterized.Parameter(3)
+    public String qryKeyPKIdx;
+
     /** */
     private Ignite ignite;
 
@@ -73,14 +85,16 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
     private IgniteCache<Object, Object> cache;
 
     /** */
-    @Parameterized.Parameters(name = "nodesCnt={0}")
+    @Parameterized.Parameters(name = "nodesCnt={0} qryIdx={1}")
     public static Collection<Object[]> testParams() {
         return Arrays.asList(
-            new Object[] {1},
-            new Object[] {2});
+            new Object[] {1, null, null, null},
+            new Object[] {2, null, null, null},
+            new Object[] {1, INDEX, DESC_INDEX, "_key_PK"},
+            new Object[] {2, INDEX, DESC_INDEX, "_key_PK"});
     }
 
-            /** {@inheritDoc} */
+    /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {
         ignite = startGrids(nodesCnt);
 
@@ -113,7 +127,7 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
 
         int pivot = new Random().nextInt(CNT);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, "_key_PK")
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryKeyPKIdx)
             .setCriteria(lt("_KEY", (long) pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
@@ -122,7 +136,7 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
     /** */
     @Test
     public void testEmptyCacheQuery() {
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", Integer.MAX_VALUE), lt("secId", Integer.MAX_VALUE));
 
         QueryCursor<Cache.Entry<Long, Person>> cursor = cache.query(qry);
@@ -130,7 +144,7 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         assertTrue(cursor.getAll().isEmpty());
 
         // Check query with single column only.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", Integer.MAX_VALUE));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
@@ -143,7 +157,7 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         cache.put(2L, new Person(1, 0));
         cache.put(3L, new Person(1, 1));
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(between("id", 0, 1), eq("secId", 1));
 
         List<Cache.Entry<Long, Person>> result = cache.query(qry).getAll();
@@ -165,24 +179,24 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         insertData();
 
         // Should return empty result for ID that less any inserted.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", -1));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
         // Should return all data for ID that greater any inserted.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1));
 
         checkPerson(cache.query(qry), 0, CNT);
 
         // Checks the same with query for DESC_IDX.
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("id", -1));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("id", 1));
 
         checkPerson(cache.query(qry), 0, CNT);
@@ -196,25 +210,25 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         int pivot = new Random().nextInt(CNT);
 
         // Should return empty result for ID that less any inserted.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", -1), lt("secId", pivot));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
         // Should return all data for ID and SECID that greater any inserted.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), lt("secId", CNT));
 
         checkPerson(cache.query(qry), 0, CNT);
 
         // Should return part of data, as ID equals to inserted data ID field.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 0), lt("secId", pivot));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
         // Should return all data for ID greater any inserted.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), lt("secId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
@@ -228,25 +242,25 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         int pivot = new Random().nextInt(CNT);
 
         // Should return empty result for ID that less any inserted.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("secId", pivot), lt("id", -1));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
         // Should return all data for ID and SECID that greater any inserted.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("secId", CNT), lt("id", 1));
 
         checkPerson(cache.query(qry), 0, CNT);
 
         // Should return part of data, as ID equals to inserted data ID field.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("secId", pivot), lt("id", 0));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
         // Should return all data for ID greater any inserted.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("secId", pivot), lt("id", 1));
 
         checkPerson(cache.query(qry), 0, pivot);
@@ -260,22 +274,22 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         int pivot = new Random().nextInt(CNT);
 
         // Eq as first criterion.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(eq("id", 1), lt("secId", pivot));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(eq("id", 0), lte("secId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(eq("id", 0), gt("secId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(eq("id", 0), gte("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
@@ -283,97 +297,97 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         int lower = new Random().nextInt(CNT / 2);
         int upper = lower + new Random().nextInt(CNT / 2);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(eq("id", 0), between("secId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
         // Lt as first criterion.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), lte("secId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), eq("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), between("secId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
         // Lte as first criterion.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lte("id", 0), lt("secId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lte("id", 1), between("secId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lte("id", 0), eq("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
         // Gt as first criterion.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gt("id", -1), gte("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gt("id", -1), eq("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gt("id", -1), between("secId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
         // Gte as first criterion.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gte("id", 0), gt("secId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gte("id", 0), between("secId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gte("id", 0), eq("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
         // Between as first criterion.
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(between("id", -1, 1), lt("secId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(between("id", -1, 1), lte("secId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(between("id", -1, 1), gt("secId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(between("id", -1, 1), gte("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(between("id", -1, 1), eq("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
@@ -389,121 +403,121 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         int upper = lower + new Random().nextInt(CNT / 2);
 
         // Eq as first criteria.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(eq("id", 1), lt("descId", pivot));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(eq("id", 0), lt("descId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(eq("id", 0), lte("descId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(eq("id", 0), gt("descId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(eq("id", 0), gte("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(eq("id", 0), between("descId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
         // Lt as first criteria.
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("id", 1), gt("descId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("id", 1), gte("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("id", 1), between("descId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lt("id", 1), eq("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
         // Lte as first criteria.
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lte("id", 0), gt("descId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lte("id", 0), gte("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lte("id", 0), between("descId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(lte("id", 0), eq("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
         // Gte as first criteria.
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(gte("id", 0), lt("descId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(gte("id", 0), lte("descId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(gte("id", 0), between("descId", lower, upper));
 
         checkPerson(cache.query(qry), lower, upper + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(gte("id", 0), eq("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
 
         // Between as first criteria.
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(between("id", -1, 1), lt("descId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(between("id", -1, 1), lte("descId", pivot));
 
         checkPerson(cache.query(qry), 0, pivot + 1);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(between("id", -1, 1), gt("descId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(between("id", -1, 1), gte("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, DESC_INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryDescIdx)
             .setCriteria(between("id", -1, 1), eq("descId", pivot));
 
         checkPerson(cache.query(qry), pivot, pivot + 1);
@@ -516,22 +530,22 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
 
         int pivot = new Random().nextInt(CNT);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), gt("secId", pivot));
 
         checkPerson(cache.query(qry), pivot + 1, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", 1), gte("secId", pivot));
 
         checkPerson(cache.query(qry), pivot, CNT);
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gt("id", 2), lt("secId", pivot));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
-        qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(gt("id", 2), eq("secId", pivot));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
@@ -543,7 +557,7 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
         insertData();
 
         // Use long boundary instead of int.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(lt("id", (long) 0));
 
         GridTestUtils.assertThrows(null,
@@ -560,7 +574,7 @@ public class MultifieldIndexQueryTest extends GridCommonAbstractTest {
 
         int pivot = new Random().nextInt(CNT);
 
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, INDEX)
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, qryIdx)
             .setCriteria(eq("id", 0), lt("secId", pivot), lt("_KEY", (long) pivot));
 
         checkPerson(cache.query(qry), 0, pivot);


### PR DESCRIPTION
Make index name optional for IndexQuery. Then Ignite find an index for query by list of criteria fields. Order of fields in the criteria list doesn't matter.