### PR TITLE
IGNITE-13804 Java thin: avoid buffer copy on send

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
@@ -17,6 +17,8 @@
 
 package org.apache.ignite.internal.binary.streams;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
@@ -27,6 +29,9 @@ import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
 public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
     /** Allocator. */
     private final BinaryMemoryAllocatorChunk chunk;
+
+    /** TODO: REMOVE THIS. */
+    private final AtomicBoolean released = new AtomicBoolean();
 
     /** Data. */
     private byte[] data;
@@ -54,6 +59,9 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
 
     /** {@inheritDoc} */
     @Override public void close() {
+        if (!released.compareAndSet(false, true))
+            throw new IgniteException("Use after free");
+
         chunk.release(data, pos);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
@@ -30,6 +30,9 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
     /** Allocator. */
     private final BinaryMemoryAllocatorChunk chunk;
 
+    /** Disable auto close flag. */
+    private final boolean disableAutoClose;
+
     /** TODO: REMOVE THIS. */
     private final AtomicBoolean released = new AtomicBoolean();
 
@@ -52,13 +55,34 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
      * @param chunk Chunk.
      */
     public BinaryHeapOutputStream(int cap, BinaryMemoryAllocatorChunk chunk) {
+        this(cap, chunk, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cap Capacity.
+     * @param chunk Chunk.
+     * @param disableAutoClose Whether to disable resource release in {@link BinaryHeapOutputStream#close()} method
+     *                         so that an explicit {@link BinaryHeapOutputStream#release()} call is required.
+     */
+    public BinaryHeapOutputStream(int cap, BinaryMemoryAllocatorChunk chunk, boolean disableAutoClose) {
         this.chunk = chunk;
+        this.disableAutoClose = disableAutoClose;
 
         data = chunk.allocate(cap);
     }
 
     /** {@inheritDoc} */
     @Override public void close() {
+        if (!disableAutoClose)
+            release();
+    }
+
+    /**
+     * Releases pooled memory.
+     */
+    public void release() {
         if (!released.compareAndSet(false, true))
             throw new IgniteException("Use after free");
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
@@ -17,8 +17,6 @@
 
 package org.apache.ignite.internal.binary.streams;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.ignite.IgniteException;
 import org.apache.ignite.internal.util.GridUnsafe;
 
 import static org.apache.ignite.internal.util.GridUnsafe.BIG_ENDIAN;
@@ -32,9 +30,6 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
 
     /** Disable auto close flag. */
     private final boolean disableAutoClose;
-
-    /** TODO: REMOVE THIS. */
-    private final AtomicBoolean released = new AtomicBoolean();
 
     /** Data. */
     private byte[] data;
@@ -83,9 +78,6 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
      * Releases pooled memory.
      */
     public void release() {
-        if (!released.compareAndSet(false, true))
-            throw new IgniteException("Use after free");
-
         chunk.release(data, pos);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
@@ -56,6 +56,9 @@ class PayloadOutputChannel implements AutoCloseable {
      * Gets output stream.
      */
     public BinaryOutputStream out() {
+        // TODO: out is being closed by callers of this property!
+        // 1. Rewrite all callers (44 of them)
+        // 2. Somehow protect from closing the stream.
         return out;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.client.thin;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ignite.internal.binary.streams.BinaryHeapOutputStream;
 import org.apache.ignite.internal.binary.streams.BinaryOutputStream;
 
@@ -32,6 +33,9 @@ class PayloadOutputChannel implements AutoCloseable {
 
     /** Output stream. */
     private final BinaryOutputStream out;
+
+    /** Close guard. */
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     /**
      * Constructor.
@@ -57,6 +61,7 @@ class PayloadOutputChannel implements AutoCloseable {
 
     /** {@inheritDoc} */
     @Override public void close() {
-        out.close();
+        if (closed.compareAndSet(false, true))
+            out.close();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
@@ -63,6 +63,8 @@ class PayloadOutputChannel implements AutoCloseable {
 
     /** {@inheritDoc} */
     @Override public void close() {
+        // Pooled buffer is reusable and should be released once and only once.
+        // Releasing more than once potentially "steals" it from another request.
         if (closed.compareAndSet(false, true))
             out.release();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
@@ -43,7 +43,7 @@ class PayloadOutputChannel implements AutoCloseable {
      */
     PayloadOutputChannel(ClientChannel ch) {
         // Disable AutoCloseable on the stream so that out callers don't release the pooled buffer before it is written to the socket.
-        out = new BinaryHeapOutputStream(INITIAL_BUFFER_CAPACITY, BinaryMemoryAllocator.THREAD_LOCAL.chunk(), true);
+        out = new BinaryHeapOutputStream(INITIAL_BUFFER_CAPACITY, BinaryMemoryAllocator.POOLED.chunk(), true);
         this.ch = ch;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -246,7 +246,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         throws ClientException {
         long id = reqId.getAndIncrement();
 
-        try (PayloadOutputChannel payloadCh = new PayloadOutputChannel(this)) {
+        PayloadOutputChannel payloadCh = new PayloadOutputChannel(this);
+
+        try {
             if (closed())
                 throw new ClientConnectionException("Channel is closed");
 
@@ -265,13 +267,13 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             req.writeInt(0, req.position() - 4); // Actual size.
 
-            // arrayCopy is required, because buffer is pooled, and write is async.
-            write(req.arrayCopy(), req.position());
+            write(req.array(), req.position(), payloadCh::close);
 
             return fut;
         }
         catch (Throwable t) {
             pendingReqs.remove(id);
+            payloadCh.close();
 
             throw t;
         }
@@ -605,7 +607,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             writer.out().writeInt(0, writer.out().position() - 4); // actual size
 
-            write(writer.out().arrayCopy(), writer.out().position());
+            write(writer.out().arrayCopy(), writer.out().position(), null);
         }
     }
 
@@ -675,11 +677,11 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     }
 
     /** Write bytes to the output stream. */
-    private void write(byte[] bytes, int len) throws ClientConnectionException {
+    private void write(byte[] bytes, int len, @Nullable Runnable onDone) throws ClientConnectionException {
         ByteBuffer buf = ByteBuffer.wrap(bytes, 0, len);
 
         try {
-            sock.send(buf);
+            sock.send(buf, onDone);
         }
         catch (IgniteCheckedException e) {
             throw new ClientConnectionException(e.getMessage(), e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -267,6 +267,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             req.writeInt(0, req.position() - 4); // Actual size.
 
+            // TODO: Looks like we close the buffer before it is fully written,
+            // returning it to the pool and causing overwrite.
+            // See testActiveTasksLimit.
             write(req.array(), req.position(), payloadCh::close);
 
             return fut;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -267,15 +267,14 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             req.writeInt(0, req.position() - 4); // Actual size.
 
-            // TODO: Looks like we close the buffer before it is fully written,
-            // returning it to the pool and causing overwrite.
-            // See testActiveTasksLimit.
             write(req.array(), req.position(), payloadCh::close);
 
             return fut;
         }
         catch (Throwable t) {
             pendingReqs.remove(id);
+
+            // Potential double-close is handled in PayloadOutputChannel.
             payloadCh.close();
 
             throw t;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/ClientConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/ClientConnection.java
@@ -19,7 +19,9 @@ package org.apache.ignite.internal.client.thin.io;
 
 import java.nio.ByteBuffer;
 
+import java.util.concurrent.Callable;
 import org.apache.ignite.IgniteCheckedException;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Client connection: abstracts away sending and receiving messages.
@@ -30,7 +32,7 @@ public interface ClientConnection extends AutoCloseable {
      *
      * @param msg Message buffer.
      */
-    void send(ByteBuffer msg) throws IgniteCheckedException;
+    void send(ByteBuffer msg, @Nullable Runnable onDone) throws IgniteCheckedException;
 
     /**
      * Closes the connection.

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/ClientConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/ClientConnection.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.client.thin.io;
 
 import java.nio.ByteBuffer;
 
-import java.util.concurrent.Callable;
 import org.apache.ignite.IgniteCheckedException;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,6 +30,7 @@ public interface ClientConnection extends AutoCloseable {
      * Sends a message.
      *
      * @param msg Message buffer.
+     * @param onDone Callback to be invoked when asynchronous send operation completes.
      */
     void send(ByteBuffer msg, @Nullable Runnable onDone) throws IgniteCheckedException;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnection.java
@@ -25,6 +25,7 @@ import org.apache.ignite.internal.client.thin.io.ClientConnectionStateHandler;
 import org.apache.ignite.internal.client.thin.io.ClientMessageHandler;
 import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.apache.ignite.internal.util.nio.GridNioSessionMetaKey;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Client connection.
@@ -62,8 +63,8 @@ class GridNioClientConnection implements ClientConnection {
     }
 
     /** {@inheritDoc} */
-    @Override public void send(ByteBuffer msg) throws IgniteCheckedException {
-        ses.sendNoFuture(msg, null);
+    @Override public void send(ByteBuffer msg, @Nullable Runnable onDone) throws IgniteCheckedException {
+        ses.sendNoFuture(msg, onDone == null ? null : e -> onDone.run());
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnection.java
@@ -64,7 +64,10 @@ class GridNioClientConnection implements ClientConnection {
 
     /** {@inheritDoc} */
     @Override public void send(ByteBuffer msg, @Nullable Runnable onDone) throws IgniteCheckedException {
-        ses.sendNoFuture(msg, onDone == null ? null : e -> onDone.run());
+        if (onDone != null)
+            ses.send(msg).listen(f -> onDone.run());
+        else
+            ses.sendNoFuture(msg, null);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
* Release pooled buffer in NIO future listener to avoid an extra copy.
* Use `BinaryMemoryAllocator.POOLED` instead of `THREAD_LOCAL` because we release the buffer asynchronously.
* Fix use-after-free caused by `PayloadOutputChannel.out()` callers which wrap it into a writer inside try-with-resources.
* Checked `JmhThinClientCacheBenchmark` - no observable difference.