### PR TITLE
IGNITE-17559 .NET: Fix TestCopyToInvalidArguments on Windows

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
@@ -216,16 +216,20 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
             var target1 = new int[3];
 
             var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => set.CopyTo(target1, -1));
-            Assert.AreEqual("Non-negative number required. (Parameter 'arrayIndex')\nActual value was -1.",
-                ex1.Message);
+            Assert.AreEqual("Non-negative number required. (Parameter 'arrayIndex') Actual value was -1.",
+                TestUtils.RemoveLineBreaks(ex1.Message));
 
             var ex2 = Assert.Throws<ArgumentException>(() => set.CopyTo(target1, 1));
-            Assert.AreEqual("Destination array is not long enough to copy all the items in the collection. " +
-                            "Check array index and length. (Parameter 'array')", ex2.Message);
+            Assert.AreEqual(
+                "Destination array is not long enough to copy all the items in the collection. " +
+                "Check array index and length. (Parameter 'array')",
+                TestUtils.RemoveLineBreaks(ex2.Message));
 
             var ex3 = Assert.Throws<ArgumentException>(() => set.CopyTo(target1, 3));
-            Assert.AreEqual("Destination array is not long enough to copy all the items in the collection. " +
-                            "Check array index and length. (Parameter 'array')", ex3.Message);
+            Assert.AreEqual(
+                "Destination array is not long enough to copy all the items in the collection. " +
+                "Check array index and length. (Parameter 'array')",
+                TestUtils.RemoveLineBreaks(ex3.Message));
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
@@ -216,20 +216,15 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
             var target1 = new int[3];
 
             var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => set.CopyTo(target1, -1));
-            Assert.AreEqual("Non-negative number required. (Parameter 'arrayIndex') Actual value was -1.",
-                TestUtils.RemoveLineBreaks(ex1.Message));
+            StringAssert.StartsWith("Non-negative number required.", ex1.Message);
 
             var ex2 = Assert.Throws<ArgumentException>(() => set.CopyTo(target1, 1));
-            Assert.AreEqual(
-                "Destination array is not long enough to copy all the items in the collection. " +
-                "Check array index and length. (Parameter 'array')",
-                TestUtils.RemoveLineBreaks(ex2.Message));
+            StringAssert.StartsWith("Destination array is not long enough to copy all the items in the collection",
+                ex2.Message);
 
             var ex3 = Assert.Throws<ArgumentException>(() => set.CopyTo(target1, 3));
-            Assert.AreEqual(
-                "Destination array is not long enough to copy all the items in the collection. " +
-                "Check array index and length. (Parameter 'array')",
-                TestUtils.RemoveLineBreaks(ex3.Message));
+            StringAssert.StartsWith("Destination array is not long enough to copy all the items in the collection",
+                ex3.Message);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -693,6 +693,14 @@ namespace Apache.Ignite.Core.Tests
         }
 
         /// <summary>
+        /// Removes line breaks from the string.
+        /// </summary>
+        public static string RemoveLineBreaks(string s)
+        {
+            return s.Replace("\r\n", " ").Replace("\n", " ");
+        }
+
+        /// <summary>
         /// Logs to test progress. Produces immediate console output on .NET Core.
         /// </summary>
         public class TestContextLogger : ILogger

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -693,14 +693,6 @@ namespace Apache.Ignite.Core.Tests
         }
 
         /// <summary>
-        /// Removes line breaks from the string.
-        /// </summary>
-        public static string RemoveLineBreaks(string s)
-        {
-            return s.Replace("\r\n", " ").Replace("\n", " ");
-        }
-
-        /// <summary>
         /// Logs to test progress. Produces immediate console output on .NET Core.
         /// </summary>
         public class TestContextLogger : ILogger


### PR DESCRIPTION
Use `StringAssert.StartsWith` because the full message differs on various platforms.