### PR TITLE
IGNITE-16983 Java thin: Add AtomicLong partition awareness

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -21,6 +21,7 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
+import org.apache.ignite.internal.processors.datastructures.DataStructuresProcessor;
 import org.apache.ignite.internal.processors.datastructures.GridCacheInternalKeyImpl;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,8 +57,9 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
         this.groupName = groupName;
         this.ch = ch;
 
-        key = new GridCacheInternalKeyImpl(name, groupName);
-        cacheId = ClientUtils.cacheId("ignite-sys-atomic-cache@" + (groupName == null ? "default-ds-group" : groupName));
+        String groupNameInternal = groupName == null ? DataStructuresProcessor.DEFAULT_DS_GROUP_NAME : groupName;
+        key = new GridCacheInternalKeyImpl(name, groupNameInternal);
+        cacheId = ClientUtils.cacheId(DataStructuresProcessor.ATOMICS_CACHE_NAME + "@" + groupNameInternal);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -22,7 +22,6 @@ import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
 import org.apache.ignite.internal.processors.datastructures.DataStructuresProcessor;
-import org.apache.ignite.internal.processors.datastructures.GridCacheInternalKeyImpl;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -37,9 +36,6 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** */
     private final ReliableChannel ch;
-
-    /** Cache key. */
-    private final GridCacheInternalKeyImpl key;
 
     /** Cache id. */
     private final int cacheId;
@@ -58,7 +54,6 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
         this.ch = ch;
 
         String groupNameInternal = groupName == null ? DataStructuresProcessor.DEFAULT_DS_GROUP_NAME : groupName;
-        key = new GridCacheInternalKeyImpl(name, groupNameInternal);
         cacheId = ClientUtils.cacheId(DataStructuresProcessor.ATOMICS_CACHE_NAME + "@" + groupNameInternal);
     }
 
@@ -69,7 +64,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long get() throws IgniteException {
-        return ch.affinityService(cacheId, key, ClientOperation.ATOMIC_LONG_VALUE_GET, this::writeName, in -> in.in().readLong());
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_GET, this::writeName, in -> in.in().readLong());
     }
 
     /** {@inheritDoc} */
@@ -84,7 +79,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long addAndGet(long l) throws IgniteException {
-        return ch.affinityService(cacheId, key, ClientOperation.ATOMIC_LONG_VALUE_ADD_AND_GET, out -> {
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_ADD_AND_GET, out -> {
             writeName(out);
             out.out().writeLong(l);
         }, in -> in.in().readLong());
@@ -107,7 +102,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long getAndSet(long l) throws IgniteException {
-        return ch.affinityService(cacheId, key, ClientOperation.ATOMIC_LONG_VALUE_GET_AND_SET, out -> {
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_GET_AND_SET, out -> {
             writeName(out);
             out.out().writeLong(l);
         }, in -> in.in().readLong());
@@ -115,7 +110,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public boolean compareAndSet(long expVal, long newVal) throws IgniteException {
-        return ch.affinityService(cacheId, key, ClientOperation.ATOMIC_LONG_VALUE_COMPARE_AND_SET, out -> {
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_COMPARE_AND_SET, out -> {
             writeName(out);
             out.out().writeLong(expVal);
             out.out().writeLong(newVal);
@@ -124,12 +119,12 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public boolean removed() {
-        return ch.affinityService(cacheId, key, ClientOperation.ATOMIC_LONG_EXISTS, this::writeName, in -> !in.in().readBoolean());
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_EXISTS, this::writeName, in -> !in.in().readBoolean());
     }
 
     /** {@inheritDoc} */
     @Override public void close() {
-        ch.affinityService(cacheId, key, ClientOperation.ATOMIC_LONG_REMOVE, this::writeName, null);
+        ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_REMOVE, this::writeName, null);
     }
 
     /**
@@ -142,5 +137,15 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
             w.writeString(name);
             w.writeString(groupName);
         }
+    }
+
+    /**
+     * Gets the affinity key for this data structure.
+     * 
+     * @return Affinity key.
+     */
+    private String affinityKey() {
+        // GridCacheInternalKeyImpl uses name as AffinityKeyMapped.
+        return name;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -57,6 +57,9 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long get() throws IgniteException {
+        // TODO:
+        // cacheName = ignite-sys-atomic-cache@
+        // key = GridCacheInternalKeyImpl
         return ch.service(ClientOperation.ATOMIC_LONG_VALUE_GET, this::writeName, in -> in.in().readLong());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -57,7 +57,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
         this.ch = ch;
 
         key = new GridCacheInternalKeyImpl(name, groupName);
-        cacheId = ClientUtils.cacheId("ignite-sys-atomic-cache@" + groupName);
+        cacheId = ClientUtils.cacheId("ignite-sys-atomic-cache@" + (groupName == null ? "default-ds-group" : groupName));
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -119,7 +119,8 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public boolean removed() {
-        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_EXISTS, this::writeName, in -> !in.in().readBoolean());
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_EXISTS, this::writeName,
+                in -> !in.in().readBoolean());
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AtomicLongTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AtomicLongTest.java
@@ -25,6 +25,7 @@ import org.apache.ignite.client.ClientAtomicConfiguration;
 import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.client.ClientException;
 import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.configuration.ClientConfiguration;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
 import org.junit.Test;
 import static org.apache.ignite.testframework.GridTestUtils.assertContains;
@@ -39,6 +40,11 @@ public class AtomicLongTest extends AbstractThinClientTest {
         super.beforeTestsStarted();
 
         startGrids(1);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected ClientConfiguration getClientConfiguration() {
+        return super.getClientConfiguration().setPartitionAwarenessEnabled(true);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AtomicLongTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AtomicLongTest.java
@@ -209,19 +209,23 @@ public class AtomicLongTest extends AbstractThinClientTest {
         try (IgniteClient client = startClient(0)) {
             client.atomicLong(name, cfg1, 1, true);
             client.atomicLong(name, cfg2, 2, true);
+            client.atomicLong(name, 3, true);
         }
 
         List<IgniteInternalCache<?, ?>> caches = new ArrayList<>(grid(0).cachesx());
-        assertEquals(3, caches.size());
+        assertEquals(4, caches.size());
 
         IgniteInternalCache<?, ?> partitionedCache = caches.get(1);
         IgniteInternalCache<?, ?> replicatedCache = caches.get(2);
+        IgniteInternalCache<?, ?> defaultCache = caches.get(3);
 
         assertEquals("ignite-sys-atomic-cache@atomic-long-group-partitioned", partitionedCache.name());
         assertEquals("ignite-sys-atomic-cache@atomic-long-group-replicated", replicatedCache.name());
+        assertEquals("ignite-sys-atomic-cache@default-ds-group", defaultCache.name());
 
         assertEquals(2, partitionedCache.configuration().getBackups());
         assertEquals(Integer.MAX_VALUE, replicatedCache.configuration().getBackups());
+        assertEquals(1, defaultCache.configuration().getBackups());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractPartitionAwarenessTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractPartitionAwarenessTest.java
@@ -148,11 +148,11 @@ public abstract class ThinClientAbstractPartitionAwarenessTest extends GridCommo
 
         assertNotNull("Unexpected (null) next operation [expCh=" + expCh + ", expOp=" + expOp + ']', nextChOp);
 
-        assertEquals("Unexpected channel for opertation [expCh=" + expCh + ", expOp=" + expOp +
-            ", nextOpCh=" + nextChOp + ']', expCh, nextChOp.get1());
-
         assertEquals("Unexpected operation on channel [expCh=" + expCh + ", expOp=" + expOp +
-            ", nextOpCh=" + nextChOp + ']', expOp, nextChOp.get2());
+                ", nextOpCh=" + nextChOp + ']', expOp, nextChOp.get2());
+
+        assertEquals("Unexpected channel for operation [expCh=" + expCh + ", expOp=" + expOp +
+            ", nextOpCh=" + nextChOp + ']', expCh, nextChOp.get1());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -189,9 +189,14 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
         String cacheName = "ignite-sys-atomic-cache@default-ds-group";
         IgniteInternalCache<Object, Object> cache = grid(0).context().cache().cache(cacheName);
 
+        // Warm up.
+        clientAtomicLong.get();
+        opsQueue.clear();
+
+        // Test.
+        clientAtomicLong.get();
         TestTcpClientChannel opCh = affinityChannel(serverAtomicLong.key(), cache);
 
-        clientAtomicLong.get();
         assertOpOnChannel(opCh, ClientOperation.ATOMIC_LONG_VALUE_GET);
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -181,8 +181,7 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
      * Test atomic long.
      */
     @Test
-    public void testAtomicLong()
-    {
+    public void testAtomicLong() {
         testAtomicLong("default-grp-partitioned", null, CacheMode.PARTITIONED);
         testAtomicLong("default-grp-replicated", null, CacheMode.REPLICATED);
         testAtomicLong("custom-grp-partitioned", "testAtomicLong", CacheMode.PARTITIONED);
@@ -192,14 +191,13 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
     /**
      * Test atomic long.
      */
-    private void testAtomicLong(String name, String grpName, CacheMode cacheMode)
-    {
+    private void testAtomicLong(String name, String grpName, CacheMode cacheMode) {
         ClientAtomicConfiguration cfg = new ClientAtomicConfiguration()
                 .setGroupName(grpName)
                 .setCacheMode(cacheMode);
 
         ClientAtomicLong clientAtomicLong = client.atomicLong(name, cfg, 1, true);
-        GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx) grid(0).atomicLong(
+        GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx)grid(0).atomicLong(
                 name, new AtomicConfiguration().setGroupName(grpName), 0, false);
 
         String cacheName = "ignite-sys-atomic-cache@" + (grpName == null ? "default-ds-group" : grpName);

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.client.thin;
 
 import java.util.function.Function;
 
-import org.apache.ignite.IgniteAtomicLong;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cache.query.ScanQuery;
 import org.apache.ignite.client.ClientAtomicLong;
@@ -187,9 +186,13 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
         ClientAtomicLong clientAtomicLong = client.atomicLong(name, 1, true);
         GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx) grid(0).atomicLong(name, 0, false);
 
-        ClusterNode expectedNode = grid(0)
-                .affinity("ignite-sys-atomic-cache@default-ds-group")
-                .mapKeyToNode(serverAtomicLong.key());
+        String cacheName = "ignite-sys-atomic-cache@default-ds-group";
+        IgniteInternalCache<Object, Object> cache = grid(0).context().cache().cache(cacheName);
+
+        TestTcpClientChannel opCh = affinityChannel(serverAtomicLong.key(), cache);
+
+        clientAtomicLong.get();
+        assertOpOnChannel(opCh, ClientOperation.ATOMIC_LONG_VALUE_GET);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -173,6 +173,15 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
     }
 
     /**
+     * Test atomic long.
+     */
+    @Test
+    public void testAtomicLong()
+    {
+        // TODO
+    }
+
+    /**
      * @param cacheName Cache name.
      */
     private void testNotApplicableCache(String cacheName) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -20,10 +20,12 @@ package org.apache.ignite.internal.client.thin;
 import java.util.function.Function;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.query.ScanQuery;
+import org.apache.ignite.client.ClientAtomicConfiguration;
 import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.client.ClientCache;
-import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.configuration.AtomicConfiguration;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
 import org.apache.ignite.internal.processors.datastructures.GridCacheAtomicLongEx;
 import org.junit.Test;
@@ -181,12 +183,26 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
     @Test
     public void testAtomicLong()
     {
-        // TODO: different group names
-        String name = "testAtomicLong";
-        ClientAtomicLong clientAtomicLong = client.atomicLong(name, 1, true);
-        GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx) grid(0).atomicLong(name, 0, false);
+        testAtomicLong("default-grp-partitioned", null, CacheMode.PARTITIONED);
+        testAtomicLong("default-grp-replicated", null, CacheMode.REPLICATED);
+        testAtomicLong("custom-grp-partitioned", "testAtomicLong", CacheMode.PARTITIONED);
+        testAtomicLong("custom-grp-replicated", "testAtomicLong", CacheMode.REPLICATED);
+    }
 
-        String cacheName = "ignite-sys-atomic-cache@default-ds-group";
+    /**
+     * Test atomic long.
+     */
+    private void testAtomicLong(String name, String grpName, CacheMode cacheMode)
+    {
+        ClientAtomicConfiguration cfg = new ClientAtomicConfiguration()
+                .setGroupName(grpName)
+                .setCacheMode(cacheMode);
+
+        ClientAtomicLong clientAtomicLong = client.atomicLong(name, cfg, 1, true);
+        GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx) grid(0).atomicLong(
+                name, new AtomicConfiguration().setGroupName(grpName), 0, false);
+
+        String cacheName = "ignite-sys-atomic-cache@" + (grpName == null ? "default-ds-group" : grpName);
         IgniteInternalCache<Object, Object> cache = grid(0).context().cache().cache(cacheName);
 
         // Warm up.

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientPartitionAwarenessStableTopologyTest.java
@@ -19,10 +19,14 @@ package org.apache.ignite.internal.client.thin;
 
 import java.util.function.Function;
 
+import org.apache.ignite.IgniteAtomicLong;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cache.query.ScanQuery;
+import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.client.ClientCache;
+import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
+import org.apache.ignite.internal.processors.datastructures.GridCacheAtomicLongEx;
 import org.junit.Test;
 
 /**
@@ -178,7 +182,14 @@ public class ThinClientPartitionAwarenessStableTopologyTest extends ThinClientAb
     @Test
     public void testAtomicLong()
     {
-        // TODO
+        // TODO: different group names
+        String name = "testAtomicLong";
+        ClientAtomicLong clientAtomicLong = client.atomicLong(name, 1, true);
+        GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx) grid(0).atomicLong(name, 0, false);
+
+        ClusterNode expectedNode = grid(0)
+                .affinity("ignite-sys-atomic-cache@default-ds-group")
+                .mapKeyToNode(serverAtomicLong.key());
     }
 
     /**


### PR DESCRIPTION
`AtomicLong` is just a cache entry underneath, where `GridCacheInternalKeyImpl` is the key. Use partition awareness to send requests to the primary node and improve performance.