### PR TITLE
IGNITE-16804 Add ability to export metrics from ducktests

### DIFF
--- a/modules/ducktests/README.md
+++ b/modules/ducktests/README.md
@@ -96,6 +96,88 @@ TBD
 ### Run with build-in authentication enabled
 TBD
 
+## Run with metrics export enabled
+
+To let Ignite nodes export metrics in different formats during test run use the `metrics` globals parameter
+as described in following sections.  
+
+You would need to install and configure metrics collecting software (like prometheus or zabbix) by yourselves. 
+
+Below is the sample `prometheus.yml` config file which may be used to collect metrics from tests running in docker:
+
+```yaml
+global:
+  scrape_interval: 1s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'ducktests'
+    static_configs:
+      - targets:
+        - 172.20.0.2:8082
+        - 172.20.0.3:8082
+        - 172.20.0.4:8082
+        - 172.20.0.5:8082
+        - 172.20.0.6:8082
+        - 172.20.0.7:8082
+        - 172.20.0.8:8082
+        - 172.20.0.9:8082
+        - 172.20.0.10:8082
+        - 172.20.0.11:8082
+        - 172.20.0.12:8082
+        - 172.20.0.13:8082
+        - 172.20.0.14:8082
+```
+
+In case of docker you might want ask it to assign the same IP addresses to containers each time it is invoked. 
+This way you will be able to create a static config file for your metrics scraper. To do so use
+the `--subnet` parameter for the `./docker/run_tests.sh` script as
+
+```
+./docker/run_tests.sh --subnet 170.20.0.0/16
+```
+
+### Run with the Prometheus metrics exporter
+
+To export metrics in the Prometheus format via the HTTP use the following `--globals-json` parameters:
+
+```json
+{
+  "metrics": { 
+    "opencensus": { 
+      "enabled":true, 
+      "port": 8082
+    }
+  }
+}
+```
+
+To separate metrics from different tests the `iin` label is used. It may be used in software like grafana for filtration.
+
+Label contains the *test id* string: dot concatenated test package name, test class name, test method name and set of
+name/value pairs for parameters, like: 
+
+`discovery_test.DiscoveryTest.test_nodes_fail_not_sequential_zk.nodes_to_kill.2.load_type.ClusterLoad.ATOMIC.ignite_version.ignite-2.11.0`
+
+**Implementation note.** The `ignite-opencensus` metrics module uses the `iin` label to expose the `IgniteInstanceName`
+cluster configuration parameter. So the `ducktests` engine exploits this fact and puts the *test id* to 
+configuration of each ignite node started in scope of particular test.
+
+### Run with the JMX metrics exporter
+
+To have Ignite nodes export metrics via the JMX use below global parameters. Note that you also might want to enable the 
+JMХ remote access (running on 1098 port) to let external tools like zabbix collect metrics. 
+```json
+{
+  "jmx_remote_enabled": true,
+  "metrics": {
+    "jmx": {
+      "enabled":true
+    }
+  }
+}
+```
+  
 # Development
 ## Preparing development environment
 - Create a virtual environment and activate it using following commands:

--- a/modules/ducktests/pom.xml
+++ b/modules/ducktests/pom.xml
@@ -30,6 +30,10 @@
         <relativePath>../../parent</relativePath>
     </parent>
 
+    <properties>
+        <prometheus.version>0.6.0</prometheus.version>
+    </properties>
+
     <artifactId>ignite-ducktests</artifactId>
     <version>${revision}</version>
     <url>http://ignite.apache.org</url>
@@ -201,6 +205,24 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ignite-opencensus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-exporter-stats-prometheus</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>${prometheus.version}</version>
         </dependency>
     </dependencies>
 

--- a/modules/ducktests/pom.xml
+++ b/modules/ducktests/pom.xml
@@ -31,7 +31,7 @@
     </parent>
 
     <properties>
-        <prometheus.version>0.6.0</prometheus.version>
+        <prometheus.version>0.3.0</prometheus.version>
     </properties>
 
     <artifactId>ignite-ducktests</artifactId>

--- a/modules/ducktests/tests/docker/Dockerfile
+++ b/modules/ducktests/tests/docker/Dockerfile
@@ -97,4 +97,4 @@ USER ducker
 CMD sudo service ssh start && tail -f /dev/null
 
 # Container port exposure
-EXPOSE 11211 47100 47500 49112 10800 8080 2888 3888 2181
+EXPOSE 11211 47100 47500 49112 10800 8080 2888 3888 2181 1098 8082

--- a/modules/ducktests/tests/docker/clean_up.sh
+++ b/modules/ducktests/tests/docker/clean_up.sh
@@ -15,5 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bash ./ducker-ignite down
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bash "$SCRIPT_DIR"/ducker-ignite down
 

--- a/modules/ducktests/tests/docker/ducker-ignite
+++ b/modules/ducktests/tests/docker/ducker-ignite
@@ -70,6 +70,7 @@ build [-j|--jdk JDK] [-c|--context] [image-name]
 
 up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
         [-C|--custom-ducktape DIR] [-e|--expose-ports ports] [-j|--jdk JDK_VERSION]
+        [--subnet SUBNET]
     Bring up a cluster with the specified amount of nodes (defaults to ${default_num_nodes}).
     The docker image name defaults to ${default_image_name}. If --force is specified, we will
     attempt to bring up an image even some parameters are not valid.
@@ -85,6 +86,9 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
 
     If --jdk is specified then we will use this argument as base image for ducktest's docker images.
     Otherwise ${default_jdk} is used.
+
+    If --subnet is specified then nodes are assigned IP addresses in this subnetwork. SUBNET is specified
+    in the CIDR format and passed directly to the docker create network command.
 
 test [test-name(s)]
     Run a test or set of tests inside the currently active Ducker nodes.
@@ -333,6 +337,7 @@ ducker_up() {
             -f|--force) force=1; shift;;
             -n|--num-nodes) set_once num_nodes "${2}" "number of nodes"; shift 2;;
             -e|--expose-ports) set_once expose_ports "${2}" "the ports to expose"; shift 2;;
+            --subnet) set_once subnet "${2}" "subnet in CIDR format that represents a network segment"; shift 2;;
             *) set_once image_name "${1}" "docker image name"; shift;;
         esac
     done
@@ -349,6 +354,7 @@ use only ${num_nodes}."
             exit 1
         fi
     fi
+    [[ "${subnet}" ]] && docker_network_options="--subnet ${subnet}"
 
     docker ps >/dev/null || die "ducker_up: failed to run docker.  Please check that the daemon is started."
 
@@ -367,7 +373,7 @@ attempting to start new ones."
     if docker network inspect ducknet &>/dev/null; then
         must_do -v docker network rm ducknet
     fi
-    must_do -v docker network create ducknet
+    must_do -v docker network create "${docker_network_options}" ducknet
     if [[ -n "${custom_ducktape}" ]]; then
         setup_custom_ducktape "${custom_ducktape}" "${image_name}"
     fi

--- a/modules/ducktests/tests/docker/run_tests.sh
+++ b/modules/ducktests/tests/docker/run_tests.sh
@@ -75,6 +75,9 @@ The options are as follows:
 -t|--tc-paths
     Path to ducktests. Must be relative path to 'IGNITE/modules/ducktests/tests' directory
 
+--subnet
+    Subnet to assign nodes IP addresses, like --subnet 172.20.0.0/16
+
 --jdk
     Set jdk version to build, default is 8
 
@@ -124,6 +127,7 @@ while [[ $# -ge 1 ]]; do
         -t|--tc-paths) TC_PATHS="$2"; shift 2;;
         -n|--num-nodes) IGNITE_NUM_CONTAINERS="$2"; shift 2;;
         -j|--max-parallel) MAX_PARALLEL="$2"; shift 2;;
+        --subnet) SUBNET="--subnet $2"; shift 2;;
         --jdk) JDK_VERSION="$2"; shift 2;;
         --image) IMAGE_NAME="$2"; shift 2;;
         -f|--force) FORCE=$1; shift;;
@@ -146,8 +150,8 @@ fi
 
 # Up cluster if nothing is running
 if "$SCRIPT_DIR"/ducker-ignite ssh | grep -q '(none)'; then
-    # do not quote FORCE as bash recognize "" as input param instead of image name
-    "$SCRIPT_DIR"/ducker-ignite up $FORCE -n "$IGNITE_NUM_CONTAINERS" "$IMAGE_NAME" || die "ducker-ignite up failed"
+    # do not quote FORCE and SUBNET as bash recognize "" as input param instead of image name
+    "$SCRIPT_DIR"/ducker-ignite up $FORCE $SUBNET -n "$IGNITE_NUM_CONTAINERS" "$IMAGE_NAME" || die "ducker-ignite up failed"
 fi
 
 DUCKTAPE_OPTIONS="--globals '$GLOBALS'"

--- a/modules/ducktests/tests/ignitetest/services/utils/control_utility.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/control_utility.py
@@ -197,7 +197,7 @@ class ControlUtility:
 
         while datetime.now() < delta_time:
             for node in self._cluster.nodes:
-                mbean = JmxClient(node).find_mbean('.*clsLdr=[[:xdigit:]]+,name=snapshot')
+                mbean = JmxClient(node).find_mbean('.*name=snapshot.*', negative_pattern='group=views')
 
                 if snapshot_name != next(mbean.LastSnapshotName, ""):
                     continue

--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_aware.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_aware.py
@@ -555,7 +555,7 @@ class IgniteAwareService(BackgroundThreadService, IgnitePathAware, metaclass=ABC
         """
         Waiting for the rebalance to complete.
         For the method, you need to set the
-        metric_exporter='org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi'
+        metric_exporters={'org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi'}
         to the config.
 
         :param timeout_sec: Timeout to wait the rebalance to complete.

--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/__init__.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/__init__.py
@@ -42,6 +42,7 @@ class IgniteConfiguration(NamedTuple):
     cluster_state: str = 'ACTIVE'
     client_mode: bool = False
     consistent_id: str = None
+    ignite_instance_name: str = None
     failure_detection_timeout: int = 10000
     sys_worker_blocked_timeout: int = 10000
     properties: str = None
@@ -56,7 +57,9 @@ class IgniteConfiguration(NamedTuple):
     plugins: list = []
     ext_beans: list = []
     peer_class_loading_enabled: bool = True
-    metric_exporter: str = None
+    metrics_log_frequency: int = 15000
+    metrics_update_frequency: int = 1000
+    metric_exporters: set = set()
     rebalance_thread_pool_size: int = None
     rebalance_batch_size: int = None
     rebalance_batches_prefetch_count: int = None

--- a/modules/ducktests/tests/ignitetest/services/utils/jmx_utils.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/jmx_utils.py
@@ -69,15 +69,19 @@ class JmxClient:
         return os.path.join(f"java -jar {self.install_root}/jmxterm.jar -v silent -n")
 
     @memoize
-    def find_mbean(self, pattern, domain='org.apache'):
+    def find_mbean(self, pattern, negative_pattern=None, domain='org.apache'):
         """
         Find mbean by specified pattern and domain on node.
         :param pattern: MBean name pattern.
+        :param negative_pattern: if passed used to filter out some MBeans
         :param domain: Domain of MBean
         :return: JmxMBean instance
         """
         cmd = "echo $'open %s\\n beans -d %s \\n close' | %s | grep -E -o '%s'" \
               % (self.pid, domain, self.jmx_util_cmd, pattern)
+
+        if negative_pattern:
+            cmd += " | grep -E -v '%s'" % negative_pattern
 
         name = next(self.__run_cmd(cmd)).strip()
 

--- a/modules/ducktests/tests/ignitetest/services/utils/metrics/metrics.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/metrics/metrics.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from typing import NamedTuple
+
+from ignitetest.utils.bean import Bean
+from ignitetest.utils.version import V_2_7_6
+
+METRICS_KEY = "metrics"
+
+ENABLED = "enabled"
+
+OPENCENSUS_TEMPLATE_FILE = "opencensus_metrics_beans_macro.j2"
+OPENCENSUS_KEY = "opencensus"
+OPENCENSUS_NAME = "OpencensusMetrics"
+
+JMX_KEY = "jmx"
+
+
+class OpencensusMetrics(NamedTuple):
+    period: int
+    port: int
+    name: str
+
+    @staticmethod
+    def enabled(service):
+        return service.config.version > V_2_7_6 and \
+               METRICS_KEY in service.context.globals and \
+               OPENCENSUS_KEY in service.context.globals[METRICS_KEY] and \
+               service.context.globals[METRICS_KEY][OPENCENSUS_KEY][ENABLED]
+
+    @staticmethod
+    def from_globals(_globals):
+        return OpencensusMetrics(period=_globals[METRICS_KEY][OPENCENSUS_KEY].get("period", 1000),
+                                 port=_globals[METRICS_KEY][OPENCENSUS_KEY].get("port", 8082),
+                                 name=OPENCENSUS_NAME)
+
+    @staticmethod
+    def add_to_config(config, _globals):
+        if config.metrics_update_frequency is None:
+            config = config._replace(metrics_update_frequency=1000)
+
+        metrics_params = OpencensusMetrics.from_globals(_globals)
+        config.metric_exporters.add(Bean("org.apache.ignite.spi.metric.opencensus.OpenCensusMetricExporterSpi",
+                                         period=metrics_params.period,
+                                         sendInstanceName=True))
+
+        if not any((bean[1].name and bean[1].name == OPENCENSUS_NAME) for bean in config.ext_beans):
+            config.ext_beans.append((OPENCENSUS_TEMPLATE_FILE, metrics_params))
+
+        return config
+
+
+class JmxMetrics:
+
+    @staticmethod
+    def enabled(service):
+        return service.config.version > V_2_7_6 and \
+               METRICS_KEY in service.context.globals and \
+               JMX_KEY in service.context.globals[METRICS_KEY] and \
+               service.context.globals[METRICS_KEY][JMX_KEY][ENABLED]
+
+    @staticmethod
+    def add_to_config(config):
+        if config.metrics_update_frequency is None:
+            config = config._replace(metrics_update_frequency=1000)
+
+        config.metric_exporters.add("org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi")
+
+        return config

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/datastorage_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/datastorage_macro.j2
@@ -22,6 +22,7 @@
                 {% if config.max_wal_archive_size %}
                     <property name="maxWalArchiveSize" value="{{ config.max_wal_archive_size }}"/>
                 {% endif %}
+                <property name="metricsEnabled" value="{{ config.metrics_enabled }}"/>
                 <property name="defaultDataRegionConfiguration">
                     {{ data_region(config.default) }}
                 </property>
@@ -45,5 +46,9 @@
         <property name="persistenceEnabled" value="{{ config.persistent }}"/>
         <property name="initialSize" value="{{ config.init_size }}"/>
         <property name="maxSize" value="{{ config.max_size }}"/>
+        <property name="metricsEnabled" value="{{ config.metrics_enabled }}"/>
+        {% if config.metrics_rate_time_interval %}
+        <property name="metricsRateTimeInterval" value="{{ config.metrics_rate_time_interval }}"/>
+        {% endif %}
     </bean>
 {% endmacro %}

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/ignite.xml.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/ignite.xml.j2
@@ -40,6 +40,7 @@
 
         <property name="clientMode" value="{{ config.client_mode or False | lower }}"/>
         <property name="consistentId" value="{{ config.consistent_id }}"/>
+        <property name="igniteInstanceName" value="{{ config.ignite_instance_name }}"/>
         <property name="failureDetectionTimeout" value="{{ config.failure_detection_timeout }}"/>
         <property name="systemWorkerBlockedTimeout" value="{{ config.sys_worker_blocked_timeout }}"/>
         <property name="peerClassLoadingEnabled" value="{{ config.peer_class_loading_enabled }}"/>
@@ -57,9 +58,21 @@
             <property name="rebalanceThrottle" value="{{ config.rebalance_throttle }}"/>
         {% endif %}
 
-        {% if config.metric_exporter %}
+        {% if config.metrics_log_frequency %}
+            <property name="metricsLogFrequency" value="{{ config.metrics_log_frequency }}"/>
+        {% endif %}
+
+        {% if config.metrics_update_frequency %}
+            <property name="metricsUpdateFrequency" value="{{ config.metrics_update_frequency }}"/>
+        {% endif %}
+
+        {% if config.metric_exporters | length > 0 %}
             <property name="metricExporterSpi">
-                <bean class="{{ config.metric_exporter }}"/>
+                <list>
+                {% for exporter in config.metric_exporters %}
+                    {{ misc_utils.bean(exporter) }}
+                {% endfor %}
+                </list>
             </property>
         {% endif %}
 

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/misc_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/misc_macro.j2
@@ -54,3 +54,15 @@
         </util:list>
     {% endif %}
 {% endmacro %}
+
+{% macro bean(bean) %}
+    {% if bean.properties | length > 0 %}
+        <bean class="{{ bean }}">
+            {% for name, value in bean.properties.items() %}
+            <property name="{{ name }}" value="{{ value }}"/>
+            {% endfor %}
+        </bean>
+    {% else %}
+        <bean class="{{ bean }}"/>
+    {% endif %}
+{% endmacro %}

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/opencensus_metrics_beans_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/opencensus_metrics_beans_macro.j2
@@ -1,0 +1,30 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+#}
+
+{% macro apply(config, metrics) %}
+
+    <bean class="org.springframework.beans.factory.config.MethodInvokingBean">
+        <property name="staticMethod" value="io.opencensus.exporter.stats.prometheus.PrometheusStatsCollector.createAndRegister"/>
+    </bean>
+
+    <bean class="io.prometheus.client.exporter.HTTPServer">
+        <constructor-arg type="java.lang.String" value="{{ config.local_host }}"/>
+        <constructor-arg type="int" value="{{ metrics.port }}"/>
+        <constructor-arg type="boolean" value="true"/>
+    </bean>
+
+{% endmacro %}

--- a/modules/ducktests/tests/ignitetest/tests/rebalance/util.py
+++ b/modules/ducktests/tests/ignitetest/tests/rebalance/util.py
@@ -115,7 +115,7 @@ def start_ignite(test_context, ignite_version: str, rebalance_params: RebalanceP
     node_config = IgniteConfiguration(
         version=IgniteVersion(ignite_version),
         data_storage=data_storage,
-        metric_exporter="org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi",
+        metric_exporters={"org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi"},
         rebalance_thread_pool_size=rebalance_params.thread_pool_size,
         rebalance_batch_size=rebalance_params.batch_size,
         rebalance_batches_prefetch_count=rebalance_params.batches_prefetch_count,

--- a/modules/ducktests/tests/ignitetest/tests/snapshot_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/snapshot_test.py
@@ -48,7 +48,7 @@ class SnapshotTest(IgniteTest):
         ignite_config = IgniteConfiguration(
             version=version,
             data_storage=DataStorageConfiguration(default=DataRegionConfiguration(persistent=True)),
-            metric_exporter='org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi'
+            metric_exporters={'org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi'}
         )
 
         nodes = IgniteService(self.test_context, ignite_config, num_nodes=self.available_cluster_size - 1)

--- a/modules/ducktests/tests/ignitetest/utils/bean.py
+++ b/modules/ducktests/tests/ignitetest/utils/bean.py
@@ -13,30 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-"""
-This module contains classes and utilities for Ignite DataStorage configuration.
-"""
+class Bean:
+    def __init__(self, class_name, **kwargs):
+        self.class_name = class_name
+        self.properties = kwargs
 
-from typing import NamedTuple
+    def __eq__(self, other):
+        return self.class_name == other.class_name
 
+    def __hash__(self):
+        return self.class_name.__hash__()
 
-class DataRegionConfiguration(NamedTuple):
-    """
-    Ignite DataRegion Configuration
-    """
-    name: str = "default"
-    persistent: bool = False
-    init_size: int = 100 * 1024 * 1024
-    max_size: int = 512 * 1024 * 1024
-    metrics_enabled: bool = True
-    metrics_rate_time_interval: int = None
+    def __repr__(self):
+        return self.class_name
 
-
-class DataStorageConfiguration(NamedTuple):
-    """
-    Ignite DataStorage configuration
-    """
-    default: DataRegionConfiguration = DataRegionConfiguration()
-    max_wal_archive_size: int = None
-    metrics_enabled: bool = True
-    regions: list = []
+    class_name: str
+    properties: {}

--- a/modules/ducktests/tests/ignitetest/utils/ignite_test.py
+++ b/modules/ducktests/tests/ignitetest/utils/ignite_test.py
@@ -26,6 +26,7 @@ from ignitetest.services.utils.ducktests_service import DucktestsService
 
 # globals:
 JFR_ENABLED = "jfr_enabled"
+JMX_REMOTE_ENABLED = "jmx_remote_enabled"
 IGNITE_TEST_CONTEXT_CLASS_KEY_NAME = "IgniteTestContext"
 
 


### PR DESCRIPTION
Added new global parameters to enable metrics exporters in Ignite nodes started in scope of ducktests.
Both JMX and HTTP Prometheus metrics are supported.

See more details in the Jira ticket and in the README.md in this patch 

***

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
