### PR TITLE
IGNITE-16491 CPP: Added EventType field to CacheEntryEvent

### DIFF
--- a/modules/platforms/cpp/core-test/src/continuous_query_test.cpp
+++ b/modules/platforms/cpp/core-test/src/continuous_query_test.cpp
@@ -133,8 +133,9 @@ public:
      * @param key Key.
      * @param oldVal Old value.
      * @param val Current value.
+     * @param eType Evenet type.
      */
-    void CheckNextEvent(const K& key, boost::optional<V> oldVal, boost::optional<V> val)
+    void CheckNextEvent(const K& key, boost::optional<V> oldVal, boost::optional<V> val, CacheEntryEventType::T eType)
     {
         CacheEntryEvent<K, V> event;
         bool success = eventQueue.Pull(event, boost::chrono::seconds(1));
@@ -144,6 +145,7 @@ public:
         BOOST_CHECK_EQUAL(event.GetKey(), key);
         BOOST_CHECK_EQUAL(event.HasOldValue(), oldVal.is_initialized());
         BOOST_CHECK_EQUAL(event.HasValue(), val.is_initialized());
+        BOOST_CHECK_EQUAL(event.GetEventType(), eType);
 
         if (oldVal && event.HasOldValue())
             BOOST_CHECK_EQUAL(event.GetOldValue().value, oldVal->value);
@@ -334,16 +336,16 @@ struct ContinuousQueryTestSuiteFixture
 void CheckEvents(Cache<int, TestEntry>& cache, Listener<int, TestEntry>& lsnr)
 {
     cache.Put(1, TestEntry(10));
-    lsnr.CheckNextEvent(1, boost::none, TestEntry(10));
+    lsnr.CheckNextEvent(1, boost::none, TestEntry(10), CacheEntryEventType::CREATE);
 
     cache.Put(1, TestEntry(20));
-    lsnr.CheckNextEvent(1, TestEntry(10), TestEntry(20));
+    lsnr.CheckNextEvent(1, TestEntry(10), TestEntry(20), CacheEntryEventType::UPDATE);
 
     cache.Put(2, TestEntry(20));
-    lsnr.CheckNextEvent(2, boost::none, TestEntry(20));
+    lsnr.CheckNextEvent(2, boost::none, TestEntry(20), CacheEntryEventType::CREATE);
 
     cache.Remove(1);
-    lsnr.CheckNextEvent(1, TestEntry(20), TestEntry(20));
+    lsnr.CheckNextEvent(1, TestEntry(20), TestEntry(20), CacheEntryEventType::REMOVE);
 }
 
 IGNITE_EXPORTED_CALL void IgniteModuleInit0(ignite::IgniteBindingContext& context)
@@ -684,14 +686,14 @@ BOOST_AUTO_TEST_CASE(TestFilterSingleNode)
     cache.Put(150, TestEntry(1502));
     cache.Remove(150);
 
-    lsnr.CheckNextEvent(100, boost::none, TestEntry(1000));
-    lsnr.CheckNextEvent(101, boost::none, TestEntry(1010));
+    lsnr.CheckNextEvent(100, boost::none, TestEntry(1000), CacheEntryEventType::CREATE);
+    lsnr.CheckNextEvent(101, boost::none, TestEntry(1010), CacheEntryEventType::CREATE);
 
-    lsnr.CheckNextEvent(142, boost::none, TestEntry(1420));
-    lsnr.CheckNextEvent(142, TestEntry(1420), TestEntry(1421));
-    lsnr.CheckNextEvent(142, TestEntry(1421), TestEntry(1421));
+    lsnr.CheckNextEvent(142, boost::none, TestEntry(1420), CacheEntryEventType::CREATE);
+    lsnr.CheckNextEvent(142, TestEntry(1420), TestEntry(1421), CacheEntryEventType::UPDATE);
+    lsnr.CheckNextEvent(142, TestEntry(1421), TestEntry(1421), CacheEntryEventType::REMOVE);
 
-    lsnr.CheckNextEvent(149, boost::none, TestEntry(1490));
+    lsnr.CheckNextEvent(149, boost::none, TestEntry(1490), CacheEntryEventType::CREATE);
 }
 
 BOOST_AUTO_TEST_CASE(TestFilterMultipleNodes)
@@ -734,14 +736,14 @@ BOOST_AUTO_TEST_CASE(TestFilterMultipleNodes)
     for (int i = 200; i < 250; ++i)
         cache2.Put(i, TestEntry(i * 10));
 
-    lsnr.CheckNextEvent(100, boost::none, TestEntry(1000));
-    lsnr.CheckNextEvent(101, boost::none, TestEntry(1010));
+    lsnr.CheckNextEvent(100, boost::none, TestEntry(1000), CacheEntryEventType::CREATE);
+    lsnr.CheckNextEvent(101, boost::none, TestEntry(1010), CacheEntryEventType::CREATE);
 
-    lsnr.CheckNextEvent(142, boost::none, TestEntry(1420));
-    lsnr.CheckNextEvent(142, TestEntry(1420), TestEntry(1421));
-    lsnr.CheckNextEvent(142, TestEntry(1421), TestEntry(1421));
+    lsnr.CheckNextEvent(142, boost::none, TestEntry(1420), CacheEntryEventType::CREATE);
+    lsnr.CheckNextEvent(142, TestEntry(1420), TestEntry(1421), CacheEntryEventType::UPDATE);
+    lsnr.CheckNextEvent(142, TestEntry(1421), TestEntry(1421), CacheEntryEventType::REMOVE);
 
-    lsnr.CheckNextEvent(149, boost::none, TestEntry(1490));
+    lsnr.CheckNextEvent(149, boost::none, TestEntry(1490), CacheEntryEventType::CREATE);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/thin-client/include/ignite/thin/cache/event/cache_entry_event.h
+++ b/modules/platforms/cpp/thin-client/include/ignite/thin/cache/event/cache_entry_event.h
@@ -68,6 +68,24 @@ namespace ignite
                     /** An event type indicating that the cache entry was removed by expiration policy. */
                     EXPIRED = 3
                 };
+
+                static Type FromInt8(int8_t val)
+                {
+                    switch (val)
+                    {
+                        case CREATED:
+                        case UPDATED:
+                        case REMOVED:
+                        case EXPIRED:
+                            return static_cast<Type>(val);
+
+                        default:
+                        {
+                            IGNITE_ERROR_FORMATTED_1(IgniteError::IGNITE_ERR_BINARY,
+                                 "Unsupported CacheEntryEventType", "val", val);
+                        }
+                    }
+                }
             };
 
             /**
@@ -183,14 +201,8 @@ namespace ignite
                     this->hasOldValue = reader.TryReadObject(this->oldVal);
                     this->hasValue = reader.TryReadObject(this->val);
 
-                    int8_t intType = reader.ReadInt8();
-                    if (intType < 0 || intType > 3)
-                    {
-                        std::string errMsg = "Event type is not supported: " + common::LexicalCast<std::string>(intType);
-                        throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, errMsg.c_str());
-                    }
-
-                    eventType = static_cast<CacheEntryEventType::Type>(intType);
+                    int8_t eventTypeByte = reader.ReadInt8();
+                    this->eventType = CacheEntryEventType::FromInt8(eventTypeByte);
                 }
 
                 /** Old value. */


### PR DESCRIPTION


### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
