### PR TITLE
IGNITE-17922 Fix nullptr access

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/deployment/local/LocalDeploymentSpi.java
@@ -34,7 +34,6 @@ import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.resources.LoggerResource;
 import org.apache.ignite.spi.IgniteSpiAdapter;
-import org.apache.ignite.spi.IgniteSpiConsistencyChecked;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.IgniteSpiMBeanAdapter;
 import org.apache.ignite.spi.IgniteSpiMultipleInstancesSupport;

--- a/modules/platforms/cpp/thin-client/src/impl/data_router.cpp
+++ b/modules/platforms/cpp/thin-client/src/impl/data_router.cpp
@@ -183,7 +183,8 @@ namespace ignite
                     InvalidateChannelLocked(channel);
                 }
 
-                channel.Get()->FailPendingRequests(err);
+                if (channel.IsValid())
+                    channel.Get()->FailPendingRequests(err);
             }
 
             void DataRouter::OnMessageReceived(uint64_t id, const network::DataBuffer& msg)

--- a/modules/urideploy/src/test/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentConfigSelfTest.java
+++ b/modules/urideploy/src/test/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentConfigSelfTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.ignite.spi.deployment.uri;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.testframework.config.GridTestProperties;
 import org.apache.ignite.testframework.junits.spi.GridSpiAbstractConfigTest;
 import org.apache.ignite.testframework.junits.spi.GridSpiTest;
 import org.junit.Test;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
 /**
  *
  */
@@ -52,15 +52,15 @@ public class GridUriDeploymentConfigSelfTest extends GridSpiAbstractConfigTest<U
         UriDeploymentSpi deploymentSpi = new UriDeploymentSpi();
         String tmpDir = GridTestProperties.getProperty("deploy.uri.tmpdir");
         File tmp = new File(tmpDir);
-        if (!tmp.exists()){
+        if (!tmp.exists()) {
             tmp.mkdir();
         }
         deploymentSpi.setUriList(Arrays.asList("file://" + tmpDir));
         scfg.setDeploymentSpi(deploymentSpi);
-        startGrid("server" , scfg);
+        startGrid("server", scfg);
 
         IgniteConfiguration ccfg = super.getConfiguration();
-        startClientGrid("client" , ccfg);
+        startClientGrid("client", ccfg);
 
         stopGrid("server");
         stopGrid("client");


### PR DESCRIPTION
Fixed `nullptr` access.

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
