### PR TITLE
IGNITE-18676 [ducktests] Add ability to control the performance statistics collecting

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/control_utility.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/control_utility.py
@@ -220,6 +220,49 @@ class ControlUtility:
         raise TimeoutError(f'Failed to wait for the snapshot operation to complete: '
                            f'snapshot_name={snapshot_name} in {timeout_sec} seconds.')
 
+    def start_performance_statistics(self):
+        """
+        Start performance statistics collecting in the cluster.
+        """
+        output = self.__performance_statistics_cmd("start")
+
+        assert "Started." in output
+
+        return output
+
+    def stop_performance_statistics(self):
+        """
+        Stop performance statistics collecting in the cluster.
+        """
+        output = self.__performance_statistics_cmd("stop")
+
+        assert "Stopped." in output
+
+        return output
+
+    def rotate_performance_statistics(self):
+        """
+        Rotate performance statistics collecting in the cluster.
+        """
+        output = self.__performance_statistics_cmd("rotate")
+
+        assert "Rotated." in output
+
+        return output
+
+    def is_performance_statistics_enabled(self):
+        """
+        Check status of performance statistics collecting in the cluster.
+        """
+        output = self.__performance_statistics_cmd("status")
+
+        assert "Enabled." in output or "Disabled." in output
+
+        return "Enabled." in output
+
+    def __performance_statistics_cmd(self, sub_command):
+        return self.__run(f"--performance-statistics {sub_command}")
+
     @staticmethod
     def __tx_command(**kwargs):
         tokens = ["--tx"]


### PR DESCRIPTION
Add ability to start/stop/rotate/get status of performance statistics collecting via the control.sh

----

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
