### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.2.4

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -13,10 +12,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -193,7 +189,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.9.1</version>
+            <version>3.2.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>

--- a/modules/ml/spark-model-parser/pom.xml
+++ b/modules/ml/spark-model-parser/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -15,13 +14,9 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
--->
-<!--
+--><!--
     POM file.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -84,7 +79,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.9.1</version>
+            <version>3.2.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>


### PR DESCRIPTION
### What happened？
There are 5 security vulnerabilities found in org.apache.hadoop:hadoop-common 2.9.1
- [CVE-2018-8009](https://www.oscs1024.com/hd/CVE-2018-8009)
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)
- [CVE-2022-26612](https://www.oscs1024.com/hd/CVE-2022-26612)
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)
- [CVE-2018-11765](https://www.oscs1024.com/hd/CVE-2018-11765)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 2.9.1 to 3.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS