### PR TITLE
IGNITE-16525 : Fix encrypted snapshots documentation.

### DIFF
--- a/docs/_docs/security/tde.adoc
+++ b/docs/_docs/security/tde.adoc
@@ -14,8 +14,6 @@
 // limitations under the License.
 = Transparent Data Encryption
 
-WARNING: This feature is in beta and not recommended for use in production environments.
-
 == Overview
 Transparent data encryption (TDE) allows users to encrypt their data at rest.
 
@@ -40,10 +38,6 @@ Transparent Data Encryption has some limitations that you should be aware of bef
 *Encryption*
 
 * No option to encrypt/decrypt existing caches/tables.
-
-*Snapshots and Recovery*
-
-* No support for snapshots. Snapshots are not encrypted and it's not possible to recover from a snapshot that includes an encrypted table or cache.
 
 == Configuration
 To enable encryption in the cluster, provide a master key in the configuration of each server node. A configuration example is shown below.

--- a/docs/_docs/snapshots/snapshots.adoc
+++ b/docs/_docs/snapshots/snapshots.adoc
@@ -253,7 +253,6 @@ The snapshot procedure has some limitations that you should be aware of before u
 
 * Snapshotting of specific caches/tables is unsupported. You always create a full cluster snapshot.
 * Caches/tables that are not persisted in Ignite Persistence are not included into the snapshot.
-* Encrypted caches are not included in the snapshot.
 * You can have only one snapshotting operation running at a time.
 * The snapshot procedure is interrupted if a server node leaves the cluster.
 


### PR DESCRIPTION
"Cluster Snapshots" doc section says: "Encrypted caches are not included in the snapshot.". Is not true any more. Also: "No option to encrypt/decrypt existing caches/tables." in the TDE section. Moreover, TDE is not beta any more.