### PR TITLE
IGNITE-17215: Write ClusterSnapshotRecord to WAL

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/WALRecord.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/WALRecord.java
@@ -279,7 +279,10 @@ public abstract class WALRecord {
         PARTITION_CLEARING_START_RECORD(73, LOGICAL),
 
         /** Ecnrypted out-of-order update which is used by atomic caches on backup nodes. (Placeholder) */
-        ENCRYPTED_OUT_OF_ORDER_UPDATE(74, LOGICAL);
+        ENCRYPTED_OUT_OF_ORDER_UPDATE(74, LOGICAL),
+
+        /** ClusterSnapshot start. */
+        CLUSTER_SNAPSHOT(75, LOGICAL);
 
         /** Index for serialization. Should be consistent throughout all versions. */
         private final int idx;

--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/delta/ClusterSnapshotRecord.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/delta/ClusterSnapshotRecord.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.pagemem.wal.record.delta;
+
+import org.apache.ignite.internal.pagemem.wal.record.WALRecord;
+import org.apache.ignite.internal.util.tostring.GridToStringInclude;
+import org.apache.ignite.internal.util.typedef.internal.S;
+
+/**
+ * ClusterSnapshot record. It splits WAL on 2 areas: any data changes before this record are part of related ClusterSnapshot,
+ * and vice versa. It's guaranteed with:
+ * 1. The record is written after ClusterSnapshot acquires checkpoint writeLock.
+ * 2. The writeLock is acquired on PME, after every transaction already committed and no active transactions anymore.
+ */
+public class ClusterSnapshotRecord extends WALRecord {
+    /** ClusterSnapshot name. */
+    @GridToStringInclude
+    private final String snpName;
+
+    /**
+     * @param snpName ClusterSnapshot name.
+     */
+    public ClusterSnapshotRecord(String snpName) {
+        this.snpName = snpName;
+    }
+
+    /** */
+    public String clusterSnapshotName() {
+        return snpName;
+    }
+
+    /** {@inheritDoc} */
+    @Override public RecordType type() {
+        return RecordType.CLUSTER_SNAPSHOT;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(ClusterSnapshotRecord.class, this);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointContextImpl.java
@@ -51,6 +51,9 @@ public class CheckpointContextImpl implements CheckpointListener.Context {
     /** Pending tasks from executor. */
     private GridCompoundFuture pendingTaskFuture;
 
+    /** Whether to force flush WAL after Checkpoint process. */
+    private boolean forceWalFlush;
+
     /**
      * @param curr Current checkpoint progress.
      * @param map Partition map.
@@ -78,6 +81,16 @@ public class CheckpointContextImpl implements CheckpointListener.Context {
     /** {@inheritDoc} */
     @Override public boolean nextSnapshot() {
         return curr.nextSnapshot();
+    }
+
+    /** {@inheritDoc} */
+    @Override public void walFlush(boolean flush) {
+        forceWalFlush = flush;
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean walFlush() {
+        return forceWalFlush || nextSnapshot();
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointListener.java
@@ -42,6 +42,16 @@ public interface CheckpointListener {
         public boolean nextSnapshot();
 
         /**
+         * @param flush If {@code True} then will flush WAL after a Checkpoint begin.
+         */
+        public void walFlush(boolean flush);
+
+        /**
+         * Whether to flush WAL after a Checkpoint begin.
+         */
+        public boolean walFlush();
+
+        /**
          * @return Checkpoint future which will be completed when checkpoint ends.
          */
         public IgniteInternalFuture<?> finishedStateFut();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointWorkflow.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointWorkflow.java
@@ -362,7 +362,7 @@ public class CheckpointWorkflow {
             return new Checkpoint(checkpointEntry, cpPages, curr);
         }
         else {
-            if (curr.nextSnapshot() && wal != null)
+            if (ctx0.walFlush() && wal != null)
                 wal.flush(null, true);
 
             return new Checkpoint(null, GridConcurrentMultiPairQueue.EMPTY, curr);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
@@ -54,6 +54,7 @@ import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.pagemem.PageIdUtils;
 import org.apache.ignite.internal.pagemem.store.PageStore;
 import org.apache.ignite.internal.pagemem.store.PageWriteListener;
+import org.apache.ignite.internal.pagemem.wal.record.delta.ClusterSnapshotRecord;
 import org.apache.ignite.internal.processors.cache.CacheGroupContext;
 import org.apache.ignite.internal.processors.cache.GridCacheSharedContext;
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtLocalPartition;
@@ -342,6 +343,9 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
             return;
 
         try {
+            if (cctx.wal() != null)
+                cctx.wal().log(new ClusterSnapshotRecord(snpName));
+
             for (Map.Entry<Integer, Set<Integer>> e : parts.entrySet()) {
                 int grpId = e.getKey();
                 Set<Integer> grpParts = e.getValue();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgniteSequentialNodeCrashRecoveryTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgniteSequentialNodeCrashRecoveryTest.java
@@ -322,6 +322,16 @@ public class IgniteSequentialNodeCrashRecoveryTest extends GridCommonAbstractTes
         }
 
         /** {@inheritDoc} */
+        @Override public void walFlush(boolean flush) {
+            // No-op.
+        }
+
+        /** {@inheritDoc} */
+        @Override public boolean walFlush() {
+            return false;
+        }
+
+        /** {@inheritDoc} */
         @Override public @Nullable Executor executor() {
             return null;
         }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/AbstractSnapshotSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/AbstractSnapshotSelfTest.java
@@ -717,12 +717,10 @@ public abstract class AbstractSnapshotSelfTest extends GridCommonAbstractTest {
 
         IgniteWalIteratorFactory factory = new IgniteWalIteratorFactory(log);
 
-        String subfolderName = ign.name().replace(".", "_");
+        String subfolderName = U.maskForFileName(ign.name());
 
-        File wals = U.resolveWorkDirectory(workDir, "db/wal/" + subfolderName, false);
-        File archive = U.resolveWorkDirectory(workDir, "db/wal/archive/" + subfolderName, false);
-        File binaryMeta = U.resolveWorkDirectory(workDir, "db/binary_meta/" + subfolderName, false);
-        File marshaller = U.resolveWorkDirectory(workDir, "db/marshaller", false);
+        File wals = Paths.get(workDir).resolve(DataStorageConfiguration.DFLT_WAL_PATH).resolve(subfolderName).toFile();
+        File archive = Paths.get(workDir).resolve(DataStorageConfiguration.DFLT_WAL_ARCHIVE_PATH).resolve(subfolderName).toFile();
 
         IgniteWalIteratorFactory.IteratorParametersBuilder params = new IgniteWalIteratorFactory.IteratorParametersBuilder()
             .filesOrDirs(archive, wals)

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/AbstractSnapshotSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/AbstractSnapshotSelfTest.java
@@ -243,7 +243,7 @@ public abstract class AbstractSnapshotSelfTest extends GridCommonAbstractTest {
             stopAllGrids();
         }
 
-//        cleanPersistenceDir();
+        cleanPersistenceDir();
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/AbstractSnapshotSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/AbstractSnapshotSelfTest.java
@@ -37,6 +37,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -67,17 +68,26 @@ import org.apache.ignite.internal.TestRecordingCommunicationSpi;
 import org.apache.ignite.internal.encryption.AbstractEncryptionTest;
 import org.apache.ignite.internal.managers.discovery.CustomMessageWrapper;
 import org.apache.ignite.internal.managers.discovery.DiscoveryCustomMessage;
+import org.apache.ignite.internal.pagemem.wal.WALIterator;
+import org.apache.ignite.internal.pagemem.wal.record.DataEntry;
+import org.apache.ignite.internal.pagemem.wal.record.DataRecord;
+import org.apache.ignite.internal.pagemem.wal.record.WALRecord;
+import org.apache.ignite.internal.pagemem.wal.record.delta.ClusterSnapshotRecord;
 import org.apache.ignite.internal.processors.cache.CacheGroupDescriptor;
 import org.apache.ignite.internal.processors.cache.GridCacheSharedContext;
 import org.apache.ignite.internal.processors.cache.persistence.file.FilePageStoreManager;
 import org.apache.ignite.internal.processors.cache.persistence.partstate.GroupPartitionId;
+import org.apache.ignite.internal.processors.cache.persistence.wal.WALPointer;
 import org.apache.ignite.internal.processors.cache.persistence.wal.crc.FastCrc;
+import org.apache.ignite.internal.processors.cache.persistence.wal.reader.IgniteWalIteratorFactory;
 import org.apache.ignite.internal.processors.marshaller.MappedName;
 import org.apache.ignite.internal.processors.resource.GridSpringResourceContext;
+import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.internal.util.typedef.internal.CU;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteFuture;
 import org.apache.ignite.lang.IgniteFutureCancelledException;
 import org.apache.ignite.lang.IgnitePredicate;
@@ -233,7 +243,7 @@ public abstract class AbstractSnapshotSelfTest extends GridCommonAbstractTest {
             stopAllGrids();
         }
 
-        cleanPersistenceDir();
+//        cleanPersistenceDir();
     }
 
     /**
@@ -653,6 +663,74 @@ public abstract class AbstractSnapshotSelfTest extends GridCommonAbstractTest {
         return (BlockingCustomMessageDiscoverySpi)ignite.context().discovery().getInjectedDiscoverySpi();
     }
 
+    /**
+     * Checks that {@link ClusterSnapshotRecord} was written and every data entry is written afer this record
+     * isn't part of ClusterSnapshot.
+     *
+     * @param ign Ignite instance.
+     * @param snpName Cluster snapshot name.
+     * @param afterSnpEntryCheck Checks every entry in WAL. It consumes two params: next DataEntry, and {@code true} if
+     *                           this entry written before {@link ClusterSnapshotRecord}, otherwise {@code false}.
+     */
+    protected void checkSnpWalRecords(IgniteEx ign, String snpName, BiConsumer<DataEntry, Boolean> afterSnpEntryCheck) throws Exception {
+        WALIterator walIt = wal(ign);
+
+        assertTrue(walIt.hasNext());
+
+        WALPointer snpRecPtr = null;
+
+        for (IgniteBiTuple<WALPointer, WALRecord> rec: walIt) {
+            if (snpRecPtr == null) {
+                if (rec.getValue() instanceof ClusterSnapshotRecord) {
+                    snpRecPtr = rec.get1();
+
+                    assertEquals(snpName, ((ClusterSnapshotRecord)rec.getValue()).clusterSnapshotName());
+                }
+            }
+            else if (rec.getValue() instanceof DataRecord) {
+                DataRecord data = (DataRecord)rec.getValue();
+
+                assertEquals(1, data.writeEntries().size());
+
+                DataEntry e = data.writeEntries().get(0);
+
+                if (snpRecPtr == null) {
+                    assertTrue(rec.getKey().compareTo(snpRecPtr) < 0);
+
+                    afterSnpEntryCheck.accept(e, false);
+                }
+                else {
+                    assertTrue(rec.getKey().compareTo(snpRecPtr) > 0);
+
+                    afterSnpEntryCheck.accept(e, true);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ign Ignite instance.
+     * @return WAL iterator over existing WAL files.
+     */
+    private WALIterator wal(IgniteEx ign) throws Exception {
+        String workDir = U.defaultWorkDirectory();
+
+        IgniteWalIteratorFactory factory = new IgniteWalIteratorFactory(log);
+
+        String subfolderName = ign.name().replace(".", "_");
+
+        File wals = U.resolveWorkDirectory(workDir, "db/wal/" + subfolderName, false);
+        File archive = U.resolveWorkDirectory(workDir, "db/wal/archive/" + subfolderName, false);
+        File binaryMeta = U.resolveWorkDirectory(workDir, "db/binary_meta/" + subfolderName, false);
+        File marshaller = U.resolveWorkDirectory(workDir, "db/marshaller", false);
+
+        IgniteWalIteratorFactory.IteratorParametersBuilder params = new IgniteWalIteratorFactory.IteratorParametersBuilder()
+            .filesOrDirs(archive, wals)
+            .sharedContext(ign.cachex(DEFAULT_CACHE_NAME).context().shared());
+
+        return factory.iterator(params);
+    }
+
     /** */
     protected static class BlockingCustomMessageDiscoverySpi extends TcpDiscoverySpi {
         /** List of messages which have been blocked. */
@@ -778,10 +856,12 @@ public abstract class AbstractSnapshotSelfTest extends GridCommonAbstractTest {
 
         /** User id. */
         @QuerySqlField(index = true)
-        private final int id;
+        @GridToStringInclude
+        protected final int id;
 
         /** Order value. */
         @QuerySqlField
+        @GridToStringInclude
         protected int balance;
 
         /**

--- a/modules/core/src/test/java/org/apache/ignite/testframework/wal/record/RecordUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/wal/record/RecordUtils.java
@@ -40,6 +40,7 @@ import org.apache.ignite.internal.pagemem.wal.record.SnapshotRecord;
 import org.apache.ignite.internal.pagemem.wal.record.SwitchSegmentRecord;
 import org.apache.ignite.internal.pagemem.wal.record.TxRecord;
 import org.apache.ignite.internal.pagemem.wal.record.WALRecord;
+import org.apache.ignite.internal.pagemem.wal.record.delta.ClusterSnapshotRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageInsertFragmentRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageInsertRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageMvccMarkUpdatedRecord;
@@ -108,6 +109,7 @@ import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.BTREE_PAGE_REMOVE;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.BTREE_PAGE_REPLACE;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.CHECKPOINT_RECORD;
+import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.CLUSTER_SNAPSHOT;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.CONSISTENT_CUT;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.DATA_PAGE_INSERT_FRAGMENT_RECORD;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.DATA_PAGE_INSERT_RECORD;
@@ -254,6 +256,7 @@ public class RecordUtils {
         put(INDEX_ROOT_PAGE_RENAME_RECORD, RecordUtils::buildIndexRenameRootPageRecord);
         put(PARTITION_CLEARING_START_RECORD, RecordUtils::buildPartitionClearingStartedRecord);
         put(ENCRYPTED_OUT_OF_ORDER_UPDATE, buildUpsupportedWalRecord(ENCRYPTED_OUT_OF_ORDER_UPDATE));
+        put(CLUSTER_SNAPSHOT, RecordUtils::buildClusterSnapshotRecord);
     }
 
     /** */
@@ -609,6 +612,11 @@ public class RecordUtils {
     /** **/
     public static PartitionClearingStartRecord buildPartitionClearingStartedRecord() {
         return new PartitionClearingStartRecord(12, 345, 123456789);
+    }
+
+    /** **/
+    public static ClusterSnapshotRecord buildClusterSnapshotRecord() {
+        return new ClusterSnapshotRecord("snp-1234567890");
     }
 
     /**


### PR DESCRIPTION
For PITR [1] process of recovering based on ClusterSnapshot + archived WALs.

It's required to have a point in WAL which splits whole WAL on 2 areas:
1. Before this point all data changes are contained within ClusterSnapshot, and no need to recover them from WAL archived files.
2. After this point all data need to be recovered from WAL archived files.

It's proposed to write ClusterSnapshotRecord while the checkpoint is running (cp#writeLock has acquired). ClusterSnapshot process guarantees:
1. there is no active transactions (or any data changes) in moment of running checkpoint.
2. ClusterSnapshot contains all data pages that will be persisted within this checkpoint process.

Then every logical record after begin CheckointRecord doesn't belong to ClusterSnapshot. Then it's safe to write ClusterSnapshotRecord within the checkpoint process.

[1] https://cwiki.apache.org/confluence/pages/editpage.action?pageId=211884314