### PR TITLE
IGNITE-16549 .NET: Add IgniteClientConfiguration.SendServerExceptionStackTraceToClient

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/ThinClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ThinClientConfiguration.java
@@ -110,6 +110,7 @@ public class ThinClientConfiguration {
 
     /**
      * @param sendServerExcStackTraceToClient If {@code true} sends a server exception stack to the client side.
+     * @return {@code this} for chaining.
      */
     public ThinClientConfiguration sendServerExceptionStackTraceToClient(boolean sendServerExcStackTraceToClient) {
         this.sendServerExcStackTraceToClient = sendServerExcStackTraceToClient;

--- a/modules/core/src/main/java/org/apache/ignite/configuration/ThinClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ThinClientConfiguration.java
@@ -111,8 +111,10 @@ public class ThinClientConfiguration {
     /**
      * @param sendServerExcStackTraceToClient If {@code true} sends a server exception stack to the client side.
      */
-    public void sendServerExceptionStackTraceToClient(boolean sendServerExcStackTraceToClient) {
+    public ThinClientConfiguration sendServerExceptionStackTraceToClient(boolean sendServerExcStackTraceToClient) {
         this.sendServerExcStackTraceToClient = sendServerExcStackTraceToClient;
+
+        return this;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientRequestHandler.java
@@ -125,8 +125,7 @@ public class ClientRequestHandler implements ClientListenerRequestHandler {
             msg = sqlState + ": " + msg;
         }
 
-        if ((X.getCause(e) != null || !X.getSuppressedList(e).isEmpty())
-                && ctx.kernalContext().sqlListener().sendServerExceptionStackTraceToClient())
+        if (ctx.kernalContext().sqlListener().sendServerExceptionStackTraceToClient())
             msg = msg + U.nl() + X.getFullStackTrace(e);
 
         return new ClientResponse(req.requestId(), status, msg);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/utils/PlatformConfigurationUtils.java
@@ -1952,6 +1952,7 @@ public class PlatformConfigurationUtils {
             cfg.setThinClientConfiguration(new ThinClientConfiguration()
                 .setMaxActiveTxPerConnection(in.readInt())
                 .setMaxActiveComputeTasksPerConnection(in.readInt())
+                .sendServerExceptionStackTraceToClient(in.readBoolean())
             );
         }
 
@@ -1991,6 +1992,7 @@ public class PlatformConfigurationUtils {
                 w.writeBoolean(true);
                 w.writeInt(thinCfg.getMaxActiveTxPerConnection());
                 w.writeInt(thinCfg.getMaxActiveComputeTasksPerConnection());
+                w.writeBoolean(thinCfg.sendServerExceptionStackTraceToClient());
             }
             else
                 w.writeBoolean(false);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -35,6 +35,7 @@ namespace Apache.Ignite.Core.Tests.Client
     using Apache.Ignite.Core.Log;
     using Apache.Ignite.Core.Tests.Client.Cache;
     using Apache.Ignite.Core.Tests.Client.Compute;
+    using Apache.Ignite.Core.Tests.Compute;
     using NUnit.Framework;
 
     /// <summary>
@@ -976,7 +977,9 @@ namespace Apache.Ignite.Core.Tests.Client
 
             using var client = StartClient();
 
-            var ex = Assert.Catch<Exception>(() => client.GetCompute().ExecuteJavaTask<object>("foo", 0)).GetBaseException();
+            var ex = Assert.Catch<Exception>(() =>
+                client.GetCompute().ExecuteJavaTask<object>(ComputeApiTest.EchoTask, -42)).GetBaseException();
+
             Assert.AreEqual("x", ex.Message);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -954,6 +954,33 @@ namespace Apache.Ignite.Core.Tests.Client
         }
 
         /// <summary>
+        /// Tests that server exception stack trace is included in error details when enabled.
+        /// </summary>
+        [Test]
+        public void TestSendServerExceptionStackTraceToClient()
+        {
+            var ignite = Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                ClientConnectorConfiguration = new ClientConnectorConfiguration
+                {
+                    ThinClientConfiguration = new ThinClientConfiguration
+                    {
+                        SendServerExceptionStackTraceToClient = true,
+                        MaxActiveComputeTasksPerConnection = 1
+                    }
+                }
+            });
+
+            Assert.IsTrue(ignite.GetConfiguration().ClientConnectorConfiguration.ThinClientConfiguration
+                .SendServerExceptionStackTraceToClient);
+
+            using var client = StartClient();
+
+            var ex = Assert.Catch<Exception>(() => client.GetCompute().ExecuteJavaTask<object>("foo", 0)).GetBaseException();
+            Assert.AreEqual("x", ex.Message);
+        }
+
+        /// <summary>
         /// Starts the client.
         /// </summary>
         private static IIgniteClient StartClient()

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -980,7 +980,8 @@ namespace Apache.Ignite.Core.Tests.Client
             var ex = Assert.Catch<Exception>(() =>
                 client.GetCompute().ExecuteJavaTask<object>(ComputeApiTest.EchoTask, -42)).GetBaseException();
 
-            Assert.AreEqual("x", ex.Message);
+            StringAssert.StartsWith("Remote job threw user exception", ex.Message);
+            StringAssert.Contains("at org.apache.ignite.platform.PlatformComputeEchoTask$EchoJob.execute", ex.Message);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/ClientConnectorConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/ClientConnectorConfiguration.cs
@@ -57,7 +57,7 @@ namespace Apache.Ignite.Core.Configuration
         /// Default SQL connector thread pool size.
         /// </summary>
         public static readonly int DefaultThreadPoolSize = IgniteConfiguration.DefaultThreadPoolSize;
-        
+
         /// <summary>
         /// Default idle timeout.
         /// </summary>
@@ -132,7 +132,8 @@ namespace Apache.Ignite.Core.Configuration
                 ThinClientConfiguration = new ThinClientConfiguration
                 {
                     MaxActiveTxPerConnection = reader.ReadInt(),
-                    MaxActiveComputeTasksPerConnection = reader.ReadInt()
+                    MaxActiveComputeTasksPerConnection = reader.ReadInt(),
+                    SendServerExceptionStackTraceToClient = reader.ReadBoolean()
                 };
             }
         }
@@ -143,7 +144,7 @@ namespace Apache.Ignite.Core.Configuration
         internal void Write(IBinaryRawWriter writer)
         {
             Debug.Assert(writer != null);
-            
+
             writer.WriteString(Host);
             writer.WriteInt(Port);
             writer.WriteInt(PortRange);
@@ -166,6 +167,7 @@ namespace Apache.Ignite.Core.Configuration
                 writer.WriteBoolean(true);
                 writer.WriteInt(ThinClientConfiguration.MaxActiveTxPerConnection);
                 writer.WriteInt(ThinClientConfiguration.MaxActiveComputeTasksPerConnection);
+                writer.WriteBoolean(ThinClientConfiguration.SendServerExceptionStackTraceToClient);
             }
             else
             {
@@ -224,7 +226,7 @@ namespace Apache.Ignite.Core.Configuration
         /// Gets or sets the size of the thread pool.
         /// </summary>
         public int ThreadPoolSize { get; set; }
-        
+
         /// <summary>
         /// Gets or sets idle timeout for client connections on the server side.
         /// If no packets come within idle timeout, the connection is closed by the server.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/ThinClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/ThinClientConfiguration.cs
@@ -35,12 +35,18 @@ namespace Apache.Ignite.Core.Configuration
         public const int DefaultMaxActiveComputeTasksPerConnection = 0;
 
         /// <summary>
+        /// Default value for <see cref="SendServerExceptionStackTraceToClient"/> property.
+        /// </summary>
+        public const bool DefaultSendServerExceptionStackTraceToClient = false;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ThinClientConfiguration"/> class.
         /// </summary>
         public ThinClientConfiguration()
         {
             MaxActiveTxPerConnection = DefaultMaxActiveTxPerConnection;
             MaxActiveComputeTasksPerConnection = DefaultMaxActiveComputeTasksPerConnection;
+            SendServerExceptionStackTraceToClient = DefaultSendServerExceptionStackTraceToClient;
         }
 
         /// <summary>
@@ -55,5 +61,14 @@ namespace Apache.Ignite.Core.Configuration
         /// </summary>
         [DefaultValue(DefaultMaxActiveComputeTasksPerConnection)]
         public int MaxActiveComputeTasksPerConnection { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether server exception stack trace
+        /// should be included in client exception details, or just the message.
+        /// <para />
+        /// Default is <c>false</c>.
+        /// </summary>
+        [DefaultValue(DefaultSendServerExceptionStackTraceToClient)]
+        public bool SendServerExceptionStackTraceToClient { get; set; }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfigurationSection.xsd
@@ -1579,6 +1579,11 @@
                                             <xs:documentation>Active compute tasks per connection limit. Or 0 if compute grid functionality is disabled for thin clients.</xs:documentation>
                                         </xs:annotation>
                                     </xs:attribute>
+                                    <xs:attribute name="sendServerExceptionStackTraceToClient" type="xs:boolean">
+                                        <xs:annotation>
+                                            <xs:documentation>Whether to send full server exception stack trace to clients.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
                                 </xs:complexType>
                             </xs:element>
                         </xs:all>


### PR DESCRIPTION
* Propagate SendServerExceptionStackTraceToClient to .NET
* Java fix: Include stack trace for Compute errors
* Java fix: Include stack trace even when cause is null