### PR TITLE
IGNITE-19221 Java thin: Add ClientConfiguration.clusterDiscoveryEnabled

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
@@ -587,6 +587,7 @@ public final class ClientConfiguration implements Serializable {
      * <p>
      * When {@code false}, client only connects to the addresses provided in {@link #setAddresses(String...)} and
      * {@link #setAddressesFinder(ClientAddressFinder)}.
+     * @return A value indicating whether cluster discovery should be enabled.
      */
     public boolean isClusterDiscoveryEnabled() {
         return clusterDiscoveryEnabled;
@@ -599,6 +600,8 @@ public final class ClientConfiguration implements Serializable {
      * <p>
      * When {@code false}, client only connects to the addresses provided in {@link #setAddresses(String...)} and
      * {@link #setAddressesFinder(ClientAddressFinder)}.
+     * @param clusterDiscoveryEnabled Value indicating whether cluster discovery should be enabled.
+     * @return {@code this} for chaining.
      */
     public ClientConfiguration setClusterDiscoveryEnabled(boolean clusterDiscoveryEnabled) {
         this.clusterDiscoveryEnabled = clusterDiscoveryEnabled;

--- a/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
@@ -127,6 +127,11 @@ public final class ClientConfiguration implements Serializable {
     private ClientPartitionAwarenessMapperFactory partitionAwarenessMapperFactory;
 
     /**
+     * Whether cluster discovery should be enabled.
+     */
+    private boolean clusterDiscoveryEnabled = true;
+
+    /**
      * Reconnect throttling period (in milliseconds). There are no more than {@code reconnectThrottlingRetries}
      * attempts to reconnect will be made within {@code reconnectThrottlingPeriod} in case of connection loss.
      * Throttling is disabled if either {@code reconnectThrottlingRetries} or {@code reconnectThrottlingPeriod} is 0.
@@ -571,6 +576,32 @@ public final class ClientConfiguration implements Serializable {
      */
     public ClientConfiguration setPartitionAwarenessEnabled(boolean partitionAwarenessEnabled) {
         this.partitionAwarenessEnabled = partitionAwarenessEnabled;
+
+        return this;
+    }
+
+    /**
+     * Gets a value indicating whether cluster discovery should be enabled.
+     * <p>
+     * Default is {@code true}: client get addresses of server nodes from the cluster and connects to all of them.
+     * <p>
+     * When {@code false}, client only connects to the addresses provided in {@link #setAddresses(String...)} and
+     * {@link #setAddressesFinder(ClientAddressFinder)}.
+     */
+    public boolean isClusterDiscoveryEnabled() {
+        return clusterDiscoveryEnabled;
+    }
+
+    /**
+     * Sets a value indicating whether cluster discovery should be enabled.
+     * <p>
+     * Default is {@code true}: client get addresses of server nodes from the cluster and connects to all of them.
+     * <p>
+     * When {@code false}, client only connects to the addresses provided in {@link #setAddresses(String...)} and
+     * {@link #setAddressesFinder(ClientAddressFinder)}.
+     */
+    public ClientConfiguration setClusterDiscoveryEnabled(boolean clusterDiscoveryEnabled) {
+        this.clusterDiscoveryEnabled = clusterDiscoveryEnabled;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientDiscoveryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientDiscoveryContext.java
@@ -64,6 +64,9 @@ public class ClientDiscoveryContext {
     @Nullable private final ClientAddressFinder addrFinder;
 
     /** */
+    private final boolean enabled;
+
+    /** */
     private volatile TopologyInfo topInfo;
 
     /** Cache addresses returned by {@link ClientAddressFinder}. */
@@ -77,6 +80,7 @@ public class ClientDiscoveryContext {
         log = NullLogger.whenNull(clientCfg.getLogger());
         addresses = clientCfg.getAddresses();
         addrFinder = clientCfg.getAddressesFinder();
+        enabled = clientCfg.isClusterDiscoveryEnabled();
         reset();
     }
 
@@ -94,8 +98,8 @@ public class ClientDiscoveryContext {
      * @return {@code True} if updated.
      */
     boolean refresh(ClientChannel ch) {
-        if (addrFinder != null)
-            return false; // Used custom address finder.
+        if (addrFinder != null || !enabled)
+            return false; // Disabled or custom finder is used.
 
         if (!ch.protocolCtx().isFeatureSupported(ProtocolBitmaskFeature.CLUSTER_GROUP_GET_NODES_ENDPOINTS))
             return false;

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -111,7 +111,8 @@ public class ReliabilityTest extends AbstractThinClientTest {
                  .setReconnectThrottlingRetries(0) // Disable throttling.
                  // Disable endpoints discovery, since in this test it reduces attempts count and sometimes one extra
                  // attempt is required to complete operation without failure.
-                 .setAddressesFinder(new StaticAddressFinder(cluster.clientAddresses().toArray(new String[CLUSTER_SIZE])))
+                 .setClusterDiscoveryEnabled(false)
+                 .setAddresses(cluster.clientAddresses().toArray(new String[CLUSTER_SIZE]))
              )
         ) {
             final Random rnd = new Random();
@@ -218,10 +219,8 @@ public class ReliabilityTest extends AbstractThinClientTest {
     public void testSingleServerDuplicatedFailover() throws Exception {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
              IgniteClient client = Ignition.startClient(getClientConfiguration()
-                 .setAddressesFinder(new StaticAddressFinder(
-                     F.first(cluster.clientAddresses()),
-                     F.first(cluster.clientAddresses())
-                 )))
+                 .setAddresses(F.first(cluster.clientAddresses()), F.first(cluster.clientAddresses()))
+                 .setClusterDiscoveryEnabled(false))
         ) {
             ClientCache<Integer, Integer> cache = client.createCache("cache");
 
@@ -244,10 +243,8 @@ public class ReliabilityTest extends AbstractThinClientTest {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
              IgniteClient client = Ignition.startClient(getClientConfiguration()
                  .setRetryPolicy(new ClientRetryReadPolicy())
-                 .setAddressesFinder(new StaticAddressFinder(
-                     F.first(cluster.clientAddresses()),
-                     F.first(cluster.clientAddresses())
-                 )))
+                 .setAddresses(F.first(cluster.clientAddresses()), F.first(cluster.clientAddresses()))
+                 .setClusterDiscoveryEnabled(false))
         ) {
             ClientCache<Integer, Integer> cache = client.createCache("cache");
 
@@ -272,10 +269,8 @@ public class ReliabilityTest extends AbstractThinClientTest {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
              IgniteClient client = Ignition.startClient(getClientConfiguration()
                  .setRetryPolicy(new ExceptionRetryPolicy())
-                 .setAddressesFinder(new StaticAddressFinder(
-                     F.first(cluster.clientAddresses()),
-                     F.first(cluster.clientAddresses())
-                 )))
+                 .setAddresses(F.first(cluster.clientAddresses()), F.first(cluster.clientAddresses()))
+                 .setClusterDiscoveryEnabled(false))
         ) {
             ClientCache<Integer, Integer> cache = client.createCache("cache");
             dropAllThinClientConnections(Ignition.allGrids().get(0));
@@ -303,10 +298,8 @@ public class ReliabilityTest extends AbstractThinClientTest {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
              IgniteClient client = Ignition.startClient(getClientConfiguration()
                  .setRetryLimit(1)
-                 .setAddressesFinder(new StaticAddressFinder(
-                     F.first(cluster.clientAddresses()),
-                     F.first(cluster.clientAddresses())
-                 )))
+                 .setAddresses(F.first(cluster.clientAddresses()), F.first(cluster.clientAddresses()))
+                 .setClusterDiscoveryEnabled(false))
         ) {
             ClientCache<Integer, Integer> cache = client.createCache("cache");
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AbstractThinClientTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AbstractThinClientTest.java
@@ -20,7 +20,6 @@ package org.apache.ignite.internal.client.thin;
 import java.util.Arrays;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.Ignition;
-import org.apache.ignite.client.ClientAddressFinder;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.ClientConfiguration;
@@ -62,10 +61,9 @@ public abstract class AbstractThinClientTest extends GridCommonAbstractTest {
             addrs[i] = clientHost(node) + ":" + clientPort(node);
         }
 
-        if (isClientEndpointsDiscoveryEnabled())
-            return getClientConfiguration().setAddresses(addrs);
-        else
-            return getClientConfiguration().setAddressesFinder(new StaticAddressFinder(addrs));
+        return getClientConfiguration()
+                .setAddresses(addrs)
+                .setClusterDiscoveryEnabled(isClientEndpointsDiscoveryEnabled());
     }
 
     /**
@@ -162,23 +160,5 @@ public abstract class AbstractThinClientTest extends GridCommonAbstractTest {
      */
     protected boolean isClientPartitionAwarenessEnabled() {
         return true;
-    }
-
-    /**
-     * Address finder with static set of addresses, used to disable endpoints discovery.
-     */
-    public static class StaticAddressFinder implements ClientAddressFinder {
-        /** */
-        private final String[] addrs;
-
-        /** */
-        public StaticAddressFinder(String... addrs) {
-            this.addrs = addrs.clone();
-        }
-
-        /** {@inheritDoc} */
-        @Override public String[] getAddresses() {
-            return addrs.clone();
-        }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientEnpointsDiscoveryTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientEnpointsDiscoveryTest.java
@@ -61,6 +61,21 @@ public class ThinClientEnpointsDiscoveryTest extends ThinClientAbstractPartition
 
     /** */
     @Test
+    public void testEndpointsDiscoveryDisabled() throws Exception {
+        startGrids(2);
+
+        // Set only subset of nodes to connect, but wait for init of all nodes channels (other nodes should be discovered).
+        initClient(getClientConfiguration(0).setClusterDiscoveryEnabled(false), 0);
+
+        Thread.sleep(300);
+
+        assertNull(channels[1]);
+        assertNull(channels[2]);
+        assertNull(channels[3]);
+    }
+
+    /** */
+    @Test
     public void testDiscoveryAfterAllNodesFailed() throws Exception {
         startGrids(2);
 


### PR DESCRIPTION
Cluster discovery is always enabled currently, which can be undesirable in some use cases. Add a config property to disable discovery.