### PR TITLE
Ignite-15603 : Calcite. NPE on subquery returning multiple results.

### DIFF
--- a/modules/calcite/src/main/java/org/apache/ignite/internal/processors/query/calcite/rule/LogicalScanConverterRule.java
+++ b/modules/calcite/src/main/java/org/apache/ignite/internal/processors/query/calcite/rule/LogicalScanConverterRule.java
@@ -81,6 +81,12 @@ public abstract class LogicalScanConverterRule<T extends ProjectableFilterableTa
                     .replace(collation);
 
                 Set<CorrelationId> corrIds = RexUtils.extractCorrelationIds(rel.condition());
+
+                if (!F.isEmpty(rel.projects())) {
+                    corrIds = new HashSet<>(corrIds);
+                    corrIds.addAll(RexUtils.extractCorrelationIds(rel.projects()));
+                }
+
                 if (!corrIds.isEmpty())
                     traits = traits.replace(CorrelationTrait.correlations(corrIds));
 

--- a/modules/calcite/src/main/java/org/apache/ignite/internal/processors/query/calcite/rule/LogicalScanConverterRule.java
+++ b/modules/calcite/src/main/java/org/apache/ignite/internal/processors/query/calcite/rule/LogicalScanConverterRule.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.processors.query.calcite.rule;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +47,7 @@ import org.apache.ignite.internal.processors.query.calcite.schema.IgniteTable;
 import org.apache.ignite.internal.processors.query.calcite.trait.CorrelationTrait;
 import org.apache.ignite.internal.processors.query.calcite.trait.RewindabilityTrait;
 import org.apache.ignite.internal.processors.query.calcite.util.RexUtils;
+import org.apache.ignite.internal.util.typedef.F;
 
 /** */
 public abstract class LogicalScanConverterRule<T extends ProjectableFilterableTableScan> extends AbstractIgniteConverterRule<T> {
@@ -131,6 +133,12 @@ public abstract class LogicalScanConverterRule<T extends ProjectableFilterableTa
                     .replace(distribution);
 
                 Set<CorrelationId> corrIds = RexUtils.extractCorrelationIds(rel.condition());
+
+                if (!F.isEmpty(rel.projects())) {
+                    corrIds = new HashSet<>(corrIds);
+                    corrIds.addAll(RexUtils.extractCorrelationIds(rel.projects()));
+                }
+
                 if (!corrIds.isEmpty())
                     traits = traits.replace(CorrelationTrait.correlations(corrIds));
 

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/CalciteQueryProcessorTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/CalciteQueryProcessorTest.java
@@ -1151,19 +1151,15 @@ public class CalciteQueryProcessorTest extends GridCommonAbstractTest {
     }
 
     /**
-     * Checks exchnage-before-correlate and correct multy-value subquery error.
+     * Checks correlates are assigned before access.
      */
     @Test
-    public void testSubqueryMultyValueError() throws IgniteInterruptedCheckedException {
+    public void testCorrelatesAssignedBeforeAccess() throws IgniteInterruptedCheckedException {
         sql("create table test_tbl(v INTEGER)", true);
 
-        sql("INSERT INTO test_tbl VALUES (1), (2), (3), (4), (5)", true);
+        sql("INSERT INTO test_tbl VALUES (1)", true);
 
-        Throwable err = GridTestUtils.assertThrows(log,
-            () -> sql("SELECT t0.v, (SELECT t0.v + t1.v FROM test_tbl t1) AS j FROM test_tbl t0"),
-            IgniteSQLException.class, null);
-
-        assertTrue(X.hasCause(err, "Subquery returned more than 1 value", IllegalArgumentException.class));
+        sql("SELECT t0.v, (SELECT t0.v + t1.v FROM test_tbl t1) AS j FROM test_tbl t0");
     }
 
     /** */

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/CalciteQueryProcessorTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/CalciteQueryProcessorTest.java
@@ -45,7 +45,6 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.processors.cache.query.QueryCursorEx;
-import org.apache.ignite.internal.processors.query.IgniteSQLException;
 import org.apache.ignite.internal.processors.query.QueryEngine;
 import org.apache.ignite.internal.processors.query.calcite.exec.MailboxRegistryImpl;
 import org.apache.ignite.internal.processors.query.calcite.exec.rel.Inbox;
@@ -55,7 +54,6 @@ import org.apache.ignite.internal.processors.query.calcite.schema.IgniteTable;
 import org.apache.ignite.internal.processors.query.calcite.util.Commons;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.G;
-import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.ListeningTestLogger;
 import org.apache.ignite.testframework.LogListener;
@@ -1159,7 +1157,10 @@ public class CalciteQueryProcessorTest extends GridCommonAbstractTest {
 
         sql("INSERT INTO test_tbl VALUES (1)", true);
 
-        sql("SELECT t0.v, (SELECT t0.v + t1.v FROM test_tbl t1) AS j FROM test_tbl t0");
+        List<List<?>> res = sql("SELECT t0.v, (SELECT t0.v + t1.v FROM test_tbl t1) AS j FROM test_tbl t0");
+
+        assertEquals(res.size(), 1);
+        assertEquals((Integer)res.get(0).get(0) * 2, res.get(0).get(1));
     }
 
     /** */

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/DataTypesTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/DataTypesTest.java
@@ -30,6 +30,28 @@ import org.junit.Test;
  * Test SQL data types.
  */
 public class DataTypesTest extends AbstractBasicIntegrationTest {
+    @Test
+    public void test1(){
+        executeSql("CREATE TABLE mydata(iv INTEGER, sv VARCHAR)");
+        executeSql("INSERT INTO mydata VALUES (11,'A'), (12,'b'), (13,'c'), (14,'d'), (15,'e'), (16,'f')");
+
+        executeSql("CREATE TABLE second(iv2 INTEGER)");
+        executeSql("INSERT INTO second VALUES (15), (16)");
+
+        executeSql("SELECT * from mydata where iv = (select iv2 from second)");
+    }
+
+    @Test
+    public void test(){
+        executeSql("CREATE TABLE mydata(i INTEGER)");
+        executeSql("INSERT INTO mydata VALUES (11), (12), (13), (14), (15), (16)");
+
+
+        executeSql("SELECT i1.i, (SELECT i1.i + i2.i FROM mydata i2) AS j FROM mydata i1");
+//        executeSql("SELECT i1.i, (SELECT i1.i + i2.i FROM mydata i2 where i2.i<15) AS j FROM mydata i1");
+
+    }
+
     /**
      * Tests numeric types mapping on Java types.
      */

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/DataTypesTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/DataTypesTest.java
@@ -30,28 +30,6 @@ import org.junit.Test;
  * Test SQL data types.
  */
 public class DataTypesTest extends AbstractBasicIntegrationTest {
-    @Test
-    public void test1(){
-        executeSql("CREATE TABLE mydata(iv INTEGER, sv VARCHAR)");
-        executeSql("INSERT INTO mydata VALUES (11,'A'), (12,'b'), (13,'c'), (14,'d'), (15,'e'), (16,'f')");
-
-        executeSql("CREATE TABLE second(iv2 INTEGER)");
-        executeSql("INSERT INTO second VALUES (15), (16)");
-
-        executeSql("SELECT * from mydata where iv = (select iv2 from second)");
-    }
-
-    @Test
-    public void test(){
-        executeSql("CREATE TABLE mydata(i INTEGER)");
-        executeSql("INSERT INTO mydata VALUES (11), (12), (13), (14), (15), (16)");
-
-
-        executeSql("SELECT i1.i, (SELECT i1.i + i2.i FROM mydata i2) AS j FROM mydata i1");
-//        executeSql("SELECT i1.i, (SELECT i1.i + i2.i FROM mydata i2 where i2.i<15) AS j FROM mydata i1");
-
-    }
-
     /**
      * Tests numeric types mapping on Java types.
      */


### PR DESCRIPTION
Fixed correlated pass in table_scan and index_scan in order to put exchange before correlate