### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -24,6 +24,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository == 'apache/ignite'

--- a/.github/workflows/publish-website-on-branch-update.yml
+++ b/.github/workflows/publish-website-on-branch-update.yml
@@ -36,8 +36,13 @@ on:
 concurrency:
   group: publish-website-group
 
+permissions:
+  contents: read
+
 jobs:
   publish-documentation:
+    permissions:
+      contents: write  # for Git to git push
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
