### PR TITLE
IGNITE-18592 Fix clean node before service start

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/ducktests_service.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ducktests_service.py
@@ -53,4 +53,4 @@ class DucktestsService(Service, metaclass=ABCMeta):
         self.stop(force_stop=True)
 
     def clean_node(self, node, **kwargs):
-        assert self.stopped
+        pass

--- a/modules/ducktests/tests/ignitetest/tests/control_utility/consistency_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/control_utility/consistency_test.py
@@ -88,7 +88,7 @@ class ConsistencyTest(IgniteTest):
 
             ignites.exec_command(node, f"sed -i 's/{orig}/{fixed}/g' {cfg_file}")
 
-        ignites.start()
+        ignites.start(clean=False)
 
         control_utility = ControlUtility(ignites)
 

--- a/modules/ducktests/tests/ignitetest/tests/snapshot_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/snapshot_test.py
@@ -87,7 +87,7 @@ class SnapshotTest(IgniteTest):
 
         nodes.stop()
         nodes.restore_from_snapshot(self.SNAPSHOT_NAME)
-        nodes.start()
+        nodes.start(clean=False)
 
         control_utility.activate()
         control_utility.validate_indexes()


### PR DESCRIPTION
Ignite's base class for ducktape services prevents nodes cleanup before start.  
It's fixed now to avoid unexpected concurrent tests failures.


----
Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
