### PR TITLE
IGNITE-16569 Add ability to customize the test context for ducktest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ modules/ducktests/tests/docker/build/**
 modules/ducktests/tests/.tox
 modules/ducktests/tests/certs/*
 modules/ducktests/tests/ignitetest.egg-info/**
+modules/ducktests/tests/build/**
+modules/ducktests/tests/dist/**

--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/__init__.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/__init__.py
@@ -62,7 +62,7 @@ class IgniteConfiguration(NamedTuple):
     rebalance_batches_prefetch_count: int = None
     rebalance_throttle: int = None
     local_event_listeners: str = None
-    include_event_types: str = None
+    include_event_types: set = set()
     event_storage_spi: str = None
     log4j_config: str = IgnitePathAware.IGNITE_LOG_CONFIG_NAME
 

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/ignite.xml.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/ignite.xml.j2
@@ -120,8 +120,8 @@
             <property name="localEventListeners" ref="{{ config.local_event_listeners }}"/>
         {% endif %}
 
-        {% if config.include_event_types %}
-            <property name="includeEventTypes" ref="{{ config.include_event_types }}"/>
+        {% if config.include_event_types | length > 0 %}
+            <property name="includeEventTypes" ref="eventTypes"/>
         {% endif %}
 
         {% if config.event_storage_spi %}
@@ -132,4 +132,8 @@
     </bean>
 
     {{ misc_utils.ext_beans(config) }}
+
+    {% if config.include_event_types | length > 0 %}
+        {{ misc_utils.event_types(config) }}
+    {% endif %}
 </beans>

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/misc_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/misc_macro.j2
@@ -44,3 +44,13 @@
         {% endfor %}
     {% endif %}
 {% endmacro %}
+
+{% macro event_types(config) %}
+    {% if config.include_event_types | length > 0 %}
+        <util:list id="eventTypes" value-type="java.lang.Integer">
+            {% for event_type in config.include_event_types %}
+                {{ event_type }}
+            {% endfor %}
+        </util:list>
+    {% endif %}
+{% endmacro %}

--- a/modules/ducktests/tests/ignitetest/services/zk/zookeeper.py
+++ b/modules/ducktests/tests/ignitetest/services/zk/zookeeper.py
@@ -79,7 +79,16 @@ class ZookeeperService(DucktestsService, PathAware):
         return os.path.join(self.persistent_root, "zookeeper.properties")
 
     def start(self, **kwargs):
+        self.start_async(**kwargs)
+        self.await_started()
+
+    def start_async(self, **kwargs):
+        """
+        Starts in async way.
+        """
         super().start(**kwargs)
+
+    def await_started(self):
         self.logger.info("Waiting for Zookeeper quorum...")
 
         for node in self.nodes:

--- a/modules/ducktests/tests/ignitetest/tests/auth_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/auth_test.py
@@ -19,7 +19,7 @@ This module contains password based authentication tests
 
 from ignitetest.services.ignite import IgniteService
 from ignitetest.services.ignite_app import IgniteApplicationService
-from ignitetest.services.utils.auth import DEFAULT_AUTH_PASSWORD, DEFAULT_AUTH_USERNAME
+from ignitetest.services.utils.auth import DEFAULT_AUTH_PASSWORD, DEFAULT_AUTH_USERNAME, is_auth_enabled
 from ignitetest.services.utils.control_utility import ControlUtility, ControlUtilityError
 from ignitetest.services.utils.ignite_configuration import IgniteConfiguration, DataStorageConfiguration
 from ignitetest.services.utils.ignite_configuration.data_storage import DataRegionConfiguration
@@ -28,6 +28,7 @@ from ignitetest.services.utils.ignite_configuration import IgniteThinClientConfi
 from ignitetest.services.utils.ssl.client_connector_configuration import ClientConnectorConfiguration
 from ignitetest.utils.ignite_test import IgniteTest
 from ignitetest.utils.version import DEV_BRANCH, LATEST, IgniteVersion
+from ignitetest.utils import ignore_if
 
 WRONG_PASSWORD = "wrong_password"
 TEST_USERNAME = "admin"
@@ -47,6 +48,7 @@ class AuthenticationTests(IgniteTest):
     NUM_NODES = 2
 
     @cluster(num_nodes=NUM_NODES)
+    @ignore_if(lambda _, _globals: is_auth_enabled(_globals))
     @ignite_versions(str(DEV_BRANCH), str(LATEST))
     def test_change_users(self, ignite_version):
         """

--- a/modules/ducktests/tests/ignitetest/tests/cellular_affinity_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/cellular_affinity_test.py
@@ -150,7 +150,7 @@ class CellularAffinity(IgniteTest):
         """
         Tests Cellular switch tx latency.
         """
-        cluster_size = len(self.test_context.cluster)
+        cluster_size = self.available_cluster_size
 
         cells_amount = math.floor((cluster_size - self.ZOOKEPER_CLUSTER_SIZE) / (self.NODES_PER_CELL + 1))
 

--- a/modules/ducktests/tests/ignitetest/tests/control_utility/consistency_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/control_utility/consistency_test.py
@@ -43,12 +43,6 @@ class ConsistencyTest(IgniteTest):
     """
     CACHE_NAME = "TEST"
 
-    PROPERTIES = """
-        <property name="includeEventTypes">
-            <util:constant static-field="org.apache.ignite.events.EventType.EVT_CONSISTENCY_VIOLATION"/>
-        </property>
-        """
-
     @cluster(num_nodes=2)
     @ignite_versions(str(DEV_BRANCH))
     def test_logging(self, ignite_version):
@@ -62,7 +56,8 @@ class ConsistencyTest(IgniteTest):
             IgniteConfiguration(
                 version=IgniteVersion(ignite_version),
                 cluster_state="INACTIVE",
-                properties=self.PROPERTIES,
+                include_event_types={"<util:constant static-field="
+                                     "\"org.apache.ignite.events.EventType.EVT_CONSISTENCY_VIOLATION\"/>"},
                 log4j_config=cfg_filename  # default AI config (will be generated below)
             ),
             java_class_name="org.apache.ignite.internal.ducktest.tests.control_utility.InconsistentNodeApplication",

--- a/modules/ducktests/tests/ignitetest/tests/control_utility/consistency_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/control_utility/consistency_test.py
@@ -73,7 +73,7 @@ class ConsistencyTest(IgniteTest):
                 "tx": False
             },
             startup_timeout_sec=180,
-            num_nodes=len(self.test_context.cluster))
+            num_nodes=self.available_cluster_size)
 
         for node in ignites.nodes:  # copying default AI config with log path replacement
             ignites.init_persistent(node)

--- a/modules/ducktests/tests/ignitetest/tests/discovery_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/discovery_test.py
@@ -175,7 +175,7 @@ class DiscoveryTest(IgniteTest):
     def _perform_node_fail_scenario(self, test_config):
         failure_detection_timeout = self._global_int(self.GLOBAL_DETECTION_TIMEOUT, self.DEFAULT_DETECTION_TIMEOUT)
 
-        cluster_size = len(self.test_context.cluster)
+        cluster_size = self.available_cluster_size
 
         # One node is required to detect the failure.
         assert cluster_size >= 1 + test_config.nodes_to_kill + (

--- a/modules/ducktests/tests/ignitetest/tests/persistence_upgrade_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/persistence_upgrade_test.py
@@ -22,7 +22,8 @@ from ignitetest.services.ignite_app import IgniteApplicationService
 from ignitetest.services.utils.control_utility import ControlUtility
 from ignitetest.services.utils.ignite_configuration import IgniteConfiguration, DataStorageConfiguration
 from ignitetest.services.utils.ignite_configuration.data_storage import DataRegionConfiguration
-from ignitetest.utils import cluster
+from ignitetest.services.utils.ssl.ssl_params import is_ssl_enabled
+from ignitetest.utils import cluster, ignite_versions, ignore_if
 from ignitetest.utils.ignite_test import IgniteTest
 from ignitetest.utils.version import IgniteVersion, LATEST, DEV_BRANCH, OLDEST
 
@@ -33,8 +34,10 @@ class PersistenceUpgradeTest(IgniteTest):
     """
 
     @cluster(num_nodes=1)
+    @ignite_versions(str(OLDEST))
+    @ignore_if(lambda _, globals: is_ssl_enabled(globals))
     @parametrize(versions=[str(OLDEST), str(LATEST), str(DEV_BRANCH)])
-    def upgrade_test(self, versions):
+    def upgrade_test(self, versions, ignite_version):
         """
         Basic upgrade test.
         """

--- a/modules/ducktests/tests/ignitetest/tests/pme_free_switch_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/pme_free_switch_test.py
@@ -75,7 +75,7 @@ class PmeFreeSwitchTest(IgniteTest):
 
         config = IgniteConfiguration(version=IgniteVersion(ignite_version), caches=caches, cluster_state="INACTIVE")
 
-        num_nodes = len(self.test_context.cluster) - 2
+        num_nodes = self.available_cluster_size - 2
 
         self.test_context.logger.info("Nodes amount calculated as %d." % num_nodes)
 

--- a/modules/ducktests/tests/ignitetest/tests/rebalance/util.py
+++ b/modules/ducktests/tests/ignitetest/tests/rebalance/util.py
@@ -97,7 +97,7 @@ def start_ignite(test_context, ignite_version: str, rebalance_params: RebalanceP
     :param rebalance_params: Rebalance parameters.
     :return: IgniteService.
     """
-    node_count = len(test_context.cluster) - rebalance_params.preloaders
+    node_count = test_context.available_cluster_size - rebalance_params.preloaders
 
     if rebalance_params.persistent:
         data_storage = DataStorageConfiguration(

--- a/modules/ducktests/tests/ignitetest/tests/snapshot_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/snapshot_test.py
@@ -17,8 +17,6 @@
 Module contains snapshot test.
 """
 
-from ducktape.mark.resource import cluster
-
 from ignitetest.services.ignite import IgniteService
 from ignitetest.services.ignite_app import IgniteApplicationService
 from ignitetest.services.utils.control_utility import ControlUtility
@@ -28,6 +26,7 @@ from ignitetest.services.utils.ignite_configuration.discovery import from_ignite
 from ignitetest.utils import ignite_versions
 from ignitetest.utils.ignite_test import IgniteTest
 from ignitetest.utils.version import IgniteVersion, LATEST, DEV_BRANCH
+from ignitetest.utils import cluster
 
 
 class SnapshotTest(IgniteTest):
@@ -52,7 +51,7 @@ class SnapshotTest(IgniteTest):
             metric_exporter='org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi'
         )
 
-        nodes = IgniteService(self.test_context, ignite_config, num_nodes=len(self.test_context.cluster) - 1)
+        nodes = IgniteService(self.test_context, ignite_config, num_nodes=self.available_cluster_size - 1)
         nodes.start()
 
         control_utility = ControlUtility(nodes)

--- a/modules/ducktests/tests/ignitetest/utils/ignite_test.py
+++ b/modules/ducktests/tests/ignitetest/utils/ignite_test.py
@@ -16,15 +16,43 @@
 """
 This module contains basic ignite test.
 """
+import importlib
 from time import monotonic
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
-from ducktape.tests.test import Test
+from ducktape.tests.test import Test, TestContext
 
 from ignitetest.services.utils.ducktests_service import DucktestsService
 
 # globals:
 JFR_ENABLED = "jfr_enabled"
+IGNITE_TEST_CONTEXT_CLASS_KEY_NAME = "IgniteTestContext"
+
+
+class IgniteTestContext(TestContext):
+    def __init__(self, test_context):
+        super().__init__()
+        self.__dict__.update(**test_context.__dict__)
+
+    @property
+    def available_cluster_size(self):
+        return len(self.cluster)
+
+    def before(self):
+        pass
+
+    def after(self, test_result):
+        return test_result
+
+    @staticmethod
+    def resolve(test_context):
+        if IGNITE_TEST_CONTEXT_CLASS_KEY_NAME in test_context.globals:
+            fqdn = test_context.globals[IGNITE_TEST_CONTEXT_CLASS_KEY_NAME]
+            (module, clazz) = fqdn.rsplit('.', 1)
+            module = importlib.import_module(module)
+            return getattr(module, clazz)(test_context)
+        else:
+            return IgniteTestContext(test_context)
 
 
 class IgniteTest(Test):
@@ -32,7 +60,15 @@ class IgniteTest(Test):
     Basic ignite test.
     """
     def __init__(self, test_context):
+        assert isinstance(test_context, IgniteTestContext),\
+            "any IgniteTest MUST BE decorated with the @ignitetest.utils.cluster decorator"
+
         super().__init__(test_context=test_context)
+
+    @property
+    def available_cluster_size(self):
+        # noinspection PyUnresolvedReferences
+        return self.test_context.available_cluster_size
 
     @staticmethod
     def monotonic():


### PR DESCRIPTION
Added ability to add extra procedures to be invoked _before_ and _after_ each ducktest transparently via the globals parameters in a way similar to customization of specs for ignite nodes.  It should be possible to invoke of extra ducktape services in these procedures on the same testing cluster.  

In this PR some modifications were also done to let tests run smoothly in presence of the customization:

* The **persistence_upgrade_test.py::PersistenceUpgradeTest** fails if SSL is enabled via the --globals options. The immediate reason is that control.sh doesn't support the SSL options (like key_store_path) in the 2.7.6 version which is the starting point for the test incremental migrations of the PDS. Solution is to ignore test if SSL is enabled.

* **The auth_test.py::AuthenticationTests** uses the default ignite auth implementation and fails if custom auth implementation if configured via the  globals. Solutuion - ignore test in such situation.

* The framework was modified to let customization to extend set of listening ignite events. The test affected is  **control_utility/consistency_test.py::ConsistencyTest**. 


More details are available in the Jira issue at https://issues.apache.org/jira/browse/IGNITE-16569

*****

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
