### PR TITLE
IGNITE-17796 .NET: Support default interface methods in Services

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
@@ -658,8 +658,11 @@ public class PlatformDeployServiceTask extends ComputeTaskAdapter<String, Object
             //This Date in Europe/Moscow have offset +3.
             Timestamp ts2 = new Timestamp(ZonedDateTime.of(1982, 3, 31, 22, 0, 0, 0, msk).toInstant().toEpochMilli());
 
-            assertEquals(ts1, cache.get(5));
-            assertEquals(ts2, cache.get(6));
+            Timestamp cacheTs1 = cache.get(5);
+            Timestamp cacheTs2 = cache.get(6);
+
+            assertEquals(ts1, cacheTs1);
+            assertEquals(ts2, cacheTs2);
 
             cache.put(7, ts1);
             cache.put(8, ts2);

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
@@ -658,11 +658,8 @@ public class PlatformDeployServiceTask extends ComputeTaskAdapter<String, Object
             //This Date in Europe/Moscow have offset +3.
             Timestamp ts2 = new Timestamp(ZonedDateTime.of(1982, 3, 31, 22, 0, 0, 0, msk).toInstant().toEpochMilli());
 
-            Timestamp cacheTs1 = cache.get(5);
-            Timestamp cacheTs2 = cache.get(6);
-
-            assertEquals(ts1, cacheTs1);
-            assertEquals(ts2, cacheTs2);
+            assertEquals(ts1, cache.get(5));
+            assertEquals(ts2, cache.get(6));
 
             cache.put(7, ts1);
             cache.put(8, ts2);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1676,6 +1676,18 @@ namespace Apache.Ignite.Core.Tests.Services
             }
         }
 
+        [Test]
+        public void TestDefaultInterfaceImplementation()
+        {
+            var name = nameof(TestDefaultInterfaceImplementation);
+            Services.DeployClusterSingleton(name, new TestServiceWithDefaultImpl());
+
+            var prx = Services.GetServiceProxy<ITestServiceWithDefaultImpl>(name);
+            var res = prx.GetInt();
+
+            Assert.AreEqual(42, res);
+        }
+
         /// <summary>
         /// Starts the grids.
         /// </summary>
@@ -2420,6 +2432,29 @@ namespace Apache.Ignite.Core.Tests.Services
             public byte[] GetBinaryAttribute(string name)
             {
                 return null;
+            }
+        }
+
+        private interface ITestServiceWithDefaultImpl
+        {
+            int GetInt() => 42;
+        }
+        
+        private class TestServiceWithDefaultImpl : ITestServiceWithDefaultImpl, IService
+        {
+            public void Init(IServiceContext context)
+            {
+                // No-op.
+            }
+
+            public void Execute(IServiceContext context)
+            {
+                // No-op.
+            }
+
+            public void Cancel(IServiceContext context)
+            {
+                // No-op.
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1697,12 +1697,15 @@ namespace Apache.Ignite.Core.Tests.Services
         [Test]
         public void TestDefaultInterfaceImplementationOverridden()
         {
+            var svcImpl = new TestServiceWithDefaultImplOverridden();
+
             var name = nameof(TestDefaultInterfaceImplementationOverridden);
-            Services.DeployClusterSingleton(name, new TestServiceWithDefaultImpl());
+            Services.DeployClusterSingleton(name, svcImpl);
 
             var prx = Services.GetServiceProxy<ITestServiceWithDefaultImpl>(name);
             var res = prx.GetInt();
 
+            Assert.AreEqual(43, ((ITestServiceWithDefaultImpl)svcImpl).GetInt());
             Assert.AreEqual(43, res);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -2460,7 +2460,7 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             int GetInt() => 42;
 
-            int GetLong();
+            int GetInt(int x) => x + 42;
         }
         
         private class TestServiceWithDefaultImpl : ITestServiceWithDefaultImpl, IService
@@ -2480,7 +2480,8 @@ namespace Apache.Ignite.Core.Tests.Services
                 // No-op.
             }
 
-            public int GetLong() => ((ITestServiceWithDefaultImpl)this).GetInt();
+            // ReSharper disable once UnusedMember.Local (ensure overload resolution)
+            int GetInt(string x) => x.Length;
         }
 
         private class TestServiceWithDefaultImplOverridden : ITestServiceWithDefaultImpl, IService
@@ -2501,8 +2502,6 @@ namespace Apache.Ignite.Core.Tests.Services
             }
 
             int ITestServiceWithDefaultImpl.GetInt() => 43;
-
-            public int GetLong() => 43;
         }
 
 #if NETCOREAPP

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1676,13 +1676,14 @@ namespace Apache.Ignite.Core.Tests.Services
             }
         }
 
+#if NETCOREAPP
         /// <summary>
         /// Tests service method with default interface implementation.
         /// </summary>
         [Test]
-        public void TestDefaultInterfaceImplementation()
+        public void TestDefaultInterfaceMethod()
         {
-            var name = nameof(TestDefaultInterfaceImplementation);
+            var name = nameof(TestDefaultInterfaceMethod);
             Services.DeployClusterSingleton(name, new TestServiceWithDefaultImpl());
 
             var prx = Services.GetServiceProxy<ITestServiceWithDefaultImpl>(name);
@@ -1695,11 +1696,11 @@ namespace Apache.Ignite.Core.Tests.Services
         /// Tests service method with default interface implementation that is overridden in the class.
         /// </summary>
         [Test]
-        public void TestDefaultInterfaceImplementationOverridden()
+        public void TestDefaultInterfaceMethodOverridden()
         {
             var svcImpl = new TestServiceWithDefaultImplOverridden();
 
-            var name = nameof(TestDefaultInterfaceImplementationOverridden);
+            var name = nameof(TestDefaultInterfaceMethodOverridden);
             Services.DeployClusterSingleton(name, svcImpl);
 
             var prx = Services.GetServiceProxy<ITestServiceWithDefaultImpl>(name);
@@ -1708,6 +1709,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(43, ((ITestServiceWithDefaultImpl)svcImpl).GetInt());
             Assert.AreEqual(43, res);
         }
+#endif
 
         /// <summary>
         /// Starts the grids.
@@ -2456,6 +2458,7 @@ namespace Apache.Ignite.Core.Tests.Services
             }
         }
 
+#if NETCOREAPP
         public interface ITestServiceWithDefaultImpl
         {
             int GetInt() => 42;
@@ -2504,7 +2507,6 @@ namespace Apache.Ignite.Core.Tests.Services
             int ITestServiceWithDefaultImpl.GetInt() => 43;
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Adds support of the local dates to the Ignite timestamp serialization.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -2442,6 +2442,8 @@ namespace Apache.Ignite.Core.Tests.Services
         public interface ITestServiceWithDefaultImpl
         {
             int GetInt() => 42;
+
+            int GetLong();
         }
         
         private class TestServiceWithDefaultImpl : ITestServiceWithDefaultImpl, IService
@@ -2460,6 +2462,8 @@ namespace Apache.Ignite.Core.Tests.Services
             {
                 // No-op.
             }
+
+            public int GetLong() => ((ITestServiceWithDefaultImpl)this).GetInt();
         }
 
 #if NETCOREAPP

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1682,7 +1682,6 @@ namespace Apache.Ignite.Core.Tests.Services
         [Test]
         public void TestDefaultInterfaceImplementation()
         {
-            // TODO: Test when the method is also overridden in the class.
             var name = nameof(TestDefaultInterfaceImplementation);
             Services.DeployClusterSingleton(name, new TestServiceWithDefaultImpl());
 
@@ -1690,6 +1689,21 @@ namespace Apache.Ignite.Core.Tests.Services
             var res = prx.GetInt();
 
             Assert.AreEqual(42, res);
+        }
+
+        /// <summary>
+        /// Tests service method with default interface implementation that is overridden in the class.
+        /// </summary>
+        [Test]
+        public void TestDefaultInterfaceImplementationOverridden()
+        {
+            var name = nameof(TestDefaultInterfaceImplementationOverridden);
+            Services.DeployClusterSingleton(name, new TestServiceWithDefaultImpl());
+
+            var prx = Services.GetServiceProxy<ITestServiceWithDefaultImpl>(name);
+            var res = prx.GetInt();
+
+            Assert.AreEqual(43, res);
         }
 
         /// <summary>
@@ -2464,6 +2478,28 @@ namespace Apache.Ignite.Core.Tests.Services
             }
 
             public int GetLong() => ((ITestServiceWithDefaultImpl)this).GetInt();
+        }
+
+        private class TestServiceWithDefaultImplOverridden : ITestServiceWithDefaultImpl, IService
+        {
+            public void Init(IServiceContext context)
+            {
+                // No-op.
+            }
+
+            public void Execute(IServiceContext context)
+            {
+                // No-op.
+            }
+
+            public void Cancel(IServiceContext context)
+            {
+                // No-op.
+            }
+
+            int ITestServiceWithDefaultImpl.GetInt() => 43;
+
+            public int GetLong() => 43;
         }
 
 #if NETCOREAPP

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -2438,7 +2438,7 @@ namespace Apache.Ignite.Core.Tests.Services
             }
         }
 
-        private interface ITestServiceWithDefaultImpl
+        public interface ITestServiceWithDefaultImpl
         {
             int GetInt() => 42;
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -42,7 +42,7 @@ namespace Apache.Ignite.Core.Tests.Services
     /// <summary>
     /// Services tests.
     /// </summary>
-#pragma warning disable 618
+#pragma warning disable CS0618 // Method is obsolete.
     public class ServicesTest
     {
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1676,6 +1676,9 @@ namespace Apache.Ignite.Core.Tests.Services
             }
         }
 
+        /// <summary>
+        /// Tests service method with default interface implementation.
+        /// </summary>
         [Test]
         public void TestDefaultInterfaceImplementation()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1682,6 +1682,7 @@ namespace Apache.Ignite.Core.Tests.Services
         [Test]
         public void TestDefaultInterfaceImplementation()
         {
+            // TODO: Test when the method is also overridden in the class.
             var name = nameof(TestDefaultInterfaceImplementation);
             Services.DeployClusterSingleton(name, new TestServiceWithDefaultImpl());
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
@@ -91,13 +91,19 @@ namespace Apache.Ignite.Core.Impl.Services
                 return res;
 
             // 1) Find methods by name
-            // Handle default interface implementations by including non-abstract methods from all interfaces.
             var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
             var methods = svcType.GetMethods(bindingFlags)
-                .Concat(svcType.GetInterfaces().SelectMany(x => x.GetMethods(bindingFlags)).Where(x => !x.IsAbstract))
                 .Where(m => CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
                 .ToArray();
+
+            if (methods.Length == 0)
+            {
+                // Check default interface implementations.
+                methods = svcType.GetInterfaces().SelectMany(x => x.GetMethods(bindingFlags))
+                    .Where(m => !m.IsAbstract && CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
+                    .ToArray();
+            }
 
             if (methods.Length == 1)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
@@ -93,11 +93,12 @@ namespace Apache.Ignite.Core.Impl.Services
             // 1) Find methods by name
             var types = new List<Type> { svcType };
 
-            // TODO: Filter out non-implemented methods?
+            // TODO: Filter out non-implemented methods? - IsAbstract.
+            // TODO: Filter out overridden methods?
             types.AddRange(svcType.GetInterfaces());
 
             var methods = types.SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
-                .Where(m => CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
+                .Where(m => !m.IsAbstract && CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
                 .ToArray();
 
             if (methods.Length == 1)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
@@ -74,6 +74,11 @@ namespace Apache.Ignite.Core.Impl.Services
 
         /// <summary>
         /// Finds suitable method in the specified type, or throws an exception.
+        /// <para />
+        /// We do not try to cover all kinds of intricate use cases with complex class hierarchies,
+        /// explicit interface implementations, and so on.
+        /// It is not possible given only the type, name, and arguments - the call can come from other languages too.
+        /// So we do our best or throw an error.
         /// </summary>
         private static Func<object, object[], object> GetMethodOrThrow(Type svcType, string methodName,
             object[] arguments)
@@ -100,6 +105,7 @@ namespace Apache.Ignite.Core.Impl.Services
             if (methods.Length == 0)
             {
                 // Check default interface implementations.
+                // This does not cover exotic use cases when methods with same signature come from multiple interfaces.
                 methods = svcType.GetInterfaces().SelectMany(x => x.GetMethods(bindingFlags))
                     .Where(m => !m.IsAbstract && CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
                     .ToArray();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
@@ -91,7 +91,12 @@ namespace Apache.Ignite.Core.Impl.Services
                 return res;
 
             // 1) Find methods by name
-            var methods = svcType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            var types = new List<Type> { svcType };
+
+            // TODO: Filter out non-implemented methods?
+            types.AddRange(svcType.GetInterfaces());
+
+            var methods = types.SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
                 .Where(m => CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
                 .ToArray();
 


### PR DESCRIPTION
When resolving service method in `ServiceProxyInvoker`, also check default interface methods.