### PR TITLE
IGNITE-17710 .NET: Fix CancellationTest.TestTask

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
@@ -130,6 +130,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             public ComputeJobResultPolicy OnResult(IComputeJobResult<int> res, IList<IComputeJobResult<int>> rcvd)
             {
+                Thread.Sleep(MillisecondsTimeout);
                 return ComputeJobResultPolicy.Wait;
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
@@ -110,7 +110,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             Job.Cancelled = false;
             Job.StartEvent.Reset();
-            Job.FinishEvent.Reset();
+            Job.CancelEvent.Reset();
 
             using (var cts = new CancellationTokenSource())
             {
@@ -173,22 +173,21 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             public static readonly ManualResetEventSlim StartEvent = new ManualResetEventSlim(false);
 
-            public static readonly ManualResetEventSlim FinishEvent = new ManualResetEventSlim(false);
+            public static readonly ManualResetEventSlim CancelEvent = new ManualResetEventSlim(false);
 
             public static volatile bool Cancelled;
 
             public int Execute()
             {
                 StartEvent.Set();
-                FinishEvent.Wait();
+                CancelEvent.Wait();
 
                 return 1;
             }
 
             public void Cancel()
             {
-                FinishEvent.Set();
-
+                CancelEvent.Set();
                 Cancelled = true;
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
@@ -157,7 +157,6 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             public ComputeJobResultPolicy OnResult(IComputeJobResult<int> res, IList<IComputeJobResult<int>> rcvd)
             {
-                Thread.Sleep(MillisecondsTimeout);
                 return ComputeJobResultPolicy.Wait;
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
@@ -152,9 +152,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             public IDictionary<IComputeJob<int>, IClusterNode> Map(IList<IClusterNode> subgrid, object arg)
             {
-                return Enumerable.Range(1, 2)
-                    .SelectMany(x => subgrid)
-                    .ToDictionary(x => (IComputeJob<int>)new Job(), x => x);
+                return subgrid.Where(x => !x.IsLocal).Take(1).ToDictionary(x => (IComputeJob<int>)new Job(), x => x);
             }
 
             public ComputeJobResultPolicy OnResult(IComputeJobResult<int> res, IList<IComputeJobResult<int>> rcvd)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
@@ -118,7 +118,6 @@ namespace Apache.Ignite.Core.Tests.Compute
                 Assert.IsFalse(task.IsCanceled);
 
                 Job.StartEvent.Wait();
-                Job.FinishEvent.Set();
 
                 cts.Cancel();
                 TestUtils.WaitForTrueCondition(() => task.IsCanceled);
@@ -190,6 +189,8 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             public void Cancel()
             {
+                FinishEvent.Set();
+
                 Cancelled = true;
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -78,7 +78,7 @@ namespace Apache.Ignite.Core.Tests
             {
                 "-XX:+HeapDumpOnOutOfMemoryError",
                 "-Xms2g",
-                "-Xmx6g",
+                "-Xmx4g",
                 "-ea",
                 "-DIGNITE_QUIET=true",
                 "-Duser.timezone=UTC"


### PR DESCRIPTION
Use synchronization primitives instead of relying on `Thread.Sleep`.

https://issues.apache.org/jira/browse/IGNITE-17710