### PR TITLE
IGNITE-17063 .NET: Improve Java detection on Linux

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -24,30 +24,22 @@ namespace Apache.Ignite.Core.Tests
     /// <summary>
     /// Tests for <see cref="Shell"/> class.
     /// </summary>
+    [Platform("Linux")]
     public class ShellTests
     {
         /// <summary>
         /// Tests <see cref="Shell.ExecuteSafe"/> method.
         /// </summary>
         [Test]
-        public void TestExecuteSafe()
+        public void TestExecuteSafeReturnsStdout()
         {
-            if (Os.IsWindows)
-            {
-                return;
-            }
-            
             var uname = Shell.ExecuteSafe("uname", string.Empty);
             Assert.IsNotEmpty(uname, uname);
 
             var readlink = Shell.ExecuteSafe("readlink", "-f /usr/bin/java");
             Assert.IsNotEmpty(readlink, readlink);
-            
-            if (Os.IsLinux)
-            {
-                Assert.AreEqual("Linux", uname.Trim());
-            }
 
+            Assert.AreEqual("Linux", uname.Trim());
             Assert.IsEmpty(Shell.ExecuteSafe("foo_bar", "abc"));
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -28,7 +28,7 @@ namespace Apache.Ignite.Core.Tests
     /// Tests for <see cref="Shell"/> class.
     /// </summary>
     [Platform("Linux")]
-    [Order(1)]
+    [Order(1)] // Execute first to avoid zombie processes (see https://issues.apache.org/jira/browse/IGNITE-13536).
     public class ShellTests
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -47,6 +47,9 @@ namespace Apache.Ignite.Core.Tests
             Assert.IsEmpty(log.Entries);
         }
 
+        /// <summary>
+        /// Tests that non-zero error code and stderr are logged.
+        /// </summary>
         [Test]
         public void TestExecuteSafeLogsNonZeroExitCodeAndStderr()
         {
@@ -64,6 +67,9 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreEqual("Shell command 'uname' exit code: 1", entries[1].Message);
         }
 
+        /// <summary>
+        /// Tests that failure to execute a command is logged.
+        /// </summary>
         [Test]
         public void TestExecuteSafeLogsException()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -28,6 +28,7 @@ namespace Apache.Ignite.Core.Tests
     /// Tests for <see cref="Shell"/> class.
     /// </summary>
     [Platform("Linux")]
+    [Order(1)]
     public class ShellTests
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -39,11 +39,11 @@ namespace Apache.Ignite.Core.Tests
             var log = GetLogger();
 
             var uname = Shell.ExecuteSafe("uname", string.Empty, log: log);
-            Assert.AreEqual("Linux", uname.Trim());
+            Assert.AreEqual("Linux", uname.Trim(), string.Join(", ", log.Entries.Select(e => e.ToString())));
             Assert.IsEmpty(log.Entries);
 
             var readlink = Shell.ExecuteSafe("readlink", "-f /usr/bin/java", log: log);
-            Assert.IsNotEmpty(readlink, readlink);
+            Assert.IsNotEmpty(readlink, readlink, string.Join(", ", log.Entries.Select(e => e.ToString())));
             Assert.IsEmpty(log.Entries);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -55,10 +55,12 @@ namespace Apache.Ignite.Core.Tests
         {
             var log = GetLogger();
             var res = Shell.ExecuteSafe("uname", "--badarg", log: log);
-            var entries = log.Entries;
 
-            Assert.IsEmpty(res);
-            Assert.AreEqual(2, entries.Count);
+            var entries = log.Entries;
+            var entriesString = string.Join(", ", entries.Select(e => e.ToString()));
+
+            Assert.IsEmpty(res, entriesString);
+            Assert.AreEqual(2, entries.Count, entriesString);
 
             Assert.AreEqual(LogLevel.Warn, entries[0].Level);
             StringAssert.StartsWith("Shell command 'uname' stderr: 'uname: unrecognized option", entries[0].Message);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
@@ -63,7 +63,7 @@ namespace Apache.Ignite.Core.Impl
                     var stdOut = process.StandardOutput.ReadToEnd();
                     var stdErr = process.StandardError.ReadToEnd();
 
-                    if (stdErr.Length > 0)
+                    if (!string.IsNullOrWhiteSpace(stdErr))
                     {
                         log?.Warn("Shell command '{0}' stderr: {1}", file, stdErr);
                     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
@@ -65,7 +65,7 @@ namespace Apache.Ignite.Core.Impl
 
                     if (!string.IsNullOrWhiteSpace(stdErr))
                     {
-                        log?.Warn("Shell command '{0}' stderr: {1}", file, stdErr);
+                        log?.Warn("Shell command '{0}' stderr: '{1}'", file, stdErr);
                     }
 
                     if (process.ExitCode != 0)
@@ -78,7 +78,7 @@ namespace Apache.Ignite.Core.Impl
             }
             catch (Exception e)
             {
-                log?.Warn("Shell command '{0}' failed: {1}", file, e.Message, e);
+                log?.Warn("Shell command '{0}' failed: '{1}'", file, e.Message, e);
 
                 return string.Empty;
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
@@ -20,8 +20,6 @@ namespace Apache.Ignite.Core.Impl
     using System;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    using System.Text;
-    using System.Threading;
     using Apache.Ignite.Core.Log;
 
     /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/JvmDll.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/JvmDll.cs
@@ -367,8 +367,13 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
                 yield break;
             }
 
-            var file = Shell.ExecuteSafe("readlink", "-f /usr/bin/java", log: log);
+            var file = Shell.ExecuteSafe("/usr/bin/readlink", "-f /usr/bin/java", log: log);
             // /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+            if (string.IsNullOrWhiteSpace(file))
+            {
+                file = Shell.ExecuteSafe("readlink", "-f /usr/bin/java", log: log);
+            }
 
             if (string.IsNullOrWhiteSpace(file))
             {


### PR DESCRIPTION
* Try `/usr/bin/readlink` as well as `readlink` - it is not in PATH in some rare scenarios.
* Improve logging when commands fail.