### PR TITLE
IGNITE-15522 Add all() IndexQuery criterion.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQueryCriteriaBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQueryCriteriaBuilder.java
@@ -25,6 +25,18 @@ import org.apache.ignite.internal.util.typedef.internal.A;
  */
 public class IndexQueryCriteriaBuilder {
     /**
+     * All.
+     *
+     * @param field Index field to apply criterion.
+     * @return Criterion.
+     */
+    public static IndexQueryCriterion all(String field) {
+        A.notNullOrEmpty(field, "field");
+
+        return new RangeIndexQueryCriterion(field, null, null);
+    }
+
+    /**
      * Equal To.
      *
      * @param field Index field to apply criterion.

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
@@ -334,7 +334,7 @@ public class IndexQueryProcessor {
              */
             private boolean rowIsOutOfRange(IndexRow row, IndexRow low, IndexRow high) throws IgniteCheckedException {
                 if (low == null && high == null)
-                    return true;  // Unbounded search, include all.
+                    return false;  // Unbounded search, include all.
 
                 int criteriaKeysCnt = treeCriteria.size();
 

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryRangeTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryRangeTest.java
@@ -43,6 +43,7 @@ import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.cache.CacheMode.REPLICATED;
+import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.all;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.between;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.eq;
 import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.gt;
@@ -208,6 +209,12 @@ public class IndexQueryRangeTest extends GridCommonAbstractTest {
         // Add data
         insertData();
 
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(all("id"));
+
+        check(cache.query(qry), 0, CNT);
+
+        // Range queries.
         int pivot = new Random().nextInt(CNT);
 
         // Eq.
@@ -253,14 +260,20 @@ public class IndexQueryRangeTest extends GridCommonAbstractTest {
     /** */
     public void checkRangeDescQueries() {
         // Query empty cache.
-        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, IDX)
-            .setCriteria(lt("id", Integer.MAX_VALUE));
+        IndexQuery<Long, Person> qry = new IndexQuery<Long, Person>(Person.class, DESC_IDX)
+            .setCriteria(lt("descId", Integer.MAX_VALUE));
 
         assertTrue(cache.query(qry).getAll().isEmpty());
 
         // Add data
         insertData();
 
+        qry = new IndexQuery<Long, Person>(Person.class, DESC_IDX)
+            .setCriteria(all("descId"));
+
+        check(cache.query(qry), 0, CNT);
+
+        // Range queries.
         int pivot = new Random().nextInt(CNT);
 
         // Eq.


### PR DESCRIPTION
Introduces the `all()` IndexQuery criterion:
1. Allows to return full index range;
2. Useful for cases with multi-fielded index (A, B, C) with criteria for fields (A, C) but no for the the middle field B.
