### PR TITLE
IGNITE-15602 Add KubernetesConnectionConfiguration.discoveryPort

### DIFF
--- a/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
+++ b/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
@@ -142,7 +142,7 @@ public class KubernetesConnectionConfiguration {
     }
 
     /**
-     * Specifies the port which is returned to the caller to use for service discovery
+     * Specifies the port which is returned to the caller to use for service discovery.
      * defaults to 0
      * @param discoveryPort Port to use for Kubernetes IP Finder
      * @return {@code this} for chaining.

--- a/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
+++ b/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
@@ -38,6 +38,9 @@ public class KubernetesConnectionConfiguration {
     /** Whether addresses of pods in not-ready state should be included. */
     private boolean includeNotReadyAddresses = false;
 
+    /** Port to use for discovery **/
+    private int discoveryPort = 0;
+    
     /**
      * Sets the name of Kubernetes service for Ignite pods' IP addresses lookup. The name of the service must be equal
      * to the name set in service's Kubernetes configuration. If this parameter is not changed then the name of the
@@ -136,6 +139,24 @@ public class KubernetesConnectionConfiguration {
      */
     public boolean getIncludeNotReadyAddresses() {
         return includeNotReadyAddresses;
+    }
+
+    /**
+     * Specifies the port which is returned to the caller to use for service discovery
+     * defaults to 0
+     * @param discoveryPort Port to use for Kubernetes IP Finder
+     * @return {@code this} for chaining.
+     */
+    public KubernetesConnectionConfiguration setDiscoveryPort(int discoveryPort) {
+        this.discoveryPort = discoveryPort;
+        return this;
+    }
+
+    /**
+     * @return Kubernetes IP Finder port.
+     */
+    public int getDiscoveryPort() {
+        return discoveryPort;
     }
 
     /**

--- a/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
+++ b/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
@@ -143,7 +143,7 @@ public class KubernetesConnectionConfiguration {
 
     /**
      * Specifies the port which is returned to the caller to use for service discovery.
-     * defaults to 0
+     * Defaults to 0.
      * @param discoveryPort Port to use for Kubernetes IP Finder
      * @return {@code this} for chaining.
      */

--- a/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
+++ b/modules/kubernetes/src/main/java/org/apache/ignite/kubernetes/configuration/KubernetesConnectionConfiguration.java
@@ -149,6 +149,7 @@ public class KubernetesConnectionConfiguration {
      */
     public KubernetesConnectionConfiguration setDiscoveryPort(int discoveryPort) {
         this.discoveryPort = discoveryPort;
+        
         return this;
     }
 

--- a/modules/kubernetes/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/kubernetes/TcpDiscoveryKubernetesIpFinder.java
+++ b/modules/kubernetes/src/main/java/org/apache/ignite/spi/discovery/tcp/ipfinder/kubernetes/TcpDiscoveryKubernetesIpFinder.java
@@ -74,7 +74,7 @@ public class TcpDiscoveryKubernetesIpFinder extends TcpDiscoveryIpFinderAdapter 
         try {
             return new KubernetesServiceAddressResolver(cfg)
                 .getServiceAddresses()
-                .stream().map(addr -> new InetSocketAddress(addr, 0))
+                .stream().map(addr -> new InetSocketAddress(addr, cfg.getDiscoveryPort()))
                 .collect(Collectors.toCollection(ArrayList::new));
         } catch (Exception e) {
             throw new IgniteSpiException(e);


### PR DESCRIPTION
Add `KubernetesConnectionConfiguration.discoveryPort` so with multiple independent Ignite clusters in a single Kubernetes namespace it is possible to connect to a specific cluster.