### PR TITLE
IGNITE-17785 Fix NodeSslConnectionMetricTest

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -428,7 +428,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
 
         waitForMetric(SESSIONS_CNT_METRIC_NAME, sesCnt, () -> mreg.<IntMetric>findMetric(SESSIONS_CNT_METRIC_NAME).value());
 
-        waitForMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME, handshakeCnt, () -> (int) Arrays.stream(
+        waitForMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME, handshakeCnt, () -> (int)Arrays.stream(
                 mreg.<HistogramMetric>findMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME).value()).sum());
 
         waitForMetric(SSL_REJECTED_SESSIONS_CNT_METRIC_NAME, rejectedSesCnt,

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -236,7 +236,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         checkNodeJoinFails(2, false, "node01", "trustone", null, "TLSv1.1");
 
         // In case of an SSL error, the client and server nodes make 2 additional connection attempts.
-        waitForMetricGreaterOrEqual("RejectedSslConnectionsCount", 12,
+        waitForMetricGreaterOrEqual("RejectedSslConnectionsCount", 6,
                 () -> reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value());
     }
 

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Supplier;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.client.ClientConnectionException;
 import org.apache.ignite.client.Config;
@@ -71,6 +72,9 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
 
     /** Cipher suite not supported by cluster nodes. */
     private static final String UNSUPPORTED_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_GCM_SHA256";
+
+    /** Metric timeout. */
+    private static final long TIMEOUT = 7_000;
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -222,6 +226,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         // Tests untrusted certificate.
         checkNodeJoinFails(2, true, "thinClient", "trusttwo", CIPHER_SUITE, "TLSv1.2");
         checkNodeJoinFails(2, false, "thinClient", "trusttwo", CIPHER_SUITE, "TLSv1.2");
+
         // Tests untrusted cipher suites.
         checkNodeJoinFails(2, true, "client", "trustone", UNSUPPORTED_CIPHER_SUITE, "TLSv1.2");
         checkNodeJoinFails(2, false, "node01", "trustone", UNSUPPORTED_CIPHER_SUITE, "TLSv1.2");
@@ -231,9 +236,8 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         checkNodeJoinFails(2, false, "node01", "trustone", null, "TLSv1.1");
 
         // In case of an SSL error, the client and server nodes make 2 additional connection attempts.
-        assertTrue(waitForCondition(() ->
-            18 == reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value(),
-            getTestTimeout()));
+        waitForMetricGreaterOrEqual("RejectedSslConnectionsCount", 12,
+                () -> reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value());
     }
 
     /** Tests SSL communication metrics produced by node connection. */
@@ -416,22 +420,33 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
     /** Checks SSL communication metrics. */
     private void checkSslCommunicationMetrics(
         MetricRegistry mreg,
-        long handshakeCnt,
+        int handshakeCnt,
         int sesCnt,
         int rejectedSesCnt
     ) throws Exception {
         assertEquals(true, mreg.<BooleanMetric>findMetric(SSL_ENABLED_METRIC_NAME).value());
-        assertTrue(waitForCondition(() ->
-            sesCnt == mreg.<IntMetric>findMetric(SESSIONS_CNT_METRIC_NAME).value(),
-            getTestTimeout()));
-        assertTrue(waitForCondition(() ->
-            handshakeCnt == Arrays.stream(
-                mreg.<HistogramMetric>findMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME).value()
-            ).sum(),
-            getTestTimeout()));
-        assertTrue(waitForCondition(() ->
-            rejectedSesCnt == mreg.<IntMetric>findMetric(SSL_REJECTED_SESSIONS_CNT_METRIC_NAME).value(),
-            getTestTimeout()));
+
+        waitForMetric(SESSIONS_CNT_METRIC_NAME, sesCnt, () -> mreg.<IntMetric>findMetric(SESSIONS_CNT_METRIC_NAME).value());
+
+        waitForMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME, handshakeCnt, () -> (int) Arrays.stream(
+                mreg.<HistogramMetric>findMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME).value()).sum());
+
+        waitForMetric(SSL_REJECTED_SESSIONS_CNT_METRIC_NAME, rejectedSesCnt,
+                () -> mreg.<IntMetric>findMetric(SSL_REJECTED_SESSIONS_CNT_METRIC_NAME).value());
+    }
+
+    /** Wait for metric value. */
+    private void waitForMetric(String name, int expected, Supplier<Integer> supplier) throws Exception {
+        assertTrue(
+            "Metric " + name + " expected " + expected + " but was " + supplier.get(),
+                waitForCondition(() -> expected == supplier.get(), TIMEOUT));
+    }
+
+    /** Wait for metric value. */
+    private void waitForMetricGreaterOrEqual(String name, int expected, Supplier<Integer> supplier) throws Exception {
+        assertTrue(
+            "Metric " + name + " expected greater or equal than " + expected + " but was " + supplier.get(),
+                waitForCondition(() -> expected <= supplier.get(), TIMEOUT));
     }
 
     /** Creates {@link SslContextFactory} with specified options. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientNioTcpConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientNioTcpConnection.java
@@ -241,10 +241,12 @@ public class GridClientNioTcpConnection extends GridClientConnection {
                 meta.put(GridNioSslFilter.HANDSHAKE_FUT_META_KEY, sslHandshakeFut);
             }
 
-            ses = (GridNioSession)srv.createSession(ch, meta, false, null).get();
+            GridNioFuture<GridNioSession> sesFut = srv.createSession(ch, meta, false, null);
 
             if (sslHandshakeFut != null)
                 sslHandshakeFut.get();
+
+            ses = sesFut.get();
 
             GridClientHandshakeRequest req = new GridClientHandshakeRequest();
 


### PR DESCRIPTION
* Fix `GridClientNioTcpConnection` hang on invalid SSL protocol (same fix as IGNITE-17367).
* Fix `rejectedSesCnt` in `GridNioSslFilter`.
* Improve assertions to show expected and actual.