### PR TITLE
IGNITE-17865 Disable partition ranges in log messages by default

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionDemander.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionDemander.java
@@ -558,7 +558,7 @@ public class GridDhtPartitionDemander {
 
                 U.error(log, "Rebalancing routine has failed, some partitions could be unavailable for reading" +
                     " [" + demandRoutineInfo(nodeId, supplyMsg) +
-                    ", unavailablePartitions=" + S.compact(unstableParts) + ']', msgExc);
+                    ", unavailablePartitions=" + F.toStringSortedDistinct(unstableParts) + ']', msgExc);
 
                 fut.error(nodeId);
 
@@ -1431,8 +1431,8 @@ public class GridDhtPartitionDemander {
                     log.info("Starting rebalance routine [" + grp.cacheOrGroupName() +
                         ", topVer=" + topVer +
                         ", supplier=" + supplierNode.id() +
-                        ", fullPartitions=" + S.compact(parts.fullSet()) +
-                        ", histPartitions=" + S.compact(parts.historicalSet()) +
+                        ", fullPartitions=" + F.toStringSortedDistinct(parts.fullSet()) +
+                        ", histPartitions=" + F.toStringSortedDistinct(parts.historicalSet()) +
                         ", rebalanceId=" + rebalanceId + ']');
 
                 ctx.io().sendOrderedMessage(supplierNode, msg.topic(),

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionDemander.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionDemander.java
@@ -558,7 +558,7 @@ public class GridDhtPartitionDemander {
 
                 U.error(log, "Rebalancing routine has failed, some partitions could be unavailable for reading" +
                     " [" + demandRoutineInfo(nodeId, supplyMsg) +
-                    ", unavailablePartitions=" + F.toStringSortedDistinct(unstableParts) + ']', msgExc);
+                    ", unavailablePartitions=" + S.toStringSortedDistinct(unstableParts) + ']', msgExc);
 
                 fut.error(nodeId);
 
@@ -1431,8 +1431,8 @@ public class GridDhtPartitionDemander {
                     log.info("Starting rebalance routine [" + grp.cacheOrGroupName() +
                         ", topVer=" + topVer +
                         ", supplier=" + supplierNode.id() +
-                        ", fullPartitions=" + F.toStringSortedDistinct(parts.fullSet()) +
-                        ", histPartitions=" + F.toStringSortedDistinct(parts.historicalSet()) +
+                        ", fullPartitions=" + S.toStringSortedDistinct(parts.fullSet()) +
+                        ", histPartitions=" + S.toStringSortedDistinct(parts.historicalSet()) +
                         ", rebalanceId=" + rebalanceId + ']');
 
                 ctx.io().sendOrderedMessage(supplierNode, msg.topic(),

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionSupplier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionSupplier.java
@@ -273,8 +273,8 @@ public class GridDhtPartitionSupplier {
             if (sctx == null) {
                 if (log.isDebugEnabled())
                     log.debug("Starting supplying rebalancing [" + supplyRoutineInfo(topicId, nodeId, demandMsg) +
-                        ", fullPartitions=" + F.toStringSortedDistinct(demandMsg.partitions().fullSet()) +
-                        ", histPartitions=" + F.toStringSortedDistinct(demandMsg.partitions().historicalSet()) + "]");
+                        ", fullPartitions=" + S.toStringSortedDistinct(demandMsg.partitions().fullSet()) +
+                        ", histPartitions=" + S.toStringSortedDistinct(demandMsg.partitions().historicalSet()) + "]");
             }
             else
                 maxBatchesCnt = 1;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionSupplier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionSupplier.java
@@ -273,8 +273,8 @@ public class GridDhtPartitionSupplier {
             if (sctx == null) {
                 if (log.isDebugEnabled())
                     log.debug("Starting supplying rebalancing [" + supplyRoutineInfo(topicId, nodeId, demandMsg) +
-                        ", fullPartitions=" + S.compact(demandMsg.partitions().fullSet()) +
-                        ", histPartitions=" + S.compact(demandMsg.partitions().historicalSet()) + "]");
+                        ", fullPartitions=" + F.toStringSortedDistinct(demandMsg.partitions().fullSet()) +
+                        ", histPartitions=" + F.toStringSortedDistinct(demandMsg.partitions().historicalSet()) + "]");
             }
             else
                 maxBatchesCnt = 1;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -4279,7 +4279,7 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
             if (hasPartitionToLog(supplyInfoMap, false)) {
                 log.info("Partitions weren't present in any history reservation: [" +
                     supplyInfoMap.entrySet().stream().map(entry ->
-                        "[grp=" + entry.getKey() + " part=[" + F.toStringSortedDistinct(entry.getValue().stream()
+                        "[grp=" + entry.getKey() + " part=[" + S.toStringSortedDistinct(entry.getValue().stream()
                             .filter(info -> !info.isHistoryReserved())
                             .map(info -> info.part()).collect(Collectors.toSet())) + "]]"
                     ).collect(Collectors.joining(", ")) + ']');

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsExchangeFuture.java
@@ -4279,7 +4279,7 @@ public class GridDhtPartitionsExchangeFuture extends GridDhtTopologyFutureAdapte
             if (hasPartitionToLog(supplyInfoMap, false)) {
                 log.info("Partitions weren't present in any history reservation: [" +
                     supplyInfoMap.entrySet().stream().map(entry ->
-                        "[grp=" + entry.getKey() + " part=[" + S.compact(entry.getValue().stream()
+                        "[grp=" + entry.getKey() + " part=[" + F.toStringSortedDistinct(entry.getValue().stream()
                             .filter(info -> !info.isHistoryReserved())
                             .map(info -> info.part()).collect(Collectors.toSet())) + "]]"
                     ).collect(Collectors.joining(", ")) + ']');

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridClientPartitionTopology.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridClientPartitionTopology.java
@@ -58,7 +58,6 @@ import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.CU;
-import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
 
@@ -1308,8 +1307,8 @@ public class GridClientPartitionTopology implements GridDhtPartitionTopology {
                     U.warn(log, "Partitions have been scheduled for rebalancing due to outdated update counter "
                         + "[grpId=" + grpId
                         + ", nodeId=" + nodeId
-                        + ", partsFull=" + S.compact(partsToRebalance)
-                        + ", partsHistorical=" + S.compact(historical) + "]");
+                        + ", partsFull=" + F.toStringSortedDistinct(partsToRebalance)
+                        + ", partsHistorical=" + F.toStringSortedDistinct(historical) + "]");
                 }
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridClientPartitionTopology.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridClientPartitionTopology.java
@@ -58,6 +58,7 @@ import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.CU;
+import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
 
@@ -1307,8 +1308,8 @@ public class GridClientPartitionTopology implements GridDhtPartitionTopology {
                     U.warn(log, "Partitions have been scheduled for rebalancing due to outdated update counter "
                         + "[grpId=" + grpId
                         + ", nodeId=" + nodeId
-                        + ", partsFull=" + F.toStringSortedDistinct(partsToRebalance)
-                        + ", partsHistorical=" + F.toStringSortedDistinct(historical) + "]");
+                        + ", partsFull=" + S.toStringSortedDistinct(partsToRebalance)
+                        + ", partsHistorical=" + S.toStringSortedDistinct(historical) + "]");
                 }
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridDhtPartitionTopologyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridDhtPartitionTopologyImpl.java
@@ -65,7 +65,6 @@ import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.CU;
-import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.SB;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.NotNull;
@@ -2278,7 +2277,7 @@ public class GridDhtPartitionTopologyImpl implements GridDhtPartitionTopology {
                 if (recentlyLost != null) {
                     U.warn(log, "Detected lost partitions" + (!safe ? " (will ignore)" : "")
                         + " [grp=" + grp.cacheOrGroupName()
-                        + ", parts=" + S.compact(recentlyLost)
+                        + ", parts=" + F.toStringSortedDistinct(recentlyLost)
                         + ", topVer=" + resTopVer + "]");
                 }
 
@@ -2442,8 +2441,8 @@ public class GridDhtPartitionTopologyImpl implements GridDhtPartitionTopology {
                             + ", readyTopVer=" + readyTopVer
                             + ", topVer=" + exchFut.initialVersion()
                             + ", nodeId=" + nodeId
-                            + ", partsFull=" + S.compact(rebalancedParts)
-                            + ", partsHistorical=" + S.compact(historical) + "]");
+                            + ", partsFull=" + F.toStringSortedDistinct(rebalancedParts)
+                            + ", partsHistorical=" + F.toStringSortedDistinct(historical) + "]");
                     }
                 }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridDhtPartitionTopologyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridDhtPartitionTopologyImpl.java
@@ -65,6 +65,7 @@ import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.CU;
+import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.SB;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.NotNull;
@@ -2277,7 +2278,7 @@ public class GridDhtPartitionTopologyImpl implements GridDhtPartitionTopology {
                 if (recentlyLost != null) {
                     U.warn(log, "Detected lost partitions" + (!safe ? " (will ignore)" : "")
                         + " [grp=" + grp.cacheOrGroupName()
-                        + ", parts=" + F.toStringSortedDistinct(recentlyLost)
+                        + ", parts=" + S.toStringSortedDistinct(recentlyLost)
                         + ", topVer=" + resTopVer + "]");
                 }
 
@@ -2441,8 +2442,8 @@ public class GridDhtPartitionTopologyImpl implements GridDhtPartitionTopology {
                             + ", readyTopVer=" + readyTopVer
                             + ", topVer=" + exchFut.initialVersion()
                             + ", nodeId=" + nodeId
-                            + ", partsFull=" + F.toStringSortedDistinct(rebalancedParts)
-                            + ", partsHistorical=" + F.toStringSortedDistinct(historical) + "]");
+                            + ", partsFull=" + S.toStringSortedDistinct(rebalancedParts)
+                            + ", partsHistorical=" + S.toStringSortedDistinct(historical) + "]");
                     }
                 }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/PartitionsEvictManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/PartitionsEvictManager.java
@@ -43,8 +43,8 @@ import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.GridCacheSharedManagerAdapter;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
-import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.LT;
+import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.thread.IgniteThreadPoolExecutor;
 
@@ -251,7 +251,7 @@ public class PartitionsEvictManager extends GridCacheSharedManagerAdapter {
 
         StringJoiner joiner = new StringJoiner(", ");
 
-        partByReason.forEach((reason, partIds) -> joiner.add(reason.toString() + '=' + F.toStringSortedDistinct(partIds)));
+        partByReason.forEach((reason, partIds) -> joiner.add(reason.toString() + '=' + S.toStringSortedDistinct(partIds)));
 
         return joiner.toString();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/PartitionsEvictManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/PartitionsEvictManager.java
@@ -43,8 +43,8 @@ import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.GridCacheSharedManagerAdapter;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
+import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.LT;
-import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.thread.IgniteThreadPoolExecutor;
 
@@ -251,7 +251,7 @@ public class PartitionsEvictManager extends GridCacheSharedManagerAdapter {
 
         StringJoiner joiner = new StringJoiner(", ");
 
-        partByReason.forEach((reason, partIds) -> joiner.add(reason.toString() + '=' + S.compact(partIds)));
+        partByReason.forEach((reason, partIds) -> joiner.add(reason.toString() + '=' + F.toStringSortedDistinct(partIds)));
 
         return joiner.toString();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
@@ -397,7 +397,7 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
                     if (!missed.isEmpty()) {
                         throw new IgniteCheckedException("Snapshot operation cancelled due to " +
                             "not all of requested partitions has OWNING state on local node [grpId=" + grpId +
-                            ", missed=" + S.compact(missed) + ']');
+                            ", missed=" + F.toStringSortedDistinct(missed) + ']');
                     }
                 }
                 else {
@@ -406,7 +406,7 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
                     if (!missed.isEmpty()) {
                         log.warning("All local cache group partitions in OWNING state have been included into a snapshot. " +
                             "Partitions which have different states skipped. Index partitions has also been skipped " +
-                            "[snpName=" + snpName + ", grpId=" + grpId + ", missed=" + S.compact(missed) + ']');
+                            "[snpName=" + snpName + ", grpId=" + grpId + ", missed=" + F.toStringSortedDistinct(missed) + ']');
                     }
                     else if (affNode && missed.isEmpty() && cctx.kernalContext().query().moduleEnabled())
                         owning.add(INDEX_PARTITION);
@@ -465,7 +465,7 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
 
         if (log.isInfoEnabled()) {
             log.info("Submit partition processing tasks to the snapshot execution pool " +
-                "[map=" + compactGroupPartitions(partFileLengths.keySet()) +
+                "[map=" + groupByGroupId(partFileLengths.keySet()) +
                 ", totalSize=" + U.humanReadableByteCount(partFileLengths.values().stream().mapToLong(v -> v).sum()) + ']');
         }
 
@@ -649,16 +649,17 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
 
     /**
      * @param grps List of processing pairs.
-     * @return Map of cache group id their partitions compacted by {@link S#compact(Collection)}.
+     *
+     * @return Map with cache group id's associated to corresponding partitions.
      */
-    private static Map<Integer, String> compactGroupPartitions(Collection<GroupPartitionId> grps) {
+    private static Map<Integer, String> groupByGroupId(Collection<GroupPartitionId> grps) {
         return grps.stream()
             .collect(Collectors.groupingBy(GroupPartitionId::getGroupId,
                 Collectors.mapping(GroupPartitionId::getPartitionId,
                     Collectors.toSet())))
             .entrySet()
             .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> S.compact(e.getValue())));
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> F.toStringSortedDistinct(e.getValue())));
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
@@ -397,7 +397,7 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
                     if (!missed.isEmpty()) {
                         throw new IgniteCheckedException("Snapshot operation cancelled due to " +
                             "not all of requested partitions has OWNING state on local node [grpId=" + grpId +
-                            ", missed=" + F.toStringSortedDistinct(missed) + ']');
+                            ", missed=" + S.toStringSortedDistinct(missed) + ']');
                     }
                 }
                 else {
@@ -406,7 +406,7 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
                     if (!missed.isEmpty()) {
                         log.warning("All local cache group partitions in OWNING state have been included into a snapshot. " +
                             "Partitions which have different states skipped. Index partitions has also been skipped " +
-                            "[snpName=" + snpName + ", grpId=" + grpId + ", missed=" + F.toStringSortedDistinct(missed) + ']');
+                            "[snpName=" + snpName + ", grpId=" + grpId + ", missed=" + S.toStringSortedDistinct(missed) + ']');
                     }
                     else if (affNode && missed.isEmpty() && cctx.kernalContext().query().moduleEnabled())
                         owning.add(INDEX_PARTITION);
@@ -659,7 +659,7 @@ class SnapshotFutureTask extends AbstractSnapshotFutureTask<Set<GroupPartitionId
                     Collectors.toSet())))
             .entrySet()
             .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> F.toStringSortedDistinct(e.getValue())));
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> S.toStringSortedDistinct(e.getValue())));
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotPartitionsQuickVerifyHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotPartitionsQuickVerifyHandler.java
@@ -88,7 +88,7 @@ public class SnapshotPartitionsQuickVerifyHandler extends SnapshotPartitionsVeri
         }));
 
         if (!wrnGrps.isEmpty()) {
-            throw new SnapshotHandlerWarningException("Cache partitions differ for cache groups " + S.compact(wrnGrps)
+            throw new SnapshotHandlerWarningException("Cache partitions differ for cache groups " + S.toStringSortedDistinct(wrnGrps)
                 + ". " + WRN_MSG);
         }
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotRestoreProcess.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotRestoreProcess.java
@@ -998,7 +998,7 @@ public class SnapshotRestoreProcess {
                         "[reqId=" + reqId +
                         ", snapshot=" + opCtx0.snpName +
                         ", map=" + snpAff.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                            e -> partitionsMapToCompactString(e.getValue()))) + ']');
+                            e -> partitionsMapToString(e.getValue()))) + ']');
                 }
 
                 for (Map.Entry<UUID, Map<Integer, Set<Integer>>> m : snpAff.entrySet()) {
@@ -1364,10 +1364,10 @@ public class SnapshotRestoreProcess {
      * @param map Map of partitions and cache groups.
      * @return String representation.
      */
-    private static String partitionsMapToCompactString(Map<Integer, Set<Integer>> map) {
+    private static String partitionsMapToString(Map<Integer, Set<Integer>> map) {
         return map.entrySet()
             .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> F.toStringSortedDistinct(e.getValue())))
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> S.toStringSortedDistinct(e.getValue())))
             .toString();
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotRestoreProcess.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotRestoreProcess.java
@@ -1367,7 +1367,7 @@ public class SnapshotRestoreProcess {
     private static String partitionsMapToCompactString(Map<Integer, Set<Integer>> map) {
         return map.entrySet()
             .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e -> S.compact(e.getValue())))
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> F.toStringSortedDistinct(e.getValue())))
             .toString();
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/lang/GridFunc.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/lang/GridFunc.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.RandomAccess;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
@@ -317,6 +318,19 @@ public class GridFunc {
                 break;
 
         return f.reduce();
+    }
+
+    /**
+     * Creates string representation of a specified collection with preliminary sorting and duplicates removing.
+     *
+     * @param c Input collection.
+     * @return String representation of collection.
+     */
+    public static String toStringSortedDistinct(Collection<? extends Comparable<?>> c) {
+        if (c.isEmpty())
+            return "[]";
+
+        return '[' + concat(new TreeSet<>(c), ",") + ']';
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/lang/GridFunc.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/lang/GridFunc.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.RandomAccess;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
@@ -318,19 +317,6 @@ public class GridFunc {
                 break;
 
         return f.reduce();
-    }
-
-    /**
-     * Creates string representation of a specified collection with preliminary sorting and duplicates removing.
-     *
-     * @param c Input collection.
-     * @return String representation of collection.
-     */
-    public static String toStringSortedDistinct(Collection<? extends Comparable<?>> c) {
-        if (c.isEmpty())
-            return "[]";
-
-        return '[' + concat(new TreeSet<>(c), ",") + ']';
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/tostring/GridToStringBuilder.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/tostring/GridToStringBuilder.java
@@ -33,6 +33,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
@@ -1883,15 +1884,16 @@ public class GridToStringBuilder {
     }
 
     /**
-     * Returns sorted and compacted string representation of given {@code col}.
-     * Two nearby numbers with difference at most 1 are compacted to one continuous segment.
-     * E.g. collection of [1, 2, 3, 5, 6, 7, 10] will be compacted to [1-3, 5-7, 10].
+     * Creates string representation of a specified collection with preliminary sorting and duplicates removing.
      *
-     * @param col Collection of integers.
-     * @return Compacted string representation of given collections.
+     * @param c Input collection.
+     * @return String representation of collection.
      */
-    public static String compact(Collection<Integer> col) {
-        return compact(col, i -> i + 1);
+    public static String toStringSortedDistinct(Collection<? extends Comparable<?>> c) {
+        if (c.isEmpty())
+            return "[]";
+
+        return '[' + F.concat(new TreeSet<>(c), ",") + ']';
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/IgniteWalRebalanceLoggingTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/IgniteWalRebalanceLoggingTest.java
@@ -117,7 +117,7 @@ public class IgniteWalRebalanceLoggingTest extends GridCommonAbstractTest {
                 str.contains("cache_group1") && str.contains("cache_group2")).times(3).
             andMatches(str -> str.startsWith("Starting rebalance routine") &&
                 (str.contains("cache_group1") || str.contains("cache_group2")) &&
-                str.contains("fullPartitions=[], histPartitions=[0-7]")).times(2).build();
+                str.contains("fullPartitions=[], histPartitions=[0,1,2,3,4,5,6,7]")).times(2).build();
 
         LogListener unexpectedMessagesLsnr = LogListener.matches((str) ->
             str.startsWith("Partitions weren't present in any history reservation:") ||
@@ -151,10 +151,10 @@ public class IgniteWalRebalanceLoggingTest extends GridCommonAbstractTest {
     public void testFullRebalanceLogMsgs() throws Exception {
         LogListener expMsgsLsnr = LogListener.
             matches("Partitions weren't present in any history reservation: " +
-                "[[grp=cache_group2 part=[[0-7]]], [grp=cache_group1 part=[[0-7]]]]").
+                "[[grp=cache_group2 part=[[0,1,2,3,4,5,6,7]]], [grp=cache_group1 part=[[0,1,2,3,4,5,6,7]]]]").
             andMatches(str -> str.startsWith("Starting rebalance routine") &&
                 (str.contains("cache_group1") || str.contains("cache_group2")) &&
-                str.contains("fullPartitions=[0-7], histPartitions=[]")).times(2).build();
+                str.contains("fullPartitions=[0,1,2,3,4,5,6,7], histPartitions=[]")).times(2).build();
 
         checkFollowingPartitionsWereReservedForPotentialHistoryRebalanceMsg(expMsgsLsnr);
 
@@ -176,7 +176,7 @@ public class IgniteWalRebalanceLoggingTest extends GridCommonAbstractTest {
                 str.contains("grp=cache_group1") && str.contains("grp=cache_group2")).
             andMatches(str -> str.startsWith("Starting rebalance routine") &&
                 (str.contains("cache_group1") || str.contains("cache_group2")) &&
-                str.contains("fullPartitions=[0-7], histPartitions=[]")).times(2).build();
+                str.contains("fullPartitions=[0,1,2,3,4,5,6,7], histPartitions=[]")).times(2).build();
 
         checkFollowingPartitionsWereReservedForPotentialHistoryRebalanceMsg(expMsgsLsnr);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/tostring/GridToStringBuilderSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/tostring/GridToStringBuilderSelfTest.java
@@ -597,22 +597,18 @@ public class GridToStringBuilderSelfTest extends GridCommonAbstractTest {
 
     /**
      * Checking that method
-     * {@link GridToStringBuilder#compact(Collection, Function) compact} works
+     * {@link GridToStringBuilder#toStringSortedDistinct(Collection)} works
      * correctly for {@link Integer}.
      */
     @Test
-    public void testCompactIntegers() {
+    public void testSortedDistinctIntegers() {
         List<Integer> emptyList = emptyList();
-        List<Integer> intList = asList(1, 2, 3, 9, 8, 7, 12);
+        List<Integer> intList = asList(12, 1, 7, 2, 3, 9, 8, 7, 12);
 
-        String compactStr = "[1-3, 7-9, 12]";
+        String sortedDistinctStr = "[1,2,3,7,8,9,12]";
 
-        Function<Integer, Integer> nextVal = i -> i + 1;
-
-        checkCompact(emptyList, intList, nextVal, compactStr);
-
-        assertEquals("[]", compact(emptyList));
-        assertEquals(compactStr, compact(intList));
+        assertEquals("[]", S.toStringSortedDistinct(emptyList));
+        assertEquals(sortedDistinctStr, S.toStringSortedDistinct(intList));
     }
 
     /**


### PR DESCRIPTION
Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.


### Implementation
Added disabled by default system property `IGNITE_PRINT_PARTITION_RANGES_IN_LOGS`.
Added GridToStringBuilder#compactPartitions method which compacts partition lists only if IGNITE_PRINT_PARTITION_RANGES_IN_LOGS is set to 'true'.