### PR TITLE
IGNITE-15513: URL to legacy documentation 

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/suggestions/GridPerformanceSuggestions.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/suggestions/GridPerformanceSuggestions.java
@@ -34,7 +34,7 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_PERFORMANCE_SUGGES
  */
 public class GridPerformanceSuggestions {
     /** Link to article about Ignite performance tuning */
-    private static final String SUGGESTIONS_LINK = "https://apacheignite.readme.io/docs/jvm-and-system-tuning";
+    private static final String SUGGESTIONS_LINK = "https://ignite.apache.org/docs/latest/perf-and-troubleshooting/memory-tuning";
 
     /** */
     private static final boolean disabled = Boolean.getBoolean(IGNITE_PERFORMANCE_SUGGESTIONS_DISABLED);


### PR DESCRIPTION
**What changes were proposed in this pull request?**

URL to legacy documentation (https://apacheignite.readme.io/docs/jvm-and-system-tuning) in GridPerformanceSuggestions class has been changed to the corresponding page of ignite.apache.org/docs/ site (https://ignite.apache.org/docs/latest/perf-and-troubleshooting/memory-tuning)

**Why are the changes needed?**

To close https://issues.apache.org/jira/browse/IGNITE-15513 issue

