### PR TITLE
IGNITE-18014 [ducktests] Use pgrep instead of jcmd to get java pids

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_aware.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_aware.py
@@ -226,7 +226,9 @@ class IgniteAwareService(BackgroundThreadService, IgnitePathAware, metaclass=ABC
         :param node: Ignite service node.
         :return: List of service's pids.
         """
-        return node.account.java_pids(self.main_java_class)
+        cmd = "pgrep -ax java | awk '/%s/ {print $1}'" % self.main_java_class
+
+        return [int(pid) for pid in node.account.ssh_capture(cmd, allow_fail=True)]
 
     def worker(self, idx, node, **kwargs):
         cmd = self.spec.command(node)


### PR DESCRIPTION
Use `pgrep` instead of `jcmd` to get pids of java processes.

This is needed to be able to run tests with the `-XX:+PerfDisableSharedMem` JVM option which makes the process invisible for utilities like `jps` and `jcmd`.

--------

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
