### PR TITLE
IGNITE-18765 [ducktests] Use PEP 440 compatible version number for python module

### DIFF
--- a/modules/ducktests/tests/ignitetest/utils/version.py
+++ b/modules/ducktests/tests/ignitetest/utils/version.py
@@ -47,7 +47,7 @@ class IgniteVersion(LooseVersion):
             self.project = self.DEFAULT_PROJECT if not match.group(1) else match.group(1)
             version = match.group(2)
 
-        self.is_dev = (version.lower() == __version__.lower()) or version == self.DEV_VERSION
+        self.is_dev = version == self.DEV_VERSION
 
         if self.is_dev:
             version = __version__  # we may also parse pom file to gain correct version (in future)
@@ -71,7 +71,7 @@ class IgniteVersion(LooseVersion):
         return "IgniteVersion ('%s')" % str(self)
 
 
-DEV_BRANCH = IgniteVersion(__version__)
+DEV_BRANCH = IgniteVersion("dev")
 
 # 2.7.x versions
 V_2_7_6 = IgniteVersion("2.7.6")

--- a/modules/ducktests/tests/setup.py
+++ b/modules/ducktests/tests/setup.py
@@ -23,7 +23,7 @@ with open('ignitetest/__init__.py', 'r') as fd:
 
 # Note: when changing the version of ducktape, also revise tests/docker/Dockerfile
 setup(name="ignitetest",
-      version=version,
+      version=version.replace("-SNAPSHOT", ".dev0"),
       description="Apache Ignite System Tests",
       author="Apache Ignite",
       platforms=["any"],


### PR DESCRIPTION
* Fixes the format of the python ducktests module to conform the PEP 440 (setuptools >= 66.0.0 forbids invalid formats)
* Disable implicit detection of the dev-mode testing by the version number.  To be able to test binary distribs built from current version.

-------------------

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
