### PR TITLE
IGNITE-18887 .NET: Fix TestContextLogger and ConsoleLogger to include exception details

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/ConsoleLoggerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Log/ConsoleLoggerTest.cs
@@ -78,10 +78,14 @@ namespace Apache.Ignite.Core.Tests.Log
                 logger.Warn("warn!");
                 logger.Error(new IgniteException("ex!"), "err!");
                 logger.Trace("trace (ignored)");
+                logger.Log(LogLevel.Debug, "dbg1", null, null, "c1", "java-err-details", new Exception("ex1"));
 
-                var expectedLog = string.Format("[04:05:06] [Warn] [my-cat] warn!{0}[04:05:06] [Error] [my-cat] err! " +
-                                                "(exception: Apache.Ignite.Core.Common.IgniteException: ex!){0}",
+                var expectedLog = string.Format("[04:05:06] [Warn] [my-cat] warn!{0}" +
+                                                "[04:05:06] [Error] [my-cat] err! " +
+                                                "(exception: Apache.Ignite.Core.Common.IgniteException: ex!){0}" +
+                                                "[04:05:06] [Debug] [c1] dbg1 (exception: System.Exception: ex1) (native error: java-err-details){0}",
                     Environment.NewLine);
+
                 Assert.AreEqual(expectedLog, writer.ToString());
             }
             finally

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -27,6 +27,7 @@ namespace Apache.Ignite.Core.Tests
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Text;
     using System.Threading;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache.Affinity;
@@ -712,11 +713,36 @@ namespace Apache.Ignite.Core.Tests
                     return;
                 }
 
-                var text = args != null
-                    ? string.Format(formatProvider ?? CultureInfo.InvariantCulture, message, args)
-                    : message;
+                var sb = new StringBuilder();
 
-                _listener.TestOutput(new TestOutput(text + Environment.NewLine, "Progress", _ctx.CurrentTest?.Id, _ctx.CurrentTest?.FullName));
+                if (args != null)
+                {
+                    sb.AppendFormat(formatProvider ?? CultureInfo.InvariantCulture, message, args);
+                }
+                else
+                {
+                    sb.Append(message);
+                }
+
+                if (nativeErrorInfo != null)
+                {
+                    sb.Append(Environment.NewLine).Append(nativeErrorInfo);
+                }
+
+                if (ex != null)
+                {
+                    sb.Append(Environment.NewLine).Append(ex);
+                }
+
+                sb.Append(Environment.NewLine);
+
+                var output = new TestOutput(
+                    text: sb.ToString(),
+                    stream: "Progress",
+                    testId: _ctx.CurrentTest?.Id,
+                    testName: _ctx.CurrentTest?.FullName);
+
+                _listener.TestOutput(output);
             }
 
             /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Log/ConsoleLogger.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Log/ConsoleLogger.cs
@@ -86,6 +86,11 @@ namespace Apache.Ignite.Core.Log
                 sb.AppendFormat(" (exception: {0})", ex);
             }
             
+            if (nativeErrorInfo != null)
+            {
+                sb.AppendFormat(" (native error: {0})", nativeErrorInfo);
+            }
+
             Console.WriteLine(sb.ToString());
         }
 


### PR DESCRIPTION
Do not omit `nativeErrorInfo`, it can contain important details from Java stack trace.