### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -24,6 +24,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository == 'apache/ignite'

--- a/.github/workflows/publish-website-on-branch-update.yml
+++ b/.github/workflows/publish-website-on-branch-update.yml
@@ -36,8 +36,13 @@ on:
 concurrency:
   group: publish-website-group
 
+permissions:
+  contents: read
+
 jobs:
   publish-documentation:
+    permissions:
+      contents: write  # for Git to git push
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/apache/ignite/actions/runs/3159837231/jobs/5143560938#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- publish-snapshot.yml
- publish-website-on-branch-update.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>