### PR TITLE
IGNITE-16462 .NET: Thin client: add heartbeats

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -58,7 +58,7 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     /** Invoke service methods with caller context. */
     SERVICE_INVOKE_CALLCTX(10),
 
-    /** Handle OP_HEARTBEAT. */
+    /** Handle OP_HEARTBEAT and OP_GET_IDLE_TIMEOUT. */
     HEARTBEAT(11);
 
     /** */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -56,7 +56,10 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     GET_SERVICE_DESCRIPTORS(9),
 
     /** Invoke service methods with caller context. */
-    SERVICE_INVOKE_CALLCTX(10);
+    SERVICE_INVOKE_CALLCTX(10),
+
+    /** Handle OP_HEARTBEAT. */
+    HEARTBEAT(11);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientGetIdleTimeoutRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientGetIdleTimeoutRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client;
+
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.configuration.ClientConnectorConfiguration;
+
+/**
+ * Get idle timeout request.
+ */
+public class ClientGetIdleTimeoutRequest extends ClientRequest {
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    ClientGetIdleTimeoutRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        return new ClientLongResponse(requestId(), getEffectiveIdleTimeout(ctx));
+    }
+
+    /**
+     * Gets the effective idle timeout.
+     *
+     * @param ctx Context.
+     * @return Idle timeout.
+     */
+    private static long getEffectiveIdleTimeout(ClientConnectionContext ctx) {
+        ClientConnectorConfiguration cfg = ctx.kernalContext().config().getClientConnectorConfiguration();
+
+        return cfg == null ? ClientConnectorConfiguration.DFLT_IDLE_TIMEOUT : cfg.getIdleTimeout();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -94,6 +94,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
     /** */
     private static final short OP_RESOURCE_CLOSE = 0;
 
+    /** */
+    private static final short OP_HEARTBEAT = 1;
+
     /* Cache operations */
     /** */
     private static final short OP_CACHE_GET = 1000;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -364,6 +364,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
             case OP_RESOURCE_CLOSE:
                 return new ClientResourceCloseRequest(reader);
 
+            case OP_HEARTBEAT:
+                return new ClientRequest(reader);
+
             case OP_CACHE_CONTAINS_KEY:
                 return new ClientCacheContainsKeyRequest(reader);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -371,7 +371,7 @@ public class ClientMessageParser implements ClientListenerMessageParser {
                 return new ClientRequest(reader);
 
             case OP_GET_IDLE_TIMEOUT:
-                return new ClientRequest(reader);
+                return new ClientGetIdleTimeoutRequest(reader);
 
             case OP_CACHE_CONTAINS_KEY:
                 return new ClientCacheContainsKeyRequest(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -97,6 +97,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
     /** */
     private static final short OP_HEARTBEAT = 1;
 
+    /** */
+    private static final short OP_GET_IDLE_TIMEOUT = 2;
+
     /* Cache operations */
     /** */
     private static final short OP_CACHE_GET = 1000;
@@ -365,6 +368,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
                 return new ClientResourceCloseRequest(reader);
 
             case OP_HEARTBEAT:
+                return new ClientRequest(reader);
+
+            case OP_GET_IDLE_TIMEOUT:
                 return new ClientRequest(reader);
 
             case OP_CACHE_CONTAINS_KEY:

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -13,7 +13,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Apache.Ignite.Core.Tests</RootNamespace>
     <CodeAnalysisRuleSet>..\Apache.Ignite.Tests.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <LangVersion>8</LangVersion>
+
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <LangVersion>8</LangVersion>
-
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -13,7 +13,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Apache.Ignite.Core.Tests</RootNamespace>
     <CodeAnalysisRuleSet>..\Apache.Ignite.Tests.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -91,6 +91,18 @@ namespace Apache.Ignite.Core.Tests.Client
                                   "HeartbeatInterval: 00:00:00.3000000", GetLogString(client));
         }
 
+        [Test]
+        public void TestCustomHeartbeatIntervalLongerThanRecommendedDoesNotOverrideCalculatedFromIdleTimeout()
+        {
+            using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 3000);
+
+            Assert.AreEqual(TimeSpan.FromMilliseconds(3000), client.GetConfiguration().HeartbeatInterval);
+
+            StringAssert.Contains(
+                "Server-side IdleTimeout is 2000ms, using 1/3 of it as heartbeat interval: 00:00:00.6660000",
+                GetLogString(client));
+        }
+
         protected override IgniteConfiguration GetIgniteConfiguration()
         {
             return new IgniteConfiguration(base.GetIgniteConfiguration())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -73,6 +73,9 @@ namespace Apache.Ignite.Core.Tests.Client
             using var ignite = Ignition.Start(TestUtils.GetTestConfiguration(name: "2"));
             using var client = GetClient(enableHeartbeats: true, port: IgniteClientConfiguration.DefaultPort + 1);
 
+            Assert.AreEqual(IgniteClientConfiguration.DefaultHeartbeatInterval,
+                client.GetConfiguration().HeartbeatInterval);
+
             StringAssert.Contains(
                 "Server-side IdleTimeout is not set, " +
                 "using IgniteClientConfiguration.HeartbeatInterval: 00:00:30", GetLogString(client));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -80,6 +80,17 @@ namespace Apache.Ignite.Core.Tests.Client
                 "using IgniteClientConfiguration.FallbackHeartbeatInterval: 00:00:30", GetLogString(client));
         }
 
+        [Test]
+        public void TestCustomHeartbeatIntervalOverridesCalculatedFromIdleTimeout()
+        {
+            using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 300);
+
+            Assert.AreEqual(TimeSpan.FromMilliseconds(300), client.GetConfiguration().HeartbeatInterval);
+
+            StringAssert.Contains("Server-side IdleTimeout is 2000ms, using configured IgniteClientConfiguration." +
+                                  "HeartbeatInterval: 00:00:00.3000000", GetLogString(client));
+        }
+
         protected override IgniteConfiguration GetIgniteConfiguration()
         {
             return new IgniteConfiguration(base.GetIgniteConfiguration())

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -29,7 +29,7 @@ namespace Apache.Ignite.Core.Tests.Client
     using NUnit.Framework;
 
     /// <summary>
-    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.DefaultHeartbeatInterval"/>).
+    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.HeartbeatInterval"/>).
     /// </summary>
     [Category(TestUtils.CategoryIntensive)]
     public class ClientHeartbeatTest : ClientTestBase
@@ -54,7 +54,7 @@ namespace Apache.Ignite.Core.Tests.Client
         {
             using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 1500);
 
-            Assert.AreEqual(1500, client.GetConfiguration().DefaultHeartbeatInterval.TotalMilliseconds);
+            Assert.AreEqual(1500, client.GetConfiguration().HeartbeatInterval.TotalMilliseconds);
             Assert.IsTrue(client.GetConfiguration().EnableHeartbeats);
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
@@ -75,7 +75,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             StringAssert.Contains(
                 "Server-side IdleTimeout is not set, " +
-                "using IgniteClientConfiguration.DefaultHeartbeatInterval: 00:00:30", GetLogString(client));
+                "using IgniteClientConfiguration.HeartbeatInterval: 00:00:30", GetLogString(client));
         }
 
         protected override IgniteConfiguration GetIgniteConfiguration()
@@ -113,7 +113,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             if (heartbeatInterval != null)
             {
-                cfg.DefaultHeartbeatInterval = TimeSpan.FromMilliseconds(heartbeatInterval.Value);
+                cfg.HeartbeatInterval = TimeSpan.FromMilliseconds(heartbeatInterval.Value);
             }
 
             return Ignition.StartClient(cfg);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -89,6 +89,7 @@ namespace Apache.Ignite.Core.Tests.Client
         {
             return new IgniteClientConfiguration(base.GetClientConfiguration())
             {
+                // Keep default client alive.
                 HeartbeatInterval = IdleTimeout / 2
             };
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -28,7 +28,7 @@ namespace Apache.Ignite.Core.Tests.Client
     using NUnit.Framework;
 
     /// <summary>
-    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.HeartbeatInterval"/>).
+    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.DefaultHeartbeatInterval"/>).
     /// </summary>
     [Category(TestUtils.CategoryIntensive)]
     public class ClientHeartbeatTest : ClientTestBase
@@ -54,7 +54,7 @@ namespace Apache.Ignite.Core.Tests.Client
             var heartbeatInterval = IdleTimeout / 4;
             using var client = GetClient(heartbeatInterval);
 
-            Assert.AreEqual(heartbeatInterval, client.GetConfiguration().HeartbeatInterval.TotalMilliseconds);
+            Assert.AreEqual(heartbeatInterval, client.GetConfiguration().DefaultHeartbeatInterval.TotalMilliseconds);
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
             Thread.Sleep(IdleTimeout * 3);
@@ -105,7 +105,7 @@ namespace Apache.Ignite.Core.Tests.Client
             {
                 // Keep default client alive.
                 // ReSharper disable once PossibleLossOfFraction
-                HeartbeatInterval = TimeSpan.FromMilliseconds(IdleTimeout / 4)
+                DefaultHeartbeatInterval = TimeSpan.FromMilliseconds(IdleTimeout / 4)
             };
         }
 
@@ -114,7 +114,7 @@ namespace Apache.Ignite.Core.Tests.Client
             var cfg = new IgniteClientConfiguration
             {
                 Endpoints = new List<string> { $"{IPAddress.Loopback}:{port}" },
-                HeartbeatInterval = TimeSpan.FromMilliseconds(heartbeatInterval),
+                DefaultHeartbeatInterval = TimeSpan.FromMilliseconds(heartbeatInterval),
                 Logger = new ListLogger()
             };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -19,7 +19,6 @@ namespace Apache.Ignite.Core.Tests.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Net;
     using System.Threading;
     using Apache.Ignite.Core.Client;
@@ -52,8 +51,10 @@ namespace Apache.Ignite.Core.Tests.Client
         [Test]
         public void TestServerDoesNotDisconnectIdleClientWithHeartbeats()
         {
-            using var client = GetClient(heartbeatInterval: IdleTimeout / 2);
+            var heartbeatInterval = IdleTimeout / 2;
+            using var client = GetClient(heartbeatInterval);
 
+            Assert.AreEqual(heartbeatInterval, client.GetConfiguration().HeartbeatInterval);
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
             Thread.Sleep(IdleCheckInterval * 2);
@@ -81,6 +82,14 @@ namespace Apache.Ignite.Core.Tests.Client
                 {
                     IdleTimeout = IdleTimeout
                 }
+            };
+        }
+
+        protected override IgniteClientConfiguration GetClientConfiguration()
+        {
+            return new IgniteClientConfiguration(base.GetClientConfiguration())
+            {
+                HeartbeatInterval = IdleTimeout / 2
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -92,8 +92,7 @@ namespace Apache.Ignite.Core.Tests.Client
             return new IgniteClientConfiguration(base.GetClientConfiguration())
             {
                 // Keep default client alive.
-                // ReSharper disable once PossibleLossOfFraction
-                DefaultHeartbeatInterval = TimeSpan.FromMilliseconds(IdleTimeout / 4)
+                EnableHeartbeats = true
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -75,11 +75,12 @@ namespace Apache.Ignite.Core.Tests.Client
             };
         }
 
-        private IIgniteClient GetClient(TimeSpan heartbeatInterval)
+        private static IIgniteClient GetClient(TimeSpan heartbeatInterval)
         {
             var cfg = new IgniteClientConfiguration
             {
-                Endpoints = new List<string> { IPAddress.Loopback.ToString() }
+                Endpoints = new List<string> { IPAddress.Loopback.ToString() },
+                HeartbeatInterval = heartbeatInterval
             };
 
             return Ignition.StartClient(cfg);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -68,16 +68,17 @@ namespace Apache.Ignite.Core.Tests.Client
         }
 
         [Test]
-        public void TestDefaultZeroIdleTimeoutUsesFallbackHeartbeatInterval()
+        public void TestDefaultZeroIdleTimeoutUsesConfiguredHeartbeatInterval()
         {
             using var ignite = Ignition.Start(TestUtils.GetTestConfiguration(name: "2"));
             using var client = GetClient(enableHeartbeats: true, port: IgniteClientConfiguration.DefaultPort + 1);
 
-            Assert.AreEqual(TimeSpan.Zero, client.GetConfiguration().HeartbeatInterval);
+            Assert.AreEqual(IgniteClientConfiguration.DefaultHeartbeatInterval,
+                client.GetConfiguration().HeartbeatInterval);
 
             StringAssert.Contains(
                 "Server-side IdleTimeout is not set, " +
-                "using IgniteClientConfiguration.FallbackHeartbeatInterval: 00:00:30", GetLogString(client));
+                "using configured IgniteClientConfiguration.HeartbeatInterval: 00:00:30", GetLogString(client));
         }
 
         [Test]
@@ -101,6 +102,13 @@ namespace Apache.Ignite.Core.Tests.Client
             StringAssert.Contains(
                 "Server-side IdleTimeout is 2000ms, using 1/3 of it as heartbeat interval: 00:00:00.6660000",
                 GetLogString(client));
+        }
+
+        [Test]
+        public void TestZeroOrNegativeHeartbeatIntervalThrows()
+        {
+            Assert.Throws<IgniteClientException>(() => GetClient(enableHeartbeats: true, heartbeatInterval: 0));
+            Assert.Throws<IgniteClientException>(() => GetClient(enableHeartbeats: true, heartbeatInterval: -1));
         }
 
         protected override IgniteConfiguration GetIgniteConfiguration()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -18,6 +18,9 @@
 namespace Apache.Ignite.Core.Tests.Client
 {
     using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Configuration;
     using NUnit.Framework;
@@ -33,7 +36,14 @@ namespace Apache.Ignite.Core.Tests.Client
         [Test]
         public void TestServerDisconnectsIdleClientWithoutHeartbeats()
         {
-            Assert.Fail("TODO");
+            using (var client = GetClient(TimeSpan.Zero))
+            {
+                Assert.AreEqual(1, client.GetCacheNames().Count);
+
+                Thread.Sleep(IdleTimeout * 2);
+
+                Assert.Throws<IgniteClientException>(() => client.GetCacheNames());
+            }
         }
 
         [Test]
@@ -63,6 +73,16 @@ namespace Apache.Ignite.Core.Tests.Client
                     IdleTimeout = IdleTimeout
                 }
             };
+        }
+
+        private IIgniteClient GetClient(TimeSpan heartbeatInterval)
+        {
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new List<string> { IPAddress.Loopback.ToString() }
+            };
+
+            return Ignition.StartClient(cfg);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -28,6 +28,7 @@ namespace Apache.Ignite.Core.Tests.Client
     /// <summary>
     /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.HeartbeatInterval"/>).
     /// </summary>
+    [Category(TestUtils.CategoryIntensive)]
     public class ClientHeartbeatTest : ClientTestBase
     {
         /** */
@@ -65,7 +66,13 @@ namespace Apache.Ignite.Core.Tests.Client
         [Test]
         public void TestServerDisconnectsIdleClientWithLongHeartbeatInterval()
         {
-            Assert.Fail("TODO");
+            using var client = GetClient(heartbeatInterval: IdleCheckInterval / 2);
+
+            Assert.AreEqual(1, client.GetCacheNames().Count);
+
+            Thread.Sleep(IdleCheckInterval * 2);
+
+            Assert.Throws<IgniteClientException>(() => client.GetCacheNames());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -63,10 +63,6 @@ namespace Apache.Ignite.Core.Tests.Client
             Assert.IsTrue(client.GetConfiguration().EnableHeartbeats);
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
-            StringAssert.Contains(
-                "Server-side IdleTimeout is 2000ms, using 1/3 of it as heartbeat interval: 00:00:00.6660000",
-                GetLogString(client));
-
             Thread.Sleep(IdleTimeout * 3);
 
             Assert.DoesNotThrow(() => client.GetCacheNames());
@@ -105,7 +101,9 @@ namespace Apache.Ignite.Core.Tests.Client
             Assert.AreEqual(TimeSpan.FromMilliseconds(3000), client.GetConfiguration().HeartbeatInterval);
 
             StringAssert.Contains(
-                "Server-side IdleTimeout is 2000ms, using 1/3 of it as heartbeat interval: 00:00:00.6660000",
+                "Server-side IdleTimeout is 2000ms, configured IgniteClientConfiguration.HeartbeatInterval is " +
+                "00:00:03, which is longer than recommended IdleTimeout / 3. " +
+                "Overriding heartbeat interval with IdleTimeout / 3: 00:00:00.6660000",
                 GetLogString(client));
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -68,17 +68,16 @@ namespace Apache.Ignite.Core.Tests.Client
         }
 
         [Test]
-        public void TestDefaultZeroIdleTimeoutUsesDefaultHeartbeatInterval()
+        public void TestDefaultZeroIdleTimeoutUsesFallbackHeartbeatInterval()
         {
             using var ignite = Ignition.Start(TestUtils.GetTestConfiguration(name: "2"));
             using var client = GetClient(enableHeartbeats: true, port: IgniteClientConfiguration.DefaultPort + 1);
 
-            Assert.AreEqual(IgniteClientConfiguration.DefaultHeartbeatInterval,
-                client.GetConfiguration().HeartbeatInterval);
+            Assert.AreEqual(TimeSpan.Zero, client.GetConfiguration().HeartbeatInterval);
 
             StringAssert.Contains(
                 "Server-side IdleTimeout is not set, " +
-                "using IgniteClientConfiguration.HeartbeatInterval: 00:00:30", GetLogString(client));
+                "using IgniteClientConfiguration.FallbackHeartbeatInterval: 00:00:30", GetLogString(client));
         }
 
         protected override IgniteConfiguration GetIgniteConfiguration()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -45,7 +45,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             Thread.Sleep(IdleTimeout * 3);
 
-            Assert.Throws<IgniteClientException>(() => client.GetCacheNames());
+            Assert.Catch(() => client.GetCacheNames());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -49,7 +49,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
-            Thread.Sleep(IdleTimeout * 3);
+            Thread.Sleep(IdleTimeout * 4);
 
             Assert.Catch(() => client.GetCacheNames());
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -58,7 +58,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             Thread.Sleep(IdleCheckInterval * 2);
 
-            Assert.Throws<IgniteClientException>(() => client.GetCacheNames());
+            Assert.DoesNotThrow(() => client.GetCacheNames());
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -37,6 +37,11 @@ namespace Apache.Ignite.Core.Tests.Client
         /** GridNioServer has hardcoded 2000ms idle check interval, so a smaller idle timeout does not make sense. */
         private static readonly int IdleTimeout = 2000;
 
+        public ClientHeartbeatTest() : base(gridCount: 2)
+        {
+            // No-op.
+        }
+
         [Test]
         public void TestServerDisconnectsIdleClientWithoutHeartbeats()
         {
@@ -71,7 +76,7 @@ namespace Apache.Ignite.Core.Tests.Client
         public void TestDefaultZeroIdleTimeoutUsesConfiguredHeartbeatInterval()
         {
             using var ignite = Ignition.Start(TestUtils.GetTestConfiguration(name: "2"));
-            using var client = GetClient(enableHeartbeats: true, port: IgniteClientConfiguration.DefaultPort + 1);
+            using var client = GetClient(enableHeartbeats: true, port: IgniteClientConfiguration.DefaultPort + 2);
 
             Assert.AreEqual(IgniteClientConfiguration.DefaultHeartbeatInterval,
                 client.GetConfiguration().HeartbeatInterval);
@@ -141,7 +146,8 @@ namespace Apache.Ignite.Core.Tests.Client
                 Logger = new ListLogger
                 {
                     EnabledLevels = new[] { LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error }
-                }
+                },
+                EnablePartitionAwareness = true
             };
 
             if (heartbeatInterval != null)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -43,7 +43,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
-            Thread.Sleep(IdleTimeout * 2);
+            Thread.Sleep(IdleTimeout * 3);
 
             Assert.Throws<IgniteClientException>(() => client.GetCacheNames());
         }
@@ -54,7 +54,7 @@ namespace Apache.Ignite.Core.Tests.Client
             var heartbeatInterval = IdleTimeout / 4;
             using var client = GetClient(heartbeatInterval);
 
-            Assert.AreEqual(heartbeatInterval, client.GetConfiguration().HeartbeatInterval);
+            Assert.AreEqual(heartbeatInterval, client.GetConfiguration().HeartbeatInterval.TotalMilliseconds);
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
             Thread.Sleep(IdleTimeout * 3);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Configuration;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.HeartbeatInterval"/>).
+    /// </summary>
+    public class ClientHeartbeatTest : ClientTestBase
+    {
+        /** */
+        private static readonly TimeSpan IdleTimeout = TimeSpan.FromMilliseconds(100);
+
+        [Test]
+        public void TestServerDisconnectsIdleClientWithoutHeartbeats()
+        {
+            Assert.Fail("TODO");
+        }
+
+        [Test]
+        public void TestServerDoesNotDisconnectIdleClientWithHeartbeats()
+        {
+            Assert.Fail("TODO");
+        }
+
+        [Test]
+        public void TestServerDisconnectsIdleClientWithLongHeartbeatInterval()
+        {
+            Assert.Fail("TODO");
+        }
+
+        [Test]
+        public void TestHeartbeatIntervalLongerThanIdleTimeoutLogsWarning()
+        {
+            Assert.Fail("TODO");
+        }
+
+        protected override IgniteConfiguration GetIgniteConfiguration()
+        {
+            return new IgniteConfiguration(base.GetIgniteConfiguration())
+            {
+                ClientConnectorConfiguration = new ClientConnectorConfiguration
+                {
+                    IdleTimeout = IdleTimeout
+                }
+            };
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -34,12 +34,12 @@ namespace Apache.Ignite.Core.Tests.Client
     public class ClientHeartbeatTest : ClientTestBase
     {
         /** GridNioServer has hardcoded 2000ms idle check interval, so a smaller idle timeout does not make sense. */
-        private static readonly TimeSpan IdleTimeout = TimeSpan.FromMilliseconds(2000);
+        private static readonly int IdleTimeout = 2000;
 
         [Test]
         public void TestServerDisconnectsIdleClientWithoutHeartbeats()
         {
-            using var client = GetClient(heartbeatInterval: TimeSpan.Zero);
+            using var client = GetClient(heartbeatInterval: 0);
 
             Assert.AreEqual(1, client.GetCacheNames().Count);
 
@@ -82,7 +82,7 @@ namespace Apache.Ignite.Core.Tests.Client
             {
                 ClientConnectorConfiguration = new ClientConnectorConfiguration
                 {
-                    IdleTimeout = IdleTimeout
+                    IdleTimeout = TimeSpan.FromMilliseconds(IdleTimeout)
                 }
             };
         }
@@ -92,16 +92,17 @@ namespace Apache.Ignite.Core.Tests.Client
             return new IgniteClientConfiguration(base.GetClientConfiguration())
             {
                 // Keep default client alive.
-                HeartbeatInterval = IdleTimeout / 2
+                // ReSharper disable once PossibleLossOfFraction
+                HeartbeatInterval = TimeSpan.FromMilliseconds(IdleTimeout / 4)
             };
         }
 
-        private static IIgniteClient GetClient(TimeSpan heartbeatInterval)
+        private static IIgniteClient GetClient(int heartbeatInterval)
         {
             var cfg = new IgniteClientConfiguration
             {
                 Endpoints = new List<string> { IPAddress.Loopback.ToString() },
-                HeartbeatInterval = heartbeatInterval,
+                HeartbeatInterval = TimeSpan.FromMilliseconds(heartbeatInterval),
                 Logger = new ListLogger()
             };
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
@@ -111,7 +111,7 @@ namespace Apache.Ignite.Core.Tests.Client
                     DefaultTransactionIsolation = TransactionIsolation.Serializable
                 },
                 RetryLimit = 33,
-                DefaultHeartbeatInterval = TimeSpan.FromSeconds(30)
+                HeartbeatInterval = TimeSpan.FromSeconds(30)
             };
 
             using (var xmlReader = XmlReader.Create(Path.Combine("Config", "Client", "IgniteClientConfiguration.xml")))

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
@@ -111,7 +111,7 @@ namespace Apache.Ignite.Core.Tests.Client
                     DefaultTransactionIsolation = TransactionIsolation.Serializable
                 },
                 RetryLimit = 33,
-                HeartbeatInterval = TimeSpan.FromSeconds(30)
+                DefaultHeartbeatInterval = TimeSpan.FromSeconds(30)
             };
 
             using (var xmlReader = XmlReader.Create(Path.Combine("Config", "Client", "IgniteClientConfiguration.xml")))

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
@@ -109,7 +109,9 @@ namespace Apache.Ignite.Core.Tests.Client
                     DefaultTimeout = TimeSpan.FromSeconds(1),
                     DefaultTransactionConcurrency = TransactionConcurrency.Optimistic,
                     DefaultTransactionIsolation = TransactionIsolation.Serializable
-                }
+                },
+                RetryLimit = 33,
+                HeartbeatInterval = TimeSpan.FromSeconds(30)
             };
 
             using (var xmlReader = XmlReader.Create(Path.Combine("Config", "Client", "IgniteClientConfiguration.xml")))

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/IgniteClientConfiguration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/IgniteClientConfiguration.xml
@@ -17,8 +17,8 @@
   limitations under the License.
 -->
 
-<igniteClientConfiguration host="test1" port="345" socketReceiveBufferSize="222" socketSendBufferSize="333"
-                           tcpNoDelay="false" socketTimeout="0:0:15" enablePartitionAwareness="true">
+<igniteClientConfiguration heartbeatInterval="0:0:30" host="test1" port="345" socketReceiveBufferSize="222" socketSendBufferSize="333"
+                           tcpNoDelay="false" socketTimeout="0:0:15" enablePartitionAwareness="true" retryLimit="33">
     <binaryConfiguration compactFooter="false" keepDeserialized="false">
         <types>
             <string>foo</string>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8</LangVersion>
+
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Apache.Ignite.Core</AssemblyName>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8</LangVersion>
-
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Apache.Ignite.Core</AssemblyName>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -25,6 +25,7 @@ namespace Apache.Ignite.Core.Client
     using System.Xml;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client.Transactions;
+    using Apache.Ignite.Core.Configuration;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Client;
     using Apache.Ignite.Core.Impl.Common;
@@ -274,6 +275,9 @@ namespace Apache.Ignite.Core.Client
         /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
+        /// <para />
+        /// Can be used together with server-side idle timeout (<see cref="ClientConnectorConfiguration.IdleTimeout"/>)
+        /// to detect half-open connections on the server.
         /// </summary>
         public TimeSpan HeartbeatInterval { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -65,6 +65,21 @@ namespace Apache.Ignite.Core.Client
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
 
         /// <summary>
+        /// Automatic heartbeat interval.
+        /// </summary>
+        public static readonly TimeSpan AutoHeartbeatInterval = TimeSpan.Zero;
+
+        /// <summary>
+        /// Disabled heartbeat interval.
+        /// </summary>
+        public static readonly TimeSpan DisabledHeartbeatInterval = TimeSpan.FromSeconds(-1);
+
+        /// <summary>
+        /// Default heartbeat interval.
+        /// </summary>
+        public static readonly TimeSpan DefaultHeartbeatInterval = AutoHeartbeatInterval;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
         /// </summary>
         public IgniteClientConfiguration()
@@ -267,7 +282,7 @@ namespace Apache.Ignite.Core.Client
         public int RetryLimit { get; set; }
 
         /// <summary>
-        /// TODO: Auto (0, default), Disabled (-1), manual (> 0).
+        /// TODO: Auto (0, default), Disabled (-1), manual (> 0). Explain the behavior.
         /// </summary>
         public TimeSpan HeartbeatInterval { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -66,9 +66,9 @@ namespace Apache.Ignite.Core.Client
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
 
         /// <summary>
-        /// Default value for <see cref="DefaultHeartbeatInterval"/>.
+        /// Default value for <see cref="HeartbeatInterval"/>.
         /// </summary>
-        public static readonly TimeSpan DefaultDefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
@@ -141,7 +141,7 @@ namespace Apache.Ignite.Core.Client
             RetryLimit = cfg.RetryLimit;
             RetryPolicy = cfg.RetryPolicy;
             EnableHeartbeats = cfg.EnableHeartbeats;
-            DefaultHeartbeatInterval = cfg.DefaultHeartbeatInterval;
+            HeartbeatInterval = cfg.HeartbeatInterval;
         }
 
         /// <summary>
@@ -280,7 +280,7 @@ namespace Apache.Ignite.Core.Client
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// <para />
-        /// See also <see cref="DefaultHeartbeatInterval"/>.
+        /// See also <see cref="HeartbeatInterval"/>.
         /// </summary>
         public bool EnableHeartbeats { get; set; }
 
@@ -291,12 +291,12 @@ namespace Apache.Ignite.Core.Client
         /// When <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not set on the server,
         /// this property value is used.
         /// <para />
-        /// Default is <see cref="DefaultDefaultHeartbeatInterval"/>.
+        /// Default is <see cref="DefaultHeartbeatInterval"/>.
         /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// </summary>
-        public TimeSpan DefaultHeartbeatInterval { get; set; } = DefaultDefaultHeartbeatInterval;
+        public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
 
         /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -66,9 +66,10 @@ namespace Apache.Ignite.Core.Client
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
 
         /// <summary>
-        /// Default value for <see cref="HeartbeatInterval"/>.
+        /// Fallback value for <see cref="HeartbeatInterval"/>
+        /// when server-side <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not set.
         /// </summary>
-        public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan FallbackHeartbeatInterval = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
@@ -285,18 +286,17 @@ namespace Apache.Ignite.Core.Client
         public bool EnableHeartbeats { get; set; }
 
         /// <summary>
-        /// Sets the default heartbeat message interval to be used when it can not be determined automatically.
-        /// Client tries to retrieve <see cref="ClientConnectorConfiguration.IdleTimeout"/> from server and,
-        /// when successful, sets the heartbeat interval to IdleTimeout / 3.
-        /// When <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not set on the server,
-        /// this property value is used.
+        /// Sets the heartbeat message interval.
         /// <para />
-        /// Default is <see cref="DefaultHeartbeatInterval"/>.
+        /// Default is <see cref="TimeSpan.Zero"/>: determine interval automatically from server-side
+        /// <see cref="ClientConnectorConfiguration.IdleTimeout"/> divided by 3, or use
+        /// <see cref="FallbackHeartbeatInterval"/> when <see cref="ClientConnectorConfiguration.IdleTimeout"/>
+        /// is not set on the server.
         /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// </summary>
-        public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
+        public TimeSpan HeartbeatInterval { get; set; }
 
         /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -267,6 +267,11 @@ namespace Apache.Ignite.Core.Client
         public int RetryLimit { get; set; }
 
         /// <summary>
+        /// TODO: Auto (0, default), Disabled (-1), manual (> 0).
+        /// </summary>
+        public TimeSpan HeartbeatInterval { get; set; }
+
+        /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.
         /// </summary>
         internal IBinaryProcessor BinaryProcessor { get; set; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -72,7 +72,7 @@ namespace Apache.Ignite.Core.Client
         /// <summary>
         /// Disabled heartbeat interval.
         /// </summary>
-        public static readonly TimeSpan DisabledHeartbeatInterval = TimeSpan.FromSeconds(-1);
+        public static readonly TimeSpan DisabledHeartbeatInterval = TimeSpan.FromMilliseconds(-1);
 
         /// <summary>
         /// Default heartbeat interval.
@@ -282,7 +282,14 @@ namespace Apache.Ignite.Core.Client
         public int RetryLimit { get; set; }
 
         /// <summary>
-        /// TODO: Auto (0, default), Disabled (-1), manual (> 0). Explain the behavior.
+        /// Sets the heartbeat message interval.
+        /// <para />
+        /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+        /// to keep the connection alive and detect potential half-open state.
+        /// <para />
+        /// TODO: Explain the behavior.
+        /// <para />
+        /// See <see cref="DefaultHeartbeatInterval"/>, <see cref="AutoHeartbeatInterval"/>, <see cref="DisabledHeartbeatInterval"/>.
         /// </summary>
         public TimeSpan HeartbeatInterval { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -134,6 +134,7 @@ namespace Apache.Ignite.Core.Client
 
             RetryLimit = cfg.RetryLimit;
             RetryPolicy = cfg.RetryPolicy;
+            HeartbeatInterval = cfg.HeartbeatInterval;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -66,6 +66,11 @@ namespace Apache.Ignite.Core.Client
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
 
         /// <summary>
+        /// Default value for <see cref="DefaultHeartbeatInterval"/>.
+        /// </summary>
+        public static readonly TimeSpan DefaultDefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
         /// </summary>
         public IgniteClientConfiguration()
@@ -135,7 +140,8 @@ namespace Apache.Ignite.Core.Client
 
             RetryLimit = cfg.RetryLimit;
             RetryPolicy = cfg.RetryPolicy;
-            HeartbeatInterval = cfg.HeartbeatInterval;
+            EnableHeartbeats = cfg.EnableHeartbeats;
+            DefaultHeartbeatInterval = cfg.DefaultHeartbeatInterval;
         }
 
         /// <summary>
@@ -269,17 +275,28 @@ namespace Apache.Ignite.Core.Client
         public int RetryLimit { get; set; }
 
         /// <summary>
-        /// Sets the heartbeat message interval.
-        /// <para />
-        /// Default is <see cref="TimeSpan.Zero"/> - heartbeats are disabled.
+        /// Gets or sets a value indicating whether heartbeats are enabled.
         /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// <para />
-        /// Can be used together with server-side idle timeout (<see cref="ClientConnectorConfiguration.IdleTimeout"/>)
-        /// to detect half-open connections on the server.
+        /// See also <see cref="DefaultHeartbeatInterval"/>.
         /// </summary>
-        public TimeSpan HeartbeatInterval { get; set; }
+        public bool EnableHeartbeats { get; set; }
+
+        /// <summary>
+        /// Sets the default heartbeat message interval to be used when it can not be determined automatically.
+        /// Client tries to retrieve <see cref="ClientConnectorConfiguration.IdleTimeout"/> from server and,
+        /// when successful, sets the heartbeat interval to IdleTimeout / 3.
+        /// When <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not set on the server,
+        /// this property value is used.
+        /// <para />
+        /// Default is <see cref="DefaultDefaultHeartbeatInterval"/>.
+        /// <para />
+        /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+        /// to keep the connection alive and detect potential half-open state.
+        /// </summary>
+        public TimeSpan DefaultHeartbeatInterval { get; set; } = DefaultDefaultHeartbeatInterval;
 
         /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -66,10 +66,9 @@ namespace Apache.Ignite.Core.Client
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
 
         /// <summary>
-        /// Fallback value for <see cref="HeartbeatInterval"/>
-        /// when server-side <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not set.
+        /// Default value for <see cref="HeartbeatInterval"/>.
         /// </summary>
-        public static readonly TimeSpan FallbackHeartbeatInterval = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
@@ -288,15 +287,15 @@ namespace Apache.Ignite.Core.Client
         /// <summary>
         /// Sets the heartbeat message interval.
         /// <para />
-        /// Default is <see cref="TimeSpan.Zero"/>: determine interval automatically from server-side
-        /// <see cref="ClientConnectorConfiguration.IdleTimeout"/> divided by 3, or use
-        /// <see cref="FallbackHeartbeatInterval"/> when <see cref="ClientConnectorConfiguration.IdleTimeout"/>
+        /// Default is <see cref="DefaultHeartbeatInterval"/>. Client determines interval automatically
+        /// from server-side <see cref="ClientConnectorConfiguration.IdleTimeout"/> divided by 3, or uses
+        /// <see cref="DefaultHeartbeatInterval"/> when <see cref="ClientConnectorConfiguration.IdleTimeout"/>
         /// is not set on the server.
         /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// </summary>
-        public TimeSpan HeartbeatInterval { get; set; }
+        public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
 
         /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -287,10 +287,10 @@ namespace Apache.Ignite.Core.Client
         /// <summary>
         /// Sets the heartbeat message interval.
         /// <para />
-        /// Default is <see cref="DefaultHeartbeatInterval"/>. Client determines interval automatically
-        /// from server-side <see cref="ClientConnectorConfiguration.IdleTimeout"/> divided by 3, or uses
-        /// <see cref="DefaultHeartbeatInterval"/> when <see cref="ClientConnectorConfiguration.IdleTimeout"/>
-        /// is not set on the server.
+        /// Default is <see cref="DefaultHeartbeatInterval"/>.
+        /// <para />
+        /// When server-side <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not zero, effective heartbeat
+        /// interval is set to <c>Min(HeartbeatInterval, IdleTimeout / 3)</c>.
         /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -295,6 +295,7 @@ namespace Apache.Ignite.Core.Client
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
         /// </summary>
+        [DefaultValue(typeof(TimeSpan), "00:00:30")]
         public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -65,21 +65,6 @@ namespace Apache.Ignite.Core.Client
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
 
         /// <summary>
-        /// Automatic heartbeat interval.
-        /// </summary>
-        public static readonly TimeSpan AutoHeartbeatInterval = TimeSpan.Zero;
-
-        /// <summary>
-        /// Disabled heartbeat interval.
-        /// </summary>
-        public static readonly TimeSpan DisabledHeartbeatInterval = TimeSpan.FromMilliseconds(-1);
-
-        /// <summary>
-        /// Default heartbeat interval.
-        /// </summary>
-        public static readonly TimeSpan DefaultHeartbeatInterval = AutoHeartbeatInterval;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
         /// </summary>
         public IgniteClientConfiguration()
@@ -284,12 +269,10 @@ namespace Apache.Ignite.Core.Client
         /// <summary>
         /// Sets the heartbeat message interval.
         /// <para />
+        /// Default is <see cref="TimeSpan.Zero"/> - heartbeats are disabled.
+        /// <para />
         /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
         /// to keep the connection alive and detect potential half-open state.
-        /// <para />
-        /// TODO: Explain the behavior.
-        /// <para />
-        /// See <see cref="DefaultHeartbeatInterval"/>, <see cref="AutoHeartbeatInterval"/>, <see cref="DisabledHeartbeatInterval"/>.
         /// </summary>
         public TimeSpan HeartbeatInterval { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -355,6 +355,11 @@
                     <xs:documentation>Heartbeat interval.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="enableHeartbeats" type="xs:boolean">
+                <xs:annotation>
+                    <xs:documentation>Enables periodic heartbeat messages.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -350,6 +350,11 @@
                     <xs:documentation>Operation retry limit when RetryPolicy is set.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="heartbeatInterval" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Heartbeat interval.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
@@ -32,6 +32,7 @@ namespace Apache.Ignite.Core.Impl.Client
         // DefaultQueryTimeout = 6, // IGNITE-13692
         QueryPartitionsBatchSize = 7,
         BinaryConfiguration = 8,
-        ServiceInvokeCtx = 10
+        ServiceInvokeCtx = 10,
+        Heartbeat = 11
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
@@ -24,6 +24,8 @@ namespace Apache.Ignite.Core.Impl.Client
     {
         // General purpose.
         ResourceClose = 0,
+        Heartbeat = 1,
+        GetIdleTimeout = 2,
 
         // Cache.
         CacheGet = 1000,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -227,8 +227,11 @@ namespace Apache.Ignite.Core.Impl.Client
                     return clientConfiguration.HeartbeatInterval;
                 }
 
-                _logger.Info($"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, " +
-                             $"using 1/3 of it as heartbeat interval: {recommendedHeartbeatInterval}");
+                _logger.Warn(
+                    $"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, configured " +
+                    $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +
+                    $"is {clientConfiguration.HeartbeatInterval}, which is longer than recommended IdleTimeout / 3. " +
+                    $"Overriding heartbeat interval with IdleTimeout / 3: {recommendedHeartbeatInterval}");
 
                 return recommendedHeartbeatInterval;
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -184,7 +184,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 var serverIdleTimeout = TimeSpan.FromMilliseconds(
                     DoOutInOp(ClientOp.GetIdleTimeout, null, r => r.Reader.ReadLong()));
 
-                if (/*serverIdleTimeout > TimeSpan.Zero && */_heartbeatInterval > serverIdleTimeout)
+                if (serverIdleTimeout > TimeSpan.Zero && _heartbeatInterval > serverIdleTimeout)
                 {
                     _logger.Warn("Client heartbeat interval is greater than server idle timeout " +
                                  $"({_heartbeatInterval} > {serverIdleTimeout}). " +

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -184,7 +184,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 var serverIdleTimeout = TimeSpan.FromMilliseconds(
                     DoOutInOp(ClientOp.GetIdleTimeout, null, r => r.Reader.ReadLong()));
 
-                if (_heartbeatInterval > serverIdleTimeout)
+                if (/*serverIdleTimeout > TimeSpan.Zero && */_heartbeatInterval > serverIdleTimeout)
                 {
                     _logger.Warn("Client heartbeat interval is greater than server idle timeout " +
                                  $"({_heartbeatInterval} > {serverIdleTimeout}). " +

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -192,11 +192,11 @@ namespace Apache.Ignite.Core.Impl.Client
                     }
                     else
                     {
-                        _heartbeatInterval = clientConfiguration.DefaultHeartbeatInterval;
+                        _heartbeatInterval = clientConfiguration.HeartbeatInterval;
 
                         _logger.Info(
                             $"Server-side IdleTimeout is not set, using {nameof(IgniteClientConfiguration)}." +
-                            $"{nameof(IgniteClientConfiguration.DefaultHeartbeatInterval)}: {_heartbeatInterval}");
+                            $"{nameof(IgniteClientConfiguration.HeartbeatInterval)}: {_heartbeatInterval}");
                     }
 
                     _heartbeatTimer = new Timer(SendHeartbeat, null, dueTime: _heartbeatInterval,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -185,7 +185,8 @@ namespace Apache.Ignite.Core.Impl.Client
 
                     if (serverIdleTimeoutMs > 0)
                     {
-                        _heartbeatInterval = TimeSpan.FromMilliseconds((long)(serverIdleTimeoutMs / 3));
+                        // ReSharper disable once PossibleLossOfFraction
+                        _heartbeatInterval = TimeSpan.FromMilliseconds(serverIdleTimeoutMs / 3);
 
                         _logger.Info($"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, " +
                                      $"using 1/3 of it as heartbeat interval: {_heartbeatInterval}");

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -183,9 +183,21 @@ namespace Apache.Ignite.Core.Impl.Client
                     var serverIdleTimeoutMs = DoOutInOp(
                         ClientOp.GetIdleTimeout, null, r => r.Reader.ReadLong());
 
-                    _heartbeatInterval = serverIdleTimeoutMs > 0
-                        ? TimeSpan.FromMilliseconds((long)(serverIdleTimeoutMs / 3))
-                        : clientConfiguration.DefaultHeartbeatInterval;
+                    if (serverIdleTimeoutMs > 0)
+                    {
+                        _heartbeatInterval = TimeSpan.FromMilliseconds((long)(serverIdleTimeoutMs / 3));
+
+                        _logger.Info($"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, " +
+                                     $"using 1/3 of it as heartbeat interval: {_heartbeatInterval}");
+                    }
+                    else
+                    {
+                        _heartbeatInterval = clientConfiguration.DefaultHeartbeatInterval;
+
+                        _logger.Info(
+                            $"Server-side IdleTimeout is not set, using {nameof(IgniteClientConfiguration)}." +
+                            $"{nameof(IgniteClientConfiguration.DefaultHeartbeatInterval)}: {_heartbeatInterval}");
+                    }
 
                     _heartbeatTimer = new Timer(SendHeartbeat, null, dueTime: _heartbeatInterval,
                         period: TimeSpan.FromMilliseconds(-1));

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -216,8 +216,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
             if (recommendedHeartbeatInterval > TimeSpan.Zero)
             {
-                if (clientConfiguration.HeartbeatInterval > TimeSpan.Zero &&
-                    clientConfiguration.HeartbeatInterval < recommendedHeartbeatInterval)
+                if (clientConfiguration.HeartbeatInterval < recommendedHeartbeatInterval)
                 {
                     _logger.Info(
                         $"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, " +
@@ -234,21 +233,11 @@ namespace Apache.Ignite.Core.Impl.Client
                 return recommendedHeartbeatInterval;
             }
 
-            if (clientConfiguration.HeartbeatInterval > TimeSpan.Zero)
-            {
-                _logger.Info(
-                    $"Server-side IdleTimeout is not set, using configured {nameof(IgniteClientConfiguration)}." +
-                    $"{nameof(IgniteClientConfiguration.HeartbeatInterval)}: {clientConfiguration.HeartbeatInterval}");
-
-                return clientConfiguration.HeartbeatInterval;
-            }
-
             _logger.Info(
-                $"Server-side IdleTimeout is not set, using {nameof(IgniteClientConfiguration)}." +
-                $"{nameof(IgniteClientConfiguration.FallbackHeartbeatInterval)}: " +
-                IgniteClientConfiguration.FallbackHeartbeatInterval);
+                $"Server-side IdleTimeout is not set, using configured {nameof(IgniteClientConfiguration)}." +
+                $"{nameof(IgniteClientConfiguration.HeartbeatInterval)}: {clientConfiguration.HeartbeatInterval}");
 
-            return IgniteClientConfiguration.FallbackHeartbeatInterval;
+            return clientConfiguration.HeartbeatInterval;
         }
 
         /// <summary>
@@ -273,6 +262,13 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 if (cfg.UserName == null)
                     throw new IgniteClientException("IgniteClientConfiguration.UserName cannot be null when Password is set.");
+            }
+
+            if (cfg.HeartbeatInterval <= TimeSpan.Zero)
+            {
+                throw new IgniteClientException(
+                    $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +
+                    "cannot be zero or less.");
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -178,6 +178,10 @@ namespace Apache.Ignite.Core.Impl.Client
                 var serverIdleTimeoutMs = DoOutInOp(ClientOp.GetIdleTimeout, null, r => r.Reader.ReadLong());
                 _serverIdleTimeout = TimeSpan.FromMilliseconds(serverIdleTimeoutMs);
             }
+            else if (clientConfiguration.HeartbeatInterval > TimeSpan.Zero)
+            {
+                _logger.Warn("Custom HeartbeatInterval is configured, but server does not support heartbeat feature.");
+            }
 
             // Check periodically if any request has timed out.
             if (_timeout > TimeSpan.Zero)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -187,7 +187,8 @@ namespace Apache.Ignite.Core.Impl.Client
                 if (_heartbeatInterval > serverIdleTimeout)
                 {
                     _logger.Warn("Client HeartbeatInterval is greater than server idle timeout " +
-                                 $"({_heartbeatInterval} > {serverIdleTimeout}).");
+                                 $"({_heartbeatInterval} > {serverIdleTimeout}). " +
+                                 "Server will the client once it becomes idle.");
                 }
 
                 _heartbeatTimer = new Timer(SendHeartbeat, null, dueTime: _heartbeatInterval,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -1059,10 +1059,8 @@ namespace Apache.Ignite.Core.Impl.Client
                 _listenerEvent.Set();
                 _listenerEvent.Dispose();
 
-                if (_timeoutCheckTimer != null)
-                {
-                    _timeoutCheckTimer.Dispose();
-                }
+                _timeoutCheckTimer?.Dispose();
+                _heartbeatTimer?.Dispose();
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -186,9 +186,9 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 if (_heartbeatInterval > serverIdleTimeout)
                 {
-                    _logger.Warn("Client HeartbeatInterval is greater than server idle timeout " +
+                    _logger.Warn("Client heartbeat interval is greater than server idle timeout " +
                                  $"({_heartbeatInterval} > {serverIdleTimeout}). " +
-                                 "Server will the client once it becomes idle.");
+                                 "Server will disconnect idle client.");
                 }
 
                 _heartbeatTimer = new Timer(SendHeartbeat, null, dueTime: _heartbeatInterval,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -890,6 +890,7 @@ namespace Apache.Ignite.Core.Impl.Client
             {
                 _stream.Write(buf, 0, len);
 
+                // Reset heartbeat timer - don't sent heartbeats when connection is active anyway.
                 _heartbeatTimer?.Change(dueTime: _heartbeatInterval, period: TimeSpan.FromMilliseconds(-1));
             }
             catch (Exception e)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -137,6 +137,9 @@ namespace Apache.Ignite.Core.Impl.Client
         /** Features. */
         private readonly ClientFeatures _features;
 
+        /** Server idle timeout. */
+        private readonly TimeSpan _serverIdleTimeout;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientSocket" /> class.
         /// </summary>
@@ -169,6 +172,12 @@ namespace Apache.Ignite.Core.Impl.Client
             Validate(clientConfiguration);
 
             _features = Handshake(clientConfiguration, ServerVersion);
+
+            if (_features.HasFeature(ClientBitmaskFeature.Heartbeat))
+            {
+                var serverIdleTimeoutMs = DoOutInOp(ClientOp.GetIdleTimeout, null, r => r.Reader.ReadLong());
+                _serverIdleTimeout = TimeSpan.FromMilliseconds(serverIdleTimeoutMs);
+            }
 
             // Check periodically if any request has timed out.
             if (_timeout > TimeSpan.Zero)

--- a/modules/platforms/dotnet/Directory.Build.props
+++ b/modules/platforms/dotnet/Directory.Build.props
@@ -17,6 +17,8 @@
 
 <Project>
     <PropertyGroup>
+        <LangVersion>8</LangVersion>
+
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <WarningsAsErrors/>
 


### PR DESCRIPTION
Implement keepalive: https://cwiki.apache.org/confluence/display/IGNITE/IEP-83+Thin+Client+Keepalive
* Add `OP_HEARTBEAT`, `OP_GET_IDLE_TIMEOUT` on server with `HEARTBEAT` feature flag.
* Implement heartbeats in .NET thin client:
  * `IgniteClientConfiguration.EnableHeartbeats`, default `false`.
  * `IgniteClientConfiguration.HeartbeatInterval`, default 30 seconds.
  * When heartbeats are enabled, get idle timeout from server, set effective heartbeat interval to `Math.Min(HeartbeatInterval, IdleTimeout / 3)`. Log warning when user-defined value is overridden.