### PR TITLE
IGNITE-17537 Append units for duration -sec and timeout -sec

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxInfo.java
@@ -283,11 +283,11 @@ public class VisorTxInfo extends VisorDataTransferObject {
             ", label=" + getLabel() +
             ", state=" + getState() +
             ", startTime=" + getFormattedStartTime() +
-            ", duration=" + getDuration() / 1000 +
+            ", duration=" + getDuration() / 1000 + " sec" +
             ", isolation=" + getIsolation() +
             ", concurrency=" + getConcurrency() +
             ", topVer=" + (getTopologyVersion() == null ? "N/A" : getTopologyVersion()) +
-            ", timeout=" + getTimeout() +
+            ", timeout=" + getTimeout() + " ms" +
             ", size=" + getSize() +
             ", dhtNodes=" + (getPrimaryNodes() == null ? "N/A" :
             F.transform(getPrimaryNodes(), new IgniteClosure<UUID, String>() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxInfo.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxInfo.java
@@ -287,7 +287,7 @@ public class VisorTxInfo extends VisorDataTransferObject {
             ", isolation=" + getIsolation() +
             ", concurrency=" + getConcurrency() +
             ", topVer=" + (getTopologyVersion() == null ? "N/A" : getTopologyVersion()) +
-            ", timeout=" + getTimeout() + " ms" +
+            ", timeout=" + getTimeout() / 1000 + " sec" +
             ", size=" + getSize() +
             ", dhtNodes=" + (getPrimaryNodes() == null ? "N/A" :
             F.transform(getPrimaryNodes(), new IgniteClosure<UUID, String>() {


### PR DESCRIPTION
Appended units to duration - sec and timeout - ms. The change is required as the execution of control.sh --tx command produces output of matching transactions (below) from which it is unclear that duration is provided in seconds while timeout is in milliseconds.

The result of executing control.sh --tx command is below. The **in bold** change is added in this PR:
Tx: [xid=fdc4d720281-00000000-0fd8-0177-0000-000000000012, label=null, state=ACTIVE, startTime=2022-07-06 05:05:07.432, duration=778 **sec**, isolation=REPEATABLE_READ, concurrency=PESSIMISTIC, topVer=AffinityTopologyVersion [topVer=199, minorTopVer=0], timeout=40000 **ms**, ...].

1) VisorTxInfo class:

https://github.com/apache/ignite/blob/bf9a460eccd07701cacac2a414c65707243350f1/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxInfo.java#L286

https://github.com/apache/ignite/blob/bf9a460eccd07701cacac2a414c65707243350f1/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxInfo.java#L290

2) long duration from getDuration() is in milliseconds as per VisorTxTask class: https://github.com/apache/ignite/blob/f6e2ebe8e62b3e442bda2a70f19544261b3c0cfa/modules/core/src/main/java/org/apache/ignite/internal/visor/tx/VisorTxTask.java#L243 

3) long timeout is in milliseconds as per IgniteInternalTx interface: https://github.com/apache/ignite/blob/e2008f4652544e51c75a8586ef8aee82fb2923b9/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteInternalTx.java#L148 

From the above 1) -3) after dividing into 1000 the duration is in seconds while timeout is still in milliseconds which should be explicitly highlighted.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
