### PR TITLE
IGNITE-14809 Add IndexQuery remote filter

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQuery.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import javax.cache.Cache;
 import org.apache.ignite.internal.util.typedef.internal.A;
+import org.apache.ignite.lang.IgniteBiPredicate;
 import org.apache.ignite.lang.IgniteExperimental;
 
 /**
@@ -43,6 +44,9 @@ public final class IndexQuery<K, V> extends Query<Cache.Entry<K, V>> {
 
     /** Index name. */
     private final String idxName;
+
+    /** Cache entries filter. Applies remotely to a query result cursor. */
+    private IgniteBiPredicate<K, V> filter;
 
     /**
      * Specify index with cache value class and index name.
@@ -117,6 +121,29 @@ public final class IndexQuery<K, V> extends Query<Cache.Entry<K, V>> {
      */
     public String getIndexName() {
         return idxName;
+    }
+
+    /**
+     * Sets remote cache entries filter.
+     *
+     * @param filter Predicate for remote filtering of query result cursor.
+     * @return {@code this} for chaining.
+     */
+    public IndexQuery<K, V> setFilter(IgniteBiPredicate<K, V> filter) {
+        A.notNull(filter, "filter");
+
+        this.filter = filter;
+
+        return this;
+    }
+
+    /**
+     * Gets remote cache entries filter.
+     *
+     * @return Filter.
+     */
+    public IgniteBiPredicate<K, V> getFilter() {
+        return filter;
     }
 
     /** */

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
@@ -92,8 +92,8 @@ public class IndexQueryProcessor {
                 while (currVal == null && cursor.next()) {
                     IndexRow r = cursor.get();
 
-                    K k = (K) CacheObjectUtils.unwrapBinaryIfNeeded(coctx, r.cacheDataRow().key(), keepBinary, false);
-                    V v = (V) CacheObjectUtils.unwrapBinaryIfNeeded(coctx, r.cacheDataRow().value(), keepBinary, false);
+                    K k = (K)CacheObjectUtils.unwrapBinaryIfNeeded(coctx, r.cacheDataRow().key(), keepBinary, false);
+                    V v = (V)CacheObjectUtils.unwrapBinaryIfNeeded(coctx, r.cacheDataRow().value(), keepBinary, false);
 
                     if (filter != null && !filter.apply(k, v))
                         continue;

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/IndexQueryProcessor.java
@@ -68,10 +68,12 @@ public class IndexQueryProcessor {
 
     /** Run query on local node. */
     public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> queryLocal(
-        GridCacheContext<K, V> cctx, IndexQueryDesc idxQryDesc, @Nullable IgniteBiPredicate<K, V> filter,
-        IndexQueryContext qryCtx, boolean keepBinary)
-        throws IgniteCheckedException {
-
+        GridCacheContext<K, V> cctx,
+        IndexQueryDesc idxQryDesc,
+        @Nullable IgniteBiPredicate<K, V> filter,
+        IndexQueryContext qryCtx,
+        boolean keepBinary
+    ) throws IgniteCheckedException {
         Index idx = index(cctx, idxQryDesc);
 
         List<IndexQueryCriterion> criteria = alignCriteriaWithIndex(idxProc.indexDefinition(idx.id()), idxQryDesc);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryAdapter.java
@@ -301,24 +301,27 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
      *
      * @param cctx Context.
      * @param type Query type.
+     * @param idxQryDesc Index query descriptor.
      * @param clsName Class name.
+     * @param filter Index query remote filter.
      */
     public GridCacheQueryAdapter(
         GridCacheContext<?, ?> cctx,
         GridCacheQueryType type,
         IndexQueryDesc idxQryDesc,
-        @Nullable String clsName
+        @Nullable String clsName,
+        @Nullable IgniteBiPredicate<Object, Object> filter
     ) {
         this.cctx = cctx;
         this.type = type;
         this.clsName = clsName;
         this.idxQryDesc = idxQryDesc;
+        this.filter = filter;
 
         log = cctx.logger(getClass());
 
-        this.clause = null;
-        this.filter = null;
-        this.incMeta = false;
+        clause = null;
+        incMeta = false;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryManager.java
@@ -646,7 +646,8 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
                     break;
 
                 case INDEX:
-                    iter = qryProc.queryIndex(cacheName, qry.queryClassName(), qry.idxQryDesc(), filter(qry), qry.keepBinary());
+                    iter = qryProc.queryIndex(cacheName, qry.queryClassName(), qry.idxQryDesc(), qry.scanFilter(),
+                        filter(qry), qry.keepBinary());
 
                     break;
 
@@ -2879,7 +2880,7 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
     public <R> CacheQuery<R> createIndexQuery(IndexQuery qry, boolean keepBinary) {
         IndexQueryDesc desc = new IndexQueryDesc(qry.getCriteria(), qry.getIndexName(), qry.getValueType());
 
-        GridCacheQueryAdapter q = new GridCacheQueryAdapter<>(cctx, INDEX, desc, qry.getValueType());
+        GridCacheQueryAdapter q = new GridCacheQueryAdapter<>(cctx, INDEX, desc, qry.getValueType(), qry.getFilter());
         q.keepBinary(keepBinary);
 
         return q;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -3374,9 +3374,14 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      * @return Key/value rows.
      * @throws IgniteCheckedException If failed.
      */
-    public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> queryIndex(String cacheName, String valCls,
-        final IndexQueryDesc idxQryDesc, @Nullable IgniteBiPredicate<K, V> filter, final IndexingQueryFilter filters,
-        boolean keepBinary) throws IgniteCheckedException {
+    public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> queryIndex(
+        String cacheName,
+        String valCls,
+        final IndexQueryDesc idxQryDesc,
+        @Nullable IgniteBiPredicate<K, V> filter,
+        final IndexingQueryFilter filters,
+        boolean keepBinary
+    ) throws IgniteCheckedException {
         if (!busyLock.enterBusy())
             throw new IllegalStateException("Failed to execute query (grid is stopping).");
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -127,6 +127,7 @@ import org.apache.ignite.internal.util.typedef.internal.CU;
 import org.apache.ignite.internal.util.typedef.internal.LT;
 import org.apache.ignite.internal.util.typedef.internal.SB;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteBiPredicate;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteFuture;
 import org.apache.ignite.lang.IgniteInClosure;
@@ -3367,13 +3368,15 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      * @param cacheName Cache name.
      * @param valCls Cache value class.
      * @param idxQryDesc Index query description.
-     * @param filters Key and value filters.
+     * @param filter Optional user defined cache entries filter.
+     * @param filters Ignite specific cache entries filters.
      * @param keepBinary Keep binary flag.
      * @return Key/value rows.
      * @throws IgniteCheckedException If failed.
      */
     public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> queryIndex(String cacheName, String valCls,
-        final IndexQueryDesc idxQryDesc, final IndexingQueryFilter filters, boolean keepBinary) throws IgniteCheckedException {
+        final IndexQueryDesc idxQryDesc, @Nullable IgniteBiPredicate<K, V> filter, final IndexingQueryFilter filters,
+        boolean keepBinary) throws IgniteCheckedException {
         if (!busyLock.enterBusy())
             throw new IllegalStateException("Failed to execute query (grid is stopping).");
 
@@ -3385,7 +3388,7 @@ public class GridQueryProcessor extends GridProcessorAdapter {
                     @Override public GridCloseableIterator<IgniteBiTuple<K, V>> applyx() throws IgniteCheckedException {
                         IndexQueryContext qryCtx = new IndexQueryContext(filters, null);
 
-                        return idxQryPrc.queryLocal(cctx, idxQryDesc, qryCtx, keepBinary);
+                        return idxQryPrc.queryLocal(cctx, idxQryDesc, filter, qryCtx, keepBinary);
 
                     }
                 }, true);

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryFilterTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryFilterTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.cache.query;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Collectors;
+import javax.cache.Cache;
+import javax.cache.CacheException;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.query.annotations.QuerySqlField;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.lang.IgniteBiPredicate;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static org.apache.ignite.cache.query.IndexQueryCriteriaBuilder.lt;
+
+/** */
+public class IndexQueryFilterTest extends GridCommonAbstractTest {
+    /** */
+    private static final String CACHE = "TEST_CACHE";
+
+    /** */
+    private static final String IDX = "IDX";
+
+    /** */
+    private static final int CNT = 10_000;
+
+    /** */
+    private static final int MAX_AGE = 100;
+
+    /** */
+    private static IgniteCache<Integer, Person> cache;
+
+    /** */
+    private static final Map<Integer, Person> persons = new HashMap<>();
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        Ignite crd = startGrids(2);
+
+        cache = crd.cache(CACHE);
+
+        Random r = new Random();
+
+        for (int i = 0; i < CNT; i++) {
+            Person p = new Person(i, r.nextInt(MAX_AGE), "name_" + i);
+
+            persons.put(i, p);
+            cache.put(i, p);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        CacheConfiguration<?, ?> ccfg1 = new CacheConfiguration<>()
+            .setName(CACHE)
+            .setIndexedTypes(Integer.class, Person.class);
+
+        cfg.setCacheConfiguration(ccfg1);
+
+        return cfg;
+    }
+
+    /** */
+    @Test
+    public void testNonIndexedFieldFilter() {
+        IgniteBiPredicate<Integer, Person> nameFilter = (k, v) -> v.name.contains("0");
+
+        IndexQuery<Integer, Person> qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter(nameFilter);
+
+        check(cache.query(qry), nameFilter);
+
+        qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", 18))
+            .setFilter(nameFilter);
+
+        check(cache.query(qry), (k, v) -> v.age < 18 && nameFilter.apply(k, v));
+    }
+
+    /** */
+    @Test
+    public void testIndexedFieldFilter() {
+        IgniteBiPredicate<Integer, Person> ageFilter = (k, v) -> v.age > 18;
+
+        IndexQuery<Integer, Person> qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter(ageFilter);
+
+        check(cache.query(qry), ageFilter);
+
+        qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", 18))
+            .setFilter(ageFilter);
+
+        assertTrue(cache.query(qry).getAll().isEmpty());
+    }
+
+    /** */
+    @Test
+    public void testKeyFilter() {
+        IgniteBiPredicate<Integer, Person> keyFilter = (k, v) -> k > CNT / 2;
+
+        IndexQuery<Integer, Person> qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter(keyFilter);
+
+        check(cache.query(qry), keyFilter);
+
+        qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", 18))
+            .setFilter(keyFilter);
+
+        check(cache.query(qry), (k, v) -> v.age < 18 && keyFilter.apply(k, v));
+    }
+
+    /** */
+    @Test
+    public void testValueFilter() {
+        IgniteBiPredicate<Integer, Person> valFilter = (k, v) ->
+            v.equals(persons.values().stream().findFirst().orElse(null));
+
+        IndexQuery<Integer, Person> qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter(valFilter);
+
+        check(cache.query(qry), valFilter);
+    }
+
+    /** */
+    @Test
+    public void testAllowOrDisallowAll() {
+        IndexQuery<Integer, Person> qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter((k, v) -> true);
+
+        assertEquals(CNT, cache.query(qry).getAll().size());
+
+        qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", 18))
+            .setFilter((k, v) -> true);
+
+        check(cache.query(qry), (k, v) -> v.age < 18);
+
+        qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter((k, v) -> false);
+
+        assertTrue(cache.query(qry).getAll().isEmpty());
+    }
+
+    /** */
+    @Test
+    public void testFilterException() {
+        IgniteBiPredicate<Integer, Person> nameFilter = (k, v) -> {
+            throw new RuntimeException();
+        };
+
+        IndexQuery<Integer, Person> qry = new IndexQuery<Integer, Person>(Person.class, IDX)
+            .setCriteria(lt("age", MAX_AGE))
+            .setFilter(nameFilter);
+
+        GridTestUtils.assertThrows(null, () -> {
+            cache.query(qry).getAll();
+
+            return null;
+        }, CacheException.class, "Failed to execute query on node");
+    }
+
+    /** */
+    private void check(QueryCursor<Cache.Entry<Integer, Person>> cursor, IgniteBiPredicate<Integer, Person> filter) {
+        Map<Integer, Person> expected = persons.entrySet().stream()
+            .filter(e -> filter.apply(e.getKey(), e.getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        List<Cache.Entry<Integer, Person>> all = cursor.getAll();
+
+        assertEquals(expected.size(), all.size());
+
+        for (int i = 0; i < all.size(); i++) {
+            Cache.Entry<Integer, Person> entry = all.get(i);
+
+            Person p = expected.remove(entry.getKey());
+
+            assertNotNull(p);
+
+            assertEquals(p, entry.getValue());
+        }
+
+        assertTrue(expected.isEmpty());
+    }
+
+    /** */
+    private static class Person {
+        /** */
+        final int id;
+
+        /** */
+        @QuerySqlField(orderedGroups = @QuerySqlField.Group(name = IDX, order = 0))
+        final int age;
+
+        /** */
+        final String name;
+
+        /** */
+        Person(int id, int age, String name) {
+            this.id = id;
+            this.age = age;
+            this.name = name;
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean equals(Object o) {
+            if (this == o)
+                return true;
+
+            if (o == null || getClass() != o.getClass())
+                return false;
+
+            Person person = (Person) o;
+
+            return Objects.equals(id, person.id) && Objects.equals(age, person.age) && Objects.equals(name, person.name);
+        }
+
+        /** {@inheritDoc} */
+        @Override public int hashCode() {
+            return Objects.hash(id, age, name);
+        }
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/cache/query/IndexQueryTestSuite.java
@@ -27,6 +27,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
     IndexQueryAllTypesTest.class,
     IndexQueryFailoverTest.class,
+    IndexQueryFilterTest.class,
     IndexQueryKeepBinaryTest.class,
     IndexQueryLocalTest.class,
     IndexQueryQueryEntityTest.class,


### PR DESCRIPTION
Add to IndexQuery functionality of remote filter:
- Consumes (K, V) as params
- Applies remotely on every node on query cursor.