### PR TITLE
IGNITE-17877 .NET: Upgrade to SDK 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
     - language: csharp
       name: ".NET 6.0"
       mono: none
-      dotnet: 6.0.401
+      dotnet: 6.0
       script:
         - dotnet build modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 
     - language: csharp
       mono: none
-      dotnet: 3.1.101
+      dotnet: 6.0.401
       script:
         - dotnet build modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ _ducktape-tox: &ducktape-tox
 matrix:
   include:
     - language: java
+      name: "Java 8"
       os: linux
       dist: bionic
       before_install:
@@ -34,6 +35,7 @@ matrix:
       cache: {directories: [$HOME/.m2/repository]}
 
     - language: java
+      name: "Java 11"
       os: linux
       dist: bionic
       before_install:
@@ -56,6 +58,7 @@ matrix:
       cache: {directories: [$HOME/.m2/repository]}
 
     - language: csharp
+      name: ".NET 6.0"
       mono: none
       dotnet: 6.0.401
       script:
@@ -75,12 +78,14 @@ matrix:
       cache: { directories: [ $HOME/.m2/repository ] }
 
     - language: python
+      name: "Python 3.7.9"
       python: 3.7.9
       <<: *ducktape-tox
       script:
         - tox -e py37
 
     - language: python
+      name: "Python 3.8.5"
       python: 3.8.5
       <<: *ducktape-tox
       script:

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Apache.Ignite.BenchmarkDotNet.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Apache.Ignite.BenchmarkDotNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyOriginatorKeyFile>Apache.Ignite.BenchmarkDotNet.snk</AssemblyOriginatorKeyFile>

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/Apache.Ignite.Benchmarks.DotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Apache.Ignite.Benchmarks</AssemblyName>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestAsync.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestAsync.cs
@@ -17,7 +17,6 @@
 
 namespace Apache.Ignite.Core.Tests.Client.Cache
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Client.Cache;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestAsync.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTestAsync.cs
@@ -43,14 +43,23 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         public void TestAsyncContinuationIsExecutedOnThreadPool()
         {
             var cache = base.GetClientCache<int>();
-            var task = cache.PutAsync(1, 1).ContinueWith(_ =>
+            int? threadId1 = null;
+            int? threadId2 = null;
+
+            cache.PutAsync(1, 1).ContinueWith(_ =>
             {
-                Thread.CurrentThread.Abort();
+                threadId1 = Thread.CurrentThread.ManagedThreadId;
+                Thread.Sleep(3000);
             }, TaskContinuationOptions.ExecuteSynchronously);
 
-            Assert.Throws<AggregateException>(() => task.Wait());
+            cache.PutAsync(1, 1).ContinueWith(_ =>
+            {
+                threadId2 = Thread.CurrentThread.ManagedThreadId;
+                Thread.Sleep(3000);
+            }, TaskContinuationOptions.ExecuteSynchronously);
 
-            Assert.AreEqual(1, cache.GetAsync(1).Result);
+            TestUtils.WaitForTrueCondition(
+                () => threadId1 != null && threadId2 != null && threadId1.Value != threadId2.Value);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ExceptionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ExceptionsTest.cs
@@ -111,6 +111,7 @@ namespace Apache.Ignite.Core.Tests
             var formatter = new BinaryFormatter();
             using (var ms = new MemoryStream())
             {
+#pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete
                 formatter.Serialize(ms, ex);
 
                 ms.Seek(0, SeekOrigin.Begin);
@@ -131,6 +132,7 @@ namespace Apache.Ignite.Core.Tests
                 Assert.AreEqual(javaEx.StackTrace, resJavaEx.StackTrace);
                 Assert.AreEqual(javaEx.Source, resJavaEx.Source);
                 Assert.AreEqual(javaEx.HelpLink, resJavaEx.HelpLink);
+#pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete
             }
         }
 
@@ -212,11 +214,13 @@ namespace Apache.Ignite.Core.Tests
                 var stream = new MemoryStream();
                 var formatter = new BinaryFormatter();
 
+#pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete
                 formatter.Serialize(stream, ex);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 ex = (Exception) formatter.Deserialize(stream);
                 Assert.AreEqual("myMessage", ex.Message);
+#pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete
 
                 // Message+cause ctor.
                 var msgCauseCtor = type.GetConstructor(new[] { typeof(string), typeof(Exception) });
@@ -238,11 +242,13 @@ namespace Apache.Ignite.Core.Tests
 
             var stream = new MemoryStream();
 
+#pragma warning disable SYSLIB0011 // BinaryFormatter is obsolete
             formatter.Serialize(stream, ex);
 
             stream.Seek(0, SeekOrigin.Begin);
 
             var ex0 = (Exception) formatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011 // BinaryFormatter is obsolete
 
             var updateEx = ((CachePartialUpdateException) ex);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcess.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/IgniteProcess.cs
@@ -65,7 +65,7 @@ namespace Apache.Ignite.Core.Tests.Process
         static IgniteProcess()
         {
             // 1. Locate executable file and related stuff.
-            DirectoryInfo dir = new FileInfo(new Uri(typeof(IgniteProcess).Assembly.CodeBase).LocalPath).Directory;
+            DirectoryInfo dir = new FileInfo(new Uri(typeof(IgniteProcess).Assembly.Location).LocalPath).Directory;
 
             // ReSharper disable once PossibleNullReferenceException
             ExeDir = dir.FullName;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -22,7 +22,6 @@ namespace Apache.Ignite.Core.Tests.Services
     using System.IO;
     using System.Linq;
     using System.Net;
-    using System.Runtime.Serialization.Formatters.Binary;
     using System.Threading;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
@@ -1051,6 +1050,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.IsTrue(argException.Message.Contains("configurations[0].Name"));
         }
 
+#if !NETCOREAPP
         /// <summary>
         /// Tests [Serializable] usage of ServiceDeploymentException.
         /// </summary>
@@ -1070,7 +1070,7 @@ namespace Apache.Ignite.Core.Tests.Services
 
             var ex = new ServiceDeploymentException("msg", new Exception("in"), new[] {cfg});
 
-            var formatter = new BinaryFormatter();
+            var formatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
             var stream = new MemoryStream();
             formatter.Serialize(stream, ex);
             stream.Seek(0, SeekOrigin.Begin);
@@ -1091,6 +1091,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.IsInstanceOf<TestIgniteServiceSerializable>(cfg.Service);
             Assert.IsInstanceOf<NodeIdFilter>(cfg.NodeFilter);
         }
+#endif
 
         /// <summary>
         /// Verifies the deployment exception.

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Apache.Ignite.Executable</AssemblyName>

--- a/modules/platforms/dotnet/DEVNOTES.txt
+++ b/modules/platforms/dotnet/DEVNOTES.txt
@@ -2,11 +2,11 @@ Requirements
 ============
 
 * Oracle JDK 8 or 11
-* .NET Core SDK 3.1
+* .NET 6 SDK
 * JAVA_HOME environment variable set to the corresponding JDK (x64 or x86)
 * Apache Maven bin directory in PATH, or MAVEN_HOME environment variable
 * PowerShell
-* Any OS supported by .NET Core SDK (Linux, Windows, macOS)
+* Any OS supported by .NET SDK (Linux, Windows, macOS)
 
 
 Build Binaries and NuGet

--- a/modules/platforms/dotnet/examples/README.md
+++ b/modules/platforms/dotnet/examples/README.md
@@ -6,7 +6,7 @@
 
 # Requirements
 
-* [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core)
+* [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet-core)
 * [JDK 8](https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html) or [JDK 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
 
 Windows, Linux, and macOS are supported.

--- a/modules/platforms/dotnet/examples/ServerNode/ServerNode.csproj
+++ b/modules/platforms/dotnet/examples/ServerNode/ServerNode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.ServerNode</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Shared/Compute/AverageSalaryTask.cs
+++ b/modules/platforms/dotnet/examples/Shared/Compute/AverageSalaryTask.cs
@@ -78,6 +78,11 @@ namespace Apache.Ignite.Examples.Shared.Compute
                 count += t.Item2;
             }
 
+            if (count == 0)
+            {
+                return 0;
+            }
+
             return sum / count;
         }
     }

--- a/modules/platforms/dotnet/examples/Shared/Shared.csproj
+++ b/modules/platforms/dotnet/examples/Shared/Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Shared</RootNamespace>
     <NoWarn>CS0649</NoWarn>
   </PropertyGroup>

--- a/modules/platforms/dotnet/examples/Thick/Cache/BinaryMode/BinaryMode.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/BinaryMode/BinaryMode.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.BinaryMode</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/DataStreamer/DataStreamer.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/DataStreamer/DataStreamer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.DataStreamer</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/EntryProcessor/EntryProcessor.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/EntryProcessor/EntryProcessor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.EntryProcessor</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/MultiTieredCache/MultiTieredCache.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/MultiTieredCache/MultiTieredCache.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.MultiTieredCache</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/NearCache/NearCache.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/NearCache/NearCache.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.NearCache</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/OptimisticTransaction/OptimisticTransaction.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/OptimisticTransaction/OptimisticTransaction.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.OptimisticTransaction</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/PutGet/PutGet.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/PutGet/PutGet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.PutGet</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/QueryContinuous/QueryContinuous.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/QueryContinuous/QueryContinuous.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.QueryContinuous</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/QueryFullText/QueryFullText.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/QueryFullText/QueryFullText.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.QueryFullText</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/QueryScan/QueryScan.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/QueryScan/QueryScan.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Cache.QueryScan</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/Store/Store.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/Store/Store.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.Store</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/Transaction/Transaction.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/Transaction/Transaction.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.Transaction</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Cache/TransactionDeadlockDetection/TransactionDeadlockDetection.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Cache/TransactionDeadlockDetection/TransactionDeadlockDetection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Cache.TransactionDeadlockDetection</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Compute/Func/Func.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Compute/Func/Func.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Compute.Func</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Compute/PeerAssemblyLoading/PeerAssemblyLoading.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Compute/PeerAssemblyLoading/PeerAssemblyLoading.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Compute.PeerAssemblyLoading</RootNamespace>
         <AssemblyVersion>1.0.*</AssemblyVersion>
         <Deterministic>false</Deterministic>

--- a/modules/platforms/dotnet/examples/Thick/Compute/Task/Task.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Compute/Task/Task.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Compute.Task</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicLong/AtomicLong.csproj
+++ b/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicLong/AtomicLong.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.DataStructures.AtomicLong</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicReference/AtomicReference.csproj
+++ b/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicReference/AtomicReference.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.DataStructures.AtomicReference</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicSequence/AtomicSequence.csproj
+++ b/modules/platforms/dotnet/examples/Thick/DataStructures/AtomicSequence/AtomicSequence.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.DataStructures.AtomicSequence</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/ClientReconnect/ClientReconnect.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/ClientReconnect/ClientReconnect.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.ClientReconnect</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Events/Events.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Events/Events.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Events</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Events/Program.cs
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Events/Program.cs
@@ -68,7 +68,7 @@ namespace Apache.Ignite.Examples.Thick.Misc.Events
         /// <param name="ignite">Ignite instance.</param>
         private static void ExecuteTask(IIgnite ignite)
         {
-            var employees = Enumerable.Range(1, 10).SelectMany(x => new[]
+            var employees = Enumerable.Range(1, 10).SelectMany(_ => new[]
             {
                 new Employee("Allison Mathis",
                     25300,

--- a/modules/platforms/dotnet/examples/Thick/Misc/Lifecycle/Lifecycle.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Lifecycle/Lifecycle.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Lifecycle</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Messaging/Messaging.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Messaging/Messaging.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Messaging</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Misc/Services/Services.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Misc/Services/Services.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Misc.Services</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Ddl/Ddl.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Ddl/Ddl.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Ddl</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Dml/Dml.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Dml/Dml.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Dml</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Linq/Linq.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Linq/Linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Linq</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thick/Sql/Sql/Sql.csproj
+++ b/modules/platforms/dotnet/examples/Thick/Sql/Sql/Sql.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thick.Sql.Sql</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/BinaryModeThin/BinaryModeThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/BinaryModeThin/BinaryModeThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thin.Cache.BinaryModeThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/OptimisticTransactionThin/OptimisticTransactionThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/OptimisticTransactionThin/OptimisticTransactionThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.OptimisticTransactionThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/PutGetThin/PutGetThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/PutGetThin/PutGetThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thin.Cache.PutGetThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/QueryContinuousThin/QueryContinuousThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/QueryContinuousThin/QueryContinuousThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.QueryContinuousThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/QueryScanThin/QueryScanThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/QueryScanThin/QueryScanThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.QueryScanThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Cache/TransactionThin/TransactionThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Cache/TransactionThin/TransactionThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Cache.TransactionThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Misc/ServicesThin/ServicesThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Misc/ServicesThin/ServicesThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thin.Misc.ServicesThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/DdlThin/DdlThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/DdlThin/DdlThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Sql.DdlThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/DmlThin/DmlThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/DmlThin/DmlThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Sql.DmlThin</RootNamespace>
     </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/LinqThin/LinqThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/LinqThin/LinqThin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Apache.Ignite.Examples.Thin.Sql.LinqThin</RootNamespace>
   </PropertyGroup>
 

--- a/modules/platforms/dotnet/examples/Thin/Sql/SqlThin/SqlThin.csproj
+++ b/modules/platforms/dotnet/examples/Thin/Sql/SqlThin/SqlThin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Apache.Ignite.Examples.Thin.Sql.SqlThin</RootNamespace>
     </PropertyGroup>
 


### PR DESCRIPTION
* Update projects from `netcoreapp3.1` to `net6.0`.
* Fix deprecated API errors in tests.