### PR TITLE
IGNITE-16608 Connection timeout affects statement execution

### DIFF
--- a/modules/platforms/cpp/odbc-test/config/queries-default.xml
+++ b/modules/platforms/cpp/odbc-test/config/queries-default.xml
@@ -74,6 +74,8 @@
         <property name="cacheMode" value="PARTITIONED"/>
         <property name="atomicityMode" value="TRANSACTIONAL"/>
 
+        <property name="sqlFunctionClasses" value="org.apache.ignite.testframework.GridTestUtils.SqlTestFunctions"/>
+
         <!-- Configure type metadata to enable queries. -->
         <property name="queryEntities">
             <list>

--- a/modules/platforms/cpp/odbc-test/include/odbc_test_suite.h
+++ b/modules/platforms/cpp/odbc-test/include/odbc_test_suite.h
@@ -119,6 +119,16 @@ namespace ignite
              *
              * @param from Index to start from.
              * @param to Index to stop.
+             * @param merge Set to true to use merge instead of insert.
+             * @return Execution result.
+             */
+            SQLRETURN InsertTestBatchNoCheck(int from, int to, bool merge = false);
+
+            /**
+             * Insert requested number of TestType values in a batch.
+             *
+             * @param from Index to start from.
+             * @param to Index to stop.
              * @param expectedToAffect Expected number of affected records.
              * @param merge Set to true to use merge instead of insert.
              * @return Records inserted.

--- a/modules/platforms/cpp/odbc-test/src/odbc_test_suite.cpp
+++ b/modules/platforms/cpp/odbc-test/src/odbc_test_suite.cpp
@@ -463,7 +463,7 @@ namespace ignite
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
         }
 
-        int OdbcTestSuite::InsertTestBatch(int from, int to, int expectedToAffect, bool merge)
+        SQLRETURN OdbcTestSuite::InsertTestBatchNoCheck(int from, int to, bool merge)
         {
             using common::FixedSizeArray;
 
@@ -526,14 +526,6 @@ namespace ignite
                 GetTestI8ArrayField(seed, &i8ArrayFields[i*42], 42);
                 i8ArrayFieldsLen[i] = 42;
             }
-
-            SQLULEN setsProcessed = 0;
-
-            BOOST_TEST_CHECKPOINT("Setting processed pointer");
-            ret = SQLSetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &setsProcessed, SQL_IS_POINTER);
-
-            if (!SQL_SUCCEEDED(ret))
-                BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
             BOOST_TEST_CHECKPOINT("Binding keys");
             ret = SQLBindParameter(stmt, 1, SQL_PARAM_INPUT, SQL_C_SBIGINT, SQL_BIGINT, 0, 0, keys.GetData(), 0, 0);
@@ -609,13 +601,27 @@ namespace ignite
 
             BOOST_TEST_CHECKPOINT("Setting paramset size");
             ret = SQLSetStmtAttr(stmt, SQL_ATTR_PARAMSET_SIZE,
-                 reinterpret_cast<SQLPOINTER>(static_cast<ptrdiff_t>(recordsNum)), 0);
+                                 reinterpret_cast<SQLPOINTER>(static_cast<ptrdiff_t>(recordsNum)), 0);
 
             if (!SQL_SUCCEEDED(ret))
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
             BOOST_TEST_CHECKPOINT("Executing query");
-            ret = SQLExecute(stmt);
+
+            return SQLExecute(stmt);
+        }
+
+        int OdbcTestSuite::InsertTestBatch(int from, int to, int expectedToAffect, bool merge)
+        {
+            SQLULEN setsProcessed = 0;
+
+            BOOST_TEST_CHECKPOINT("Setting processed pointer");
+            SQLRETURN ret = SQLSetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &setsProcessed, SQL_IS_POINTER);
+
+            if (!SQL_SUCCEEDED(ret))
+                BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+            ret = InsertTestBatchNoCheck(from, to, merge);
 
             if (!SQL_SUCCEEDED(ret))
                 BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));

--- a/modules/platforms/cpp/odbc-test/src/queries_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/queries_test.cpp
@@ -1958,7 +1958,7 @@ BOOST_AUTO_TEST_CASE(TestConnectionTimeoutQueryExpires)
 
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_DBC, dbc);
 
-    ret = InsertTestBatchNoCheck(0, 5000);
+    ret = InsertTestBatchNoCheck(0, 500000);
 
     BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
 

--- a/modules/platforms/cpp/odbc-test/src/queries_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/queries_test.cpp
@@ -1952,13 +1952,15 @@ BOOST_AUTO_TEST_CASE(TestConnectionTimeoutQuery)
 
 BOOST_AUTO_TEST_CASE(TestConnectionTimeoutQueryExpires)
 {
-    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache;PAGE_SIZE=500000");
 
     SQLRETURN ret = SQLSetConnectAttr(dbc, SQL_ATTR_CONNECTION_TIMEOUT, reinterpret_cast<SQLPOINTER>(1), 0);
 
     ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_DBC, dbc);
 
-    ret = InsertTestBatchNoCheck(0, 500000);
+    SQLCHAR req[] = "select delay(5000)";
+
+    ret = SQLExecDirect(stmt, req, SQL_NTS);
 
     BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
 

--- a/modules/platforms/cpp/odbc-test/src/queries_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/queries_test.cpp
@@ -1950,6 +1950,25 @@ BOOST_AUTO_TEST_CASE(TestConnectionTimeoutQuery)
     InsertTestStrings(10, false);
 }
 
+BOOST_AUTO_TEST_CASE(TestConnectionTimeoutQueryExpires)
+{
+    Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");
+
+    SQLRETURN ret = SQLSetConnectAttr(dbc, SQL_ATTR_CONNECTION_TIMEOUT, reinterpret_cast<SQLPOINTER>(1), 0);
+
+    ODBC_FAIL_ON_ERROR(ret, SQL_HANDLE_DBC, dbc);
+
+    ret = InsertTestBatchNoCheck(0, 5000);
+
+    BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
+
+    std::string error = GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt);
+    std::string pattern = "HYT01: Receive operation timed out";
+
+    if (error.substr(0, pattern.size()) != pattern)
+        BOOST_FAIL("'" + error + "' does not match '" + pattern + "'");
+}
+
 BOOST_AUTO_TEST_CASE(TestConnectionTimeoutBatch)
 {
     Connect("DRIVER={Apache Ignite};ADDRESS=127.0.0.1:11110;SCHEMA=cache");

--- a/modules/platforms/cpp/odbc/include/ignite/odbc/connection.h
+++ b/modules/platforms/cpp/odbc/include/ignite/odbc/connection.h
@@ -204,27 +204,25 @@ namespace ignite
              *
              * @param req Request message.
              * @param rsp Response message.
-             * @param timeout Timeout. 0 means disabled and -1 means to use default connection timeout.
+             * @param timeout Timeout. 0 means disabled.
              * @return @c true on success, @c false on timeout.
              * @throw OdbcError on error.
              */
             template<typename ReqT, typename RspT>
-            bool SyncMessage(const ReqT& req, RspT& rsp, int32_t timeout0)
+            bool SyncMessage(const ReqT& req, RspT& rsp, int32_t timeout)
             {
-                int32_t actualTimeout = timeout0 < 0 ? timeout : timeout0;
-
                 EnsureConnected();
 
                 std::vector<int8_t> tempBuffer;
 
                 parser.Encode(req, tempBuffer);
 
-                bool success = Send(tempBuffer.data(), tempBuffer.size(), actualTimeout);
+                bool success = Send(tempBuffer.data(), tempBuffer.size(), timeout);
 
                 if (!success)
                     return false;
 
-                success = Receive(tempBuffer, actualTimeout);
+                success = Receive(tempBuffer, timeout);
 
                 if (!success)
                     return false;

--- a/modules/platforms/cpp/odbc/include/ignite/odbc/connection.h
+++ b/modules/platforms/cpp/odbc/include/ignite/odbc/connection.h
@@ -204,25 +204,27 @@ namespace ignite
              *
              * @param req Request message.
              * @param rsp Response message.
-             * @param timeout Timeout.
+             * @param timeout Timeout. 0 means disabled and -1 means to use default connection timeout.
              * @return @c true on success, @c false on timeout.
              * @throw OdbcError on error.
              */
             template<typename ReqT, typename RspT>
-            bool SyncMessage(const ReqT& req, RspT& rsp, int32_t timeout)
+            bool SyncMessage(const ReqT& req, RspT& rsp, int32_t timeout0)
             {
+                int32_t actualTimeout = timeout0 < 0 ? timeout : timeout0;
+
                 EnsureConnected();
 
                 std::vector<int8_t> tempBuffer;
 
                 parser.Encode(req, tempBuffer);
 
-                bool success = Send(tempBuffer.data(), tempBuffer.size(), timeout);
+                bool success = Send(tempBuffer.data(), tempBuffer.size(), actualTimeout);
 
                 if (!success)
                     return false;
 
-                success = Receive(tempBuffer, timeout);
+                success = Receive(tempBuffer, actualTimeout);
 
                 if (!success)
                     return false;

--- a/modules/platforms/cpp/odbc/src/query/batch_query.cpp
+++ b/modules/platforms/cpp/odbc/src/query/batch_query.cpp
@@ -144,23 +144,12 @@ namespace ignite
             {
                 const std::string& schema = connection.GetSchema();
 
-                QueryExecuteBatchRequest req(schema, sql, params, begin, end, last, timeout,
-                    connection.IsAutoCommit());
+                QueryExecuteBatchRequest req(schema, sql, params, begin, end, last, timeout, connection.IsAutoCommit());
                 QueryExecuteBatchResponse rsp;
 
                 try
                 {
-                    // Setting connection timeout to 1 second more than query timeout itself.
-                    int32_t connectionTimeout = timeout ? timeout + 1 : 0;
-
-                    bool success = connection.SyncMessage(req, rsp, connectionTimeout);
-
-                    if (!success)
-                    {
-                        diag.AddStatusRecord(SqlState::SHYT00_TIMEOUT_EXPIRED, "Query timeout expired");
-
-                        return SqlResult::AI_ERROR;
-                    }
+                    connection.SyncMessage(req, rsp);
                 }
                 catch (const OdbcError& err)
                 {

--- a/modules/platforms/cpp/odbc/src/query/data_query.cpp
+++ b/modules/platforms/cpp/odbc/src/query/data_query.cpp
@@ -233,17 +233,7 @@ namespace ignite
 
                 try
                 {
-                    // Setting connection timeout to 1 second more than query timeout itself.
-                    int32_t connectionTimeout = timeout ? timeout + 1 : 0;
-
-                    bool success = connection.SyncMessage(req, rsp, connectionTimeout);
-
-                    if (!success)
-                    {
-                        diag.AddStatusRecord(SqlState::SHYT00_TIMEOUT_EXPIRED, "Query timeout expired");
-
-                        return SqlResult::AI_ERROR;
-                    }
+                    connection.SyncMessage(req, rsp);
                 }
                 catch (const OdbcError& err)
                 {
@@ -408,16 +398,7 @@ namespace ignite
 
                 try
                 {
-                    // Setting connection timeout to 1 second more than query timeout itself.
-                    int32_t connectionTimeout = timeout ? timeout + 1 : 0;
-                    bool success = connection.SyncMessage(req, rsp, connectionTimeout);
-
-                    if (!success)
-                    {
-                        diag.AddStatusRecord(SqlState::SHYT00_TIMEOUT_EXPIRED, "Query timeout expired");
-
-                        return SqlResult::AI_ERROR;
-                    }
+                    connection.SyncMessage(req, rsp);
                 }
                 catch (const OdbcError& err)
                 {


### PR DESCRIPTION
1. SQL_ATTR_CONNECTION_TIMEOUT now affects statement execution
2. Added test.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
