### PR TITLE
IGNITE-15535 Add inclusive flags for the between() criterion

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQueryCriteriaBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQueryCriteriaBuilder.java
@@ -114,11 +114,25 @@ public class IndexQueryCriteriaBuilder {
      * @return Criterion.
      */
     public static IndexQueryCriterion between(String field, Object lower, Object upper) {
+        return between(field, lower, upper, true, true);
+    }
+
+    /**
+     * Between.
+     *
+     * @param field Index field to apply criterion.
+     * @param lower Lower bound.
+     * @param upper Upper bound.
+     * @param lowerIncl Include lower bound if {@code true}, exclude it if {@code false}.
+     * @param upperIncl Include upper bound if {@code true}, exclude it if {@code false}.
+     * @return Criterion.
+     */
+    public static IndexQueryCriterion between(String field, Object lower, Object upper, boolean lowerIncl, boolean upperIncl) {
         A.notNullOrEmpty(field, "field");
 
         RangeIndexQueryCriterion c = new RangeIndexQueryCriterion(field, lower, upper);
-        c.lowerIncl(true);
-        c.upperIncl(true);
+        c.lowerIncl(lowerIncl);
+        c.upperIncl(upperIncl);
         c.lowerNull(lower == null);
         c.upperNull(upper == null);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryRangeTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryRangeTest.java
@@ -248,6 +248,24 @@ public class IndexQueryRangeTest extends GridCommonAbstractTest {
             .setCriteria(between("id", lower, upper));
 
         check(cache.query(qry), lower, upper + 1);
+
+        // Between lower exclusive.
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(between("id", lower, upper, false, true));
+
+        check(cache.query(qry), lower + 1, upper + 1);
+
+        // Between upper exclusive.
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(between("id", lower, upper, true, false));
+
+        check(cache.query(qry), lower, upper);
+
+        // Between lower and upper exclusive.
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(between("id", lower, upper, false, false));
+
+        check(cache.query(qry), lower + 1, upper);
     }
 
     /** */
@@ -301,6 +319,24 @@ public class IndexQueryRangeTest extends GridCommonAbstractTest {
             .setCriteria(between("descId", lower, upper));
 
         check(cache.query(descQry), lower, upper + 1);
+
+        // Between lower exclusive, desc index.
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(between("id", lower, upper, false, true));
+
+        check(cache.query(qry), lower + 1, upper + 1);
+
+        // Between upper exclusive, desc index.
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(between("id", lower, upper, true, false));
+
+        check(cache.query(qry), lower, upper);
+
+        // Between lower and upper exclusive, desc index.
+        qry = new IndexQuery<Long, Person>(Person.class, IDX)
+            .setCriteria(between("id", lower, upper, false, false));
+
+        check(cache.query(qry), lower + 1, upper);
     }
 
     /**


### PR DESCRIPTION
between() supports exclusion of bounds to allow queries like (a > 10 && a <= 100).