### PR TITLE
IGNITE-18346 .NET: Fix timestamp in IgniteProductVersion

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/IgniteProductVersionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/IgniteProductVersionTests.cs
@@ -76,7 +76,7 @@ namespace Apache.Ignite.Core.Tests.Common
                 writer.WriteByte(_defaultVersion.Minor);
                 writer.WriteByte(_defaultVersion.Maintenance);
                 writer.WriteString(_defaultVersion.Stage);
-                writer.WriteLong(BinaryUtils.DateTimeToJavaTicks(_defaultVersion.ReleaseDate));
+                writer.WriteLong((_defaultVersion.ReleaseDate.Ticks - BinaryUtils.JavaDateTicks) / TimeSpan.TicksPerSecond);
                 writer.WriteByteArray(hash);
 
                 stream.Seek(0, SeekOrigin.Begin);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/IgniteProductVersionTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/IgniteProductVersionTests.cs
@@ -149,6 +149,9 @@ namespace Apache.Ignite.Core.Tests.Common
             // We do not add -SNAPSHOT in .NET
             logVersion = logVersion.Replace("-SNAPSHOT", "");
 
+            // For development environments
+            logVersion = logVersion.Replace(":DEV", ":00000000");
+
             IgniteProductVersion version = Ignite.GetVersion();
 
             Assert.AreEqual(logVersion, version.ToString());

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Common/IgniteProductVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Common/IgniteProductVersion.cs
@@ -83,7 +83,7 @@ namespace Apache.Ignite.Core.Common
             _minor = reader.ReadByte();
             _maintenance = reader.ReadByte();
             _stage = reader.ReadString();
-            _releaseDate = BinaryUtils.JavaTicksToDateTime(reader.ReadLong());
+            _releaseDate = RevisionTimestampToDateTime(reader.ReadLong());
             _revHash = reader.ReadByteArray();
         }
 
@@ -205,6 +205,16 @@ namespace Apache.Ignite.Core.Common
         public override bool Equals(object obj)
         {
             return Equals(obj as IgniteProductVersion);
+        }
+
+        /// <summary>
+        /// Convert Java revision timestamp (seconds since epoch) to DateTime.
+        /// </summary>
+        /// <param name="revTs">Revision timestamp.</param>
+        /// <returns>Resulting DateTime.</returns>
+        private static DateTime RevisionTimestampToDateTime(long revTs)
+        {
+            return new DateTime(BinaryUtils.JavaDateTicks, DateTimeKind.Utc).AddSeconds(revTs);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -422,26 +422,6 @@ namespace Apache.Ignite.Core.Impl.Binary
         }
 
         /// <summary>
-        /// Convert Java ticks to DateTime.
-        /// </summary>
-        /// <param name="javaTicks">Ticks.</param>
-        /// <returns>Resulting DateTime.</returns>
-        public static DateTime JavaTicksToDateTime(long javaTicks)
-        {
-            return new DateTime(JavaDateTicks + javaTicks * 10000000, DateTimeKind.Utc);
-        }
-
-        /// <summary>
-        /// Convert DateTime struct to Java ticks
-        /// <param name="dateTime">DateTime to convert</param>
-        /// </summary>
-        /// <returns>Ticks count</returns>
-        public static long DateTimeToJavaTicks(DateTime dateTime)
-        {
-            return (dateTime.Ticks - JavaDateTicks) / 10000000;
-        }
-
-        /// <summary>
         /// Write nullable date array.
         /// </summary>
         /// <param name="vals">Values.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -428,7 +428,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// <returns>Resulting DateTime.</returns>
         public static DateTime JavaTicksToDateTime(long javaTicks)
         {
-            return new DateTime(JavaDateTicks + javaTicks * 1000, DateTimeKind.Utc);
+            return new DateTime(JavaDateTicks + javaTicks * 10000000, DateTimeKind.Utc);
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// <returns>Ticks count</returns>
         public static long DateTimeToJavaTicks(DateTime dateTime)
         {
-            return (dateTime.Ticks - JavaDateTicks) / 1000;
+            return (dateTime.Ticks - JavaDateTicks) / 10000000;
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed timestamp part of Ignite version in .NET;
- Added test (needs review).

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
