### PR TITLE
IGNITE-16351 C++ thin, ODBC: SSL certificates, keys and CA are not mandatory

### DIFF
--- a/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
@@ -117,6 +117,13 @@ namespace ignite
          * @return Random seed.
          */
         IGNITE_IMPORT_EXPORT unsigned GetRandSeed();
+
+        /**
+         * Try extract from system error stack, and return platform-specific error.
+         *
+         * @return Error in human-readable format.
+         */
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError();
     }
 }
 

--- a/modules/platforms/cpp/common/include/ignite/common/utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/utils.h
@@ -706,6 +706,55 @@ namespace ignite
             /** Sequence of fibonacci numbers */
             size_t sequence[size];
         };
+
+        /**
+         * Throw platform-specific error.
+         *
+         * @param msg Error message.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowSystemError(const std::string& msg);
+
+        /**
+         * Try extract from system error stack and throw platform-specific error.
+         *
+         * @param description Error description.
+         * @param advice User advice.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description, const std::string& advice);
+
+        /**
+         * Try extract from system error stack and throw platform-specific error.
+         *
+         * @param description Error description.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description);
+
+        /**
+         * Format error message.
+         *
+         * @param description Error description.
+         * @param description Error details.
+         * @param advice User advice.
+         */
+        IGNITE_IMPORT_EXPORT std::string FormatErrorMessage(const std::string& description, const std::string& details,
+            const std::string& advice);
+
+        /**
+         * Try extract from system error stack, format and return platform-specific error.
+         *
+         * @param description Error description.
+         * @return Error in human-readable format.
+         */
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError(const std::string& description);
+
+        /**
+         * Try extract from system error stack, format and return platform-specific error.
+         *
+         * @param description Error description.
+         * @param advice User advice.
+         * @return Error in human-readable format.
+         */
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError(const std::string& description, const std::string& advice);
     }
 }
 

--- a/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
@@ -23,8 +23,9 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <glob.h>
-#include <unistd.h>
 #include <ftw.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include <ignite/common/utils.h>
 
@@ -124,7 +125,7 @@ namespace ignite
             return ostr;
         }
 
-        IGNITE_IMPORT_EXPORT unsigned GetRandSeed()
+        unsigned GetRandSeed()
         {
             timespec ts;
 
@@ -135,6 +136,23 @@ namespace ignite
             res ^= static_cast<unsigned>(getpid());
 
             return res;
+        }
+
+        std::string GetLastSystemError()
+        {
+            int errorCode = errno;
+
+            std::string errorDetails;
+            if (errorCode != 0)
+            {
+                char errBuf[1024] = { 0 };
+
+                const char* res = strerror_r(errorCode, errBuf, sizeof(errBuf));
+                if (res)
+                    errorDetails.assign(res);
+            }
+
+            return errorDetails;
         }
     }
 }

--- a/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
@@ -17,9 +17,11 @@
 
 #include <time.h>
 #include <vector>
+#include <sstream>
 
 #include <windows.h>
 
+#include <ignite/ignite_error.h>
 #include <ignite/common/platform_utils.h>
 
 namespace ignite
@@ -130,9 +132,28 @@ namespace ignite
             return ostr;
         }
 
-        IGNITE_IMPORT_EXPORT unsigned GetRandSeed()
+        unsigned GetRandSeed()
         {
             return static_cast<unsigned>(GetTickCount() ^ GetCurrentProcessId());
+        }
+
+        std::string GetLastSystemError()
+        {
+            DWORD errorCode = GetLastError();
+
+            std::string errorDetails;
+            if (errorCode != ERROR_SUCCESS)
+            {
+                char errBuf[1024] = { 0 };
+
+                FormatMessageA(
+                        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errorCode,
+                        MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), errBuf, sizeof(errBuf), NULL);
+
+                errorDetails.assign(errBuf);
+            }
+
+            return errorDetails;
         }
     }
 }

--- a/modules/platforms/cpp/common/src/common/utils.cpp
+++ b/modules/platforms/cpp/common/src/common/utils.cpp
@@ -16,7 +16,9 @@
  */
 
 #include <iomanip>
+#include <sstream>
 
+#include <ignite/ignite_error.h>
 #include <ignite/common/utils.h>
 
 namespace ignite
@@ -227,6 +229,47 @@ namespace ignite
                 dump << std::hex << std::setfill('0') << std::setw(2) << (int)*p << " ";
             }
             return dump.str();
+        }
+
+        void ThrowSystemError(const std::string &msg)
+        {
+            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, msg.c_str());
+        }
+
+        void ThrowLastSystemError(const std::string& description, const std::string& advice)
+        {
+            ThrowSystemError(GetLastSystemError(description, advice));
+        }
+
+        void ThrowLastSystemError(const std::string& description)
+        {
+            std::string empty;
+            ThrowLastSystemError(description, empty);
+        }
+
+        std::string FormatErrorMessage(const std::string &description, const std::string &details,
+            const std::string &advice)
+        {
+            std::stringstream messageBuilder;
+            messageBuilder << description;
+            if (!details.empty())
+                messageBuilder << ": " << details;
+
+            if (!advice.empty())
+                messageBuilder << ". " << advice;
+
+            return messageBuilder.str();
+        }
+
+        std::string GetLastSystemError(const std::string& description, const std::string& advice)
+        {
+            return common::FormatErrorMessage(description, GetLastSystemError(), advice);
+        }
+
+        std::string GetLastSystemError(const std::string &description)
+        {
+            std::string empty;
+            return GetLastSystemError(description, empty);
         }
 
     }

--- a/modules/platforms/cpp/common/src/common/utils.cpp
+++ b/modules/platforms/cpp/common/src/common/utils.cpp
@@ -263,7 +263,7 @@ namespace ignite
 
         std::string GetLastSystemError(const std::string& description, const std::string& advice)
         {
-            return common::FormatErrorMessage(description, GetLastSystemError(), advice);
+            return FormatErrorMessage(description, GetLastSystemError(), advice);
         }
 
         std::string GetLastSystemError(const std::string &description)

--- a/modules/platforms/cpp/core-test/CMakeLists.txt
+++ b/modules/platforms/cpp/core-test/CMakeLists.txt
@@ -28,7 +28,8 @@ find_package(Boost 1.53 REQUIRED COMPONENTS unit_test_framework chrono thread sy
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 include_directories(include)
 
-set(SOURCES src/reference_test.cpp
+set(SOURCES
+        src/reference_test.cpp
         src/bits_test.cpp
         src/binary_identity_resolver_test.cpp
         src/cache_test.cpp

--- a/modules/platforms/cpp/network/CMakeLists.txt
+++ b/modules/platforms/cpp/network/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SOURCES
         src/network/network.cpp
         src/network/ssl/secure_data_filter.cpp
         src/network/ssl/secure_socket_client.cpp
+        src/network/ssl/secure_utils.cpp
         src/network/ssl/ssl_gateway.cpp)
 
 if (WIN32)
@@ -83,7 +84,7 @@ foreach(_target_lib IN LISTS _target_libs)
     endif()
 
     if (WIN32)
-        target_link_libraries(${_target_lib} wsock32 ws2_32 iphlpapi)
+        target_link_libraries(${_target_lib} wsock32 ws2_32 iphlpapi crypt32)
     endif()
 
     target_include_directories(${_target_lib} INTERFACE include ${OS_INCLUDE})

--- a/modules/platforms/cpp/network/include/ignite/network/network.h
+++ b/modules/platforms/cpp/network/include/ignite/network/network.h
@@ -23,6 +23,7 @@
 #include <ignite/common/common.h>
 #include <ignite/network/socket_client.h>
 #include <ignite/network/async_client_pool.h>
+#include <ignite/network/ssl/secure_configuration.h>
 
 namespace ignite
 {
@@ -43,14 +44,11 @@ namespace ignite
             /**
              * Make secure socket for SSL/TLS connection.
              *
-             * @param certPath Certificate file path.
-             * @param keyPath Private key file path.
-             * @param caPath Certificate authority file path.
+             * @param cfg Configuration.
              *
              * @throw IgniteError if it is not possible to load SSL library.
              */
-            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const std::string& certPath,
-                const std::string& keyPath, const std::string& caPath);
+            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const SecureConfiguration& cfg);
         }
 
         /**

--- a/modules/platforms/cpp/network/include/ignite/network/ssl/secure_configuration.h
+++ b/modules/platforms/cpp/network/include/ignite/network/ssl/secure_configuration.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_NETWORK_SSL_SECURE_CONFIGURATION
+#define _IGNITE_NETWORK_SSL_SECURE_CONFIGURATION
+
+#include <string>
+
+namespace ignite
+{
+    namespace network
+    {
+        namespace ssl
+        {
+            /**
+             * TLS/SSL configuration parameters.
+             */
+            struct SecureConfiguration
+            {
+                /** Path to file containing security certificate to use. */
+                std::string certPath;
+
+                /** Path to file containing private key to use. */
+                std::string keyPath;
+
+                /** Path to file containing Certificate authority to use. */
+                std::string caPath;
+            };
+        }
+    }
+}
+
+#endif //_IGNITE_NETWORK_SSL_SECURE_CONFIGURATION

--- a/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
+++ b/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
@@ -22,7 +22,7 @@
 
 #include <ignite/common/concurrent.h>
 #include <ignite/network/data_filter_adapter.h>
-
+#include <ignite/network/ssl/secure_configuration.h>
 
 namespace ignite
 {
@@ -30,21 +30,6 @@ namespace ignite
     {
         namespace ssl
         {
-            /**
-             * TLS/SSL configuration parameters.
-             */
-            struct SecureConfiguration
-            {
-                /** Path to file containing security certificate to use. */
-                std::string certPath;
-
-                /** Path to file containing private key to use. */
-                std::string keyPath;
-
-                /** Path to file containing Certificate authority to use. */
-                std::string caPath;
-            };
-
             /**
              * TLS/SSL Data Filter.
              */
@@ -123,8 +108,10 @@ namespace ignite
 
                     /**
                      * Start connection procedure including handshake.
+                     *
+                     * @return @c true, if connection complete.
                      */
-                    void DoConnect();
+                    bool DoConnect();
 
                     /**
                      * Check whether connection is established.
@@ -238,9 +225,6 @@ namespace ignite
                  * @throw IgniteError on error.
                  */
                 bool SendInternal(uint64_t id, const DataBuffer& data);
-
-                /** Secure configuration. */
-                const SecureConfiguration cfg;
 
                 /** SSL context. */
                 void* sslContext;

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_client.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_client.cpp
@@ -71,17 +71,15 @@ namespace ignite
 
         bool LinuxAsyncClient::Close()
         {
-            State::Type stateBefore = state;
+            if (State::CLOSED == state)
+                return false;
 
-            if (state != State::CLOSED)
-            {
-                StopMonitoring();
-                close(fd);
-                fd = -1;
-                state = State::CLOSED;
-            }
+            StopMonitoring();
+            close(fd);
+            fd = -1;
+            state = State::CLOSED;
 
-            return stateBefore == State::CONNECTED;
+            return true;
         }
 
         bool LinuxAsyncClient::Send(const DataBuffer& data)

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_client_pool.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_client_pool.cpp
@@ -86,10 +86,8 @@ namespace ignite
                 return;
 
             SP_LinuxAsyncClient client = FindClient(id);
-            if (!client.IsValid() || client.Get()->IsClosed())
-                return;
-
-            client.Get()->Shutdown(err);
+            if (client.IsValid() && !client.Get()->IsClosed())
+                client.Get()->Shutdown(err);
         }
 
         void LinuxAsyncClientPool::CloseAndRelease(uint64_t id, const IgniteError *err)
@@ -112,7 +110,16 @@ namespace ignite
 
             bool closed = client.Get()->Close();
             if (closed)
+            {
+                IgniteError err0(client.Get()->GetCloseError());
+                if (err0.GetCode() == IgniteError::IGNITE_SUCCESS)
+                    err0 = IgniteError(IgniteError::IGNITE_ERR_NETWORK_FAILURE, "Connection closed by server");
+
+                if (!err)
+                    err = &err0;
+
                 HandleConnectionClosed(id, err);
+            }
         }
 
         bool LinuxAsyncClientPool::AddClient(SP_LinuxAsyncClient &client)

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.cpp
@@ -64,13 +64,14 @@ namespace ignite
         {
             epoll = epoll_create(1);
             if (epoll < 0)
-                ThrowSystemError("Failed to create epoll instance");
+                common::ThrowLastSystemError("Failed to create epoll instance");
 
             stopEvent = eventfd(0, EFD_NONBLOCK);
             if (stopEvent < 0)
             {
+                std::string msg = common::GetLastSystemError("Failed to create stop event instance");
                 close(stopEvent);
-                ThrowSystemError("Failed to create stop event instance");
+                common::ThrowSystemError(msg);
             }
 
             epoll_event event;
@@ -81,9 +82,10 @@ namespace ignite
             int res = epoll_ctl(epoll, EPOLL_CTL_ADD, stopEvent, &event);
             if (res < 0)
             {
+                std::string msg = common::GetLastSystemError("Failed to create stop event instance");
                 close(stopEvent);
                 close(epoll);
-                ThrowSystemError("Failed to add stop event to epoll");
+                common::ThrowSystemError(msg);
             }
 
             stopping = false;
@@ -188,7 +190,7 @@ namespace ignite
             currentClient = currentConnection->ToClient(socketFd);
             bool ok = currentClient.Get()->StartMonitoring(epoll);
             if (!ok)
-                ThrowSystemError("Can not add file descriptor to epoll");
+                common::ThrowLastSystemError("Can not add file descriptor to epoll");
 
             // Connect to server.
             int res = connect(socketFd, addr->ai_addr, addr->ai_addrlen);
@@ -239,7 +241,7 @@ namespace ignite
                     HandleConnectionSuccess(client);
                 }
 
-                if (currentEvent.events & (EPOLLRDHUP | EPOLLERR))
+                if (currentEvent.events & (EPOLLRDHUP | EPOLLERR | EPOLLHUP))
                 {
                     HandleConnectionClosed(client);
 
@@ -298,8 +300,7 @@ namespace ignite
 
             nonConnected.push_back(client->GetRange());
 
-            IgniteError err(IgniteError::IGNITE_ERR_NETWORK_FAILURE, "Connection closed");
-            clientPool.CloseAndRelease(client->GetId(), &err);
+            clientPool.CloseAndRelease(client->GetId(), 0);
         }
 
         void LinuxAsyncWorkerThread::HandleConnectionSuccess(LinuxAsyncClient* client)
@@ -342,15 +343,6 @@ namespace ignite
         bool LinuxAsyncWorkerThread::ShouldInitiateNewConnection() const
         {
             return !currentClient.Get() && nonConnected.size() > minAddrs;
-        }
-
-        void LinuxAsyncWorkerThread::ThrowSystemError(const std::string &msg)
-        {
-            std::stringstream buf;
-
-            buf << "Linux system error: " << msg << ", system error code: " << errno;
-
-            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, buf.str().c_str());
         }
     }
 }

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.h
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.h
@@ -85,14 +85,6 @@ namespace ignite
             void HandleConnectionEvents();
 
             /**
-             * Add file descriptor to epoll for monitoring.
-             *
-             * @param fd File descriptor to add.
-             * @param client Client. May be null.
-             */
-            void StartMonitoringFd(int fd, LinuxAsyncClient* client);
-
-            /**
              * Handle network error during connection establishment.
              *
              * @param addr End point.

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.h
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.h
@@ -135,13 +135,6 @@ namespace ignite
              */
             bool ShouldInitiateNewConnection() const;
 
-            /**
-             * Throw window specific error with error code.
-             *
-             * @param msg Error message.
-             */
-            void ThrowSystemError(const std::string &msg);
-
             /** Client pool. */
             LinuxAsyncClientPool& clientPool;
 

--- a/modules/platforms/cpp/network/os/linux/src/network/sockets.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/sockets.cpp
@@ -60,10 +60,11 @@ namespace ignite
                 if (error == 0)
                     return res.str();
 
-                char buffer[1024] = "";
+                char errBuf[1024] = { 0 };
 
-                if (!strerror_r(error, buffer, sizeof(buffer)))
-                    res << ", msg=" << buffer;
+                const char* errStr = strerror_r(error, errBuf, sizeof(errBuf));
+                if (errStr)
+                    res << ", msg=" << errStr;
 
                 return res.str();
             }

--- a/modules/platforms/cpp/network/os/win/src/network/utils.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/utils.cpp
@@ -25,6 +25,7 @@
 #include <ws2ipdef.h>
 #include <ws2tcpip.h>
 #include <windows.h>
+#include <winbase.h>
 #include <iphlpapi.h>
 
 #include <ignite/ignite_error.h>

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client.cpp
@@ -19,8 +19,6 @@
 
 #include <ignite/network/utils.h>
 
-#include <ignite/impl/binary/binary_utils.h>
-
 #include "network/sockets.h"
 #include "network/win_async_client.h"
 
@@ -28,7 +26,7 @@ namespace ignite
 {
     namespace network
     {
-        WinAsyncClient::WinAsyncClient(SOCKET socket, const EndPoint &addr, const TcpRange& range, int32_t bufLen) :
+        WinAsyncClient::WinAsyncClient(SOCKET socket, const EndPoint& addr, const TcpRange& range, int32_t bufLen) :
             bufLen(bufLen),
             state(State::CONNECTED),
             socket(socket),

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.cpp
@@ -56,7 +56,7 @@ namespace ignite
 
             iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
             if (iocp == NULL)
-                ThrowSystemError("Failed to create IOCP instance");
+                common::ThrowLastSystemError("Failed to create IOCP instance");
 
             try
             {
@@ -118,7 +118,7 @@ namespace ignite
 
                 HANDLE iocp0 = clientRef.AddToIocp(iocp);
                 if (iocp0 == NULL)
-                    ThrowSystemError("Can not add socket to IOCP");
+                    common::ThrowLastSystemError("Can not add socket to IOCP");
 
                 iocp = iocp0;
 
@@ -211,17 +211,8 @@ namespace ignite
         void WinAsyncClientPool::Close(uint64_t id, const IgniteError* err)
         {
             SP_WinAsyncClient client = FindClient(id);
-            if (client.IsValid() && client.Get()->IsClosed())
+            if (client.IsValid() && !client.Get()->IsClosed())
                 client.Get()->Shutdown(err);
-        }
-
-        void WinAsyncClientPool::ThrowSystemError(const std::string& msg)
-        {
-            std::stringstream buf;
-
-            buf << "Windows system error: " << msg << ", system error code: " << GetLastError();
-
-            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, buf.str().c_str());
         }
 
         SP_WinAsyncClient WinAsyncClientPool::FindClient(uint64_t id) const

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.h
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.h
@@ -178,13 +178,6 @@ namespace ignite
              */
             SP_WinAsyncClient FindClientLocked(uint64_t id) const;
 
-            /**
-             * Throw window specific error with error code.
-             *
-             * @param msg Error message.
-             */
-            static void ThrowSystemError(const std::string& msg);
-
             /** Flag indicating that pool is stopping. */
             volatile bool stopping;
 

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_worker_thread.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_worker_thread.cpp
@@ -114,7 +114,10 @@ namespace ignite
                             if (!data.IsEmpty())
                                 clientPool->HandleMessageReceived(client->GetId(), data);
 
-                            client->Receive();
+                            bool success = client->Receive();
+
+                            if (!success)
+                                clientPool->CloseAndRelease(client->GetId(), 0);
 
                             break;
                         }

--- a/modules/platforms/cpp/network/src/network/network.cpp
+++ b/modules/platforms/cpp/network/src/network/network.cpp
@@ -17,7 +17,7 @@
 
 #include "network/sockets.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #   include "network/win_async_client_pool.h"
 #else // Other. Assume Linux
 #   include "network/linux_async_client_pool.h"
@@ -41,12 +41,11 @@ namespace ignite
                 SslGateway::GetInstance().LoadAll();
             }
 
-            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const std::string& certPath,
-                const std::string& keyPath, const std::string& caPath)
+            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const SecureConfiguration& cfg)
             {
                 EnsureSslLoaded();
 
-                return new SecureSocketClient(certPath, keyPath, caPath);
+                return new SecureSocketClient(cfg);
             }
         }
 
@@ -58,7 +57,7 @@ namespace ignite
         IGNITE_IMPORT_EXPORT SP_AsyncClientPool MakeAsyncClientPool(const std::vector<SP_DataFilter>& filters)
         {
             SP_AsyncClientPool platformPool = SP_AsyncClientPool(
-#ifdef WIN32
+#ifdef _WIN32
                 new WinAsyncClientPool()
 #else // Other. Assume Linux
                 new LinuxAsyncClientPool()

--- a/modules/platforms/cpp/network/src/network/ssl/secure_socket_client.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_socket_client.cpp
@@ -21,25 +21,13 @@
 #include <cassert>
 
 #include <ignite/common/utils.h>
-#include <ignite/common/concurrent.h>
-#include <ignite/ignite_error.h>
 #include <ignite/network/utils.h>
 
 #include "network/ssl/secure_socket_client.h"
+#include "network/ssl/secure_utils.h"
 #include "network/ssl/ssl_gateway.h"
 
-enum { OPERATION_SUCCESS = 1 };
-
-void FreeContext(SSL_CTX* ctx)
-{
-    using namespace ignite::network::ssl;
-
-    SslGateway &sslGateway = SslGateway::GetInstance();
-
-    assert(sslGateway.Loaded());
-
-    sslGateway.SSL_CTX_free_(ctx);
-}
+using namespace ignite::network::ssl;
 
 void FreeBio(BIO* bio)
 {
@@ -58,11 +46,8 @@ namespace ignite
     {
         namespace ssl
         {
-            SecureSocketClient::SecureSocketClient(const std::string& certPath, const std::string& keyPath,
-                const std::string& caPath):
-                certPath(certPath),
-                keyPath(keyPath),
-                caPath(caPath),
+            SecureSocketClient::SecureSocketClient(const SecureConfiguration& cfg):
+                cfg(cfg),
                 context(0),
                 ssl(0),
                 blocking(true)
@@ -75,7 +60,7 @@ namespace ignite
                 CloseInternal();
 
                 if (context)
-                    SslGateway::GetInstance().SSL_CTX_free_(reinterpret_cast<SSL_CTX*>(context));
+                    FreeContext(reinterpret_cast<SSL_CTX*>(context));
             }
 
             bool SecureSocketClient::Connect(const char* hostname, uint16_t port, int32_t timeout)
@@ -88,10 +73,10 @@ namespace ignite
 
                 if (!context)
                 {
-                    context = MakeContext(certPath, keyPath, caPath);
+                    context = MakeContext(cfg);
 
                     if (!context)
-                        ThrowSecureError("Can not create SSL context. Aborting connect");
+                        ThrowLastSecureError("Can not create SSL context", "Aborting connect");
                 }
 
                 ssl = MakeSsl(context, hostname, port, blocking);
@@ -104,8 +89,8 @@ namespace ignite
 
                 int res = sslGateway.SSL_set_tlsext_host_name_(ssl0, hostname);
 
-                if (res != OPERATION_SUCCESS)
-                    ThrowSecureError("Can not set host name for secure connection: " + GetSslError(ssl0, res));
+                if (res != SSL_OPERATION_SUCCESS)
+                    ThrowLastSecureError("Can not set host name for secure connection");
 
                 sslGateway.SSL_set_connect_state_(ssl0);
 
@@ -119,13 +104,21 @@ namespace ignite
                 if (cert)
                     sslGateway.X509_free_(cert);
                 else
-                    ThrowSecureError("Remote host did not provide certificate: " + GetSslError(ssl0, res));
+                    ThrowLastSecureError("Remote host did not provide certificate");
 
                 // Verify the result of chain verification.
                 // Verification performed according to RFC 4158.
                 res = sslGateway.SSL_get_verify_result_(ssl0);
                 if (X509_V_OK != res)
-                    ThrowSecureError("Certificate chain verification failed: " + GetSslError(ssl0, res));
+                    ThrowLastSecureError("Certificate chain verification failed");
+
+                res = WaitOnSocket(ssl, timeout, false);
+
+                if (res == WaitResult::TIMEOUT)
+                    return false;
+
+                if (res != WaitResult::SUCCESS)
+                    ThrowLastSecureError("Error while establishing secure connection");
 
                 guard.Release();
 
@@ -198,53 +191,6 @@ namespace ignite
                 return blocking;
             }
 
-            void* SecureSocketClient::MakeContext(const std::string& certPath, const std::string& keyPath,
-                const std::string& caPath)
-            {
-                SslGateway &sslGateway = SslGateway::GetInstance();
-
-                assert(sslGateway.Loaded());
-
-                const SSL_METHOD* method = sslGateway.SSLv23_client_method_();
-                if (!method)
-                    ThrowSecureError("Can not get SSL method");
-
-                SSL_CTX* ctx = sslGateway.SSL_CTX_new_(method);
-                if (!ctx)
-                    ThrowSecureError("Can not create new SSL context");
-
-                common::DeinitGuard<SSL_CTX> guard(ctx, &FreeContext);
-
-                sslGateway.SSL_CTX_set_verify_(ctx, SSL_VERIFY_PEER, 0);
-
-                sslGateway.SSL_CTX_set_verify_depth_(ctx, 8);
-
-                sslGateway.SSL_CTX_set_options_(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
-
-                const char* cCaPath = caPath.empty() ? 0 : caPath.c_str();
-
-                long res = sslGateway.SSL_CTX_load_verify_locations_(ctx, cCaPath, 0);
-                if (res != OPERATION_SUCCESS)
-                    ThrowSecureError("Can not set Certificate Authority path for secure connection");
-
-                res = sslGateway.SSL_CTX_use_certificate_chain_file_(ctx, certPath.c_str());
-                if (res != OPERATION_SUCCESS)
-                    ThrowSecureError("Can not set client certificate file for secure connection");
-
-                res = sslGateway.SSL_CTX_use_RSAPrivateKey_file_(ctx, keyPath.c_str(), SSL_FILETYPE_PEM);
-                if (res != OPERATION_SUCCESS)
-                    ThrowSecureError("Can not set private key file for secure connection");
-
-                const char* const PREFERRED_CIPHERS = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4";
-                res = sslGateway.SSL_CTX_set_cipher_list_(ctx, PREFERRED_CIPHERS);
-                if (res != OPERATION_SUCCESS)
-                    ThrowSecureError("Can not set ciphers list for secure connection");
-
-                guard.Release();
-
-                return ctx;
-            }
-
             void* SecureSocketClient::MakeSsl(void* context, const char* hostname, uint16_t port, bool& blocking)
             {
                 SslGateway &sslGateway = SslGateway::GetInstance();
@@ -253,11 +199,11 @@ namespace ignite
 
                 BIO* bio = sslGateway.BIO_new_ssl_connect_(reinterpret_cast<SSL_CTX*>(context));
                 if (!bio)
-                    ThrowSecureError("Can not create SSL connection");
+                    ThrowLastSecureError("Can not create SSL connection");
 
                 common::DeinitGuard<BIO> guard(bio, &FreeBio);
 
-                blocking = sslGateway.BIO_set_nbio_(bio, 1) != OPERATION_SUCCESS;
+                blocking = sslGateway.BIO_set_nbio_(bio, 1) != SSL_OPERATION_SUCCESS;
 
                 std::stringstream stream;
                 stream << hostname << ":" << port;
@@ -265,13 +211,13 @@ namespace ignite
                 std::string address = stream.str();
 
                 long res = sslGateway.BIO_set_conn_hostname_(bio, address.c_str());
-                if (res != OPERATION_SUCCESS)
-                    ThrowSecureError("Can not set SSL connection hostname");
+                if (res != SSL_OPERATION_SUCCESS)
+                    ThrowLastSecureError("Can not set SSL connection hostname");
 
                 SSL* ssl = 0;
                 sslGateway.BIO_get_ssl_(bio, &ssl);
                 if (!ssl)
-                    ThrowSecureError("Can not get SSL instance from BIO");
+                    ThrowLastSecureError("Can not get SSL instance from BIO");
 
                 guard.Release();
 
@@ -290,13 +236,13 @@ namespace ignite
                 {
                     int res = sslGateway.SSL_connect_(ssl0);
 
-                    if (res == OPERATION_SUCCESS)
+                    if (res == SSL_OPERATION_SUCCESS)
                         return true;
 
                     int sslError = sslGateway.SSL_get_error_(ssl0, res);
 
                     if (IsActualError(sslError))
-                        ThrowSecureError("Can not establish secure connection: " + GetSslError(ssl0, res));
+                        ThrowLastSecureError("Can not establish secure connection");
 
                     int want = sslGateway.SSL_want_(ssl0);
 
@@ -306,58 +252,7 @@ namespace ignite
                         return false;
 
                     if (res != WaitResult::SUCCESS)
-                        ThrowSecureError("Error while establishing secure connection: " + GetSslError(ssl0, res));
-                }
-            }
-
-            std::string SecureSocketClient::GetSslError(void* ssl, int ret)
-            {
-                SslGateway &sslGateway = SslGateway::GetInstance();
-
-                assert(sslGateway.Loaded());
-
-                SSL* ssl0 = reinterpret_cast<SSL*>(ssl);
-
-                int sslError = sslGateway.SSL_get_error_(ssl0, ret);
-
-                switch (sslError)
-                {
-                    case SSL_ERROR_NONE:
-                        break;
-
-                    case SSL_ERROR_WANT_WRITE:
-                        return std::string("SSL_connect wants write");
-
-                    case SSL_ERROR_WANT_READ:
-                        return std::string("SSL_connect wants read");
-
-                    default:
-                        return std::string("SSL error: ") + common::LexicalCast<std::string>(sslError);
-                }
-
-                long error = sslGateway.ERR_get_error_();
-
-                char errBuf[1024] = { 0 };
-
-                sslGateway.ERR_error_string_n_(error, errBuf, sizeof(errBuf));
-
-                return std::string(errBuf);
-            }
-
-            bool SecureSocketClient::IsActualError(int err)
-            {
-                switch (err)
-                {
-                    case SSL_ERROR_NONE:
-                    case SSL_ERROR_WANT_WRITE:
-                    case SSL_ERROR_WANT_READ:
-                    case SSL_ERROR_WANT_CONNECT:
-                    case SSL_ERROR_WANT_ACCEPT:
-                    case SSL_ERROR_WANT_X509_LOOKUP:
-                        return false;
-
-                    default:
-                        return true;
+                        ThrowLastSecureError("Error while establishing secure connection");
                 }
             }
 
@@ -373,27 +268,21 @@ namespace ignite
                 }
             }
 
-            void SecureSocketClient::ThrowSecureError(const std::string& err)
-            {
-                throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, err.c_str());
-            }
-
             int SecureSocketClient::WaitOnSocket(void* ssl, int32_t timeout, bool rd)
             {
                 SslGateway &sslGateway = SslGateway::GetInstance();
 
                 assert(sslGateway.Loaded());
-                
+
                 SSL* ssl0 = reinterpret_cast<SSL*>(ssl);
                 int fd = sslGateway.SSL_get_fd_(ssl0);
 
                 if (fd < 0)
                 {
                     std::stringstream ss;
+                    ss << "Can not get file descriptor from the SSL socket, fd=" << fd;
 
-                    ss << "Can not get file descriptor from the SSL socket: " << fd << ", " << GetSslError(ssl, fd);
-
-                    utils::ThrowNetworkError(ss.str());
+                    ThrowLastSecureError(ss.str());
                 }
 
                 return sockets::WaitOnSocket(fd, timeout, rd);

--- a/modules/platforms/cpp/network/src/network/ssl/secure_socket_client.h
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_socket_client.h
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <ignite/network/socket_client.h>
+#include <ignite/network/ssl/secure_configuration.h>
 
 namespace ignite
 {
@@ -38,11 +39,9 @@ namespace ignite
                 /**
                  * Constructor.
                  *
-                 * @param certPath Certificate file path.
-                 * @param keyPath Private key file path.
-                 * @param caPath Certificate authority file path.
+                 * @param cfg Secure configuration.
                  */
-                SecureSocketClient(const std::string& certPath, const std::string& keyPath, const std::string& caPath);
+                SecureSocketClient(const SecureConfiguration& cfg);
 
                 /**
                  * Destructor.
@@ -99,13 +98,6 @@ namespace ignite
                 void CloseInternal();
 
                 /**
-                 * Throw SSL-related error.
-                 *
-                 * @param err Error message.
-                 */
-                static void ThrowSecureError(const std::string& err);
-
-                /**
                  * Wait on the socket for any event for specified time.
                  * This function uses poll to achive timeout functionality
                  * for every separate socket operation.
@@ -119,15 +111,14 @@ namespace ignite
                 static int WaitOnSocket(void* ssl, int32_t timeout, bool rd);
 
                 /**
-                 * Make new context instance.
+                 * Wait on the socket if it's required by SSL.
                  *
-                 * @param certPath Certificate file path.
-                 * @param keyPath Private key file path.
-                 * @param caPath Certificate authority file path.
-                 * @return New context instance on success and null-pointer on fail.
+                 * @param res Operation result.
+                 * @param ssl SSl instance.
+                 * @param timeout Timeout in seconds.
+                 * @return
                  */
-                static void* MakeContext(const std::string& certPath, const std::string& keyPath,
-                    const std::string& caPath);
+                static int WaitOnSocketIfNeeded(int res, void* ssl, int timeout);
 
                 /**
                  * Make new SSL instance.
@@ -149,31 +140,8 @@ namespace ignite
                  */
                 static bool CompleteConnectInternal(void* ssl, int timeout);
 
-                /**
-                 * Get SSL error.
-                 *
-                 * @param ssl SSL instance.
-                 * @param ret Return value of the pervious operation.
-                 * @return Error string.
-                 */
-                static std::string GetSslError(void* ssl, int ret);
-
-                /**
-                 * Check if a actual error occured.
-                 *
-                 * @param err SSL error code.
-                 * @return @true if a actual error occured
-                 */
-                static bool IsActualError(int err);
-
-                /** Certificate file path. */
-                std::string certPath;
-
-                /** Private key file path. */
-                std::string keyPath;
-
-                /** Certificate authority file path. */
-                std::string caPath;
+                /** Secure configuration. */
+                SecureConfiguration cfg;
 
                 /** SSL context. */
                 void* context;

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef _WIN32
+#include "network/sockets.h"
+#include <wincrypt.h>
+#endif
+
+#include <ignite/ignite_error.h>
+
+#include <ignite/common/utils.h>
+#include <ignite/network/network.h>
+
+#include "network/ssl/secure_utils.h"
+
+namespace
+{
+    void LoadDefaultCa(SSL_CTX* sslContext)
+    {
+        using namespace ignite::common;
+        using namespace ignite::network::ssl;
+
+        assert(sslContext != 0);
+        SslGateway &sslGateway = SslGateway::GetInstance();
+
+#ifndef _WIN32
+        long res = sslGateway.SSL_CTX_set_default_verify_paths_(sslContext);
+        if (res != SSL_OPERATION_SUCCESS)
+            ThrowLastSecureError("Can not set default Certificate Authority for secure connection",
+                 "Try setting custom CA");
+#else
+        X509_STORE *sslStore = sslGateway.X509_STORE_new_();
+        if (!sslStore)
+            ThrowLastSecureError("Can not create X509_STORE certificate store", "Try setting custom CA");
+
+        HCERTSTORE sysStore = CertOpenSystemStoreA(NULL, "ROOT");
+        if (!sysStore)
+            ThrowSecureError(GetLastSystemError("Can not open System Certificate store for secure connection",
+                "Try setting custom CA"));
+
+        PCCERT_CONTEXT certIter = CertEnumCertificatesInStore(sysStore, NULL);
+        while (certIter)
+        {
+            const unsigned char *currentCert = certIter->pbCertEncoded;
+            X509* x509 = sslGateway.d2i_X509_(NULL, &currentCert, static_cast<long>(certIter->cbCertEncoded));
+            if (x509)
+            {
+                sslGateway.X509_STORE_add_cert_(sslStore, x509);
+
+                sslGateway.X509_free_(x509);
+            }
+            certIter = CertEnumCertificatesInStore(sysStore, certIter);
+        }
+
+        CertCloseStore(sysStore, 0);
+
+        sslGateway.SSL_CTX_set_cert_store_(sslContext, sslStore);
+#endif
+    }
+}
+
+namespace ignite
+{
+    namespace network
+    {
+        namespace ssl
+        {
+            SSL_CTX* MakeContext(const SecureConfiguration& cfg)
+            {
+                EnsureSslLoaded();
+
+                SslGateway &sslGateway = SslGateway::GetInstance();
+
+                const SSL_METHOD* method = sslGateway.SSLv23_client_method_();
+                if (!method)
+                    ThrowLastSecureError("Can not get SSL method");
+
+                SSL_CTX* sslContext = sslGateway.SSL_CTX_new_(method);
+                if (!sslContext)
+                    ThrowLastSecureError("Can not create new SSL context");
+
+                common::DeinitGuard<SSL_CTX> guard(sslContext, &FreeContext);
+
+                sslGateway.SSL_CTX_set_verify_(sslContext, SSL_VERIFY_PEER, 0);
+
+                sslGateway.SSL_CTX_set_verify_depth_(sslContext, 8);
+
+                sslGateway.SSL_CTX_set_options_(sslContext, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
+
+                if (!cfg.caPath.empty())
+                {
+                    long res = sslGateway.SSL_CTX_load_verify_locations_(sslContext, cfg.caPath.c_str(), 0);
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowLastSecureError("Can not set Certificate Authority path for secure connection, path=" +
+                            cfg.caPath);
+                }
+                else
+                    LoadDefaultCa(sslContext);
+
+                if (!cfg.certPath.empty())
+                {
+                    long res = sslGateway.SSL_CTX_use_certificate_chain_file_(sslContext, cfg.certPath.c_str());
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowLastSecureError("Can not set client certificate file for secure connection, path=" +
+                            cfg.certPath);
+                }
+
+                if (!cfg.keyPath.empty())
+                {
+                    long res = sslGateway.SSL_CTX_use_RSAPrivateKey_file_(sslContext, cfg.keyPath.c_str(), SSL_FILETYPE_PEM);
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowLastSecureError("Can not set private key file for secure connection, path=" + cfg.keyPath);
+                }
+
+                const char* const PREFERRED_CIPHERS = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4";
+                long res = sslGateway.SSL_CTX_set_cipher_list_(sslContext, PREFERRED_CIPHERS);
+                if (res != SSL_OPERATION_SUCCESS)
+                    ThrowLastSecureError("Can not set ciphers list for secure connection");
+
+                guard.Release();
+                return sslContext;
+            }
+
+            void FreeContext(SSL_CTX* ctx)
+            {
+                using namespace ignite::network::ssl;
+
+                SslGateway &sslGateway = SslGateway::GetInstance();
+
+                assert(sslGateway.Loaded());
+
+                sslGateway.SSL_CTX_free_(ctx);
+            }
+
+            bool IsActualError(int err)
+            {
+                switch (err)
+                {
+                    case SSL_ERROR_NONE:
+                    case SSL_ERROR_WANT_READ:
+                    case SSL_ERROR_WANT_WRITE:
+                    case SSL_ERROR_WANT_X509_LOOKUP:
+                    case SSL_ERROR_WANT_CONNECT:
+                    case SSL_ERROR_WANT_ACCEPT:
+                        return false;
+
+                    default:
+                        return true;
+                }
+            }
+
+            void ThrowSecureError(const std::string& err)
+            {
+                throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, err.c_str());
+            }
+
+            std::string GetLastSecureError()
+            {
+                using namespace ignite::network::ssl;
+
+                SslGateway &sslGateway = SslGateway::GetInstance();
+
+                assert(sslGateway.Loaded());
+
+                unsigned long errorCode = sslGateway.ERR_get_error_();
+
+                std::string errorDetails;
+                if (errorCode != 0)
+                {
+                    char errBuf[1024] = { 0 };
+
+                    sslGateway.ERR_error_string_n_(errorCode, errBuf, sizeof(errBuf));
+
+                    errorDetails.assign(errBuf);
+                }
+
+                return errorDetails;
+            }
+
+            void ThrowLastSecureError(const std::string& description, const std::string& advice)
+            {
+                ThrowSecureError(common::FormatErrorMessage(description, GetLastSecureError(), advice));
+            }
+
+            void ThrowLastSecureError(const std::string& description)
+            {
+                std::string empty;
+                ThrowLastSecureError(description, empty);
+            }
+        }
+    }
+}

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_NETWORK_SSL_SECURE_UTILS
+#define _IGNITE_NETWORK_SSL_SECURE_UTILS
+
+#include <ignite/network/ssl/secure_configuration.h>
+#include "network/ssl/ssl_gateway.h"
+
+namespace ignite
+{
+    namespace network
+    {
+        namespace ssl
+        {
+            enum
+            {
+                /** OpenSSL functions return this code on success. */
+                SSL_OPERATION_SUCCESS = 1,
+            };
+
+            /**
+             * Make SSL context using configuration.
+             *
+             * @param cfg Configuration to use.
+             * @return New context instance on success.
+             * @throw IgniteError on error.
+             */
+            SSL_CTX* MakeContext(const SecureConfiguration& cfg);
+
+            /**
+             * Free context.
+             *
+             * @param ctx Context to free.
+             */
+            void FreeContext(SSL_CTX* ctx);
+
+            /**
+             * Check whether error is actual error or code returned when used in async environment.
+             *
+             * @param err Error obtained with SSL_get_error.
+             * @return @c true if the code returned on actual error.
+             */
+            bool IsActualError(int err);
+
+            /**
+             * Throw SSL-related error.
+             *
+             * @param err Error message.
+             */
+            void ThrowSecureError(const std::string& err);
+
+            /**
+             * Get SSL-related error in text format.
+             *
+             * @param err Error message in human-readable format.
+             */
+            std::string GetLastSecureError();
+
+            /**
+             * Try extract from OpenSSL error stack and throw SSL-related error.
+             *
+             * @param description Error description.
+             * @param advice User advice.
+             */
+            void ThrowLastSecureError(const std::string& description, const std::string& advice);
+
+            /**
+             * Try extract from OpenSSL error stack and throw SSL-related error.
+             *
+             * @param description Error description.
+             */
+            void ThrowLastSecureError(const std::string& description);
+        }
+    }
+}
+
+#endif //_IGNITE_NETWORK_SSL_SECURE_UTILS

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
@@ -195,6 +195,8 @@ namespace ignite
                 functions.fpSSL_CTX_free = LoadSslMethod("SSL_CTX_free");
                 functions.fpSSL_CTX_set_verify = LoadSslMethod("SSL_CTX_set_verify");
                 functions.fpSSL_CTX_set_verify_depth = LoadSslMethod("SSL_CTX_set_verify_depth");
+                functions.fpSSL_CTX_set_cert_store = LoadSslMethod("SSL_CTX_set_cert_store");
+                functions.fpSSL_CTX_set_default_verify_paths = LoadSslMethod("SSL_CTX_set_default_verify_paths");
                 functions.fpSSL_CTX_load_verify_locations = LoadSslMethod("SSL_CTX_load_verify_locations");
                 functions.fpSSL_CTX_use_certificate_chain_file = LoadSslMethod("SSL_CTX_use_certificate_chain_file");
                 functions.fpSSL_CTX_use_RSAPrivateKey_file = LoadSslMethod("SSL_CTX_use_RSAPrivateKey_file");
@@ -218,9 +220,7 @@ namespace ignite
                 functions.fpSSL_write = LoadSslMethod("SSL_write");
                 functions.fpSSL_read = LoadSslMethod("SSL_read");
                 functions.fpSSL_pending = LoadSslMethod("SSL_pending");
-                functions.fpSSL_get_state = TryLoadSslMethod("SSL_get_state");
-                if (!functions.fpSSL_get_state)
-                    functions.fpSSL_get_state = LoadSslMethod("SSL_state");
+                functions.fpSSL_get_version = LoadSslMethod("SSL_get_version");
 
                 functions.fpSSL_get_fd = LoadSslMethod("SSL_get_fd");
                 functions.fpSSL_new = LoadSslMethod("SSL_new");
@@ -233,6 +233,9 @@ namespace ignite
 
 
                 functions.fpOPENSSL_config = LoadSslMethod("OPENSSL_config");
+                functions.fpX509_STORE_new = LoadSslMethod("X509_STORE_new");
+                functions.fpX509_STORE_add_cert = LoadSslMethod("X509_STORE_add_cert");
+                functions.fpd2i_X509 = LoadSslMethod("d2i_X509");
                 functions.fpX509_free = LoadSslMethod("X509_free");
 
                 functions.fpBIO_free_all = LoadSslMethod("BIO_free_all");
@@ -268,7 +271,6 @@ namespace ignite
                 LoadMandatoryMethods();
 
                 functions.fpSSL_CTX_set_options = TryLoadSslMethod("SSL_CTX_set_options");
-                functions.fpERR_print_errors_fp = TryLoadSslMethod("ERR_print_errors_fp");
 
                 IGNITE_UNUSED(SSL_library_init_());
 
@@ -409,6 +411,28 @@ namespace ignite
                 FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_CTX_set_verify_depth);
 
                 fp(ctx, depth);
+            }
+
+            void SslGateway::SSL_CTX_set_cert_store_(SSL_CTX* ctx, X509_STORE* store)
+            {
+                assert(functions.fpSSL_CTX_set_cert_store != 0);
+
+                typedef int (FuncType)(SSL_CTX*, X509_STORE*);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_CTX_set_cert_store);
+
+                fp(ctx, store);
+            }
+
+            int SslGateway::SSL_CTX_set_default_verify_paths_(SSL_CTX* ctx)
+            {
+                assert(functions.fpSSL_CTX_set_default_verify_paths != 0);
+
+                typedef int (FuncType)(SSL_CTX*);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_CTX_set_default_verify_paths);
+
+                return fp(ctx);
             }
 
             int SslGateway::SSL_CTX_load_verify_locations_(SSL_CTX* ctx, const char* cAfile, const char* cApath)
@@ -612,26 +636,6 @@ namespace ignite
                 return fp(ssl);
             }
 
-            int SslGateway::SSL_is_init_finished_(const SSL* ssl)
-            {
-                assert(functions.fpSSL_get_state != 0);
-
-                typedef int (FuncType)(const SSL*);
-
-                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_get_state);
-
-                enum {
-                    IGNITE_SSL_STATE_OK =
-#ifdef SSL_ST_OK
-                    SSL_ST_OK
-#else
-                    TLS_ST_OK
-#endif
-                };
-
-                return fp(ssl) == IGNITE_SSL_STATE_OK ? 1 : 0;
-            }
-
             int SslGateway::SSL_get_fd_(const SSL* ssl)
             {
                 assert(functions.fpSSL_get_fd != 0);
@@ -701,15 +705,48 @@ namespace ignite
                 fp(configName);
             }
 
-            void SslGateway::X509_free_(X509* a)
+            X509_STORE* SslGateway::X509_STORE_new_()
+            {
+                assert(functions.fpX509_STORE_new != 0);
+
+                typedef X509_STORE*(FuncType)();
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpX509_STORE_new);
+
+                return fp();
+            }
+
+            int SslGateway::X509_STORE_add_cert_(X509_STORE* ctx, X509* cert)
+            {
+                assert(functions.fpX509_STORE_add_cert != 0);
+
+                typedef int(FuncType)(X509_STORE*, X509*);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpX509_STORE_add_cert);
+
+                return fp(ctx, cert);
+            }
+
+            X509* SslGateway::d2i_X509_(X509** cert, const unsigned char** ppin, long length)
+            {
+                assert(functions.fpd2i_X509 != 0);
+
+                typedef X509*(FuncType)(X509**, const unsigned char**, long);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpd2i_X509);
+
+                return fp(cert, ppin, length);
+            }
+
+            void SslGateway::X509_free_(X509* cert)
             {
                 assert(functions.fpX509_free != 0);
 
-                typedef void (FuncType)(X509*);
+                typedef void(FuncType)(X509*);
 
                 FuncType* fp = reinterpret_cast<FuncType*>(functions.fpX509_free);
 
-                fp(a);
+                fp(cert);
             }
 
             BIO* SslGateway::BIO_new_(const BIO_METHOD* method)
@@ -794,11 +831,6 @@ namespace ignite
                 return fp(bp, cmd, larg, parg);
             }
 
-            long SslGateway::BIO_get_fd_(BIO* bp, int* fd)
-            {
-                return BIO_ctrl_(bp, BIO_C_GET_FD, 0, reinterpret_cast<void*>(fd));
-            }
-
             long SslGateway::BIO_get_ssl_(BIO* bp, SSL** ssl)
             {
                 return BIO_ctrl_(bp, BIO_C_GET_SSL, 0, reinterpret_cast<void*>(ssl));
@@ -834,18 +866,6 @@ namespace ignite
                 FuncType* fp = reinterpret_cast<FuncType*>(functions.fpERR_error_string_n);
 
                 fp(e, buf, len);
-            }
-
-            void SslGateway::ERR_print_errors_fp_(FILE* fd)
-            {
-                if (!functions.fpERR_print_errors_fp)
-                    return;
-
-                typedef void (FuncType)(FILE*);
-
-                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpERR_print_errors_fp);
-
-                fp(fd);
             }
         }
     }

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
@@ -636,6 +636,17 @@ namespace ignite
                 return fp(ssl);
             }
 
+            const char* SslGateway::SSL_get_version_(const SSL* ssl)
+            {
+                assert(functions.fpSSL_get_version != 0);
+
+                typedef const char*(FuncType)(const SSL*);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_get_version);
+
+                return fp(ssl);
+            }
+
             int SslGateway::SSL_get_fd_(const SSL* ssl)
             {
                 assert(functions.fpSSL_get_fd != 0);

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
@@ -43,6 +43,8 @@ namespace ignite
                 void *fpSSL_CTX_free;
                 void *fpSSL_CTX_set_verify;
                 void *fpSSL_CTX_set_verify_depth;
+                void *fpSSL_CTX_set_cert_store;
+                void *fpSSL_CTX_set_default_verify_paths;
                 void *fpSSL_CTX_load_verify_locations;
                 void *fpSSL_CTX_use_certificate_chain_file;
                 void *fpSSL_CTX_use_RSAPrivateKey_file;
@@ -62,11 +64,14 @@ namespace ignite
                 void *fpSSL_write;
                 void *fpSSL_read;
                 void *fpSSL_pending;
-                void *fpSSL_get_state;
+                void *fpSSL_get_version;
                 void *fpSSL_get_fd;
                 void *fpSSL_new;
                 void *fpSSL_free;
                 void *fpOPENSSL_config;
+                void *fpX509_STORE_new;
+                void *fpX509_STORE_add_cert;
+                void *fpd2i_X509;
                 void *fpX509_free;
                 void *fpBIO_new;
                 void *fpBIO_new_ssl_connect;
@@ -77,7 +82,6 @@ namespace ignite
                 void *fpBIO_ctrl;
                 void *fpERR_get_error;
                 void *fpERR_error_string_n;
-                void *fpERR_print_errors_fp;
 
                 void *fpOpenSSL_version;
                 void *fpSSL_CTX_set_options;
@@ -105,15 +109,6 @@ namespace ignite
                 void LoadAll();
 
                 /**
-                 * Get functions.
-                 * @return Functions structure.
-                 */
-                SslFunctions& GetFunctions()
-                {
-                    return functions;
-                }
-
-                /**
                  * Check whether the libraries are loaded.
                  * @return @c true if loaded.
                  */
@@ -137,6 +132,10 @@ namespace ignite
                 void SSL_CTX_set_verify_(SSL_CTX* ctx, int mode, int (*callback)(int, X509_STORE_CTX*));
 
                 void SSL_CTX_set_verify_depth_(SSL_CTX* ctx, int depth);
+
+                void SSL_CTX_set_cert_store_(SSL_CTX* ctx, X509_STORE* store);
+
+                int SSL_CTX_set_default_verify_paths_(SSL_CTX* ctx);
 
                 int SSL_CTX_load_verify_locations_(SSL_CTX* ctx, const char* cAfile, const char* cApath);
 
@@ -174,7 +173,7 @@ namespace ignite
 
                 int SSL_pending_(const SSL* ssl);
 
-                int SSL_is_init_finished_(const SSL* ssl);
+                const char* SSL_get_version_(const SSL* ssl);
 
                 int SSL_get_fd_(const SSL* ssl);
 
@@ -188,7 +187,13 @@ namespace ignite
 
                 void OPENSSL_config_(const char* configName);
 
-                void X509_free_(X509* a);
+                X509_STORE* X509_STORE_new_();
+
+                int X509_STORE_add_cert_(X509_STORE* ctx, X509* cert);
+
+                X509* d2i_X509_(X509** cert, const unsigned char** ppin, long length);
+
+                void X509_free_(X509* cert);
 
                 BIO* BIO_new_(const BIO_METHOD* method);
 
@@ -206,8 +211,6 @@ namespace ignite
 
                 long BIO_ctrl_(BIO* bp, int cmd, long larg, void* parg);
 
-                long BIO_get_fd_(BIO* bp, int* fd);
-
                 long BIO_get_ssl_(BIO* bp, SSL** ssl);
 
                 long BIO_set_nbio_(BIO* bp, long n);
@@ -217,8 +220,6 @@ namespace ignite
                 unsigned long ERR_get_error_();
 
                 void ERR_error_string_n_(unsigned long e, char* buf, size_t len);
-
-                void ERR_print_errors_fp_(FILE *fd);
 
             private:
                 /**
@@ -242,7 +243,7 @@ namespace ignite
                  * @param homeDir OpenSSL home directory.
                  * @return Module.
                  */
-                common::dynamic::Module LoadSslLibrary(const std::string& name, const std::string& homeDir);
+                static common::dynamic::Module LoadSslLibrary(const std::string& name, const std::string& homeDir);
 
                 /**
                  * Load all SSL libraries.

--- a/modules/platforms/cpp/odbc-test/CMakeLists.txt
+++ b/modules/platforms/cpp/odbc-test/CMakeLists.txt
@@ -30,7 +30,8 @@ find_package(ODBC REQUIRED)
 include_directories(SYSTEM ${ODBC_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 include_directories(include ../odbc/include ../network/include)
 
-set(SOURCES src/teamcity/teamcity_boost.cpp
+set(SOURCES
+        src/teamcity/teamcity_boost.cpp
         src/teamcity/teamcity_messages.cpp
         src/parser_test.cpp
         src/cursor_test.cpp

--- a/modules/platforms/cpp/odbc/src/connection.cpp
+++ b/modules/platforms/cpp/odbc/src/connection.cpp
@@ -165,8 +165,12 @@ namespace ignite
                 return SqlResult::AI_ERROR;
             }
 
-            socket.reset(network::ssl::MakeSecureSocketClient(
-                config.GetSslCertFile(), config.GetSslKeyFile(), config.GetSslCaFile()));
+            network::ssl::SecureConfiguration sslCfg;
+            sslCfg.certPath = config.GetSslCertFile();
+            sslCfg.keyPath = config.GetSslKeyFile();
+            sslCfg.caPath = config.GetSslCaFile();
+
+            socket.reset(network::ssl::MakeSecureSocketClient(sslCfg));
 
             return SqlResult::AI_SUCCESS;
         }

--- a/modules/platforms/cpp/thin-client-test/CMakeLists.txt
+++ b/modules/platforms/cpp/thin-client-test/CMakeLists.txt
@@ -28,7 +28,8 @@ find_package(Boost 1.53 REQUIRED COMPONENTS unit_test_framework chrono thread sy
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 include_directories(include)
 
-set(SOURCES src/teamcity/teamcity_boost.cpp
+set(SOURCES
+        src/teamcity/teamcity_boost.cpp
         src/teamcity/teamcity_messages.cpp
         src/cache_client_test.cpp
         src/compute_client_test.cpp

--- a/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-32.xml
+++ b/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-32.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="ssl-no-client-auth-default.xml"/>
+
+    <bean parent="no-client-auth.cfg">
+        <property name="memoryConfiguration">
+            <bean class="org.apache.ignite.configuration.MemoryConfiguration">
+                <property name="systemCacheInitialSize" value="#{10 * 1024 * 1024}"/>
+                <property name="systemCacheMaxSize" value="#{40 * 1024 * 1024}"/>
+                <property name="defaultMemoryPolicyName" value="dfltPlc"/>
+
+                <property name="memoryPolicies">
+                    <list>
+                        <bean class="org.apache.ignite.configuration.MemoryPolicyConfiguration">
+                            <property name="name" value="dfltPlc"/>
+                            <property name="maxSize" value="#{100 * 1024 * 1024}"/>
+                            <property name="initialSize" value="#{10 * 1024 * 1024}"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-default.xml
+++ b/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-default.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!--
+        Initialize property configurer so we can reference environment variables.
+    -->
+    <bean id="propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_FALLBACK"/>
+        <property name="searchSystemEnvironment" value="true"/>
+    </bean>
+  
+    <bean abstract="true" id="no-client-auth.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="clientConnectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ClientConnectorConfiguration">
+                <property name="host" value="127.0.0.1"/>
+                <property name="port" value="11110"/>
+                <property name="portRange" value="10"/>
+                <property name="sslEnabled" value="true"/>
+                <property name="useIgniteSslContextFactory" value="false"/>
+                <property name="sslClientAuth" value="false"/>
+
+                <!-- Provide Ssl context. -->
+                <property name="sslContextFactory">
+                    <bean class="org.apache.ignite.ssl.SslContextFactory">
+                        <property name="keyStoreFilePath" value="${IGNITE_NATIVE_TEST_CPP_THIN_CONFIG_PATH}/ssl/server.jks"/>
+                        <property name="keyStorePassword" value="123456"/>
+                        <property name="trustStoreFilePath" value="${IGNITE_NATIVE_TEST_CPP_THIN_CONFIG_PATH}/ssl/trust.jks"/>
+                        <property name="trustStorePassword" value="123456"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <!--
+                        Ignite provides several options for automatic discovery that can be used
+                        instead os static IP based discovery.
+                    -->
+                    <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth.xml
+++ b/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="ssl-no-client-auth-default.xml"/>
+
+    <bean parent="no-client-auth.cfg"/>
+
+</beans>


### PR DESCRIPTION
- Improved error reporting during SSL failures.
- Fixed issue when client compiled and run with different OpenSSL versions.
- Re-factored to remove SSL-related code duplication.
- Added missing tests to some test suites.
- Certificate, private key and CA are not mandatory parameters for client now. Also, implemented extracting and usage of system CA for Windows by default.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
