### PR TITLE
IGNITE-15781 CacheGroupMetricsImpl#numberOfPartitionCopies uses existing set of partitions keys

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionMap.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionMap.java
@@ -157,8 +157,8 @@ public class GridDhtPartitionMap implements Comparable<GridDhtPartitionMap>, Ext
      * @param part Partition.
      * @return Partition state.
      */
-    public GridDhtPartitionState get(Integer part) {
-        return map.get(part);
+    public GridDhtPartitionState get(int part) {
+        return map.state(part);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/GridPartitionStateMap.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/GridPartitionStateMap.java
@@ -215,7 +215,7 @@ public class GridPartitionStateMap extends AbstractMap<Integer, GridDhtPartition
     }
 
     /** */
-    private GridDhtPartitionState state(int part) {
+    public GridDhtPartitionState state(int part) {
         int off = part * BITS;
 
         int st = 0;


### PR DESCRIPTION
CacheGroupMetricsImpl#numberOfPartitionCopies created a lot of objects of `java.lang.Integer` for every call. Amount of objects linearly depends on cache partitions count. Replaced it with existing set objects.