### PR TITLE
IGNITE-17245 AbstractContinuousQuery.setIncludeExpired returns this for chaining

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/AbstractContinuousQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/AbstractContinuousQuery.java
@@ -187,8 +187,10 @@ public abstract class AbstractContinuousQuery<K, V> extends Query<Cache.Entry<K,
      *
      * @param includeExpired Whether to notify about {@link EventType#EXPIRED} events.
      */
-    public void setIncludeExpired(boolean includeExpired) {
+    public AbstractContinuousQuery<K, V> setIncludeExpired(boolean includeExpired) {
         this.includeExpired = includeExpired;
+
+        return this;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/AbstractContinuousQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/AbstractContinuousQuery.java
@@ -186,6 +186,7 @@ public abstract class AbstractContinuousQuery<K, V> extends Query<Cache.Entry<K,
      * This flag is {@code false} by default, so {@link EventType#EXPIRED} events are disabled.
      *
      * @param includeExpired Whether to notify about {@link EventType#EXPIRED} events.
+     * @return {@code this} for chaining.
      */
     public AbstractContinuousQuery<K, V> setIncludeExpired(boolean includeExpired) {
         this.includeExpired = includeExpired;


### PR DESCRIPTION
All the setters for ContinuousQueries return `this` to help with chaining... except for `.setIncludeExpired`. This PR fixes that.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
