### PR TITLE
IGNITE-17387 Thin: Fix server-side message parsing for big messages

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientMessage.java
@@ -169,7 +169,7 @@ public class ClientMessage implements Message, Externalizable {
             if (missing > 0) {
                 int len = Math.min(missing, remaining);
 
-                if (isFirstMessage) {
+                if (isFirstMessage && data == null) {
                     // Sanity check: first 3 bytes in handshake are always 1 1 0 (handshake = 1, major version = 1).
                     // Do not allocate the buffer before validating the header to protect us from garbage data sent by unrelated application
                     // connecting on our port by accident.

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -80,6 +80,24 @@ public class ConnectionTest {
     }
 
     /** */
+    @Test(expected = org.apache.ignite.client.ClientConnectionException.class)
+    public void testInvalidBigHandshakeMessage() throws Exception {
+        char[] data = new char[1024 * 1024 * 128];
+        String userName = new String(data);
+
+        testConnectionWithUsername(userName, Config.SERVER);
+    }
+
+    /** */
+    @Test
+    public void testValidBigHandshakeMessage() throws Exception {
+        char[] data = new char[1024 * 65];
+        String userName = new String(data);
+
+        testConnectionWithUsername(userName, Config.SERVER);
+    }
+
+    /** */
     @Test
     public void testHandshakeTooLargeServerDropsConnection() throws Exception {
         try (LocalIgniteCluster ignored = LocalIgniteCluster.start(1, IPv4_HOST)) {
@@ -132,6 +150,18 @@ public class ConnectionTest {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1, host);
              IgniteClient client = Ignition.startClient(new ClientConfiguration()
                      .setAddresses(addrs))) {
+        }
+    }
+
+    /**
+     * @param userName User name.
+     * @param addrs Addresses to connect.
+     */
+    private void testConnectionWithUsername(String userName, String... addrs) throws Exception {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(new ClientConfiguration()
+                 .setAddresses(addrs)
+                 .setUserName(userName))) {
         }
     }
 }


### PR DESCRIPTION
Fixed bug that caused wrong first message reconstruction if it is divided in more than one TCP packet. 

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
