### PR TITLE
IGNITE-15986 .NET: Fix ClientConnectionTest.TestFailover flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTest.cs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// ReSharper disable LoopVariableIsNeverChangedInsideLoop
 namespace Apache.Ignite.Core.Tests.Cache.Platform
 {
     using System;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -606,17 +606,20 @@ namespace Apache.Ignite.Core.Tests.Client
                     // First operation may fail or may not.
                     // Sometimes the client will switch to another socket in background due to
                     // OnAffinityTopologyVersionChange callback.
-                    try
-                    {
-                        Assert.AreEqual(0, client.GetCacheNames().Count);
-                    }
-                    catch (Exception e)
-                    {
-                        Assert.IsNotNull(GetSocketException(e));
-                    }
+                    var timeout = DateTime.Now.AddSeconds(0.3);
 
-                    // Second operation always succeeds.
-                    Assert.AreEqual(0, client.GetCacheNames().Count);
+                    while (DateTime.Now < timeout)
+                    {
+                        try
+                        {
+                            Assert.AreEqual(0, client.GetCacheNames().Count);
+                            break;
+                        }
+                        catch (Exception e)
+                        {
+                            Assert.IsNotNull(GetSocketException(e));
+                        }
+                    }
                 };
 
                 // Stop first node.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -381,7 +381,7 @@ namespace Apache.Ignite.Core.Tests.Client
             {
                 Assert.Contains(
                     socketEx.SocketErrorCode,
-                    new[] {SocketError.ConnectionAborted, SocketError.ConnectionReset});
+                    new[] {SocketError.ConnectionAborted, SocketError.ConnectionReset, SocketError.ConnectionRefused});
             }
             else
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -614,8 +614,17 @@ namespace Apache.Ignite.Core.Tests.Client
                 nodeId = ((IPEndPoint) client.RemoteEndPoint).Port - port;
                 Ignition.Stop(nodeId.ToString(), true);
 
-                // Check failure.
-                Assert.IsNotNull(GetSocketException(Assert.Catch(() => client.GetCacheNames())));
+                // Check failure or reconnect.
+                // Sometimes the client will switch to another socket in background due to
+                // OnAffinityTopologyVersionChange callback.
+                try
+                {
+                    Assert.AreEqual(0, client.GetCacheNames().Count);
+                }
+                catch (Exception e)
+                {
+                    Assert.IsNotNull(GetSocketException(e));
+                }
 
                 // Check reconnect.
                 Assert.AreEqual(0, client.GetCacheNames().Count);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/CallPlatformServiceTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/CallPlatformServiceTest.cs
@@ -165,6 +165,7 @@ namespace Apache.Ignite.Core.Tests.Services
             BinarizableTestValue AddOne(BinarizableTestValue val);
 
             /** */
+            // ReSharper disable once InconsistentNaming
             string contextAttribute(string name);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceProxyTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceProxyTest.cs
@@ -214,7 +214,7 @@ namespace Apache.Ignite.Core.Tests.Services
         public void TestBinarizableMarshallingException()
         {
             var prx = GetProxy();
-                
+
             var ex = Assert.Throws<ServiceInvocationException>(() => prx.CustomExceptionBinarizableMethod(false, false));
 
             if (KeepBinary)
@@ -293,9 +293,9 @@ namespace Apache.Ignite.Core.Tests.Services
                 // 2) call InvokeServiceMethod
                 string mthdName;
                 object[] mthdArgs;
-                IServiceCallContext callCtx;
+                IServiceCallContext unused;
 
-                ServiceProxySerializer.ReadProxyMethod(inStream, _marsh, out mthdName, out mthdArgs, out callCtx);
+                ServiceProxySerializer.ReadProxyMethod(inStream, _marsh, out mthdName, out mthdArgs, out unused);
 
                 var result = ServiceProxyInvoker.InvokeServiceMethod(_svc, mthdName, mthdArgs);
 
@@ -759,7 +759,7 @@ namespace Apache.Ignite.Core.Tests.Services
         public void TestBinarizableMethods()
         {
             var prx = GetProxy();
-            
+
             var obj = new TestBinarizableClass { Prop = "PropValue" };
             var portObj = Binary.ToBinary<IBinaryObject>(obj);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesAsyncWrapper.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Core.Tests.Services
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cluster;
@@ -193,7 +192,7 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             return _services.GetServiceProxy<T>(name, sticky);
         }
-        
+
         /** <inheritDoc /> */
         public T GetServiceProxy<T>(string name, bool sticky, IServiceCallContext callCtx) where T : class
         {
@@ -211,7 +210,7 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             return _services.GetDynamicServiceProxy(name, sticky);
         }
-        
+
         /** <inheritDoc /> */
         public dynamic GetDynamicServiceProxy(string name, bool sticky, IServiceCallContext callCtx)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceContext.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceContext.cs
@@ -29,7 +29,7 @@ namespace Apache.Ignite.Core.Impl.Services
     internal class ServiceContext : IServiceContext
     {
         /** Service call context of the current thread. */
-        private static readonly ThreadLocal<IServiceCallContext> locCallCtx = new ThreadLocal<IServiceCallContext>();
+        private static readonly ThreadLocal<IServiceCallContext> LocalCallContext = new ThreadLocal<IServiceCallContext>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceContext"/> class.
@@ -64,7 +64,7 @@ namespace Apache.Ignite.Core.Impl.Services
         /** <inheritdoc /> */
         public IServiceCallContext CurrentCallContext
         {
-            get { return locCallCtx.Value; }
+            get { return LocalCallContext.Value; }
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Apache.Ignite.Core.Impl.Services
         /// </summary>
         /// <param name="callCtx">Service call context for the current thread.</param>
         internal static void SetCurrentCallContext(IServiceCallContext callCtx) {
-            locCallCtx.Value = callCtx;
+            LocalCallContext.Value = callCtx;
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedCallbacks.cs
@@ -18,7 +18,6 @@
 namespace Apache.Ignite.Core.Impl.Unmanaged
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
@@ -1109,7 +1108,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                 IServiceCallContext callCtx;
 
                 ServiceProxySerializer.ReadProxyMethod(stream, _ignite.Marshaller, out mthdName, out mthdArgs, out callCtx);
-                
+
                 if (callCtx != null)
                     ServiceContext.SetCurrentCallContext(callCtx);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Services/ServiceCallContextBuilder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Services/ServiceCallContextBuilder.cs
@@ -19,7 +19,6 @@ namespace Apache.Ignite.Core.Services
 {
     using System;
     using System.Collections;
-    using System.Linq;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.Impl.Services;
@@ -32,7 +31,7 @@ namespace Apache.Ignite.Core.Services
     {
         /** Context attributes. */
         private readonly Hashtable _attrs = new Hashtable();
-        
+
         /// <summary>
         /// Set string attribute.
         /// </summary>
@@ -63,7 +62,7 @@ namespace Apache.Ignite.Core.Services
             IgniteArgumentCheck.NotNull(value, "value");
 
             _attrs[name] = value;
-            
+
             return this;
         }
 


### PR DESCRIPTION
* Fix `TestFailover` flakiness.
* Fix `TestServerConnectionAborted` flakiness.
* Fix IDE warnings.