### PR TITLE
IGNITE-17815 Java thin: Fix RetryPolicy exception handling, propagate exceptions to API caller

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
@@ -874,7 +874,12 @@ final class ReliableChannel implements AutoCloseable {
 
         ClientRetryPolicyContext ctx = new ClientRetryPolicyContextImpl(clientCfg, opType, iteration, exception);
 
-        return plc.shouldRetry(ctx);
+        try {
+            return plc.shouldRetry(ctx);
+        } catch (Throwable t) {
+            exception.addSuppressed(t);
+            return false;
+        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
@@ -876,7 +876,8 @@ final class ReliableChannel implements AutoCloseable {
 
         try {
             return plc.shouldRetry(ctx);
-        } catch (Throwable t) {
+        }
+        catch (Throwable t) {
             exception.addSuppressed(t);
             return false;
         }

--- a/modules/core/src/test/java/org/apache/ignite/client/ExceptionRetryPolicy.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ExceptionRetryPolicy.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+/**
+ * Retry policy that throws an exception.
+ */
+public class ExceptionRetryPolicy implements ClientRetryPolicy {
+    /** {@inheritDoc} */
+    @Override public boolean shouldRetry(ClientRetryPolicyContext context) {
+        throw new RuntimeException("Error in policy.");
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -225,6 +225,31 @@ public class ReliabilityTest extends AbstractThinClientTest {
     }
 
     /**
+     * Tests retry policy exception handling.
+     */
+    @Test
+    public void testExceptionInRetryPolicyPropagatesToCaller() {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(getClientConfiguration()
+                 .setRetryPolicy(new ExceptionRetryPolicy())
+                 .setAddresses(
+                     cluster.clientAddresses().iterator().next(),
+                     cluster.clientAddresses().iterator().next()))
+        ) {
+            ClientCache<Integer, Integer> cache = client.createCache("cache");
+
+            // Before fail.
+            cachePut(cache, 0, 0);
+
+            // Fail.
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            // Reuse second address without fail.
+            cache.get(0);
+        }
+    }
+
+    /**
      * Tests that retry limit of 1 effectively disables retry/failover.
      */
     @SuppressWarnings("ThrowableNotThrown")

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -230,6 +230,9 @@ public class ReliabilityTest extends AbstractThinClientTest {
      */
     @Test
     public void testExceptionInRetryPolicyPropagatesToCaller() {
+        if (isPartitionAware())
+            return;
+
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
              IgniteClient client = Ignition.startClient(getClientConfiguration()
                  .setRetryPolicy(new ExceptionRetryPolicy())

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -240,11 +240,17 @@ public class ReliabilityTest extends AbstractThinClientTest {
             ClientCache<Integer, Integer> cache = client.createCache("cache");
             dropAllThinClientConnections(Ignition.allGrids().get(0));
 
-            Throwable ex = GridTestUtils.assertThrows(null, () -> cache.getAsync(0).get(),
+            Throwable asyncEx = GridTestUtils.assertThrows(null, () -> cache.getAsync(0).get(),
                     ExecutionException.class, "Channel is closed");
 
-            ClientConnectionException cause = (ClientConnectionException) ex.getCause();
-            assertEquals("Error in policy.", cause.getSuppressed()[0].getMessage());
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            Throwable syncEx = GridTestUtils.assertThrows(null, () -> cache.get(0),
+                    ClientConnectionException.class, "Channel is closed");
+
+            for (Throwable t : new Throwable[] {asyncEx.getCause(), syncEx}) {
+                assertEquals("Error in policy.", t.getSuppressed()[0].getMessage());
+            }
         }
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/TestRetryPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/TestRetryPolicy.cs
@@ -17,6 +17,7 @@
 
 namespace Apache.Ignite.Core.Tests.Client
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Apache.Ignite.Core.Client;
@@ -46,10 +47,20 @@ namespace Apache.Ignite.Core.Tests.Client
         /// </summary>
         public IReadOnlyList<IClientRetryPolicyContext> Invocations => _invocations;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this policy should throw an exception.
+        /// </summary>
+        public bool ShouldThrow { get; set; }
+
         /** <inheritDoc /> */
         public bool ShouldRetry(IClientRetryPolicyContext context)
         {
             _invocations.Add(context);
+
+            if (ShouldThrow)
+            {
+                throw new Exception("Error in policy.");
+            }
 
             return _allowedOperations.Contains(context.Operation);
         }


### PR DESCRIPTION
Fix API call hang when there is an exception in `RetryPolicy` implementation. Catch exceptions and propagate to the caller.