### PR TITLE
IGNITE-17005 Implement metrics for a snapshot create operation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -140,6 +141,12 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
 
     /** Flag indicates that task already scheduled on checkpoint. */
     private final AtomicBoolean started = new AtomicBoolean();
+
+    /** Estimated snapshot size in bytes. The value may grow during snapshotting. */
+    private final AtomicLong totalSize = new AtomicLong();
+
+    /** Processed snapshot size in bytes. */
+    private final AtomicLong processedSize = new AtomicLong();
 
     /**
      * @param cctx Shared context.
@@ -420,6 +427,8 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
             cctx.cache().configManager().readConfigurationFiles(ccfgs,
                 (ccfg, ccfgFile) -> ccfgSndrs.add(new CacheConfigurationSender(ccfg.getName(),
                     FilePageStoreManager.cacheDirName(ccfg), ccfgFile)));
+
+            totalSize.set(partFileLengths.values().stream().mapToLong(v -> v).sum());
         }
         catch (IgniteCheckedException e) {
             acceptException(e);
@@ -494,6 +503,8 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
 
                             // Stop partition writer.
                             partDeltaWriters.get(pair).markPartitionProcessed();
+
+                            processedSize.addAndGet(partLen);
                         }),
                         snpSndr.executor())
                         // Wait for the completion of both futures - checkpoint end, copy partition.
@@ -512,9 +523,13 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
 
                                 snpSndr.sendDelta(delta, cacheDirName, pair);
 
+                                long deltaLen = delta.length();
+
                                 boolean deleted = delta.delete();
 
                                 assert deleted;
+
+                                processedSize.addAndGet(deltaLen);
                             }),
                             snpSndr.executor());
 
@@ -594,6 +609,16 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
         }
 
         return closeFut;
+    }
+
+    /** @return Estimated snapshot size in bytes. The value may grow during snapshotting. */
+    public long totalSize() {
+        return totalSize.get();
+    }
+
+    /** @return Processed snapshot size in bytes. */
+    public long processedSize() {
+        return processedSize.get();
     }
 
     /** {@inheritDoc} */
@@ -930,7 +955,9 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
             }
 
             // Write buffer to the end of the file.
-            deltaFileIo.writeFully(pageBuf);
+            int len = deltaFileIo.writeFully(pageBuf);
+
+            totalSize.addAndGet(len);
         }
 
         /** {@inheritDoc} */

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteClusterSnapshotMetricsTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/IgniteClusterSnapshotMetricsTest.java
@@ -19,29 +19,41 @@ package org.apache.ignite.internal.processors.cache.persistence.snapshot;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.Serializable;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.management.AttributeNotFoundException;
 import javax.management.DynamicMBean;
 import javax.management.MBeanException;
 import javax.management.ReflectionException;
+import org.apache.commons.io.FileUtils;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.QueryEntity;
 import org.apache.ignite.cache.QueryIndex;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.processors.cache.persistence.file.FileIO;
 import org.apache.ignite.internal.processors.cache.persistence.file.FileIOFactory;
 import org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager;
 import org.apache.ignite.internal.processors.cache.persistence.file.RandomAccessFileIOFactory;
+import org.apache.ignite.internal.processors.cache.persistence.filename.PdsFolderSettings;
+import org.apache.ignite.internal.processors.configuration.distributed.DistributedChangeableProperty;
+import org.apache.ignite.internal.processors.metric.MetricRegistry;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteFuture;
+import org.apache.ignite.spi.metric.LongMetric;
 import org.apache.ignite.spi.metric.jmx.JmxMetricExporterSpi;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.After;
@@ -50,12 +62,14 @@ import org.junit.Test;
 
 import static org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager.FILE_SUFFIX;
 import static org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager.PART_FILE_PREFIX;
+import static org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteSnapshotManager.SNAPSHOT_METRICS;
+import static org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteSnapshotManager.SNAPSHOT_TRANSFER_RATE_DMS_KEY;
 import static org.apache.ignite.internal.processors.cache.persistence.snapshot.SnapshotRestoreProcess.SNAPSHOT_RESTORE_METRICS;
 
 /**
- * Tests snapshot restore metrics.
+ * Tests snapshot create/restore metrics.
  */
-public class IgniteClusterSnapshotRestoreMetricsTest extends IgniteClusterSnapshotRestoreBaseTest {
+public class IgniteClusterSnapshotMetricsTest extends IgniteClusterSnapshotRestoreBaseTest {
     /** Separate working directory prefix. */
     private static final String DEDICATED_DIR_PREFIX = "dedicated-";
 
@@ -99,7 +113,7 @@ public class IgniteClusterSnapshotRestoreMetricsTest extends IgniteClusterSnapsh
     @Override public void beforeTestSnapshot() throws Exception {
         super.beforeTestSnapshot();
 
-        cleanuo();
+        cleanup();
     }
 
     /** {@inheritDoc} */
@@ -107,13 +121,13 @@ public class IgniteClusterSnapshotRestoreMetricsTest extends IgniteClusterSnapsh
     @Override public void afterTestSnapshot() throws Exception {
         super.afterTestSnapshot();
 
-        cleanuo();
+        cleanup();
     }
 
     /** @throws Exception If fails. */
     @Test
     public void testRestoreSnapshotProgress() throws Exception {
-        // Caches with differebt partition distribution.
+        // Caches with different partition distribution.
         CacheConfiguration<Integer, Object> ccfg1 = cacheConfig("cache1").setBackups(0);
         CacheConfiguration<Integer, Object> ccfg2 = cacheConfig("cache2").setCacheMode(CacheMode.REPLICATED);
 
@@ -212,6 +226,85 @@ public class IgniteClusterSnapshotRestoreMetricsTest extends IgniteClusterSnapsh
         }
     }
 
+    /** @throws Exception If fails. */
+    @Test
+    public void testCreateSnapshotProgress() throws Exception {
+        CacheConfiguration<Integer, Object> ccfg1 = cacheConfig("cache1");
+
+        IgniteEx ignite = startGridsWithCache(DEDICATED_CNT, CACHE_KEYS_RANGE, key -> new Account(key, key), ccfg1);
+
+        MetricRegistry mreg = ignite.context().metric().registry(SNAPSHOT_METRICS);
+
+        LongMetric totalSize = mreg.findMetric("CurrentSnapshotTotalSize");
+        LongMetric processedSize = mreg.findMetric("CurrentSnapshotProcessedSize");
+
+        assertEquals(-1, totalSize.value());
+        assertEquals(-1, processedSize.value());
+
+        // Calculate transfer rate limit.
+        PdsFolderSettings<?> folderSettings = ignite.context().pdsFolderResolver().resolveFolders();
+        File storeWorkDir = new File(folderSettings.persistentStoreRootPath(), folderSettings.folderName());
+
+        long limit = FileUtils.sizeOfDirectory(storeWorkDir) / 10;
+
+        // Limit snapshot transfer rate.
+        DistributedChangeableProperty<Serializable> rateProp =
+            ignite.context().distributedConfiguration().property(SNAPSHOT_TRANSFER_RATE_DMS_KEY);
+
+        rateProp.propagate(limit);
+
+        // Start cluster snapshot.
+        IgniteFuture<Void> fut = ignite.snapshot().createSnapshot(SNAPSHOT_NAME);
+
+        // Run load.
+        IgniteInternalFuture<?> loadFut = GridTestUtils.runAsync(() -> {
+            IgniteCache<Integer, Object> cache = ignite.getOrCreateCache(ccfg1);
+
+            while (!fut.isDone()) {
+                Integer key = ThreadLocalRandom.current().nextInt(CACHE_KEYS_RANGE);
+                Account val = new Account(ThreadLocalRandom.current().nextInt(), ThreadLocalRandom.current().nextInt());
+
+                cache.put(key, val);
+            }
+        });
+
+        List<Long> totalVals = new ArrayList<>();
+        List<Long> processedVals = new ArrayList<>();
+
+        // Store metrics values during cluster snapshot.
+        IgniteInternalFuture<?> metricFut = GridTestUtils.runAsync(() -> {
+            while (!fut.isDone()) {
+                long total = totalSize.value();
+                long processed = processedSize.value();
+
+                if (total != -1 && processed != -1) {
+                    totalVals.add(totalSize.value());
+                    processedVals.add(processedSize.value());
+                }
+
+                U.sleep(500);
+            }
+        });
+
+        fut.get(getTestTimeout());
+
+        metricFut.get();
+        loadFut.get();
+
+        assertTrue("Expected distinct values: " + totalVals,
+            totalVals.stream().mapToLong(v -> v).distinct().count() > 1);
+        assertTrue("Expected distinct values: " + processedVals,
+            processedVals.stream().mapToLong(v -> v).distinct().count() > 1);
+
+        assertTrue("Expected sorted values: " + totalVals,
+            F.isSorted(totalVals.stream().mapToLong(v -> v).toArray()));
+        assertTrue("Expected sorted values: " + processedVals,
+            F.isSorted(processedVals.stream().mapToLong(v -> v).toArray()));
+
+        assertEquals(-1, totalSize.value());
+        assertEquals(-1, processedSize.value());
+    }
+
     /**
      * @throws Exception If failed.
      */
@@ -245,7 +338,7 @@ public class IgniteClusterSnapshotRestoreMetricsTest extends IgniteClusterSnapsh
     /**
      * @throws Exception If failed.
      */
-    private void cleanuo() throws Exception {
+    private void cleanup() throws Exception {
         FilenameFilter filter = (file, name) -> file.isDirectory() && name.startsWith(DEDICATED_DIR_PREFIX);
 
         for (File file : new File(U.defaultWorkDirectory()).listFiles(filter))

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteSnapshotWithIndexingTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteSnapshotWithIndexingTestSuite.java
@@ -18,7 +18,7 @@
 package org.apache.ignite.testsuites;
 
 import org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteClusterSnapshotCheckWithIndexesTest;
-import org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteClusterSnapshotRestoreMetricsTest;
+import org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteClusterSnapshotMetricsTest;
 import org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteClusterSnapshotRestoreWithIndexingTest;
 import org.apache.ignite.internal.processors.cache.persistence.snapshot.IgniteClusterSnapshotWithIndexesTest;
 import org.junit.runner.RunWith;
@@ -30,7 +30,7 @@ import org.junit.runners.Suite;
     IgniteClusterSnapshotWithIndexesTest.class,
     IgniteClusterSnapshotCheckWithIndexesTest.class,
     IgniteClusterSnapshotRestoreWithIndexingTest.class,
-    IgniteClusterSnapshotRestoreMetricsTest.class
+    IgniteClusterSnapshotMetricsTest.class
 })
 public class IgniteSnapshotWithIndexingTestSuite {
 }


### PR DESCRIPTION
The following metrics implemented:
**CurrentSnapshotTotalSize** - Estimated size of current cluster snapshot in bytes on this node. The value may grow during snapshotting.
**CurrentSnapshotProcessedSize** - Processed size of current cluster snapshot in bytes on this node.