### PR TITLE
IGNITE-16649 .NET: Fix missing binary schema update when field is removed

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryChangeSchemaTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryChangeSchemaTest.cs
@@ -1,0 +1,96 @@
+namespace Apache.Ignite.Core.Tests.Binary
+{
+    using System.Collections.Generic;
+    using Apache.Ignite.Core.Binary;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using NUnit.Framework;
+
+    public class BinaryChangeSchemaTest
+    {
+        private const string CacheName = "TEST";
+        /** */
+        private IIgnite _grid;
+
+        /** */
+        private IIgnite _clientGrid;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _grid = Ignition.Start(Config("Config\\Compute\\compute-grid1.xml"));
+            _clientGrid = Ignition.Start(Config("Config\\Compute\\compute-grid3.xml"));
+            _grid.GetOrCreateCache<int, object>(new CacheConfiguration()
+            {
+                Name = CacheName,
+                CacheMode = CacheMode.Replicated
+            });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        [Test]
+        public void TestChangedSchema()
+        {
+            var objWith2Fields = new TestObj()
+                { fields = new List<string>() { "Field1", "Field2" }, Field1 = "test1", Field2 = "test2" };
+            var objWith1Field = new TestObj() { fields = new List<string>() { "Field1" }, Field1 = "test1" };
+
+            _clientGrid.GetOrCreateCache<int, TestObj>(CacheName).Put(1, objWith2Fields);
+            _grid.GetOrCreateCache<int, TestObj>(CacheName).TryGet(1, out var res);
+            _grid.GetOrCreateCache<int, TestObj>(CacheName).Remove(1);
+            _clientGrid.GetCache<int, TestObj>(CacheName).Put(1, objWith1Field);
+            _grid.GetCache<int, TestObj>(CacheName).TryGet(1, out res);
+        }
+
+        private static IgniteConfiguration Config(string springUrl)
+        {
+            return new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = springUrl,
+                BinaryConfiguration = new BinaryConfiguration()
+                {
+                    NameMapper = BinaryBasicNameMapper.SimpleNameInstance
+                }
+            };
+        }
+
+        public class TestObj : IBinarizable
+        {
+            public List<string> fields = new List<string>();
+            public string Field1;
+            public string Field2;
+            public string Field3;
+
+            public void WriteBinary(IBinaryWriter writer)
+            {
+                writer.WriteCollection(nameof(fields), fields);
+
+                if (fields.Contains("Field1"))
+                    writer.WriteString(nameof(Field1), Field1);
+                if (fields.Contains("Field2"))
+                    writer.WriteString(nameof(Field2), Field2);
+                if (fields.Contains("Field3"))
+                    writer.WriteString(nameof(Field3), Field3);
+
+            }
+
+            /// <inheritdoc />
+            public void ReadBinary(IBinaryReader reader)
+            {
+                fields = (List<string>)reader.ReadCollection(nameof(fields), (size) => new List<string>(size),
+                    (col, obj) => ((List<string>)col).Add((string)obj));
+
+                if (fields.Contains("Field1"))
+                    Field1 = reader.ReadString(nameof(Field1));
+                if (fields.Contains("Field2"))
+                    Field2 = reader.ReadString(nameof(Field2));
+                if (fields.Contains("Field3"))
+                    Field3 = reader.ReadString(nameof(Field3));
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryChangeSchemaTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinaryChangeSchemaTest.cs
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Apache.Ignite.Core.Tests.Binary
 {
     using System.Collections.Generic;
@@ -19,7 +36,7 @@ namespace Apache.Ignite.Core.Tests.Binary
         {
             _grid = Ignition.Start(Config("Config\\Compute\\compute-grid1.xml"));
             _clientGrid = Ignition.Start(Config("Config\\Compute\\compute-grid3.xml"));
-            _grid.GetOrCreateCache<int, object>(new CacheConfiguration()
+            _grid.GetOrCreateCache<int, object>(new CacheConfiguration
             {
                 Name = CacheName,
                 CacheMode = CacheMode.Replicated
@@ -35,9 +52,8 @@ namespace Apache.Ignite.Core.Tests.Binary
         [Test]
         public void TestChangedSchema()
         {
-            var objWith2Fields = new TestObj()
-                { fields = new List<string>() { "Field1", "Field2" }, Field1 = "test1", Field2 = "test2" };
-            var objWith1Field = new TestObj() { fields = new List<string>() { "Field1" }, Field1 = "test1" };
+            var objWith2Fields = new TestObj { fields = new List<string> { "Field1", "Field2" }, Field1 = "test1", Field2 = "test2" };
+            var objWith1Field = new TestObj { fields = new List<string> { "Field1" }, Field1 = "test1" };
 
             _clientGrid.GetOrCreateCache<int, TestObj>(CacheName).Put(1, objWith2Fields);
             _grid.GetOrCreateCache<int, TestObj>(CacheName).TryGet(1, out var res);
@@ -51,7 +67,7 @@ namespace Apache.Ignite.Core.Tests.Binary
             return new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
                 SpringConfigUrl = springUrl,
-                BinaryConfiguration = new BinaryConfiguration()
+                BinaryConfiguration = new BinaryConfiguration
                 {
                     NameMapper = BinaryBasicNameMapper.SimpleNameInstance
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySchemaChangeTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySchemaChangeTest.cs
@@ -38,8 +38,13 @@ namespace Apache.Ignite.Core.Tests.Binary
         [SetUp]
         public void SetUp()
         {
-            _grid = Ignition.Start(Config("Config\\Compute\\compute-grid1.xml"));
-            _clientGrid = Ignition.Start(Config("Config\\Compute\\compute-grid3.xml"));
+            _grid = Ignition.Start(TestUtils.GetTestConfiguration());
+
+            _clientGrid = Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                ClientMode = true,
+                IgniteInstanceName = "client"
+            });
 
             _grid.GetOrCreateCache<int, object>(CacheName);
         }
@@ -51,7 +56,7 @@ namespace Apache.Ignite.Core.Tests.Binary
         }
 
         [Test]
-        public void TestChangedSchema()
+        public void TestAddRemoveFieldsUpdatesSchema()
         {
             var objWith3Fields = new TestObj
             {
@@ -87,18 +92,6 @@ namespace Apache.Ignite.Core.Tests.Binary
             serverCache.Get(3);
         }
 
-        private static IgniteConfiguration Config(string springUrl)
-        {
-            return new IgniteConfiguration(TestUtils.GetTestConfiguration())
-            {
-                SpringConfigUrl = springUrl,
-                BinaryConfiguration = new BinaryConfiguration
-                {
-                    NameMapper = BinaryBasicNameMapper.SimpleNameInstance
-                }
-            };
-        }
-
         private class TestObj : IBinarizable
         {
             public string[] Fields { get; set; }
@@ -113,11 +106,13 @@ namespace Apache.Ignite.Core.Tests.Binary
             {
                 writer.WriteStringArray(nameof(Fields), Fields);
 
-                if (Fields.Contains("Field1"))
+                if (Fields.Contains(nameof(Field1)))
                     writer.WriteString(nameof(Field1), Field1);
-                if (Fields.Contains("Field2"))
+
+                if (Fields.Contains(nameof(Field2)))
                     writer.WriteString(nameof(Field2), Field2);
-                if (Fields.Contains("Field3"))
+
+                if (Fields.Contains(nameof(Field3)))
                     writer.WriteString(nameof(Field3), Field3);
 
             }
@@ -126,11 +121,13 @@ namespace Apache.Ignite.Core.Tests.Binary
             {
                 Fields = reader.ReadStringArray(nameof(Fields));
 
-                if (Fields.Contains("Field1"))
+                if (Fields.Contains(nameof(Field1)))
                     Field1 = reader.ReadString(nameof(Field1));
-                if (Fields.Contains("Field2"))
+
+                if (Fields.Contains(nameof(Field2)))
                     Field2 = reader.ReadString(nameof(Field2));
-                if (Fields.Contains("Field3"))
+
+                if (Fields.Contains(nameof(Field3)))
                     Field3 = reader.ReadString(nameof(Field3));
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -1239,6 +1239,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             _frame.HasCustomTypeData = false;
 
             var schemaIdx = _schema.PushSchema();
+            bool isNewSchema = false;
 
             try
             {
@@ -1273,7 +1274,10 @@ namespace Apache.Ignite.Core.Impl.Binary
 
                     // Update schema in type descriptor
                     if (desc.Schema.Get(schemaId) == null)
+                    {
                         desc.Schema.Add(schemaId, _schema.GetSchema(schemaIdx));
+                        isNewSchema = true;
+                    }
                 }
                 else
                     schemaOffset = headerSize;
@@ -1304,7 +1308,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
 
             // Apply structure updates if any.
-            _frame.Struct.UpdateWriterStructure(this);
+            _frame.Struct.UpdateWriterStructure(this, isNewSchema);
 
             // Restore old frame.
             _frame = oldFrame;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
@@ -223,6 +223,12 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             return res;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether specified action index is at the path end or further.
+        /// </summary>
+        /// <param name="pathIdx">Path index.</param>
+        /// <param name="actionIdx">Action index.</param>
+        /// <returns>True when specified action is at or beyond the path end; false otherwise.</returns>
         public bool IsPathEnd(int pathIdx, int actionIdx)
         {
             BinaryStructureEntry[] path = _paths[pathIdx];

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
@@ -230,6 +230,25 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             return actionIdx >= path.Length - 1;
         }
 
+        public IEnumerable<BinaryStructureEntry> GetEntries(int pathIdx)
+        {
+            var path = _paths[pathIdx];
+
+            foreach (var entry in path)
+            {
+                if (entry.IsEmpty)
+                    yield break;
+
+                if (entry.IsJumpTable)
+                {
+                    // TODO
+                    continue;
+                }
+
+                yield return entry;
+            }
+        }
+
         /// <summary>
         /// Copy and possibly expand paths.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
@@ -227,7 +227,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         {
             BinaryStructureEntry[] path = _paths[pathIdx];
 
-            return actionIdx == path.Length - 1;
+            return actionIdx >= path.Length - 1;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
@@ -230,25 +230,6 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             return actionIdx >= path.Length - 1;
         }
 
-        public IEnumerable<BinaryStructureEntry> GetEntries(int pathIdx)
-        {
-            var path = _paths[pathIdx];
-
-            foreach (var entry in path)
-            {
-                if (entry.IsEmpty)
-                    yield break;
-
-                if (entry.IsJumpTable)
-                {
-                    // TODO
-                    continue;
-                }
-
-                yield return entry;
-            }
-        }
-
         /// <summary>
         /// Copy and possibly expand paths.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
@@ -26,7 +26,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
     /// Binary type structure. Cache field IDs and metadata to improve marshalling performance.
     /// Every object write contains a set of field writes. Every unique ordered set of written fields
     /// produce write "path". We cache these paths allowing for very fast traverse over object structure
-    /// without expensive map lookups and field ID calculations. 
+    /// without expensive map lookups and field ID calculations.
     /// </summary>
     internal class BinaryStructure
     {
@@ -36,7 +36,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         /// <returns>Empty type structure.</returns>
         public static BinaryStructure CreateEmpty()
         {
-            return new BinaryStructure(new[] { new BinaryStructureEntry[0] }, 
+            return new BinaryStructure(new[] { new BinaryStructureEntry[0] },
                 new BinaryStructureJumpTable[1], new Dictionary<string, byte>());
         }
 
@@ -61,7 +61,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             Debug.Assert(paths != null);
             Debug.Assert(jumps != null);
             Debug.Assert(fieldTypes != null);
-            
+
             _paths = paths;
             _jumps = jumps;
             _fieldTypes = fieldTypes;
@@ -79,7 +79,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         {
             Debug.Assert(fieldName != null);
             Debug.Assert(pathIdx <= _paths.Length);
-            
+
             // Get path.
             BinaryStructureEntry[] path = _paths[pathIdx];
 
@@ -223,6 +223,13 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             return res;
         }
 
+        public bool IsPathEnd(int pathIdx, int actionIdx)
+        {
+            BinaryStructureEntry[] path = _paths[pathIdx];
+
+            return actionIdx == path.Length - 1;
+        }
+
         /// <summary>
         /// Copy and possibly expand paths.
         /// </summary>
@@ -312,6 +319,6 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         internal IDictionary<string, byte> FieldTypes
         {
             get { return _fieldTypes; }
-        } 
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Core.Impl.Binary.Structure
 {
-    using System;
     using System.Collections.Generic;
 
     /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -124,6 +124,11 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
                 writer.SaveMetadata(_desc, null);
                 _desc.UpdateWriteStructure(_curStructPath, null);
             }
+            // TODO: Check if _curStructAction + _curStructPath form a complete path.
+            else if (_curStructAction < _portStruct.FieldTypes.Count)
+            {
+                // Subset of current schema is still a different schema.
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -125,7 +125,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
                 writer.SaveMetadata(_desc, null);
                 _desc.UpdateWriteStructure(_curStructPath, null);
             }
-            else if (!_portStruct.IsPathEnd(_curStructPath, _curStructAction) && isNewSchema)
+            else if (isNewSchema && _portStruct != null && !_portStruct.IsPathEnd(_curStructPath, _curStructAction))
             {
                 // Subset of current schema is a different schema and should be saved.
                 writer.SaveMetadata(_desc, null);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -124,10 +124,10 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
                 writer.SaveMetadata(_desc, null);
                 _desc.UpdateWriteStructure(_curStructPath, null);
             }
-            // TODO: Check if _curStructAction + _curStructPath form a complete path.
-            else if (_curStructAction < _portStruct.FieldTypes.Count)
+            else if (!_portStruct.IsPathEnd(_curStructPath, _curStructAction))
             {
-                // Subset of current schema is still a different schema.
+                // Subset of current schema is a different schema.
+                //
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -128,19 +128,8 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             }
             else if (!_portStruct.IsPathEnd(_curStructPath, _curStructAction) && isNewSchema)
             {
-                // Subset of current schema is a different schema.
-                // TODO: Get fields up to _curStructAction
-                // metaHnd.OnFieldWrite, OnObjectWriteFinished, SaveMetadata
-                var metaHnd = writer.Marshaller.GetBinaryTypeHandler(_desc);
-
-                if (metaHnd != null)
-                {
-                    foreach (var entry in _portStruct.GetEntries(_curStructPath))
-                    {
-                        // TODO: type?
-                        metaHnd.OnFieldWrite(entry.Id, entry.Name, 0);
-                    }
-                }
+                // Subset of current schema is a different schema without new fields.
+                writer.SaveMetadata(_desc, null);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Core.Impl.Binary.Structure
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -127,7 +128,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             else if (!_portStruct.IsPathEnd(_curStructPath, _curStructAction))
             {
                 // Subset of current schema is a different schema.
-                //
+                throw new NotSupportedException("TODO");
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -128,6 +128,8 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             else if (!_portStruct.IsPathEnd(_curStructPath, _curStructAction))
             {
                 // Subset of current schema is a different schema.
+                // TODO: Get fields up to _curStructAction
+                // metaHnd.OnFieldWrite, OnObjectWriteFinished, SaveMetadata
                 throw new NotSupportedException("TODO");
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -127,7 +127,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             }
             else if (!_portStruct.IsPathEnd(_curStructPath, _curStructAction) && isNewSchema)
             {
-                // Subset of current schema is a different schema without new fields.
+                // Subset of current schema is a different schema and should be saved.
                 writer.SaveMetadata(_desc, null);
             }
         }


### PR DESCRIPTION
When new binary object schema is a subset of existing schema, it was not sent to the cluster. Detect this case and send the schema.