### PR TITLE
IGNITE-15954 .NET: Fix dynamic assemblies handling in TypeResolver

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
@@ -251,6 +251,11 @@ namespace Apache.Ignite.Core.Tests.Binary
                 @"Foo.Bar+<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1");
 
             Assert.AreEqual(@"<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1", res2.GetName());
+
+            var res3 = TypeNameParser.Parse(
+                @"Program\+IFoo`2\[\[System.Int32\, System.Private.CoreLib\, Version=4.0.0.0\, Culture=neutral\, PublicKeyToken=567\]\,\[System.String\, System.Private.CoreLib\, Version=4.0.0.0\, Culture=neutral\, PublicKeyToken=123\]\]");
+
+            Assert.AreEqual(@"TODO", res3.GetName());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
@@ -240,22 +240,19 @@ namespace Apache.Ignite.Core.Tests.Binary
         }
 
         [Test]
-        public void TestCompilerGeneratedTypes()
+        public void TestCompilerGeneratedTypes([Values(
+                @"Foo.Bar+<Abc-Def<System-String\,System-Byte\[\]>-Convert>d__0",
+                @"Foo.Bar+<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1",
+                @"Program\+IFoo`2\[\[System.Int32\, System.Private.CoreLib\, Version=4.0.0.0\, Culture=neutral\, PublicKeyToken=567\]\,\[System.String\, System.Private.CoreLib\, Version=4.0.0.0\, Culture=neutral\, PublicKeyToken=123\]\]"
+                )]
+            string typeName)
         {
-            var res = TypeNameParser.Parse(
-                @"Foo.Bar+<Abc-Def<System-String\,System-Byte\[\]>-Convert>d__0");
+            var res = TypeNameParser.Parse(typeName);
 
-            Assert.AreEqual(@"<Abc-Def<System-String\,System-Byte\[\]>-Convert>d__0", res.GetName());
-
-            var res2 = TypeNameParser.Parse(
-                @"Foo.Bar+<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1");
-
-            Assert.AreEqual(@"<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1", res2.GetName());
-
-            var res3 = TypeNameParser.Parse(
-                @"Program\+IFoo`2\[\[System.Int32\, System.Private.CoreLib\, Version=4.0.0.0\, Culture=neutral\, PublicKeyToken=567\]\,\[System.String\, System.Private.CoreLib\, Version=4.0.0.0\, Culture=neutral\, PublicKeyToken=123\]\]");
-
-            Assert.AreEqual(@"TODO", res3.GetName());
+            Assert.AreEqual(typeName, res.GetName());
+            Assert.IsNull(res.GetAssemblyName());
+            Assert.IsNull(res.GetArray());
+            Assert.IsFalse(res.HasNamespace());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeResolverTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeResolverTest.cs
@@ -19,6 +19,8 @@ namespace Apache.Ignite.Core.Tests.Binary
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
 #if !NETCOREAPP
     using System.Linq;
     using System.Reflection;
@@ -169,6 +171,27 @@ namespace Apache.Ignite.Core.Tests.Binary
 
             Assert.AreEqual(typeof(TestGenericBinarizable<TypeResolverTest>[]),
                 resolver.ResolveType("TestGenericBinarizable`1[[TypeResolverTest]][]", nameMapper: mapper));
+        }
+
+        /// <summary>
+        /// Tests that types from dynamic assemblies can be resolved.
+        /// </summary>
+        [Test]
+        public void TestDynamicallyGeneratedType()
+        {
+            var typeName = nameof(TestDynamicallyGeneratedType) + new Random().Next();
+
+            var assemblyName = new AssemblyName("DynamicAssembly1");
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule("DynamicModule1");
+            var typeAttributes = TypeAttributes.Public | TypeAttributes.Class;
+            var typeBuilder = moduleBuilder.DefineType(typeName, typeAttributes);
+            var generatedType = typeBuilder.CreateType();
+
+            var resolver = new TypeResolver();
+            var resolvedType = resolver.ResolveType(typeName);
+
+            Assert.AreEqual(generatedType, resolvedType);
         }
 
 #if !NETCOREAPP

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeResolverTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeResolverTest.cs
@@ -23,7 +23,6 @@ namespace Apache.Ignite.Core.Tests.Binary
     using System.Reflection.Emit;
 #if !NETCOREAPP
     using System.Linq;
-    using System.Reflection;
 #endif
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Impl.Binary;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ExamplesTestBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Examples/ExamplesTestBase.cs
@@ -35,6 +35,9 @@ namespace Apache.Ignite.Core.Tests.Examples
         /** */
         private TextWriter _oldOut;
 
+        /** */
+        private TextWriter _oldError;
+
         /// <summary>
         /// Sets up the test.
         /// </summary>
@@ -42,8 +45,13 @@ namespace Apache.Ignite.Core.Tests.Examples
         public void SetUp()
         {
             _oldOut = Console.Out;
+            _oldError = Console.Error;
+
             _outSb = new StringBuilder();
-            Console.SetOut(new StringWriter(_outSb));
+            var outWriter = new StringWriter(_outSb);
+
+            Console.SetOut(outWriter);
+            Console.SetError(outWriter);
         }
 
         /// <summary>
@@ -53,9 +61,11 @@ namespace Apache.Ignite.Core.Tests.Examples
         public void TearDown()
         {
             Console.SetOut(_oldOut);
+            Console.SetError(_oldError);
             Console.WriteLine(_outSb);
 
-            StringAssert.Contains(">>> Example finished, press any key to exit ...", GetOutput());
+            var output = GetOutput();
+            StringAssert.Contains(">>> Example finished, press any key to exit ...", output, output);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
@@ -56,11 +56,31 @@ namespace Apache.Ignite.Core.Impl.Binary
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TypeNameParser" /> class.
+        /// </summary>
+        private TypeNameParser(string typeName)
+        {
+            _typeName = typeName;
+            NameStart = 0;
+            NameEnd = typeName.Length - 1;
+
+            AssemblyStart = -1;
+            AssemblyEnd = -1;
+            ArrayStart = -1;
+        }
+
+        /// <summary>
         /// Parses the specified type name.
         /// </summary>
         public static TypeNameParser Parse(string typeName)
         {
             IgniteArgumentCheck.NotNullOrEmpty(typeName, "typeName");
+
+            if (typeName.Contains("\\"))
+            {
+                // Do not parse compiler-generated special names, return as is.
+                return new TypeNameParser(typeName);
+            }
 
             int pos = 0;
 
@@ -411,19 +431,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         private char Char
         {
-            get
-            {
-                const char escape = '\\';
-
-                if (_pos > 0 && _typeName[_pos - 1] == escape)
-                {
-                    // Ignore escaped characters in compiler-generated type names.
-                    // Return any non-separator character to continue parsing.
-                    return default(char);
-                }
-
-                return _typeName[_pos];
-            }
+            get { return _typeName[_pos]; }
         }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeResolver.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeResolver.cs
@@ -267,11 +267,6 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         private static Type FindType(Assembly asm, string typeName, IBinaryNameMapper mapper)
         {
-            if (asm.IsDynamic)
-            {
-                return null;
-            }
-
             if (mapper == null)
             {
                 return asm.GetType(typeName);


### PR DESCRIPTION
* Allow dynamic assemblies in `TypeResolver`.
* Skip compiler-generated type names parsing in `TypeNameParser`.