### PR TITLE
IGNITE-15943 Fix comparison inlined fields with decimal search key

### DIFF
--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/H2RowComparator.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/H2RowComparator.java
@@ -26,6 +26,7 @@ import org.apache.ignite.internal.cache.query.index.sorted.inline.InlineIndexKey
 import org.apache.ignite.internal.cache.query.index.sorted.inline.types.NullableInlineIndexKeyType;
 import org.apache.ignite.internal.cache.query.index.sorted.keys.IndexKey;
 import org.apache.ignite.internal.cache.query.index.sorted.keys.IndexKeyFactory;
+import org.apache.ignite.internal.cache.query.index.sorted.keys.NullIndexKey;
 import org.apache.ignite.internal.processors.cache.CacheObjectContext;
 import org.apache.ignite.internal.processors.query.h2.H2Utils;
 import org.apache.ignite.internal.processors.query.h2.opt.GridH2Table;
@@ -68,7 +69,7 @@ public class H2RowComparator extends IndexRowCompartorImpl {
         if (cmp != COMPARE_UNSUPPORTED)
             return cmp;
 
-        int objType = InlineIndexKeyTypeRegistry.get(key, curType, keyTypeSettings).type();
+        int objType = key == NullIndexKey.INSTANCE ? curType : key.type();
 
         int highOrder = Value.getHigherOrder(curType, objType);
 
@@ -82,8 +83,9 @@ public class H2RowComparator extends IndexRowCompartorImpl {
 
             InlineIndexKeyType highType = InlineIndexKeyTypeRegistry.get(objHighOrder, highOrder, keyTypeSettings);
 
-            // The only way to invoke inline comparation again.
-            return ((NullableInlineIndexKeyType) highType).compare0(pageAddr, off, objHighOrder);
+            // The only way to invoke inline comparison again.
+            if (highType != null)
+                return ((NullableInlineIndexKeyType) highType).compare0(pageAddr, off, objHighOrder);
         }
 
         return COMPARE_UNSUPPORTED;

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlQueryDecimalArgumentsWithTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlQueryDecimalArgumentsWithTest.java
@@ -22,26 +22,57 @@ import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.cache.query.index.IndexName;
+import org.apache.ignite.internal.cache.query.index.sorted.inline.InlineIndex;
+import org.apache.ignite.internal.processors.cache.GridCacheContext;
+import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-/** */
+/** Checks whether correctly compare non-inlined decimal search key with inlined types. */
+@RunWith(Parameterized.class)
 public class IgniteSqlQueryDecimalArgumentsWithTest extends GridCommonAbstractTest {
     /** */
-    private static final String IDX_NAME = "FLAG_IDX";
+    private static final String IDX_NAME = "FLD_IDX";
+
+    /** */
+    private static final String TABLE_NAME = "FLD_TABLE";
+
+    /** */
+    private static final String TABLE_CACHE_NAME = "FLD_TABLE_CACHE";
 
     /** */
     private IgniteEx node;
+
+    /** */
+    @Parameterized.Parameter()
+    public String idxFldName;
+
+    /** */
+    @Parameterized.Parameter(1)
+    public String idxFldType;
+
+    /** */
+    @Parameterized.Parameters(name = "fld={0} type={1}")
+    public static List<Object[]> params() {
+        return F.asList(
+            new Object[] {"intFld", "int"},
+            new Object[] {"dblFld", "double"}
+        );
+    }
 
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {
         node = startGrid();
 
-        query("create table test_table(id varchar primary key, flag int);");
+        query("create table " + TABLE_NAME + "(id varchar primary key, " + idxFldName + " " + idxFldType + ")" +
+            " WITH \"CACHE_NAME=" + TABLE_CACHE_NAME + "\";");
 
-        query("create index " + IDX_NAME + " on test_table(flag);");
+        query("create index " + IDX_NAME + " on " + TABLE_NAME + "(" + idxFldName + ");");
 
-        query("insert into test_table(id, flag) values('a1', 1);");
+        query("insert into " + TABLE_NAME + "(id, " + idxFldName + ") values('a1', 1);");
     }
 
     /** {@inheritDoc} */
@@ -51,44 +82,44 @@ public class IgniteSqlQueryDecimalArgumentsWithTest extends GridCommonAbstractTe
 
     /** Math calculations produces decimal values for searching index tree. */
     @Test
-    public void testDecimalCalculatedFieldComparedCorrectly() {
-        String checkSql = "select * from test_table where flag < 100 * 0.5;";
-
-        assertIndexUsed(checkSql);
-
-        List<List<?>> result = query(checkSql);
-
-        assertEquals(1, result.size());
-        assertEquals(2, result.get(0).size());
-        assertEquals(1, result.get(0).get(1));
+    public void testDecimalCalculatedField() {
+        check("select * from " + TABLE_NAME + " where " + idxFldName + " < 100 * 0.5;");
     }
 
-    /** Math calculations produces decimal values for searching index tree. */
+    /** */
     @Test
-    public void testExplicitDecimalField() {
-        String checkSql = "select * from test_table where flag < ?;";
-        BigDecimal arg = new BigDecimal("50.0");
-
-        assertIndexUsed(checkSql, arg);
-
-        List<List<?>> result = query(checkSql, arg);
-
-        assertEquals(1, result.size());
-        assertEquals(2, result.get(0).size());
-        assertEquals(1, result.get(0).get(1));
+    public void testExplicitDecimalArgument() {
+        check("select * from " + TABLE_NAME + " where " + idxFldName + " < ?;", new BigDecimal("50.0"));
     }
 
-    /** Assert if index is not used for searching. */
-    private void assertIndexUsed(String sql, Object... args) {
+    /** */
+    private void check(String sql, Object... arg) {
+        assertTrue(idxInlineSize() > 0);
+
         String explain = "explain " + sql;
 
-        String res = query(explain, args).get(0).get(0).toString();
+        String res = query(explain, arg).get(0).get(0).toString();
 
-        assertTrue(Pattern.compile(IDX_NAME + "[^\\s]+: FLAG <").matcher(res).find());
+        // Assert if index is not used for searching.
+        assertTrue(Pattern.compile(IDX_NAME + "[^\\s]+: " + idxFldName.toUpperCase() + " <").matcher(res).find());
+
+        List<List<?>> result = query(sql, arg);
+
+        assertEquals(1, result.size());
     }
 
     /** */
     private List<List<?>> query(String qry, Object... args) {
         return node.context().query().querySqlFields(new SqlFieldsQuery(qry).setArgs(args), false).getAll();
+    }
+
+    /** */
+    private int idxInlineSize() {
+        GridCacheContext<?, ?> cctx = node.cachex(TABLE_CACHE_NAME).context();
+
+        InlineIndex idx = (InlineIndex)node.context().indexProcessor().index(
+            new IndexName(cctx.name(), "PUBLIC", TABLE_NAME, IDX_NAME));
+
+        return idx.inlineSize();
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlQueryDecimalArgumentsWithTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/query/IgniteSqlQueryDecimalArgumentsWithTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/** */
+public class IgniteSqlQueryDecimalArgumentsWithTest extends GridCommonAbstractTest {
+    /** */
+    private static final String IDX_NAME = "FLAG_IDX";
+
+    /** */
+    private IgniteEx node;
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        node = startGrid();
+
+        query("create table test_table(id varchar primary key, flag int);");
+
+        query("create index " + IDX_NAME + " on test_table(flag);");
+
+        query("insert into test_table(id, flag) values('a1', 1);");
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+    }
+
+    /** Math calculations produces decimal values for searching index tree. */
+    @Test
+    public void testDecimalCalculatedFieldComparedCorrectly() {
+        String checkSql = "select * from test_table where flag < 100 * 0.5;";
+
+        assertIndexUsed(checkSql);
+
+        List<List<?>> result = query(checkSql);
+
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).size());
+        assertEquals(1, result.get(0).get(1));
+    }
+
+    /** Math calculations produces decimal values for searching index tree. */
+    @Test
+    public void testExplicitDecimalField() {
+        String checkSql = "select * from test_table where flag < ?;";
+        BigDecimal arg = new BigDecimal("50.0");
+
+        assertIndexUsed(checkSql, arg);
+
+        List<List<?>> result = query(checkSql, arg);
+
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).size());
+        assertEquals(1, result.get(0).get(1));
+    }
+
+    /** Assert if index is not used for searching. */
+    private void assertIndexUsed(String sql, Object... args) {
+        String explain = "explain " + sql;
+
+        String res = query(explain, args).get(0).get(0).toString();
+
+        assertTrue(Pattern.compile(IDX_NAME + "[^\\s]+: FLAG <").matcher(res).find());
+    }
+
+    /** */
+    private List<List<?>> query(String qry, Object... args) {
+        return node.context().query().querySqlFields(new SqlFieldsQuery(qry).setArgs(args), false).getAll();
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
@@ -216,6 +216,7 @@ import org.apache.ignite.internal.processors.query.IgniteSqlGroupConcatNotColloc
 import org.apache.ignite.internal.processors.query.IgniteSqlKeyValueFieldsTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlNotNullConstraintTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlParameterizedQueryTest;
+import org.apache.ignite.internal.processors.query.IgniteSqlQueryDecimalArgumentsWithTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlQueryParallelismTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlRoutingTest;
 import org.apache.ignite.internal.processors.query.IgniteSqlSchemaIndexingTest;
@@ -496,6 +497,7 @@ import org.junit.runners.Suite;
     GridCacheQueryIndexingDisabledSelfTest.class,
     GridOrderedMessageCancelSelfTest.class,
     CacheQueryEvictDataLostTest.class,
+    IgniteSqlQueryDecimalArgumentsWithTest.class,
 
     // Full text queries.
     GridCacheFullTextQueryFailoverTest.class,


### PR DESCRIPTION
Decimal is only index key that isn't inlined and in the same type can be used for searching data by keys that are inlines (int, double). Tested both int and double, because they have different compare differently with decimal.