### PR TITLE
IGNITE-16400 : Deprecate direct references to local services. Fix service proxy.

### DIFF
--- a/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/services/ServiceExample.java
+++ b/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/services/ServiceExample.java
@@ -172,6 +172,7 @@ public class ServiceExample {
 
         ignite.services().deploy(serviceCfg);
 
+        // NOTE: work via proxy. Direct references like 'IgniteServices#service()' corrupt the statistics.
         MyCounterService svc = ignite.services().serviceProxy("myService", MyCounterService.class, true)
         //end::start-with-statistics[]
 

--- a/docs/_docs/services/services.adoc
+++ b/docs/_docs/services/services.adoc
@@ -283,10 +283,12 @@ tab:C++[]
 ====
 You should be aware:
 
-1. Overloaded service methods have the same metric by the method name.
-2. Service statistics do not take in account serialization and network issues.
-3. Service statistics slows down the invocations of service methods. Probably it's not
-an issue for slow-by-nature jobs like working with a DB.
+1. Direct references to the services like `IgniteServices.service(name)` corrupt the statistics. Use the proxies
+instead (`IgniteServices.serviceProxy(...)`).
+2. Overloaded service methods have the same metric by the method name.
+3. Service statistics do not take in account serialization and network issues.
+4. Service statistics slows down the invocations of service methods. It's not
+an issue for real jobs like working with a DB or a cache.
 ====
 
 // TODO: add how to  call java services from .NET

--- a/modules/core/src/main/java/org/apache/ignite/IgniteServices.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteServices.java
@@ -567,7 +567,11 @@ public interface IgniteServices extends IgniteAsyncSupport {
      * @param name Service name.
      * @param <T> Service type
      * @return Deployed service with specified name.
+     * @see ServiceConfiguration#setStatisticsEnabled(boolean)
+     * @deprecated Use the proxies like {@link #serviceProxy(String, Class, boolean)}. References to local services
+     * corrupt the service statistics and bring no real performance optimization.
      */
+    @Deprecated
     public <T> T service(String name);
 
     /**
@@ -576,13 +580,15 @@ public interface IgniteServices extends IgniteAsyncSupport {
      * @param name Service name.
      * @param <T> Service type.
      * @return all deployed services with specified name.
+     * @see ServiceConfiguration#setStatisticsEnabled(boolean)
+     * @deprecated Use the proxies like {@link #serviceProxy(String, Class, boolean)}. References to local services
+     * corrupt the service statistics and bring no real performance optimization.
      */
+    @Deprecated
     public <T> Collection<T> services(String name);
 
     /**
-     * Gets a remote handle on the service. If service is available locally,
-     * then local instance is returned, otherwise, a remote proxy is dynamically
-     * created and provided for the specified service.
+     * Gets a handle on the service.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.
@@ -595,9 +601,7 @@ public interface IgniteServices extends IgniteAsyncSupport {
     public <T> T serviceProxy(String name, Class<? super T> svcItf, boolean sticky) throws IgniteException;
 
     /**
-     * Gets a remote handle on the service with timeout. If service is available locally,
-     * then local instance is returned and timeout ignored, otherwise, a remote proxy is dynamically
-     * created and provided for the specified service.
+     * Gets a handle on the service with the timeout.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.
@@ -613,8 +617,7 @@ public interface IgniteServices extends IgniteAsyncSupport {
         throws IgniteException;
 
     /**
-     * Gets a remote handle on the service with the specified caller context. The proxy
-     * is dynamically created and provided for the specified service.
+     * Gets a handle on the service with the specified caller context.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.
@@ -635,8 +638,7 @@ public interface IgniteServices extends IgniteAsyncSupport {
     ) throws IgniteException;
 
     /**
-     * Gets a remote handle on the service with the specified caller context and timeout.
-     * The proxy is dynamically created and provided for the specified service.
+     * Gets a handle on the service with the specified caller context and the timeout.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.

--- a/modules/core/src/main/java/org/apache/ignite/IgniteServices.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteServices.java
@@ -618,7 +618,7 @@ public interface IgniteServices extends IgniteAsyncSupport {
         throws IgniteException;
 
     /**
-     * Gets a handle on remote or local service with the precified caller context. The proxy is dynamically created and
+     * Gets a handle on remote or local service with the specified caller context. The proxy is dynamically created and
      * provided for the specified service.
      *
      * @param name Service name.

--- a/modules/core/src/main/java/org/apache/ignite/IgniteServices.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteServices.java
@@ -588,7 +588,7 @@ public interface IgniteServices extends IgniteAsyncSupport {
     public <T> Collection<T> services(String name);
 
     /**
-     * Gets a handle on the service.
+     * Gets a handle on remote or local service. The proxy is dynamically created and provided for the specified service.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.
@@ -601,7 +601,8 @@ public interface IgniteServices extends IgniteAsyncSupport {
     public <T> T serviceProxy(String name, Class<? super T> svcItf, boolean sticky) throws IgniteException;
 
     /**
-     * Gets a handle on the service with the timeout.
+     * Gets a handle on remote or local service with the timeout. The proxy is dynamically created and provided for the
+     * specified service.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.
@@ -617,7 +618,8 @@ public interface IgniteServices extends IgniteAsyncSupport {
         throws IgniteException;
 
     /**
-     * Gets a handle on the service with the specified caller context.
+     * Gets a handle on remote or local service with the precified caller context. The proxy is dynamically created and
+     * provided for the specified service.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.
@@ -638,7 +640,8 @@ public interface IgniteServices extends IgniteAsyncSupport {
     ) throws IgniteException;
 
     /**
-     * Gets a handle on the service with the specified caller context and the timeout.
+     * Gets a handle on remote or local service with the specified caller context and the timeout. The proxy is
+     * dynamically created and provided for the specified service.
      *
      * @param name Service name.
      * @param svcItf Interface for the service.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/service/IgniteServiceProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/service/IgniteServiceProcessor.java
@@ -1061,23 +1061,6 @@ public class IgniteServiceProcessor extends GridProcessorAdapter implements Igni
     ) throws IgniteException {
         ctx.security().authorize(name, SecurityPermission.SERVICE_INVOKE);
 
-        if (hasLocalNode(prj)) {
-            ServiceContextImpl ctx = serviceContext(name);
-
-            if (ctx != null && !ctx.isStatisticsEnabled()) {
-                Service srvc = ctx.service();
-
-                if (srvc != null && callAttrsProvider == null) {
-                    if (srvcCls.isAssignableFrom(srvc.getClass()))
-                        return (T)srvc;
-                    else if (!PlatformService.class.isAssignableFrom(srvc.getClass())) {
-                        throw new IgniteException("Service does not implement specified interface [srvcCls="
-                                + srvcCls.getName() + ", srvcCls=" + srvc.getClass().getName() + ']');
-                    }
-                }
-            }
-        }
-
         return new GridServiceProxy<T>(prj, name, srvcCls, sticky, timeout, ctx, callAttrsProvider, keepBinary).proxy();
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/service/IgniteServiceProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/service/IgniteServiceProcessor.java
@@ -1065,19 +1065,6 @@ public class IgniteServiceProcessor extends GridProcessorAdapter implements Igni
     }
 
     /**
-     * @param prj Grid nodes projection.
-     * @return Whether given projection contains any local node.
-     */
-    private boolean hasLocalNode(ClusterGroup prj) {
-        for (ClusterNode n : prj.nodes()) {
-            if (n.isLocal())
-                return true;
-        }
-
-        return false;
-    }
-
-    /**
      * @param name Service name.
      * @param <T> Service type.
      * @return Services by specified service name.

--- a/modules/core/src/main/java/org/apache/ignite/services/ServiceConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/services/ServiceConfiguration.java
@@ -268,7 +268,7 @@ public class ServiceConfiguration implements Serializable {
      * {@link IgniteServiceProcessor#SERVICE_METRIC_REGISTRY} by service name.
      * <p>
      * <b>NOTE:</b> Statistics are collected only with service proxies obtaining by methods like
-     * {@link IgniteServices#serviceProxy(String, Class, boolean)} and won't work for direct referense of local
+     * {@link IgniteServices#serviceProxy(String, Class, boolean)} and won't work for direct reference of local
      * services which you can get by, for example, {@link IgniteServices#service(String)}.
      * <p>
      * <b>NOTE:</b> Statistics are collected only for all service's interfaces except {@link Service} and

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorProxySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/service/GridServiceProcessorProxySelfTest.java
@@ -376,7 +376,7 @@ public class GridServiceProcessorProxySelfTest extends GridServiceProcessorAbstr
 
                     ref.set(svc);
 
-                    return (withStat ? Proxy.isProxyClass(svc.getClass()) : svc instanceof Service) &&
+                    return (Proxy.isProxyClass(svc.getClass())) &&
                         Arrays.asList(svc.getClass().getInterfaces()).contains(MapService.class);
                 }
             }, 2000);

--- a/modules/spring/src/test/java/org/apache/ignite/internal/processors/resource/GridServiceInjectionSelfTest.java
+++ b/modules/spring/src/test/java/org/apache/ignite/internal/processors/resource/GridServiceInjectionSelfTest.java
@@ -109,9 +109,6 @@ public class GridServiceInjectionSelfTest extends GridCommonAbstractTest impleme
             @Override public Object call() throws Exception {
                 assertNotNull(svc);
 
-                // Ensure proxy instance.
-                assertTrue(svc instanceof Service);
-
                 svc.noop();
 
                 return null;
@@ -204,9 +201,6 @@ public class GridServiceInjectionSelfTest extends GridCommonAbstractTest impleme
             @ServiceResource(serviceName = SERVICE_NAME1, proxyInterface = DummyService.class)
             private void service(DummyService svc) {
                 assertNotNull(svc);
-
-                // Ensure proxy instance.
-                assertTrue(svc instanceof Service);
 
                 this.svc = svc;
             }


### PR DESCRIPTION
As discussed in the threads related to the main ticket #IGNITE-12464, we deprecate references to local services. Also we will return service proxy every time even for local services by `serviceProxy()`