### PR TITLE
fix(sec): upgrade com.beust:jcommander to 1.75

### DIFF
--- a/modules/yardstick/pom.xml
+++ b/modules/yardstick/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -15,12 +14,9 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-
-<!--
+--><!--
     POM file.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -73,7 +69,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.32</version>
+            <version>1.75</version>
         </dependency>
 
         <dependency>
@@ -204,7 +200,7 @@
                         <configuration>
                             <target>
                                 <copy todir="${basedir}/target/assembly/config">
-                                    <fileset dir="${basedir}/config" />
+                                    <fileset dir="${basedir}/config"/>
                                 </copy>
                             </target>
                         </configuration>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.beust:jcommander 1.32
- [MPS-2022-12225](https://www.oscs1024.com/hd/MPS-2022-12225)


### What did I do？
Upgrade com.beust:jcommander from 1.32 to 1.75 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS