### PR TITLE
IGNITE-17247 Fix race condition on close in GridNioClientConnectionMultiplexer

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -135,7 +135,7 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
     }
 
     /** {@inheritDoc} */
-    @Override public synchronized ClientConnection open(InetSocketAddress addr,
+    @Override public ClientConnection open(InetSocketAddress addr,
                                            ClientMessageHandler msgHnd,
                                            ClientConnectionStateHandler stateHnd)
             throws ClientConnectionException {

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -136,6 +136,7 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
                 meta.put(GridNioSslFilter.HANDSHAKE_FUT_META_KEY, sslHandshakeFut);
             }
 
+            // TODO: Why does this hang sometimes? It should not do any socket IO!
             GridNioSession ses = srv.createSession(ch, meta, false, null).get(NIO_REGISTER_TIMEOUT);
 
             if (sslHandshakeFut != null)

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -55,6 +55,9 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
     private static final int CLIENT_MODE_PORT = -1;
 
     /** */
+    private static final int NIO_REGISTER_TIMEOUT = 1000;
+
+    /** */
     private final GridNioServer<ByteBuffer> srv;
 
     /** */
@@ -133,7 +136,7 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
                 meta.put(GridNioSslFilter.HANDSHAKE_FUT_META_KEY, sslHandshakeFut);
             }
 
-            GridNioSession ses = srv.createSession(ch, meta, false, null).get();
+            GridNioSession ses = srv.createSession(ch, meta, false, null).get(NIO_REGISTER_TIMEOUT);
 
             if (sslHandshakeFut != null)
                 sslHandshakeFut.get();

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -23,6 +23,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.SocketChannel;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.net.ssl.SSLContext;
 
 import org.apache.ignite.IgniteCheckedException;
@@ -55,13 +57,13 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
     private static final int CLIENT_MODE_PORT = -1;
 
     /** */
-    private static final int NIO_REGISTER_TIMEOUT = 1000;
-
-    /** */
     private final GridNioServer<ByteBuffer> srv;
 
     /** */
     private final SSLContext sslCtx;
+
+    /** */
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
 
     /**
      * Constructor.
@@ -110,19 +112,35 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
 
     /** {@inheritDoc} */
     @Override public void start() {
-        srv.start();
+        rwLock.writeLock().lock();
+
+        try {
+            srv.start();
+        }
+        finally {
+            rwLock.writeLock().unlock();
+        }
     }
 
     /** {@inheritDoc} */
-    @Override public void stop() {
-        srv.stop();
+    @Override public synchronized void stop() {
+        rwLock.writeLock().lock();
+
+        try {
+            srv.stop();
+        }
+        finally {
+            rwLock.writeLock().unlock();
+        }
     }
 
     /** {@inheritDoc} */
-    @Override public ClientConnection open(InetSocketAddress addr,
+    @Override public synchronized ClientConnection open(InetSocketAddress addr,
                                            ClientMessageHandler msgHnd,
                                            ClientConnectionStateHandler stateHnd)
             throws ClientConnectionException {
+        rwLock.readLock().lock();
+
         try {
             SocketChannel ch = SocketChannel.open();
             ch.socket().connect(new InetSocketAddress(addr.getHostName(), addr.getPort()), Integer.MAX_VALUE);
@@ -136,8 +154,7 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
                 meta.put(GridNioSslFilter.HANDSHAKE_FUT_META_KEY, sslHandshakeFut);
             }
 
-            // TODO: Why does this hang sometimes? It should not do any socket IO!
-            GridNioSession ses = srv.createSession(ch, meta, false, null).get(NIO_REGISTER_TIMEOUT);
+            GridNioSession ses = srv.createSession(ch, meta, false, null).get();
 
             if (sslHandshakeFut != null)
                 sslHandshakeFut.get();
@@ -146,6 +163,9 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
         }
         catch (Exception e) {
             throw new ClientConnectionException(e.getMessage(), e);
+        }
+        finally {
+            rwLock.readLock().unlock();
         }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -69,6 +69,9 @@ public class ConnectionTest {
     /** */
     @Test
     public void testValidInvalidNodeAddressesMix() throws Exception {
+        // TODO this is what happens:
+        // Connection establishes on one channel, binaryCfg request is sent, onTopologyChanged is fired because of that,
+        // then initAllChannelsAsync starts in a separate thread, causing a live lock (?).
         testConnection(IPv4_HOST, "127.0.0.1:47500", "127.0.0.1:10801", Config.SERVER);
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -71,7 +71,8 @@ public class ConnectionTest {
     public void testValidInvalidNodeAddressesMix() throws Exception {
         // TODO this is what happens:
         // Connection establishes on one channel, binaryCfg request is sent, onTopologyChanged is fired because of that,
-        // then initAllChannelsAsync starts in a separate thread, causing a live lock (?).
+        // then initAllChannelsAsync starts in a separate thread, tries to initialize connection to 127.0.0.1:47500, which hangs (WHY?)
+        // Main thread tries to close the same channel (ClientChannelHolder#close), waits on a lock, hangs.
         testConnection(IPv4_HOST, "127.0.0.1:47500", "127.0.0.1:10801", Config.SERVER);
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -69,10 +69,6 @@ public class ConnectionTest {
     /** */
     @Test
     public void testValidInvalidNodeAddressesMix() throws Exception {
-        // TODO this is what happens:
-        // Connection establishes on one channel, binaryCfg request is sent, onTopologyChanged is fired because of that,
-        // then initAllChannelsAsync starts in a separate thread, tries to initialize connection to 127.0.0.1:47500, which hangs (WHY?)
-        // Main thread tries to close the same channel (ClientChannelHolder#close), waits on a lock, hangs.
         testConnection(IPv4_HOST, "127.0.0.1:47500", "127.0.0.1:10801", Config.SERVER);
     }
 


### PR DESCRIPTION
When `GridNioServer.createSession` is called concurrently with `GridNioServer.stop`, it is possible that `GridNioFuture` returned by `createSession` will never complete. Add RW lock in `GridNioClientConnectionMultiplexer` to fix this.