### PR TITLE
IGNITE-18427 .NET: Fix platform cache invalidation on client nodes with near cache

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -6724,14 +6724,12 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
 
         try {
             CacheObjectContext ctx = this.cctx.cacheObjectContext();
-
-            boolean valid = ver != null && this.valid(ver);
+            byte[] keyBytes = this.key.valueBytes(ctx);
 
             // val is null when entry is removed.
-            byte[] keyBytes = this.key.valueBytes(ctx);
+            boolean valid = ver != null && this.valid(ver);
             byte[] valBytes = val == null || !valid ? null : val.valueBytes(ctx);
 
-            // TODO: if ((GridNearCacheEntry)this).topVer == NONE then remove from platform cache.
             proc.context().updatePlatformCache(this.cctx.cacheId(), keyBytes, valBytes, partition(), ver);
         }
         catch (Throwable e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -6718,19 +6718,22 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
         if (!hasPlatformCache())
             return;
 
-        PlatformProcessor proc = this.cctx.kernalContext().platform();
+        PlatformProcessor proc = cctx.kernalContext().platform();
         if (!proc.hasContext() || !proc.context().isPlatformCacheSupported())
             return;
 
         try {
-            CacheObjectContext ctx = this.cctx.cacheObjectContext();
-            byte[] keyBytes = this.key.valueBytes(ctx);
+            CacheObjectContext ctx = cctx.cacheObjectContext();
+            byte[] keyBytes = key.valueBytes(ctx);
 
             // val is null when entry is removed.
-            boolean valid = ver != null && this.valid(ver);
-            byte[] valBytes = val == null || !valid ? null : val.valueBytes(ctx);
+            // valid(ver) is false when near cache entry is out of sync.
+            boolean valid = val != null && ver != null && valid(ver);
 
-            proc.context().updatePlatformCache(this.cctx.cacheId(), keyBytes, valBytes, partition(), ver);
+            // null valBytes means that entry should be removed from platform cache.
+            byte[] valBytes = valid ? val.valueBytes(ctx) : null;
+
+            proc.context().updatePlatformCache(cctx.cacheId(), keyBytes, valBytes, partition(), ver);
         }
         catch (Throwable e) {
             U.error(log, "Failed to update Platform Cache: " + e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -6725,10 +6725,13 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
         try {
             CacheObjectContext ctx = this.cctx.cacheObjectContext();
 
+            boolean valid = ver != null && this.valid(ver);
+
             // val is null when entry is removed.
             byte[] keyBytes = this.key.valueBytes(ctx);
-            byte[] valBytes = val == null ? null : val.valueBytes(ctx);
+            byte[] valBytes = val == null || !valid ? null : val.valueBytes(ctx);
 
+            // TODO: if ((GridNearCacheEntry)this).topVer == NONE then remove from platform cache.
             proc.context().updatePlatformCache(this.cctx.cacheId(), keyBytes, valBytes, partition(), ver);
         }
         catch (Throwable e) {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheReadFromBackupTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheReadFromBackupTest.cs
@@ -34,8 +34,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         private const string CacheName = "cache1";
         private const string AttrMacs = "org.apache.ignite.macs";
 
-        private const string Key = "k";
-        private const string InitialValue = "0";
+        private const int Key = 1;
+        private const int InitialValue = 0;
 
         [TearDown]
         public void TearDown()
@@ -60,8 +60,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var client2 = Ignition.Start(GetConfiguration(true, backupServer2Mac, backupServer2Mac));
 
             // Check initial value.
-            var client1Cache = client1.GetOrCreateNearCache<string, string>(CacheName, new NearCacheConfiguration());
-            var client2Cache = client2.GetOrCreateNearCache<string, string>(CacheName, new NearCacheConfiguration());
+            var client1Cache = client1.GetOrCreateNearCache<int, int>(CacheName, new NearCacheConfiguration());
+            var client2Cache = client2.GetOrCreateNearCache<int, int>(CacheName, new NearCacheConfiguration());
 
             var client1Value = client1Cache.Get(Key);
             var client2Value = client2Cache.Get(Key);
@@ -70,7 +70,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             Assert.AreEqual(InitialValue, client2Value);
 
             // Update value from client 1.
-            const string newValue = "1";
+            const int newValue = 1;
             client1Cache.Put(Key, newValue);
 
             // Read value from client 1 and 2.
@@ -125,12 +125,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 ReadFromBackup = true, // Does not reproduce without this
                 PlatformCacheConfiguration = new PlatformCacheConfiguration
                 {
-                    KeyTypeName = typeof(string).FullName,
-                    ValueTypeName = typeof(string).FullName
+                    KeyTypeName = typeof(int).FullName,
+                    ValueTypeName = typeof(int).FullName
                 }
             };
 
-            var cache = ignite.GetOrCreateCache<string, string>(cacheConfig);
+            var cache = ignite.GetOrCreateCache<int, int>(cacheConfig);
             cache.Put(Key, InitialValue);
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheReadFromBackupTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheReadFromBackupTest.cs
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Cache.Platform
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Discovery.Tcp;
+    using Apache.Ignite.Core.Discovery.Tcp.Static;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests platform cache with <see cref="CacheConfiguration.ReadFromBackup"/> enabled.
+    /// </summary>
+    public class PlatformCacheReadFromBackupTest
+    {
+        private const string CacheName = "cache1";
+        private const string AttrMacs = "org.apache.ignite.macs";
+
+        private const string Key = "k";
+        private const string InitialValue = "0";
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        [Test]
+        public static void TestPutFromOneClientGetFromAnother()
+        {
+            var servers = Enumerable.Range(0, 3).Select(i => Ignition.Start(NewIgniteConfiguration(false, i, 0)))
+                .ToArray();
+            InitCache(servers[0]);
+
+            var nodes = servers[0].GetAffinity(CacheName).MapKeyToPrimaryAndBackups(Key);
+            var backupServer1MacAddress = Convert.ToInt32(nodes[1].Attributes[AttrMacs]);
+            var backupServer2MacAddress = Convert.ToInt32(nodes[2].Attributes[AttrMacs]);
+
+            var client1 =
+                Ignition.Start(NewIgniteConfiguration(true, backupServer1MacAddress, backupServer1MacAddress));
+            var client2 =
+                Ignition.Start(NewIgniteConfiguration(true, backupServer2MacAddress, backupServer2MacAddress));
+
+            // Check initial value.
+            var client1Cache = client1.GetOrCreateNearCache<string, string>(CacheName, new NearCacheConfiguration());
+            var client2Cache = client2.GetOrCreateNearCache<string, string>(CacheName, new NearCacheConfiguration());
+
+            var client1Value = client1Cache.Get(Key);
+            var client2Value = client2Cache.Get(Key);
+
+            Assert.AreEqual(InitialValue, client1Value);
+            Assert.AreEqual(InitialValue, client2Value);
+
+            // Update value from client 1.
+            const string newValue = "1";
+            client1Cache.Put(Key, newValue);
+
+            // Read value from client 1 and 2.
+            client1Value = client1Cache.Get(Key);
+            client2Value = client2Cache.Get(Key);
+
+            Assert.AreEqual(newValue, client1Value);
+            Assert.AreEqual(newValue, client2Value); // Second client does not have correct value.
+        }
+
+        private static IgniteConfiguration NewIgniteConfiguration(
+            bool clientMode,
+            int localMacAddress,
+            int remoteMacAddress)
+        {
+            var name = (clientMode ? "client" : "server") + localMacAddress;
+            var remotePort = 48500 + remoteMacAddress;
+            var discoverySpi = new TcpDiscoverySpi
+            {
+                IpFinder = new TcpDiscoveryStaticIpFinder
+                {
+                    Endpoints = new List<string> { $"127.0.0.1:{remotePort}" }
+                }
+            };
+
+            var igniteConfig = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                ClientMode = clientMode,
+                IgniteInstanceName = name,
+                ConsistentId = name,
+                UserAttributes = new Dictionary<string, object>
+                {
+                    [$"override.{AttrMacs}"] = localMacAddress.ToString()
+                },
+                DiscoverySpi = discoverySpi
+            };
+
+            if (!clientMode)
+            {
+                var localPort = 48500 + localMacAddress;
+                discoverySpi.LocalPort = localPort;
+                discoverySpi.LocalPortRange = 1;
+            }
+
+            return igniteConfig;
+        }
+
+        private static void InitCache(IIgnite ignite)
+        {
+            var cacheConfig = new CacheConfiguration(CacheName)
+            {
+                CacheMode = CacheMode.Replicated,
+                ReadFromBackup = true, // Does not reproduce without this
+                PlatformCacheConfiguration = new PlatformCacheConfiguration
+                {
+                    KeyTypeName = typeof(string).FullName,
+                    ValueTypeName = typeof(string).FullName
+                }
+            };
+
+            var cache = ignite.GetOrCreateCache<string, string>(cacheConfig);
+            cache.Put(Key, InitialValue);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheReadFromBackupTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheReadFromBackupTest.cs
@@ -122,7 +122,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var cacheConfig = new CacheConfiguration(CacheName)
             {
                 CacheMode = CacheMode.Replicated,
-                ReadFromBackup = true, // Does not reproduce without this
+                ReadFromBackup = true, // Does not reproduce when false.
                 PlatformCacheConfiguration = new PlatformCacheConfiguration
                 {
                     KeyTypeName = typeof(int).FullName,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTest.cs
@@ -1229,13 +1229,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         /// Tests that Replicated cache puts all entries on all nodes to platform cache.
         /// </summary>
         [Test]
-        public void TestPlatformCachingReplicated()
+        public void TestPlatformCachingReplicated([Values(false, true)] bool readFromBackup)
         {
             var cfg = new CacheConfiguration(TestUtils.TestName)
             {
                 CacheMode = CacheMode.Replicated,
                 PlatformCacheConfiguration = new PlatformCacheConfiguration(),
-                WriteSynchronizationMode = CacheWriteSynchronizationMode.FullSync
+                WriteSynchronizationMode = CacheWriteSynchronizationMode.FullSync,
+                ReadFromBackup = readFromBackup
             };
 
             var cache1 = _grid.CreateCache<int, int>(cfg);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IIgnite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IIgnite.cs
@@ -33,7 +33,6 @@ namespace Apache.Ignite.Core
     using Apache.Ignite.Core.Log;
     using Apache.Ignite.Core.Lifecycle;
     using Apache.Ignite.Core.Messaging;
-    using Apache.Ignite.Core.PersistentStore;
     using Apache.Ignite.Core.Plugin;
     using Apache.Ignite.Core.Services;
     using Apache.Ignite.Core.Transactions;


### PR DESCRIPTION
* Remove platform cache entry when corresponding `GridCacheMapEntry` is not `valid`.
* Add a test where two thick client nodes with near cache connect to different backup server nodes.