### PR TITLE
IGNITE-17391 Minimize stored data while traversing trees for index-reader

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -592,7 +592,7 @@ public class IgniteIndexReader implements AutoCloseable {
                         ", msg=Possibly orphan " + io.getClass().getSimpleName() + " page" +
                         ", pageId=" + normalizePageId(pageId) + ']');
                 }
-                catch (Exception e) {
+                catch (Exception | AssertionError e) {
                     ctx.onError(pageId, "Error [step=" + i + ", msg=" + e.getMessage() + ']');
                 }
             }
@@ -714,7 +714,7 @@ public class IgniteIndexReader implements AutoCloseable {
         try {
             x.run();
         }
-        catch (Exception e) {
+        catch (Exception | AssertionError e) {
             ctx.onError(pageId, e.getMessage());
         }
     }
@@ -1289,7 +1289,7 @@ public class IgniteIndexReader implements AutoCloseable {
                             pageId = ((BPlusIO<?>)pageIO).getForward(addr);
                         }
                     }
-                    catch (Exception e) {
+                    catch (Exception | AssertionError e) {
                         ctx.onError(pageId, e.getMessage());
                     }
                 }
@@ -1378,7 +1378,7 @@ public class IgniteIndexReader implements AutoCloseable {
                     try {
                         idxKeyType = IndexKeyType.forCode(type0);
                     }
-                    catch (Exception t) {
+                    catch (Exception | AssertionError t) {
                         log.log(Level.FINEST, "Unknown index key type [type=" + type0 + ']');
 
                         break;
@@ -1406,7 +1406,7 @@ public class IgniteIndexReader implements AutoCloseable {
                             realInlineSz += Short.BYTES; /* size of the array is short number. */
                             realInlineSz += bytes.length;
                         }
-                        catch (Exception e) {
+                        catch (Exception | AssertionError e) {
                             log.warning("Error while reading inline [msg=" + e.getMessage() + ']');
 
                             break;

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -589,8 +589,8 @@ public class IgniteIndexReader implements AutoCloseable {
                         continue;
 
                     ctx.onError(pageId, "Error [step=" + i +
-                            ", msg=Possibly orphan " + io.getClass().getSimpleName() + " page" +
-                            ", pageId=" + normalizePageId(pageId) + ']');
+                        ", msg=Possibly orphan " + io.getClass().getSimpleName() + " page" +
+                        ", pageId=" + normalizePageId(pageId) + ']');
                 }
                 catch (Exception e) {
                     ctx.onError(pageId, "Error [step=" + i + ", msg=" + e.getMessage() + ']');

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -702,7 +702,7 @@ public class IgniteIndexReader implements AutoCloseable {
             x.run();
         }
         catch (Throwable e) {
-            ctx.errors.computeIfAbsent(pageId, k -> new LinkedList<>()).add(e.getMessage());
+            ctx.onError(pageId, e.getMessage());
         }
     }
 
@@ -948,13 +948,6 @@ public class IgniteIndexReader implements AutoCloseable {
     /** Prints sequential file scan results. */
     private void printSequentialScanInfo(ScanContext ctx) {
         printIoStat("", "---- These pages types were encountered during sequential scan:", ctx.stats);
-
-        if (!ctx.errors.isEmpty()) {
-            log.severe("----");
-            log.severe("Errors:");
-
-            ctx.errors.values().forEach(e -> log.severe(e.get(0)));
-        }
 
         log.info("----");
 
@@ -1322,7 +1315,7 @@ public class IgniteIndexReader implements AutoCloseable {
                         }
                     }
                     catch (Throwable e) {
-                        ctx.errors.computeIfAbsent(pageId, k -> new LinkedList<>()).add(e.getMessage());
+                        ctx.onError(pageId, e.getMessage());
                     }
                 }
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -1009,7 +1009,7 @@ public class IgniteIndexReader implements AutoCloseable {
             if (ctx.errCnt == 0)
                 log.info(prefix + "No errors occurred while traversing.");
 
-            totalErr += ctx.errors.size();
+            totalErr += ctx.errCnt;
 
             GridTuple3<Integer, Integer, String> parsed = cacheAndTypeId(idxName);
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -491,7 +491,7 @@ public class IgniteIndexReader implements AutoCloseable {
                             }
                             catch (Exception err) {
                                 errCnt++;
-                                ScanContext.onError(log, PAGE_LISTS_PREFIX, listId, err.getMessage(), errCnt);
+                                ScanContext.onError(log, PAGE_LISTS_PREFIX, listId, err.getMessage());
                             }
                         }
 
@@ -502,7 +502,7 @@ public class IgniteIndexReader implements AutoCloseable {
                 }
                 catch (Exception err) {
                     errCnt++;
-                    ScanContext.onError(log, PAGE_LISTS_PREFIX, currMetaPageId, err.getMessage(), errCnt);
+                    ScanContext.onError(log, PAGE_LISTS_PREFIX, currMetaPageId, err.getMessage());
 
                     break;
                 }
@@ -745,7 +745,7 @@ public class IgniteIndexReader implements AutoCloseable {
         else
             parsed = new GridTuple3<>(UNKNOWN_CACHE, 0, null);
 
-        return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix, idxName, printer);
+        return new ScanContext(parsed.get1(), idxName, inlineFieldsCount(parsed), store, items, log, prefix, printer);
     }
 
     /**

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -736,7 +736,7 @@ public class IgniteIndexReader implements AutoCloseable {
         else
             parsed = new GridTuple3<>(UNKNOWN_CACHE, 0, null);
 
-        return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix);
+        return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix, idxName);
     }
 
     /**
@@ -1006,13 +1006,8 @@ public class IgniteIndexReader implements AutoCloseable {
                 );
             }
 
-            printErrors(
-                prefix,
-                "Errors:",
-                "No errors occurred while traversing.",
-                "Page id=%s, exceptions:",
-                ctx.errors
-            );
+            if (ctx.errCnt == 0)
+                log.info(prefix + "No errors occurred while traversing.");
 
             totalErr += ctx.errors.size();
 
@@ -1130,12 +1125,6 @@ public class IgniteIndexReader implements AutoCloseable {
 
     /** */
     private void printErrors(String prefix, String caption, String emptyCaption, String msg, Map<?, List<String>> errors) {
-        if (errors.isEmpty()) {
-            log.info(prefix + emptyCaption);
-
-            return;
-        }
-
         log.info(prefix + ERROR_PREFIX + caption);
 
         errors.forEach((k, v) -> {

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReader.java
@@ -396,7 +396,12 @@ public class IgniteIndexReader implements AutoCloseable {
 
         ProgressPrinter progressPrinter = createProgressPrinter(caption, pagesCnt);
 
-        ScanContext metaTreeCtx = scanner.scan(metaTreeRoot, META_TREE_NAME, new ItemsListStorage<IndexStorageImpl.IndexItem>(), progressPrinter);
+        ScanContext metaTreeCtx = scanner.scan(
+            metaTreeRoot,
+            META_TREE_NAME,
+            new ItemsListStorage<IndexStorageImpl.IndexItem>(),
+            progressPrinter
+        );
 
         log.info("Going to scan " + metaTreeCtx.items.size() + " trees.");
 
@@ -405,13 +410,18 @@ public class IgniteIndexReader implements AutoCloseable {
         AtomicInteger treeCnt = new AtomicInteger();
 
         ((ItemsListStorage<IndexStorageImpl.IndexItem>)metaTreeCtx.items).forEach(item -> {
-            log.info("Scanning [num=" + treeCnt.incrementAndGet() + ", of=" + metaTreeCtx.items.size() + ", item=" + item.nameString() + "]");
+            log.info("Scanning [num=" + treeCnt.incrementAndGet() + ", of=" + metaTreeCtx.items.size() +
+                ", idx=" + item.nameString() + "]");
 
             if (nonNull(idxFilter) && !idxFilter.test(item.nameString()))
                 return;
 
-            ScanContext ctx =
-                scanner.scan(normalizePageId(item.pageId()), item.nameString(), itemStorageFactory.get(), progressPrinter);
+            ScanContext ctx = scanner.scan(
+                normalizePageId(item.pageId()),
+                item.nameString(),
+                itemStorageFactory.get(),
+                progressPrinter
+            );
 
             ctxs.put(item.toString(), ctx);
         });

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/PageListsInfo.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/PageListsInfo.java
@@ -40,19 +40,18 @@ class PageListsInfo {
     /** Pages statistics. */
     final Map<Class<? extends PageIO>, ScanContext.PagesStatistic> stats;
 
-    /** Map of errors, pageId -> list of exceptions. */
-    final Map<Long, List<String>> errors;
+    final long errCnt;
 
     /** */
     public PageListsInfo(
         Map<IgniteBiTuple<Long, Integer>, List<Long>> bucketsData,
         long pagesCnt,
         Map<Class<? extends PageIO>, ScanContext.PagesStatistic> stats,
-        Map<Long, List<String>> errors
+        long errCnt
     ) {
         this.bucketsData = bucketsData;
         this.pagesCnt = pagesCnt;
         this.stats = stats;
-        this.errors = errors;
+        this.errCnt = errCnt;
     }
 }

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/PageListsInfo.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/PageListsInfo.java
@@ -40,6 +40,7 @@ class PageListsInfo {
     /** Pages statistics. */
     final Map<Class<? extends PageIO>, ScanContext.PagesStatistic> stats;
 
+    /** Errors count. */
     final long errCnt;
 
     /** */

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -69,7 +69,16 @@ class ScanContext {
     private final ProgressPrinter printer;
 
     /** */
-    public ScanContext(int cacheId, int inlineFldCnt, FilePageStore store, ItemStorage items, Logger log, String prefix, String idxName, ProgressPrinter printer) {
+    public ScanContext(
+        int cacheId,
+        String idxName,
+        int inlineFldCnt,
+        FilePageStore store,
+        ItemStorage items,
+        Logger log,
+        String prefix,
+        ProgressPrinter printer
+    ) {
         this.cacheId = cacheId;
         this.inlineFldCnt = inlineFldCnt;
         this.store = store;
@@ -127,11 +136,11 @@ class ScanContext {
 
         errCnt++;
 
-        onError(log, prefix, pageId, message, errCnt);
+        onError(log, prefix, pageId, message);
     }
 
-    public static void onError(Logger log, String prefix, long pageId, String message, long errCnt) {
-        log.warning(prefix + ERROR_PREFIX + "Err#" + errCnt + ", Page id: " + pageId + ", exceptions: " + message);
+    public static void onError(Logger log, String prefix, long pageId, String message) {
+        log.warning(prefix + ERROR_PREFIX + "Page id: " + pageId + ", exceptions: " + message);
     }
 
     /** */

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import org.apache.ignite.internal.commandline.ProgressPrinter;
 import org.apache.ignite.internal.processors.cache.persistence.file.FilePageStore;
 import org.apache.ignite.internal.processors.cache.persistence.tree.io.PageIO;
 
@@ -65,7 +66,10 @@ class ScanContext {
     private final String idxName;
 
     /** */
-    public ScanContext(int cacheId, int inlineFldCnt, FilePageStore store, ItemStorage items, Logger log, String prefix, String idxName) {
+    private final ProgressPrinter printer;
+
+    /** */
+    public ScanContext(int cacheId, int inlineFldCnt, FilePageStore store, ItemStorage items, Logger log, String prefix, String idxName, ProgressPrinter printer) {
         this.cacheId = cacheId;
         this.inlineFldCnt = inlineFldCnt;
         this.store = store;
@@ -74,6 +78,13 @@ class ScanContext {
         this.log = log;
         this.prefix = prefix;
         this.idxName = idxName;
+        this.printer = printer;
+    }
+
+    /** */
+    public void progress() {
+        if (printer != null)
+            printer.printProgress();
     }
 
     /** */
@@ -116,11 +127,11 @@ class ScanContext {
 
         errCnt++;
 
-        onError(log, prefix, pageId, message);
+        onError(log, prefix, pageId, message, errCnt);
     }
 
-    public static void onError(Logger log, String prefix, long pageId, String message) {
-        log.warning(prefix + ERROR_PREFIX + "Page id: " + pageId + ", exceptions: " + message);
+    public static void onError(Logger log, String prefix, long pageId, String message, long errCnt) {
+        log.warning(prefix + ERROR_PREFIX + "Err#" + errCnt + ", Page id: " + pageId + ", exceptions: " + message);
     }
 
     /** */

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -47,6 +47,7 @@ class ScanContext {
     /** Page type statistics. */
     final Map<Class<? extends PageIO>, PagesStatistic> stats;
 
+    /** Errors count. */
     long errCnt;
 
     /** List of items storage. */
@@ -139,6 +140,7 @@ class ScanContext {
         onError(log, prefix, pageId, message);
     }
 
+    /** */
     public static void onError(Logger log, String prefix, long pageId, String message) {
         log.warning(prefix + ERROR_PREFIX + "Page id: " + pageId + ", exceptions: " + message);
     }

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.commandline.indexreader;
 
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -43,9 +42,6 @@ class ScanContext {
 
     /** Page type statistics. */
     final Map<Class<? extends PageIO>, PagesStatistic> stats;
-
-    /** Map of errors, pageId -> set of exceptions. */
-    final Map<Long, List<String>> errors;
 
     long errCnt;
 
@@ -75,7 +71,6 @@ class ScanContext {
         this.store = store;
         this.items = items;
         this.stats = new LinkedHashMap<>();
-        this.errors = new LinkedHashMap<>();
         this.log = log;
         this.prefix = prefix;
         this.idxName = idxName;
@@ -113,8 +108,6 @@ class ScanContext {
 
     /** */
     public void onError(long pageId, String message) {
-        errors.computeIfAbsent(pageId, k -> new LinkedList<>()).add(message);
-
         if (errCnt == 0) {
             log.warning(prefix + ERROR_PREFIX + "-----");
             log.warning(prefix + ERROR_PREFIX + "Index tree: " + idxName);

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -43,6 +43,8 @@ class ScanContext {
     /** Map of errors, pageId -> set of exceptions. */
     final Map<Long, List<String>> errors;
 
+    long errCnt;
+
     /** List of items storage. */
     final ItemStorage items;
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -35,6 +35,9 @@ class ScanContext {
     /** Cache id or {@code -1} for sequential scan. */
     final int cacheId;
 
+    /** Index name. */
+    final String idxName;
+
     /** Count of inline fields. */
     final int inlineFldCnt;
 
@@ -63,9 +66,6 @@ class ScanContext {
     private final String prefix;
 
     /** */
-    private final String idxName;
-
-    /** */
     private final ProgressPrinter printer;
 
     /** */
@@ -80,13 +80,13 @@ class ScanContext {
         ProgressPrinter printer
     ) {
         this.cacheId = cacheId;
+        this.idxName = idxName;
         this.inlineFldCnt = inlineFldCnt;
         this.store = store;
         this.items = items;
         this.stats = new LinkedHashMap<>();
         this.log = log;
         this.prefix = prefix;
-        this.idxName = idxName;
         this.printer = printer;
     }
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -66,7 +66,10 @@ class ScanContext {
     private final String prefix;
 
     /** */
-    public ScanContext(int cacheId, int inlineFldCnt, FilePageStore store, ItemStorage items, Logger log, String prefix) {
+    private final String idxName;
+
+    /** */
+    public ScanContext(int cacheId, int inlineFldCnt, FilePageStore store, ItemStorage items, Logger log, String prefix, String idxName) {
         this.cacheId = cacheId;
         this.inlineFldCnt = inlineFldCnt;
         this.store = store;
@@ -75,6 +78,7 @@ class ScanContext {
         this.errors = new LinkedHashMap<>();
         this.log = log;
         this.prefix = prefix;
+        this.idxName = idxName;
     }
 
     /** */
@@ -111,8 +115,11 @@ class ScanContext {
     public void onError(long pageId, String message) {
         errors.computeIfAbsent(pageId, k -> new LinkedList<>()).add(message);
 
-        if (errCnt == 0)
+        if (errCnt == 0) {
+            log.warning(prefix + ERROR_PREFIX + "-----");
+            log.warning(prefix + ERROR_PREFIX + "Index tree: " + idxName);
             log.warning(prefix + ERROR_PREFIX + "---- Errors:");
+        }
 
         errCnt++;
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/indexreader/ScanContext.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.commandline.indexreader;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -93,6 +94,11 @@ class ScanContext {
     /** */
     public void onLeafPage(long pageId, List<Object> data) {
         data.forEach(items::add);
+    }
+
+    /** */
+    public void onError(long pageId, String message) {
+        errors.computeIfAbsent(pageId, k -> new LinkedList<>()).add(message);
     }
 
     /** */

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
@@ -287,7 +287,13 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
         Logger log = createTestLogger();
 
         IgniteIndexReader reader0 = new IgniteIndexReader(PAGE_SIZE, PART_CNT, PAGE_STORE_VER, dir, null, false, log) {
-            @Override ScanContext createContext(String idxName, FilePageStore store, ItemStorage items, String prefix, ProgressPrinter printer) {
+            @Override ScanContext createContext(
+                String idxName,
+                FilePageStore store,
+                ItemStorage items,
+                String prefix,
+                ProgressPrinter printer
+            ) {
                 GridTuple3<Integer, Integer, String> parsed;
 
                 if (idxName != null)

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
@@ -285,8 +285,10 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
         // Take any inner page from tree.
         AtomicLong anyLeafId = new AtomicLong();
 
-        IgniteIndexReader reader0 = new IgniteIndexReader(PAGE_SIZE, PART_CNT, PAGE_STORE_VER, dir, null, false, createTestLogger()) {
-            @Override ScanContext createContext(String idxName, FilePageStore store, ItemStorage items) {
+        Logger log = createTestLogger();
+
+        IgniteIndexReader reader0 = new IgniteIndexReader(PAGE_SIZE, PART_CNT, PAGE_STORE_VER, dir, null, false, log) {
+            @Override ScanContext createContext(String idxName, FilePageStore store, ItemStorage items, String prefix) {
                 GridTuple3<Integer, Integer, String> parsed;
 
                 if (idxName != null)
@@ -294,7 +296,7 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
                 else
                     parsed = new GridTuple3<>(UNKNOWN_CACHE, 0, null);
 
-                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items) {
+                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix) {
                     @Override public void onLeafPage(long pageId, List<Object> data) {
                         super.onLeafPage(pageId, data);
 

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
@@ -295,7 +295,7 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
                 else
                     parsed = new GridTuple3<>(UNKNOWN_CACHE, 0, null);
 
-                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix, idxName, printer) {
+                return new ScanContext(parsed.get1(), idxName, inlineFieldsCount(parsed), store, items, log, prefix, printer) {
                     @Override public void onLeafPage(long pageId, List<Object> data) {
                         super.onLeafPage(pageId, data);
 

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
@@ -144,9 +144,8 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
 
     /** Regexp to validate output of corrupted index. */
     private static final String CHECK_IDX_PTRN_WITH_ERRORS =
-        CHECK_IDX_PTRN_COMMON + "<PREFIX>" + ERROR_PREFIX + "Errors:" +
-            LINE_DELIM + "<PREFIX>" + ERROR_PREFIX + "Page id=[0-9]{1,30}, exceptions:" +
-            LINE_DELIM + "Failed to read page.*";
+        "<PREFIX>" + ERROR_PREFIX + "---- Errors:" +
+            LINE_DELIM + "<PREFIX>" + ERROR_PREFIX + "Page id: [0-9]{1,30}, exceptions: Failed to read page.*";
 
     /** Work directory, containing cache group directories. */
     private static File workDir;
@@ -296,7 +295,7 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
                 else
                     parsed = new GridTuple3<>(UNKNOWN_CACHE, 0, null);
 
-                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix) {
+                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix, idxName) {
                     @Override public void onLeafPage(long pageId, List<Object> data) {
                         super.onLeafPage(pageId, data);
 

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/indexreader/IgniteIndexReaderTest.java
@@ -287,7 +287,7 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
         Logger log = createTestLogger();
 
         IgniteIndexReader reader0 = new IgniteIndexReader(PAGE_SIZE, PART_CNT, PAGE_STORE_VER, dir, null, false, log) {
-            @Override ScanContext createContext(String idxName, FilePageStore store, ItemStorage items, String prefix) {
+            @Override ScanContext createContext(String idxName, FilePageStore store, ItemStorage items, String prefix, ProgressPrinter printer) {
                 GridTuple3<Integer, Integer, String> parsed;
 
                 if (idxName != null)
@@ -295,7 +295,7 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
                 else
                     parsed = new GridTuple3<>(UNKNOWN_CACHE, 0, null);
 
-                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix, idxName) {
+                return new ScanContext(parsed.get1(), inlineFieldsCount(parsed), store, items, log, prefix, idxName, printer) {
                     @Override public void onLeafPage(long pageId, List<Object> data) {
                         super.onLeafPage(pageId, data);
 
@@ -310,7 +310,7 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
 
             ItemsListStorage<IndexStorageImpl.IndexItem> idxItemStorage = new ItemsListStorage<>();
 
-            reader.recursiveTreeScan(partitionRoots[0], META_TREE_NAME, idxItemStorage);
+            reader.recursiveTreeScan(partitionRoots[0], META_TREE_NAME, idxItemStorage, null);
 
             // Take any index item.
             IndexStorageImpl.IndexItem idxItem = idxItemStorage.iterator().next();
@@ -320,7 +320,8 @@ public class IgniteIndexReaderTest extends GridCommandHandlerAbstractTest {
             reader.recursiveTreeScan(
                 normalizePageId(idxItem.pageId()),
                 idxItem.nameString(),
-                linkStorage
+                linkStorage,
+                null
             );
 
             // Take any link.


### PR DESCRIPTION
- Eliminate storing errors in list. This leads to OOM on huge files with many issues.
- Instead of progress by index count show progress by pages which shows more fair info.