### PR TITLE
IGNITE-19064 [ducktests] Allow several server nodes and partition awareness option in thin client configuration

### DIFF
--- a/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/__init__.py
+++ b/modules/ducktests/tests/ignitetest/services/utils/ignite_configuration/__init__.py
@@ -133,12 +133,13 @@ class IgniteThinClientConfiguration(NamedTuple):
     """
     Thin client configuration.
     """
-    addresses: str = None
+    addresses: list = []
     version: IgniteVersion = DEV_BRANCH
     ssl_params: SslParams = None
     username: str = None
     password: str = None
     ext_beans: list = []
+    partition_awareness_enabled: bool = None
 
     def prepare_ssl(self, test_globals, shared_root):
         """

--- a/modules/ducktests/tests/ignitetest/services/utils/templates/client_configuration_macro.j2
+++ b/modules/ducktests/tests/ignitetest/services/utils/templates/client_configuration_macro.j2
@@ -21,7 +21,9 @@
     <bean class="org.apache.ignite.configuration.ClientConfiguration" id="thin.client.cfg">
         <property name="addresses">
             <list>
-                <value>{{ config.addresses }}</value>
+                {% for address in config.addresses %}
+                    <value>{{ address }}</value>
+                {% endfor %}
             </list>
         </property>
 
@@ -36,6 +38,10 @@
         <property name="sslClientCertificateKeyStorePassword" value="{{ config.ssl_params.key_store_password }}"/>
         <property name="sslTrustCertificateKeyStorePath" value="{{ config.ssl_params.trust_store_path }}"/>
         <property name="sslTrustCertificateKeyStorePassword" value="{{ config.ssl_params.trust_store_password }}"/>
+        {% endif %}
+
+        {% if config.partition_awareness_enabled %}
+        <property name="partitionAwarenessEnabled" value="{{ config.partition_awareness_enabled }}"/>
         {% endif %}
     </bean>
 {% endmacro %}

--- a/modules/ducktests/tests/ignitetest/tests/auth_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/auth_test.py
@@ -68,7 +68,7 @@ class AuthenticationTests(IgniteTest):
         ControlUtility(cluster=servers, username=DEFAULT_AUTH_USERNAME, password=DEFAULT_AUTH_PASSWORD).activate()
 
         client_cfg = IgniteThinClientConfiguration(
-            addresses=servers.nodes[0].account.hostname + ":" + str(config.client_connector_configuration.port),
+            addresses=[servers.nodes[0].account.hostname + ":" + str(config.client_connector_configuration.port)],
             version=IgniteVersion(ignite_version),
             username=DEFAULT_AUTH_USERNAME,
             password=DEFAULT_AUTH_PASSWORD)

--- a/modules/ducktests/tests/ignitetest/tests/thin_client_test.py
+++ b/modules/ducktests/tests/ignitetest/tests/thin_client_test.py
@@ -48,7 +48,7 @@ class ThinClientTest(IgniteTest):
 
         ignite = IgniteService(self.test_context, server_config, 1)
 
-        addresses = ignite.nodes[0].account.hostname + ":" + str(server_config.client_connector_configuration.port)
+        addresses = [ignite.nodes[0].account.hostname + ":" + str(server_config.client_connector_configuration.port)]
 
         thin_clients = IgniteApplicationService(self.test_context,
                                                 IgniteThinClientConfiguration(addresses=addresses,


### PR DESCRIPTION
Add ability to pass several server nodes addresses to thin client configuration in ducktests. Previousluy the only address may be used.

Also added option to control the partition awareness mode.

-------------------

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [X] There is a single JIRA ticket related to the pull request. 
- [X] The web-link to the pull request is attached to the JIRA ticket.
- [X] The JIRA ticket has the _Patch Available_ state.
- [X] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [X] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [X] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
