### PR TITLE
IGNITE-16604: Fix GeoSpatial indexes for client nodes

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/AbstractIndex.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/AbstractIndex.java
@@ -39,4 +39,17 @@ public abstract class AbstractIndex implements Index {
     public boolean rebuildInProgress() {
         return rebuildInProgress.get();
     }
+
+    /** {@inheritDoc} */
+    @Override public <T extends Index> T unwrap(Class<T> clazz) {
+        if (clazz == null)
+            return null;
+
+        if (clazz.isAssignableFrom(getClass()))
+            return clazz.cast(this);
+
+        throw new IllegalArgumentException(
+            String.format("Cannot unwrap [%s] to [%s]", getClass().getName(), clazz.getName())
+        );
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/sorted/inline/InlineIndexImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/index/sorted/inline/InlineIndexImpl.java
@@ -23,7 +23,6 @@ import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.failure.FailureContext;
 import org.apache.ignite.internal.cache.query.index.AbstractIndex;
-import org.apache.ignite.internal.cache.query.index.Index;
 import org.apache.ignite.internal.cache.query.index.SingleCursor;
 import org.apache.ignite.internal.cache.query.index.sorted.DurableBackgroundCleanupIndexTreeTaskV2;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexKeyTypeSettings;
@@ -312,19 +311,6 @@ public class InlineIndexImpl extends AbstractIndex implements InlineIndex {
         finally {
             ThreadLocalRowHandlerHolder.clearRowHandler();
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override public <T extends Index> T unwrap(Class<T> clazz) {
-        if (clazz == null)
-            return null;
-
-        if (clazz.isAssignableFrom(getClass()))
-            return clazz.cast(this);
-
-        throw new IllegalArgumentException(
-            String.format("Cannot unwrap [%s] to [%s]", getClass().getName(), clazz.getName())
-        );
     }
 
     /** {@inheritDoc} */

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndex.java
@@ -19,42 +19,28 @@ package org.apache.ignite.internal.processors.query.h2.opt;
 
 import java.util.List;
 import java.util.UUID;
-import org.apache.ignite.IgniteCheckedException;
-import org.apache.ignite.internal.cache.query.index.AbstractIndex;
-import org.apache.ignite.internal.cache.query.index.Index;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexRow;
-import org.apache.ignite.internal.processors.cache.persistence.CacheDataRow;
+import org.apache.ignite.internal.processors.query.h2.index.client.AbstractClientIndex;
 import org.apache.ignite.internal.util.lang.GridCursor;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
-import org.jetbrains.annotations.Nullable;
 import org.locationtech.jts.geom.Geometry;
-
-import static org.apache.ignite.internal.processors.query.h2.index.client.ClientInlineIndex.unsupported;
 
 /**
  * Mock for client nodes to support Geo-Spatial indexes.
  */
-public class GeoSpatialClientIndex extends AbstractIndex implements GeoSpatialIndex {
+public class GeoSpatialClientIndex extends AbstractClientIndex implements GeoSpatialIndex {
     /** Index unique ID. */
     private final UUID id = UUID.randomUUID();
 
     /** */
-    private final String name;
-
-    /** */
-    private final GridH2Table tbl;
-
-    /** */
-    private final List<IndexColumn> cols;
+    private final GeoSpatialClientIndexDefinition def;
 
     /**
      * @param def Index definition.
      */
     public GeoSpatialClientIndex(GeoSpatialClientIndexDefinition def) {
-        name = def.idxName().idxName();
-        tbl = def.tbl();
-        cols = def.cols();
+        this.def = def;
     }
 
     /** {@inheritDoc} */
@@ -64,55 +50,20 @@ public class GeoSpatialClientIndex extends AbstractIndex implements GeoSpatialIn
 
     /** {@inheritDoc} */
     @Override public String name() {
-        return name;
+        return def.idxName().idxName();
     }
 
     /** */
     public GridH2Table tbl() {
-        return tbl;
+        return def.tbl();
     }
 
     /** */
     public List<IndexColumn> cols() {
-        return cols;
+        return def.cols();
     }
 
     /** {@inheritDoc} */
-    @Override public boolean canHandle(CacheDataRow row) throws IgniteCheckedException {
-        throw unsupported();
-    }
-
-    /** {@inheritDoc} */
-    @Override public void onUpdate(
-        @Nullable CacheDataRow oldRow,
-        @Nullable CacheDataRow newRow,
-        boolean prevRowAvailable
-    ) {
-        throw unsupported();
-    }
-
-    /** {@inheritDoc} */
-    @Override public <T extends Index> T unwrap(Class<T> clazz) {
-        if (clazz == null)
-            return null;
-
-        if (clazz.isAssignableFrom(getClass()))
-            return clazz.cast(this);
-
-        throw new IllegalArgumentException(
-            String.format("Cannot unwrap [%s] to [%s]", getClass().getName(), clazz.getName())
-        );
-    }
-
-    /** {@inheritDoc} */
-    @Override public void destroy(boolean softDelete) {
-        // No-op.
-    }
-
-    /**
-     * @param filter Table filter.
-     * @return Cursor.
-     */
     @Override public GridCursor<IndexRow> find(int seg, TableFilter filter) {
         throw unsupported();
     }

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndex.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2.opt;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.internal.cache.query.index.AbstractIndex;
+import org.apache.ignite.internal.cache.query.index.Index;
+import org.apache.ignite.internal.cache.query.index.sorted.IndexRow;
+import org.apache.ignite.internal.processors.cache.persistence.CacheDataRow;
+import org.apache.ignite.internal.util.lang.GridCursor;
+import org.h2.table.IndexColumn;
+import org.h2.table.TableFilter;
+import org.jetbrains.annotations.Nullable;
+import org.locationtech.jts.geom.Geometry;
+
+import static org.apache.ignite.internal.processors.query.h2.index.client.ClientInlineIndex.unsupported;
+
+/**
+ * Mock for client nodes to support Geo-Spatial indexes.
+ */
+public class GeoSpatialClientIndex extends AbstractIndex implements GeoSpatialIndex {
+    /** Index unique ID. */
+    private final UUID id = UUID.randomUUID();
+
+    /** */
+    private final String name;
+
+    /** */
+    private final GridH2Table tbl;
+
+    /** */
+    private final List<IndexColumn> cols;
+
+    /**
+     * @param def Index definition.
+     */
+    public GeoSpatialClientIndex(GeoSpatialClientIndexDefinition def) {
+        name = def.idxName().idxName();
+        tbl = def.tbl();
+        cols = def.cols();
+    }
+
+    /** {@inheritDoc} */
+    @Override public UUID id() {
+        return id;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String name() {
+        return name;
+    }
+
+    /** */
+    public GridH2Table tbl() {
+        return tbl;
+    }
+
+    /** */
+    public List<IndexColumn> cols() {
+        return cols;
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean canHandle(CacheDataRow row) throws IgniteCheckedException {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public void onUpdate(
+        @Nullable CacheDataRow oldRow,
+        @Nullable CacheDataRow newRow,
+        boolean prevRowAvailable
+    ) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public <T extends Index> T unwrap(Class<T> clazz) {
+        if (clazz == null)
+            return null;
+
+        if (clazz.isAssignableFrom(getClass()))
+            return clazz.cast(this);
+
+        throw new IllegalArgumentException(
+            String.format("Cannot unwrap [%s] to [%s]", getClass().getName(), clazz.getName())
+        );
+    }
+
+    /** {@inheritDoc} */
+    @Override public void destroy(boolean softDelete) {
+        // No-op.
+    }
+
+    /**
+     * @param filter Table filter.
+     * @return Cursor.
+     */
+    @Override public GridCursor<IndexRow> find(int seg, TableFilter filter) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public GridCursor<IndexRow> findFirstOrLast(int seg, boolean first) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public long totalCount() {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public GridCursor<IndexRow> findByGeometry(int seg, TableFilter filter, Geometry intersection) {
+        throw unsupported();
+    }
+}

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndexDefinition.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndexDefinition.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2.opt;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.apache.ignite.internal.cache.query.index.IndexDefinition;
+import org.apache.ignite.internal.cache.query.index.IndexName;
+import org.apache.ignite.internal.cache.query.index.sorted.IndexKeyDefinition;
+import org.h2.table.IndexColumn;
+
+/**
+ * Definition of Geo-Spatial client index.
+ */
+public class GeoSpatialClientIndexDefinition implements IndexDefinition {
+    /** */
+    private final LinkedHashMap<String, IndexKeyDefinition> keyDefs;
+
+    /** */
+    private final IndexName idxName;
+
+    /** */
+    private final GridH2Table tbl;
+
+    /** */
+    private final List<IndexColumn> cols;
+
+    /** */
+    public GeoSpatialClientIndexDefinition(
+        GridH2Table tbl,
+        IndexName idxName,
+        LinkedHashMap<String, IndexKeyDefinition> keyDefs,
+        List<IndexColumn> cols
+    ) {
+        this.idxName = idxName;
+        this.keyDefs = keyDefs;
+        this.tbl = tbl;
+        this.cols = cols;
+    }
+
+    /** */
+    public GridH2Table tbl() {
+        return tbl;
+    }
+
+    /** */
+    public List<IndexColumn> cols() {
+        return cols;
+    }
+
+    /** {@inheritDoc} */
+    @Override public IndexName idxName() {
+        return idxName;
+    }
+
+    /** {@inheritDoc} */
+    @Override public LinkedHashMap<String, IndexKeyDefinition> indexKeyDefinitions() {
+        return keyDefs;
+    }
+}

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndexFactory.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialClientIndexFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2.opt;
+
+import org.apache.ignite.internal.cache.query.index.Index;
+import org.apache.ignite.internal.cache.query.index.IndexDefinition;
+import org.apache.ignite.internal.cache.query.index.IndexFactory;
+import org.apache.ignite.internal.processors.cache.GridCacheContext;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Index factory for creating Geo-Spatial indexes for client node.
+ */
+public class GeoSpatialClientIndexFactory implements IndexFactory {
+    /** Instance of the factory. */
+    public static final GeoSpatialClientIndexFactory INSTANCE = new GeoSpatialClientIndexFactory();
+
+    /** {@inheritDoc} */
+    @Override public Index createIndex(@Nullable GridCacheContext<?, ?> cctx, IndexDefinition definition) {
+        GeoSpatialClientIndexDefinition def = (GeoSpatialClientIndexDefinition)definition;
+
+        return new GeoSpatialClientIndex(def);
+    }
+}

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialIndexImpl.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GeoSpatialIndexImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.internal.cache.query.index.AbstractIndex;
-import org.apache.ignite.internal.cache.query.index.Index;
 import org.apache.ignite.internal.cache.query.index.SingleCursor;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexRow;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexRowImpl;
@@ -241,19 +240,6 @@ public class GeoSpatialIndexImpl extends AbstractIndex implements GeoSpatialInde
         rowCnt--;
 
         return oldRow != null;
-    }
-
-    /** {@inheritDoc} */
-    @Override public <T extends Index> T unwrap(Class<T> clazz) {
-        if (clazz == null)
-            return null;
-
-        if (clazz.isAssignableFrom(getClass()))
-            return clazz.cast(this);
-
-        throw new IllegalArgumentException(
-            String.format("Cannot unwrap [%s] to [%s]", getClass().getName(), clazz.getName())
-        );
     }
 
     /** {@inheritDoc} */

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GriH2SpatialBaseIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GriH2SpatialBaseIndex.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2.opt;
+
+import java.util.HashSet;
+import org.h2.engine.Session;
+import org.h2.index.IndexType;
+import org.h2.index.SpatialIndex;
+import org.h2.index.SpatialTreeIndex;
+import org.h2.result.SearchRow;
+import org.h2.result.SortOrder;
+import org.h2.table.Column;
+import org.h2.table.IndexColumn;
+import org.h2.table.TableFilter;
+
+/** Base class for Geo-Spatial indexes to register in the H2 engine. */
+public abstract class GriH2SpatialBaseIndex extends GridH2IndexBase implements SpatialIndex {
+    /**
+     * Constructor.
+     *
+     * @param tbl  Table.
+     * @param name Index name.
+     * @param cols Indexed columns.
+     * @param type Index type.
+     */
+    protected GriH2SpatialBaseIndex(GridH2Table tbl, String name, IndexColumn[] cols, IndexType type) {
+        super(tbl, name, cols, type);
+    }
+
+    /** {@inheritDoc} */
+    @Override public H2CacheRow put(H2CacheRow row) {
+        throw new IllegalStateException("Must not be invoked.");
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean putx(H2CacheRow row) {
+        throw new IllegalStateException("Must not be invoked.");
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean removex(SearchRow row) {
+        throw new IllegalStateException("Must not be invoked.");
+    }
+
+    /** {@inheritDoc} */
+    @Override public double getCost(Session ses, int[] masks, TableFilter[] filters, int filter,
+        SortOrder sortOrder, HashSet<Column> cols) {
+        return SpatialTreeIndex.getCostRangeIndex(masks, columns) / 10;
+    }
+}

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialBaseIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialBaseIndex.java
@@ -29,7 +29,7 @@ import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 
 /** Base class for Geo-Spatial indexes to register in the H2 engine. */
-public abstract class GriH2SpatialBaseIndex extends GridH2IndexBase implements SpatialIndex {
+public abstract class GridH2SpatialBaseIndex extends GridH2IndexBase implements SpatialIndex {
     /**
      * Constructor.
      *
@@ -38,7 +38,7 @@ public abstract class GriH2SpatialBaseIndex extends GridH2IndexBase implements S
      * @param cols Indexed columns.
      * @param type Index type.
      */
-    protected GriH2SpatialBaseIndex(GridH2Table tbl, String name, IndexColumn[] cols, IndexType type) {
+    protected GridH2SpatialBaseIndex(GridH2Table tbl, String name, IndexColumn[] cols, IndexType type) {
         super(tbl, name, cols, type);
     }
 
@@ -60,6 +60,6 @@ public abstract class GriH2SpatialBaseIndex extends GridH2IndexBase implements S
     /** {@inheritDoc} */
     @Override public double getCost(Session ses, int[] masks, TableFilter[] filters, int filter,
         SortOrder sortOrder, HashSet<Column> cols) {
-        return SpatialTreeIndex.getCostRangeIndex(masks, columns) / 10;
+        return SpatialTreeIndex.getCostRangeIndex(masks, columns) / 10d;
     }
 }

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialClientIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialClientIndex.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2.opt;
+
+import org.apache.ignite.spi.indexing.IndexingQueryCacheFilter;
+import org.h2.engine.Session;
+import org.h2.index.Cursor;
+import org.h2.index.IndexType;
+import org.h2.result.SearchRow;
+import org.h2.table.IndexColumn;
+import org.h2.table.TableFilter;
+
+import static org.apache.ignite.internal.processors.query.h2.index.client.ClientInlineIndex.unsupported;
+
+/** Mock for registering Geo-Spatial indexes on client nodes in the H2 engine. */
+public class GridH2SpatialClientIndex extends GriH2SpatialBaseIndex {
+    /** */
+    public GridH2SpatialClientIndex(GeoSpatialClientIndex delegate) {
+        super(delegate.tbl(), delegate.name(), delegate.cols().toArray(new IndexColumn[0]),
+            IndexType.createNonUnique(false, false, true));
+    }
+
+    /** {@inheritDoc} */
+    @Override public H2CacheRow put(H2CacheRow row) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean putx(H2CacheRow row) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean removex(SearchRow row) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public int segmentsCount() {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public long totalRowCount(IndexingQueryCacheFilter partsFilter) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public Cursor find(Session ses, SearchRow first, SearchRow last) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean canGetFirstOrLast() {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public Cursor findFirstOrLast(Session ses, boolean first) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getRowCount(Session ses) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public Cursor findByGeometry(TableFilter filter, SearchRow first, SearchRow last, SearchRow intersection) {
+        throw unsupported();
+    }
+}

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialClientIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialClientIndex.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.processors.query.h2.opt;
 
+import org.apache.ignite.internal.processors.query.h2.index.client.AbstractClientIndex;
 import org.apache.ignite.spi.indexing.IndexingQueryCacheFilter;
 import org.h2.engine.Session;
 import org.h2.index.Cursor;
@@ -25,63 +26,66 @@ import org.h2.result.SearchRow;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 
-import static org.apache.ignite.internal.processors.query.h2.index.client.ClientInlineIndex.unsupported;
-
 /** Mock for registering Geo-Spatial indexes on client nodes in the H2 engine. */
-public class GridH2SpatialClientIndex extends GriH2SpatialBaseIndex {
+public class GridH2SpatialClientIndex extends GridH2SpatialBaseIndex {
+    /** */
+    private final AbstractClientIndex delegate;
+
     /** */
     public GridH2SpatialClientIndex(GeoSpatialClientIndex delegate) {
         super(delegate.tbl(), delegate.name(), delegate.cols().toArray(new IndexColumn[0]),
             IndexType.createNonUnique(false, false, true));
+
+        this.delegate = delegate;
     }
 
     /** {@inheritDoc} */
     @Override public H2CacheRow put(H2CacheRow row) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public boolean putx(H2CacheRow row) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public boolean removex(SearchRow row) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public int segmentsCount() {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public long totalRowCount(IndexingQueryCacheFilter partsFilter) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public Cursor find(Session ses, SearchRow first, SearchRow last) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public boolean canGetFirstOrLast() {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public Cursor findFirstOrLast(Session ses, boolean first) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public long getRowCount(Session ses) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 
     /** {@inheritDoc} */
     @Override public Cursor findByGeometry(TableFilter filter, SearchRow first, SearchRow last, SearchRow intersection) {
-        throw unsupported();
+        throw delegate.unsupported();
     }
 }

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialIndex.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.internal.processors.query.h2.opt;
 
-import java.util.HashSet;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexRow;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexValueCursor;
 import org.apache.ignite.internal.processors.query.h2.H2Cursor;
@@ -28,11 +27,7 @@ import org.h2.engine.Session;
 import org.h2.index.Cursor;
 import org.h2.index.IndexLookupBatch;
 import org.h2.index.IndexType;
-import org.h2.index.SpatialIndex;
-import org.h2.index.SpatialTreeIndex;
 import org.h2.result.SearchRow;
-import org.h2.result.SortOrder;
-import org.h2.table.Column;
 import org.h2.table.IndexColumn;
 import org.h2.table.TableFilter;
 import org.h2.value.Value;
@@ -40,16 +35,18 @@ import org.h2.value.ValueGeometry;
 import org.locationtech.jts.geom.Geometry;
 
 /**
- * H2 wrapper for spatial index.
+ * H2 wrapper for a Geo-Spatial index.
  */
-public class GridH2SpatialIndex extends GridH2IndexBase implements SpatialIndex {
+public class GridH2SpatialIndex extends GriH2SpatialBaseIndex {
     /** */
     private final GeoSpatialIndexImpl delegate;
 
     /** */
     public GridH2SpatialIndex(GeoSpatialIndexImpl idx) {
-        super(idx.def.rowHandler().getTable(), idx.def.idxName().idxName(),
-            idx.def.rowHandler().getH2IdxColumns().toArray(new IndexColumn[0]), IndexType.createNonUnique(false, false, true));
+        super(idx.def.rowHandler().getTable(),
+            idx.def.idxName().idxName(),
+            idx.def.rowHandler().getH2IdxColumns().toArray(new IndexColumn[0]),
+            IndexType.createNonUnique(false, false, true));
 
         delegate = idx;
     }
@@ -57,21 +54,6 @@ public class GridH2SpatialIndex extends GridH2IndexBase implements SpatialIndex 
     /** {@inheritDoc} */
     @Override public IndexLookupBatch createLookupBatch(TableFilter[] filters, int filter) {
         return delegate.createLookupBatch(filters, filter);
-    }
-
-    /** {@inheritDoc} */
-    @Override public H2CacheRow put(H2CacheRow row) {
-        throw new IllegalStateException("Must not be invoked.");
-    }
-
-    /** {@inheritDoc} */
-    @Override public boolean putx(H2CacheRow row) {
-        throw new IllegalStateException("Must not be invoked.");
-    }
-
-    /** {@inheritDoc} */
-    @Override public boolean removex(SearchRow row) {
-        throw new IllegalStateException("Must not be invoked.");
     }
 
     /** {@inheritDoc} */
@@ -84,12 +66,6 @@ public class GridH2SpatialIndex extends GridH2IndexBase implements SpatialIndex 
         delegate.destroy(!rmIdx);
 
         super.destroy(rmIdx);
-    }
-
-    /** {@inheritDoc} */
-    @Override public double getCost(Session ses, int[] masks, TableFilter[] filters, int filter,
-        SortOrder sortOrder, HashSet<Column> cols) {
-        return SpatialTreeIndex.getCostRangeIndex(masks, columns) / 10;
     }
 
     /** {@inheritDoc} */

--- a/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialIndex.java
+++ b/modules/geospatial/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2SpatialIndex.java
@@ -37,7 +37,7 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * H2 wrapper for a Geo-Spatial index.
  */
-public class GridH2SpatialIndex extends GriH2SpatialBaseIndex {
+public class GridH2SpatialIndex extends GridH2SpatialBaseIndex {
     /** */
     private final GeoSpatialIndexImpl delegate;
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/client/AbstractClientIndex.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/client/AbstractClientIndex.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.query.h2.index.client;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.internal.cache.query.index.AbstractIndex;
+import org.apache.ignite.internal.processors.cache.persistence.CacheDataRow;
+import org.apache.ignite.internal.processors.query.IgniteSQLException;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Base class for all index implementations for Ignite client nodes. Client nodes don't persist any data, but they
+ * still need to know about indexes structures for planning of queries that starts on client nodes.
+ */
+public abstract class AbstractClientIndex extends AbstractIndex {
+    /** {@inheritDoc} */
+    @Override public boolean canHandle(CacheDataRow row) {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public void onUpdate(@Nullable CacheDataRow oldRow, @Nullable CacheDataRow newRow,
+        boolean prevRowAvailable) throws IgniteCheckedException {
+        throw unsupported();
+    }
+
+    /** {@inheritDoc} */
+    @Override public void destroy(boolean softDelete) {
+        // No-op.
+    }
+
+    /**
+     * @return Exception about unsupported operation.
+     */
+    public IgniteException unsupported() {
+        return new IgniteSQLException("Shouldn't be invoked on non-affinity node.");
+    }
+}

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/client/ClientInlineIndex.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/client/ClientInlineIndex.java
@@ -18,22 +18,16 @@
 package org.apache.ignite.internal.processors.query.h2.index.client;
 
 import java.util.UUID;
-import org.apache.ignite.IgniteCheckedException;
-import org.apache.ignite.IgniteException;
-import org.apache.ignite.internal.cache.query.index.Index;
 import org.apache.ignite.internal.cache.query.index.sorted.IndexRow;
 import org.apache.ignite.internal.cache.query.index.sorted.inline.IndexQueryContext;
 import org.apache.ignite.internal.cache.query.index.sorted.inline.InlineIndex;
 import org.apache.ignite.internal.cache.query.index.sorted.inline.InlineIndexTree;
-import org.apache.ignite.internal.processors.cache.persistence.CacheDataRow;
-import org.apache.ignite.internal.processors.query.IgniteSQLException;
 import org.apache.ignite.internal.util.lang.GridCursor;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * We need indexes on non-affinity nodes. This index does not contain any data.
  */
-public class ClientInlineIndex implements InlineIndex {
+public class ClientInlineIndex extends AbstractClientIndex implements InlineIndex {
     /** */
     private final int inlineSize;
 
@@ -72,32 +66,32 @@ public class ClientInlineIndex implements InlineIndex {
         boolean upIncl,
         int segment,
         IndexQueryContext qryCtx
-    ) throws IgniteCheckedException {
+    ) {
         throw unsupported();
     }
 
     /** {@inheritDoc} */
-    @Override public GridCursor<IndexRow> findFirst(int segment, IndexQueryContext qryCtx) throws IgniteCheckedException {
+    @Override public GridCursor<IndexRow> findFirst(int segment, IndexQueryContext qryCtx) {
         throw unsupported();
     }
 
     /** {@inheritDoc} */
-    @Override public GridCursor<IndexRow> findLast(int segment, IndexQueryContext qryCtx) throws IgniteCheckedException {
+    @Override public GridCursor<IndexRow> findLast(int segment, IndexQueryContext qryCtx) {
         throw unsupported();
     }
 
     /** {@inheritDoc} */
-    @Override public long count(int segment) throws IgniteCheckedException {
+    @Override public long count(int segment) {
         throw unsupported();
     }
 
     /** {@inheritDoc} */
-    @Override public long totalCount() throws IgniteCheckedException {
+    @Override public long totalCount() {
         throw unsupported();
     }
 
     /** {@inheritDoc} */
-    @Override public long count(int segment, IndexQueryContext qryCtx) throws IgniteCheckedException {
+    @Override public long count(int segment, IndexQueryContext qryCtx) {
         throw unsupported();
     }
 
@@ -114,41 +108,5 @@ public class ClientInlineIndex implements InlineIndex {
     /** {@inheritDoc} */
     @Override public String name() {
         return name;
-    }
-
-    /** {@inheritDoc} */
-    @Override public boolean canHandle(CacheDataRow row) throws IgniteCheckedException {
-        throw unsupported();
-    }
-
-    /** {@inheritDoc} */
-    @Override public void onUpdate(@Nullable CacheDataRow oldRow, @Nullable CacheDataRow newRow,
-        boolean prevRowAvailable) throws IgniteCheckedException {
-        throw unsupported();
-    }
-
-    /** {@inheritDoc} */
-    @Override public <T extends Index> T unwrap(Class<T> clazz) {
-        if (clazz == null)
-            return null;
-
-        if (clazz.isAssignableFrom(getClass()))
-            return clazz.cast(this);
-
-        throw new IllegalArgumentException(
-            String.format("Cannot unwrap [%s] to [%s]", getClass().getName(), clazz.getName())
-        );
-    }
-
-    /** {@inheritDoc} */
-    @Override public void destroy(boolean softDelete) {
-        // No-op.
-    }
-
-    /**
-     * @return Exception about unsupported operation.
-     */
-    public static IgniteException unsupported() {
-        return new IgniteSQLException("Shouldn't be invoked on non-affinity node.");
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/client/ClientInlineIndex.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/index/client/ClientInlineIndex.java
@@ -148,7 +148,7 @@ public class ClientInlineIndex implements InlineIndex {
     /**
      * @return Exception about unsupported operation.
      */
-    private static IgniteException unsupported() {
+    public static IgniteException unsupported() {
         return new IgniteSQLException("Shouldn't be invoked on non-affinity node.");
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2Table.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2Table.java
@@ -182,7 +182,7 @@ public class GridH2Table extends TableBase {
 
     /** Index manager. */
     @GridToStringExclude
-    private IndexProcessor idxMgr;
+    private final IndexProcessor idxProc;
 
     /** Table name. Use it to persist table name for destroy index after destroying table. */
     private String tableName;
@@ -201,7 +201,7 @@ public class GridH2Table extends TableBase {
         GridH2RowDescriptor desc,
         H2TableDescriptor tblDesc,
         GridCacheContextInfo cacheInfo,
-        IndexProcessor idxMgr
+        IndexProcessor idxProc
     ) {
         super(createTblData);
 
@@ -209,7 +209,7 @@ public class GridH2Table extends TableBase {
 
         this.desc = desc;
         this.cacheInfo = cacheInfo;
-        this.idxMgr = idxMgr;
+        this.idxProc = idxProc;
 
         this.tableName = createTblData.tableName;
 
@@ -754,11 +754,18 @@ public class GridH2Table extends TableBase {
                 }
             };
 
-            idxMgr.removeIndex(cacheContext(), deleteDef.idxName(), !rmIndex);
+            idxProc.removeIndex(cacheContext(), deleteDef.idxName(), !rmIndex);
 
             // Call it too, if H2 index stores some state.
             h2idx.destroy(rmIndex);
         }
+    }
+
+    /**
+     * @return Index Processor.
+     */
+    public IndexProcessor idxProc() {
+        return idxProc;
     }
 
     /**

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2Table.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2Table.java
@@ -185,7 +185,7 @@ public class GridH2Table extends TableBase {
     private final IndexProcessor idxProc;
 
     /** Table name. Use it to persist table name for destroy index after destroying table. */
-    private String tableName;
+    private final String tableName;
 
     /**
      * Creates table.
@@ -211,7 +211,7 @@ public class GridH2Table extends TableBase {
         this.cacheInfo = cacheInfo;
         this.idxProc = idxProc;
 
-        this.tableName = createTblData.tableName;
+        tableName = createTblData.tableName;
 
         affKeyCol = calculateAffinityKeyColumn();
         affKeyColIsKey = affKeyCol != null && desc.isKeyColumn(affKeyCol.column.getColumnId());


### PR DESCRIPTION
Client nodes incorrectly handle geo-spatial indexes, and fail on trying to create index. This patch provides a mock for geo-spatial indexes on client nodes by analogue with ClientInlineIndex for sorted indexes. It enables creation of indexes on Ignite client nodes.