### PR TITLE
IGNITE-16753 Add junit to exclusions for curator-test library

### DIFF
--- a/modules/control-utility/pom.xml
+++ b/modules/control-utility/pom.xml
@@ -126,6 +126,16 @@
             <artifactId>curator-test</artifactId>
             <version>${curator.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/modules/zookeeper/pom.xml
+++ b/modules/zookeeper/pom.xml
@@ -90,6 +90,16 @@
             <artifactId>curator-test</artifactId>
             <version>${curator.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/ZookeeperDiscoverySpiTestSuite1.java
+++ b/modules/zookeeper/src/test/java/org/apache/ignite/spi/discovery/zk/ZookeeperDiscoverySpiTestSuite1.java
@@ -63,5 +63,6 @@ public class ZookeeperDiscoverySpiTestSuite1 {
     public static void init() {
         System.setProperty("zookeeper.forceSync", "false");
         System.setProperty("zookeeper.jmx.log4j.disable", "true");
+        System.setProperty("jute.maxbuffer", String.valueOf(2 * 1024 * 1024));  // 2 MB.
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -136,7 +136,7 @@
         <yammer.metrics.core.version>2.2.0</yammer.metrics.core.version>
         <yardstick.version>0.8.3</yardstick.version>
         <zkclient.version>0.5</zkclient.version>
-        <zookeeper.version>3.8.0</zookeeper.version>
+        <zookeeper.version>3.6.3</zookeeper.version>
         <zstd.version>1.3.7-2</zstd.version>
         <opencensus.version>0.22.0</opencensus.version>
         <commons.lang3.version>3.9</commons.lang3.version>


### PR DESCRIPTION
Fix zookeeper tests didn't run. Downgrade zoo version, exclude transitive junit deps, add system property (actually default one)