### PR TITLE
IGNITE-15915 .NET: Allow null SslStreamFactory.CertificatePath

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -107,6 +107,9 @@
     <None Update="Examples\ExpectedOutput\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\Client\server-with-ssl-no-client-auth.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -686,11 +686,7 @@ namespace Apache.Ignite.Core.Tests.Client
                     CertificatePassword = "123456",
                     SkipServerCertificateValidation = true,
                     CheckCertificateRevocation = true,
-#if !NETCOREAPP
-                    SslProtocols = SslProtocols.Tls
-#else
                     SslProtocols = SslProtocols.Tls12
-#endif
                 }
             };
 
@@ -720,7 +716,8 @@ namespace Apache.Ignite.Core.Tests.Client
                 Endpoints = new[] { "127.0.0.1:11120" },
                 SslStreamFactory = new SslStreamFactory
                 {
-                    SkipServerCertificateValidation = true
+                    SkipServerCertificateValidation = true,
+                    SslProtocols = SslProtocols.Tls12
                 }
             };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Core.Tests.Client
     using System.Linq;
     using System.Net;
     using System.Net.Sockets;
+    using System.Security.Authentication;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
@@ -663,6 +664,70 @@ namespace Apache.Ignite.Core.Tests.Client
 
             TestUtils.WaitForTrueCondition(() => logger.Entries.Any(
                 e => e.Message == string.Format("Receiver thread #{0} stopped.", threadId)));
+        }
+
+        /// <summary>
+        /// Tests SSL connection with client-side SSL certificate.
+        /// </summary>
+        [Test]
+        public void TestSslConnectionWithClientAuth()
+        {
+            Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl.xml")
+            });
+
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new[] { "127.0.0.1:11110" },
+                SslStreamFactory = new SslStreamFactory
+                {
+                    CertificatePath = Path.Combine("Config", "Client", "thin-client-cert.pfx"),
+                    CertificatePassword = "123456",
+                    SkipServerCertificateValidation = true,
+                    CheckCertificateRevocation = true,
+#if !NETCOREAPP
+                    SslProtocols = SslProtocols.Tls
+#else
+                    SslProtocols = SslProtocols.Tls12
+#endif
+                }
+            };
+
+            using (var client = Ignition.StartClient(cfg))
+            {
+                Assert.AreEqual(1, client.GetCluster().GetNodes().Count);
+            }
+
+            // Does not connect without client certificate.
+            cfg.SslStreamFactory = new SslStreamFactory { SkipServerCertificateValidation = true };
+            Assert.Catch<Exception>(() => Ignition.StartClient(cfg));
+        }
+
+        /// <summary>
+        /// Tests SSL connection without client-side SSL certificate.
+        /// </summary>
+        [Test]
+        public void TestSslConnectionWithoutClientAuth()
+        {
+            Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl-no-client-auth.xml"),
+            });
+
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new[] { "127.0.0.1:11120" },
+                SslStreamFactory = new SslStreamFactory
+                {
+                    SkipServerCertificateValidation = true
+                }
+            };
+
+            using (var client = Ignition.StartClient(cfg))
+            {
+                Assert.AreEqual(1, client.GetCluster().GetNodes().Count);
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/RawSecureSocketTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/RawSecureSocketTest.cs
@@ -70,16 +70,6 @@ namespace Apache.Ignite.Core.Tests.Client
             {
                 var certsCollection = new X509CertificateCollection(new X509Certificate[] { LoadCertificateFile() });
 
-#if !NETCOREAPP
-                if (clientCert)
-                {
-                    sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls, false);
-                }
-                else
-                {
-                    sslStream.AuthenticateAsClient(host);
-                }
-#else
                 if (clientCert)
                 {
                     sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls12, false);
@@ -88,7 +78,6 @@ namespace Apache.Ignite.Core.Tests.Client
                 {
                     sslStream.AuthenticateAsClient(host);
                 }
-#endif
 
                 Assert.IsTrue(sslStream.IsAuthenticated);
                 Assert.AreEqual(clientCert, sslStream.IsMutuallyAuthenticated);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/RawSecureSocketTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/RawSecureSocketTest.cs
@@ -31,35 +31,70 @@ namespace Apache.Ignite.Core.Tests.Client
     /// </summary>
     public class RawSecureSocketTest
     {
-        /// <summary>
-        /// Tests that we can do handshake over SSL without using Ignite.NET APIs.
-        /// </summary>
-        [Test]
-        public void TestHandshake()
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
         {
-            var igniteConfiguration = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
                 SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl.xml")
             };
 
-            using (Ignition.Start(igniteConfiguration))
+            Ignition.Start(cfg);
+
+            var cfgNoClientAuth = new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
-                const string host = "127.0.0.1";
-                const int port = 11110;
+                SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl-no-client-auth.xml"),
+                AutoGenerateIgniteInstanceName = true
+            };
 
-                using (var client = new TcpClient(host, port))
-                using (var sslStream = new SslStream(client.GetStream(), false, ValidateServerCertificate, null))
+            Ignition.Start(cfgNoClientAuth);
+        }
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        /// <summary>
+        /// Tests that we can do handshake over SSL without using Ignite.NET APIs.
+        /// </summary>
+        [Test]
+        public void TestHandshake([Values(true, false)] bool clientCert)
+        {
+            const string host = "127.0.0.1";
+            var port = clientCert ? 11110 : 11120;
+
+            using (var client = new TcpClient(host, port))
+            using (var sslStream = new SslStream(client.GetStream(), false, ValidateServerCertificate, null))
+            {
+                var certsCollection = new X509CertificateCollection(new X509Certificate[] { LoadCertificateFile() });
+
+#if !NETCOREAPP
+                if (clientCert)
                 {
-                    var certsCollection = new X509CertificateCollection(new X509Certificate[] {LoadCertificateFile()});
-
-                    sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls12, false);
-
-                    Assert.IsTrue(sslStream.IsAuthenticated);
-                    Assert.IsTrue(sslStream.IsMutuallyAuthenticated);
-                    Assert.IsTrue(sslStream.IsEncrypted);
-
-                    DoHandshake(sslStream);
+                    sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls, false);
                 }
+                else
+                {
+                    sslStream.AuthenticateAsClient(host);
+                }
+#else
+                if (clientCert)
+                {
+                    sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls12, false);
+                }
+                else
+                {
+                    sslStream.AuthenticateAsClient(host);
+                }
+#endif
+
+                Assert.IsTrue(sslStream.IsAuthenticated);
+                Assert.AreEqual(clientCert, sslStream.IsMutuallyAuthenticated);
+                Assert.IsTrue(sslStream.IsEncrypted);
+
+                DoHandshake(sslStream);
             }
         }
 
@@ -123,7 +158,9 @@ namespace Apache.Ignite.Core.Tests.Client
         private static byte[] ReceiveMessage(Stream sock)
         {
             var buf = new byte[4];
-            sock.Read(buf, 0, 4);
+            var read = sock.Read(buf, 0, 4);
+
+            Assert.AreEqual(4, read);
 
             using (var stream = new BinaryHeapStream(buf))
             {
@@ -150,6 +187,5 @@ namespace Apache.Ignite.Core.Tests.Client
                 sock.Write(stream.GetArray(), 0, stream.Position);
             }
         }
-
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/server-with-ssl-no-client-auth.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/server-with-ssl-no-client-auth.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright 2019 GridGain Systems, Inc. and Contributors.
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
- Licensed under the GridGain Community Edition License (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
 
-     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/server-with-ssl-no-client-auth.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/server-with-ssl-no-client-auth.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -31,11 +30,11 @@
         <property name="clientConnectorConfiguration">
             <bean class="org.apache.ignite.configuration.ClientConnectorConfiguration">
                 <property name="host" value="127.0.0.1"/>
-                <property name="port" value="11110"/>
+                <property name="port" value="11120"/>
                 <property name="portRange" value="10"/>
                 <property name="sslEnabled" value="true"/>
                 <property name="useIgniteSslContextFactory" value="false"/>
-                <property name="sslClientAuth" value="true"/>
+                <property name="sslClientAuth" value="false"/>
 
                 <property name="sslContextFactory">
                     <bean class="org.apache.ignite.ssl.SslContextFactory">

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/SslStreamFactory.cs
@@ -49,8 +49,13 @@ namespace Apache.Ignite.Core.Client
 
             var sslStream = new SslStream(stream, false, ValidateServerCertificate, null);
 
-            var cert = new X509Certificate2(CertificatePath, CertificatePassword);
-            var certs = new X509CertificateCollection(new X509Certificate[] { cert });
+            var cert = string.IsNullOrEmpty(CertificatePath)
+                ? null
+                : new X509Certificate2(CertificatePath, CertificatePassword);
+
+            var certs = cert == null
+                ? null
+                : new X509CertificateCollection(new X509Certificate[] { cert });
 
             sslStream.AuthenticateAsClient(targetHost, certs, SslProtocols, CheckCertificateRevocation);
 


### PR DESCRIPTION
Allow thin client to establish SSL connection without client-side certificate when `ClientConnectorConfiguration.sslClientAuth` is `false` on server.