### PR TITLE
IGNITE-8801 Remove IGNITE_ALLOW_ATOMIC_OPS_IN_TX, set default as false

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
@@ -604,13 +604,6 @@ public final class IgniteSystemProperties {
     public static final String IGNITE_PERFORMANCE_SUGGESTIONS_DISABLED = "IGNITE_PERFORMANCE_SUGGESTIONS_DISABLED";
 
     /**
-     * Flag indicating whether atomic operations allowed for use inside transactions.
-     */
-    @SystemProperty(value = "Allows atomic operations inside transactions",
-        defaults = "true")
-    public static final String IGNITE_ALLOW_ATOMIC_OPS_IN_TX = "IGNITE_ALLOW_ATOMIC_OPS_IN_TX";
-
-    /**
      * Atomic cache deferred update response buffer size.
      */
     @SystemProperty(value = "Atomic cache deferred update response buffer size", type = Integer.class,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheOperationContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/CacheOperationContext.java
@@ -17,24 +17,18 @@
 
 package org.apache.ignite.internal.processors.cache;
 
-import java.io.Serializable;
-import javax.cache.expiry.ExpiryPolicy;
-import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cache.ReadRepairStrategy;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.jetbrains.annotations.Nullable;
 
-import static org.apache.ignite.IgniteSystemProperties.IGNITE_ALLOW_ATOMIC_OPS_IN_TX;
+import javax.cache.expiry.ExpiryPolicy;
+import java.io.Serializable;
 
 /**
  * Cache operation context.
  */
 public class CacheOperationContext implements Serializable {
-    /** */
-    //TODO IGNITE-8801 remove this and set default as `false`.
-    public static final boolean DFLT_ALLOW_ATOMIC_OPS_IN_TX =
-        IgniteSystemProperties.getBoolean(IGNITE_ALLOW_ATOMIC_OPS_IN_TX, true);
 
     /** */
     private static final long serialVersionUID = 0L;
@@ -76,7 +70,7 @@ public class CacheOperationContext implements Serializable {
         recovery = false;
         readRepairStrategy = null;
         dataCenterId = null;
-        allowAtomicOpsInTx = DFLT_ALLOW_ATOMIC_OPS_IN_TX;
+        allowAtomicOpsInTx = false;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheAdapter.java
@@ -169,7 +169,6 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_CACHE_RETRIES_COUNT;
 import static org.apache.ignite.internal.GridClosureCallMode.BROADCAST;
-import static org.apache.ignite.internal.processors.cache.CacheOperationContext.DFLT_ALLOW_ATOMIC_OPS_IN_TX;
 import static org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtPartitionState.OWNING;
 import static org.apache.ignite.internal.processors.dr.GridDrType.DR_LOAD;
 import static org.apache.ignite.internal.processors.dr.GridDrType.DR_NONE;
@@ -493,14 +492,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
     /** {@inheritDoc} */
     @Override public final GridCacheProxyImpl<K, V> setSkipStore(boolean skipStore) {
         CacheOperationContext opCtx = new CacheOperationContext(
-            true,
-            false,
-            null,
-            false,
-            null,
-            false,
-            null,
-            DFLT_ALLOW_ATOMIC_OPS_IN_TX);
+                true,
+                false,
+                null,
+                false,
+                null,
+                false,
+                null,
+                false);
 
         return new GridCacheProxyImpl<>(ctx, this, opCtx);
     }
@@ -508,14 +507,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
     /** {@inheritDoc} */
     @Override public final <K1, V1> GridCacheProxyImpl<K1, V1> keepBinary() {
         CacheOperationContext opCtx = new CacheOperationContext(
-            false,
-            true,
-            null,
-            false,
-            null,
-            false,
-            null,
-            DFLT_ALLOW_ATOMIC_OPS_IN_TX);
+                false,
+                true,
+                null,
+                false,
+                null,
+                false,
+                null,
+                false);
 
         return new GridCacheProxyImpl<>((GridCacheContext<K1, V1>)ctx, (GridCacheAdapter<K1, V1>)this, opCtx);
     }
@@ -530,14 +529,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
         assert !CU.isUtilityCache(ctx.name());
 
         CacheOperationContext opCtx = new CacheOperationContext(
-            false,
-            false,
-            plc,
-            false,
-            null,
-            false,
-            null,
-            DFLT_ALLOW_ATOMIC_OPS_IN_TX);
+                false,
+                false,
+                plc,
+                false,
+                null,
+                false,
+                null,
+                false);
 
         return new GridCacheProxyImpl<>(ctx, this, opCtx);
     }
@@ -545,14 +544,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
     /** {@inheritDoc} */
     @Override public final IgniteInternalCache<K, V> withNoRetries() {
         CacheOperationContext opCtx = new CacheOperationContext(
-            false,
-            false,
-            null,
-            true,
-            null,
-            false,
-            null,
-            DFLT_ALLOW_ATOMIC_OPS_IN_TX);
+                false,
+                false,
+                null,
+                true,
+                null,
+                false,
+                null,
+                false);
 
         return new GridCacheProxyImpl<>(ctx, this, opCtx);
     }
@@ -560,14 +559,14 @@ public abstract class GridCacheAdapter<K, V> implements IgniteInternalCache<K, V
     /** {@inheritDoc} */
     @Override public final IgniteInternalCache<K, V> withAllowAtomicOpsInTx() {
         CacheOperationContext opCtx = new CacheOperationContext(
-            false,
-            false,
-            null,
-            false,
-            null,
-            false,
-            null,
-            DFLT_ALLOW_ATOMIC_OPS_IN_TX);
+                false,
+                false,
+                null,
+                false,
+                null,
+                false,
+                null,
+                false);
 
         return new GridCacheProxyImpl<>(ctx, this, opCtx);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProxyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProxyImpl.java
@@ -51,8 +51,6 @@ import org.apache.ignite.transactions.TransactionConcurrency;
 import org.apache.ignite.transactions.TransactionIsolation;
 import org.jetbrains.annotations.Nullable;
 
-import static org.apache.ignite.internal.processors.cache.CacheOperationContext.DFLT_ALLOW_ATOMIC_OPS_IN_TX;
-
 /**
  * Cache proxy.
  */
@@ -295,7 +293,7 @@ public class GridCacheProxyImpl<K, V> implements IgniteInternalCache<K, V>, Exte
                         null,
                         false,
                         null,
-                        DFLT_ALLOW_ATOMIC_OPS_IN_TX));
+                        false));
         }
         finally {
             gate.leave(prev);
@@ -317,7 +315,7 @@ public class GridCacheProxyImpl<K, V> implements IgniteInternalCache<K, V>, Exte
                     null,
                     false,
                     null,
-                    DFLT_ALLOW_ATOMIC_OPS_IN_TX));
+                    false));
     }
 
     /** {@inheritDoc} */
@@ -1567,7 +1565,7 @@ public class GridCacheProxyImpl<K, V> implements IgniteInternalCache<K, V>, Exte
                         null,
                         false,
                         null,
-                        DFLT_ALLOW_ATOMIC_OPS_IN_TX));
+                        false));
         }
         finally {
             gate.leave(prev);
@@ -1588,7 +1586,7 @@ public class GridCacheProxyImpl<K, V> implements IgniteInternalCache<K, V>, Exte
                     null,
                     false,
                     null,
-                    DFLT_ALLOW_ATOMIC_OPS_IN_TX));
+                    false));
         }
         finally {
             gate.leave(prev);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheQueueAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheQueueAdapter.java
@@ -53,7 +53,6 @@ import org.apache.ignite.lang.IgniteUuid;
 import org.jetbrains.annotations.Nullable;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.ignite.internal.processors.cache.CacheOperationContext.DFLT_ALLOW_ATOMIC_OPS_IN_TX;
 
 /**
  * Common code for {@link IgniteQueue} implementation.
@@ -442,7 +441,7 @@ public abstract class GridCacheQueueAdapter<T> extends AbstractCollection<T> imp
             null,
             false,
             null,
-            DFLT_ALLOW_ATOMIC_OPS_IN_TX)
+            false)
             : opCtx.keepBinary();
 
         cctx.operationContextPerCall(opCtx);

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -157,7 +157,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 
 import static java.util.Collections.newSetFromMap;
-import static org.apache.ignite.IgniteSystemProperties.IGNITE_ALLOW_ATOMIC_OPS_IN_TX;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_ATOMIC_CACHE_DELETE_HISTORY_SIZE;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_CLIENT_CACHE_CHANGE_MESSAGE_TIMEOUT;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_DISCO_FAILED_CLIENT_RECONNECT_DELAY;
@@ -289,7 +288,6 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
 
     /** */
     static {
-        System.setProperty(IGNITE_ALLOW_ATOMIC_OPS_IN_TX, "false");
         System.setProperty(IGNITE_ATOMIC_CACHE_DELETE_HISTORY_SIZE, "10000");
         System.setProperty(IGNITE_UPDATE_NOTIFIER, "false");
         System.setProperty(IGNITE_DISCO_FAILED_CLIENT_RECONNECT_DELAY, "1");


### PR DESCRIPTION
Need to change default behaviour of atomic operations to fail inside transactions.

1) IGNITE_ALLOW_ATOMIC_OPS_IN_TX system property is removed.
2) Set default value to restrict atomic operations in CacheOperationContext constructor without arguments and arguments for calls of another constructor.
3) Fix javadocs.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
