### PR TITLE
IGNITE-17513 [ducktests] Set locale to c.utf-8 in docker image

### DIFF
--- a/modules/ducktests/tests/docker/Dockerfile
+++ b/modules/ducktests/tests/docker/Dockerfile
@@ -91,7 +91,14 @@ RUN cd /opt && curl -OL https://github.com/jiaqi/jmxterm/releases/download/v$JMX
        && mv $JMXTERM_ARTIFACT $JMXTERM_NAME.jar
 
 # Set up the ducker user.
-RUN useradd -ms /bin/bash ducker && mkdir -p /home/ducker/ && rsync -aiq /root/.ssh/ /home/ducker/.ssh && chown -R ducker /home/ducker/ /mnt/ /var/log/ && echo "PATH=$(runuser -l ducker -c 'echo $PATH'):$JAVA_HOME/bin" >> /home/ducker/.ssh/environment && echo 'PATH=$PATH:'"$JAVA_HOME/bin" >> /home/ducker/.profile && echo 'ducker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN useradd -ms /bin/bash ducker \
+    && mkdir -p /home/ducker/ \
+    && rsync -aiq /root/.ssh/ /home/ducker/.ssh \
+    && chown -R ducker /home/ducker/ /mnt/ /var/log/ \
+    && echo "LANG=C.UTF-8" >> /home/ducker/.ssh/environment \
+    && echo "PATH=$(runuser -l ducker -c 'echo $PATH'):$JAVA_HOME/bin" >> /home/ducker/.ssh/environment \
+    && echo 'PATH=$PATH:'"$JAVA_HOME/bin" >> /home/ducker/.profile \
+    && echo 'ducker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 USER ducker
 
 CMD sudo service ssh start && tail -f /dev/null

--- a/modules/ducktests/tests/ignitetest/tests/auth_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/auth_test.py
@@ -32,7 +32,7 @@ from ignitetest.utils.version import DEV_BRANCH, LATEST, IgniteVersion
 WRONG_PASSWORD = "wrong_password"
 TEST_USERNAME = "admin"
 TEST_PASSWORD = "qwe123"
-TEST_PASSWORD2 = "123qwe"
+TEST_PASSWORD2 = "123qwe_ßß_üü"
 
 ADD_USER = 'adduser'
 UPDATE_USER = 'updateuser'


### PR DESCRIPTION
In docker image update the environment of the program started via the SSH to use the UTF-8 locale instead of the default POSIX one.  In particular the ```LANG=C.UTF-8```  was added into the /home/ducker/.ssh/environment file.

This is needed for example to pass the password with  non-ascii symbols to control.sh


------------


Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
