### PR TITLE
IGNITE-14294 .NET: Fix ClientServerCompatibilityTest flakiness

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformProcessUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformProcessUtils.java
@@ -54,7 +54,7 @@ public class PlatformProcessUtils {
         pb.directory(new File(workDir));
         pb.redirectErrorStream(true);
         
-        if (env != null) {
+        if (env != null && !env.isEmpty()) {
             for (String pair : env.split("\\|")) {
                 String[] kv = pair.split("#");
                 assert kv.length == 2;

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformProcessUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformProcessUtils.java
@@ -41,10 +41,11 @@ public class PlatformProcessUtils {
      * @param file Executable name.
      * @param arg1 Argument.
      * @param arg2 Argument.
+     * @param env Environment.
      * @param workDir Work directory.
      * @param waitForOutput A string to look for in the output.
      */
-    public static void startProcess(String file, String arg1, String arg2, String workDir, String waitForOutput)
+    public static void startProcess(String file, String arg1, String arg2, String env, String workDir, String waitForOutput)
             throws Exception {
         if (process != null)
             throw new Exception("PlatformProcessUtils can't start more than one process at a time.");
@@ -52,6 +53,16 @@ public class PlatformProcessUtils {
         ProcessBuilder pb = new ProcessBuilder(file, arg1, arg2);
         pb.directory(new File(workDir));
         pb.redirectErrorStream(true);
+        
+        if (env != null) {
+            for (String pair : env.split("\\|")) {
+                String[] kv = pair.split("#");
+                assert kv.length == 2;
+                
+                pb.environment().put(kv[0], kv[1]);
+            }
+        }
+        
         process = pb.start();
 
         InputStreamReader isr = new InputStreamReader(process.getInputStream());

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -20,7 +20,6 @@ namespace Apache.Ignite.Core.Tests
     using System;
     using System.IO;
     using System.Linq;
-    using System.Text;
     using System.Text.RegularExpressions;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Impl.Common;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -70,22 +70,13 @@ namespace Apache.Ignite.Core.Tests
 
             var time = DateTime.Now;
 
-            if (Jvm.IsJava9())
-            {
-                // foreach (var option in Jvm.Java9Options)
-                // {
-                //     // commandSb.Append(" -D")
-                //     En
-                // }
-
-                var opts = string.Join(' ', Jvm.Java9Options);
-                Environment.SetEnvironmentVariable("MAVEN_OPTS", opts);
-            }
-
             TestUtilsJni.StartProcess(
                 file: Os.IsWindows ? "cmd.exe" : "/bin/bash",
                 arg1: Os.IsWindows ? "/c" : "-c",
                 arg2: string.Format("{0} {1}", MavenPath, MavenCommandExec),
+                envVars: Jvm.IsJava9()
+                    ? "MAVEN_OPTS#" + string.Join(' ', Jvm.Java9Options)
+                    : string.Empty,
                 workDir: JavaServerSourcePath,
                 waitForOutput: "Ignite node started OK");
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Tests
     using System;
     using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Text.RegularExpressions;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Impl.Common;
@@ -68,6 +69,18 @@ namespace Apache.Ignite.Core.Tests
             EnsureJvmCreated();
 
             var time = DateTime.Now;
+
+            if (Jvm.IsJava9())
+            {
+                // foreach (var option in Jvm.Java9Options)
+                // {
+                //     // commandSb.Append(" -D")
+                //     En
+                // }
+
+                var opts = string.Join(' ', Jvm.Java9Options);
+                Environment.SetEnvironmentVariable("MAVEN_OPTS", opts);
+            }
 
             TestUtilsJni.StartProcess(
                 file: Os.IsWindows ? "cmd.exe" : "/bin/bash",

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -74,7 +74,7 @@ namespace Apache.Ignite.Core.Tests
                 arg1: Os.IsWindows ? "/c" : "-c",
                 arg2: string.Format("{0} {1}", MavenPath, MavenCommandExec),
                 envVars: Jvm.IsJava9()
-                    ? "MAVEN_OPTS#" + string.Join(' ', Jvm.Java9Options)
+                    ? "MAVEN_OPTS#" + string.Join(" ", Jvm.Java9Options)
                     : string.Empty,
                 workDir: JavaServerSourcePath,
                 waitForOutput: "Ignite node started OK");

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
@@ -56,10 +56,11 @@ namespace Apache.Ignite.Core.Tests
         /// <param name="file">Executable name.</param>
         /// <param name="arg1">Argument.</param>
         /// <param name="arg2">Argument.</param>
+        /// <param name="envVars">Environment variables. Pairs are separated by |, key and value by #.</param>
         /// <param name="workDir">Work directory.</param>
         /// <param name="waitForOutput">A string to look for in the output.</param>
         public static unsafe void StartProcess(
-            string file, string arg1, string arg2, string workDir, string waitForOutput)
+            string file, string arg1, string arg2, string envVars, string workDir, string waitForOutput)
         {
             Debug.Assert(file != null);
             Debug.Assert(arg1 != null);
@@ -70,20 +71,22 @@ namespace Apache.Ignite.Core.Tests
             using (var cls = env.FindClass(ClassPlatformProcessUtils))
             {
                 var methodId = env.GetStaticMethodId(cls, "startProcess",
-                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
 
                 using (var fileRef = env.NewStringUtf(file))
                 using (var arg1Ref = env.NewStringUtf(arg1))
                 using (var arg2Ref = env.NewStringUtf(arg2))
+                using (var envRef = env.NewStringUtf(envVars))
                 using (var workDirRef = env.NewStringUtf(workDir))
                 using (var waitForOutputRef = env.NewStringUtf(waitForOutput))
                 {
-                    var methodArgs = stackalloc long[5];
+                    var methodArgs = stackalloc long[6];
                     methodArgs[0] = fileRef.Target.ToInt64();
                     methodArgs[1] = arg1Ref.Target.ToInt64();
                     methodArgs[2] = arg2Ref.Target.ToInt64();
-                    methodArgs[3] = workDirRef.Target.ToInt64();
-                    methodArgs[4] = waitForOutputRef == null ? 0 : waitForOutputRef.Target.ToInt64();
+                    methodArgs[3] = envRef.Target.ToInt64();
+                    methodArgs[4] = workDirRef.Target.ToInt64();
+                    methodArgs[5] = waitForOutputRef == null ? 0 : waitForOutputRef.Target.ToInt64();
 
                     env.CallStaticVoidMethod(cls, methodId, methodArgs);
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
@@ -419,7 +419,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                 {
                     // Ignore escaped characters in compiler-generated type names.
                     // Return any non-separator character to continue parsing.
-                    return default;
+                    return default(char);
                 }
 
                 return _typeName[_pos];

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Jvm.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Jvm.cs
@@ -43,7 +43,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private const int JNI_VERSION_9 = 0x00090000;
 
         /** Options to enable startup on Java 9. */
-        private static readonly string[] Java9Options =
+        public static readonly string[] Java9Options =
         {
             "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
             "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
@@ -246,7 +246,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         /// <summary>
         /// Determines whether we are on Java 9.
         /// </summary>
-        private static bool IsJava9()
+        public static bool IsJava9()
         {
             var args = new JvmInitArgs
             {


### PR DESCRIPTION
Pass Java 9+ specific JVM arguments when necessary (`illegal-access=permit`, `add-exports`).