### PR TITLE
IGNITE-19222 .NET: Add IgniteClientConfiguration.EnableClusterDiscovery

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessWithClusterDiscoveryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessWithClusterDiscoveryTest.cs
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Cache
+{
+    using System.Linq;
+    using Apache.Ignite.Core.Client;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests Partition Awareness functionality combined with Cluster Discovery.
+    /// </summary>
+    public class PartitionAwarenessWithClusterDiscoveryTest : PartitionAwarenessTest
+    {
+#if NETCOREAPP // TODO: IGNITE-15710
+        [Test]
+        public void CacheGet_NewNodeEnteredTopology_RequestIsRoutedToNewNode()
+        {
+            // Warm-up.
+            Assert.AreEqual(1, _cache.Get(1));
+
+            // Before topology change.
+            Assert.AreEqual(12, _cache.Get(12));
+            Assert.AreEqual(1, GetClientRequestGridIndex());
+
+            Assert.AreEqual(14, _cache.Get(14));
+            Assert.AreEqual(2, GetClientRequestGridIndex());
+
+            // After topology change.
+            var cfg = GetIgniteConfiguration();
+            cfg.AutoGenerateIgniteInstanceName = true;
+
+            using (Ignition.Start(cfg))
+            {
+                TestUtils.WaitForTrueCondition(() =>
+                {
+                    // Keys 12 and 14 belong to a new node now (-1).
+                    Assert.AreEqual(12, _cache.Get(12));
+                    if (GetClientRequestGridIndex() != -1)
+                    {
+                        return false;
+                    }
+
+                    Assert.AreEqual(14, _cache.Get(14));
+                    Assert.AreEqual(-1, GetClientRequestGridIndex());
+
+                    return true;
+                }, 6000);
+            }
+        }
+#endif
+
+
+        protected override IgniteClientConfiguration GetClientConfiguration()
+        {
+            var cfg = base.GetClientConfiguration();
+
+            // Enable discovery and keep only one endpoint, let the client discover others.
+            cfg.EnableClusterDiscovery = true;
+            cfg.Endpoints = cfg.Endpoints.Take(1).ToList();
+
+            return cfg;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTests.cs
@@ -82,12 +82,14 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         /// Tests that originally known node can leave and client maintains connections to other cluster nodes.
         /// </summary>
         [Test]
-        public void TestClientMaintainsConnectionWhenOriginalNodeLeaves()
+        public void TestClientMaintainsConnectionWhenOriginalNodeLeaves(
+            [Values(true, false)] bool enablePartitionAwareness)
         {
             // Client knows about single server node initially.
             var ignite = Ignition.Start(GetIgniteConfiguration());
             var cfg = GetClientConfiguration();
             cfg.Endpoints = new[] {IPAddress.Loopback + ":10803"};
+            cfg.EnablePartitionAwareness = enablePartitionAwareness;
 
             // Client starts and discovers other server nodes.
             var client = Ignition.StartClient(cfg);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBase.cs
@@ -60,6 +60,38 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
                 AssertClientConnectionCount(client, 3);
             }
         }
+
+        /// <summary>
+        /// Tests that client with one initial endpoint discovers all servers.
+        /// </summary>
+        [Test]
+        public void TestDisabledDiscovery()
+        {
+            var cfg = new IgniteClientConfiguration(GetClientConfiguration())
+            {
+                EnableClusterDiscovery = false
+            };
+
+            using var client = Ignition.StartClient(cfg);
+
+            AssertClientConnectionCount(client, 1);
+        }
+
+        /// <summary>
+        /// Tests that client with one initial endpoint discovers all servers.
+        /// </summary>
+        [Test]
+        public void TestDisabledPartitionAwareness()
+        {
+            var cfg = new IgniteClientConfiguration(GetClientConfiguration())
+            {
+                EnablePartitionAwareness = false
+            };
+
+            using var client = Ignition.StartClient(cfg);
+
+            AssertClientConnectionCount(client, 1);
+        }
 #endif
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -61,6 +61,11 @@ namespace Apache.Ignite.Core.Client
         public const bool DefaultEnablePartitionAwareness = true;
 
         /// <summary>
+        /// Default value of <see cref="EnableClusterDiscovery" /> property.
+        /// </summary>
+        public const bool DefaultEnableClusterDiscovery = true;
+
+        /// <summary>
         /// Default socket timeout.
         /// </summary>
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
@@ -84,6 +89,7 @@ namespace Apache.Ignite.Core.Client
             SocketTimeout = DefaultSocketTimeout;
             Logger = new ConsoleLogger();
             EnablePartitionAwareness = DefaultEnablePartitionAwareness;
+            EnableClusterDiscovery = DefaultEnableClusterDiscovery;
         }
 
         /// <summary>
@@ -130,6 +136,7 @@ namespace Apache.Ignite.Core.Client
             Endpoints = cfg.Endpoints == null ? null : cfg.Endpoints.ToList();
             ReconnectDisabled = cfg.ReconnectDisabled;
             EnablePartitionAwareness = cfg.EnablePartitionAwareness;
+            EnableClusterDiscovery = cfg.EnableClusterDiscovery;
             Logger = cfg.Logger;
             ProtocolVersion = cfg.ProtocolVersion;
 
@@ -239,9 +246,24 @@ namespace Apache.Ignite.Core.Client
         /// To do so, connection is established to every known server node at all times.
         /// <para />
         /// When false: only one connection is established at a given moment to a random server node.
+        /// <para />
+        /// See also <see cref="EnableClusterDiscovery"/>.
         /// </summary>
         [DefaultValue(DefaultEnablePartitionAwareness)]
         public bool EnablePartitionAwareness { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Cluster Discovery should be enabled.
+        /// <para />
+        /// Default is true: Ignite will maintain an actual list of all server nodes in the cluster and connect to
+        /// them when necessary.
+        /// When <see cref="EnablePartitionAwareness"/> is false, this list of nodes will be used for failover.
+        /// When <see cref="EnablePartitionAwareness"/> is true, connections will be established to all known nodes.
+        /// <para />
+        /// When false: Ignite client will connect only to nodes in the <see cref="Endpoints"/> list.
+        /// </summary>
+        [DefaultValue(DefaultEnableClusterDiscovery)]
+        public bool EnableClusterDiscovery { get; set; }
 
         /// <summary>
         /// Gets or sets the logger.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -335,6 +335,11 @@
                     <xs:documentation>Enables affinity-aware connection: client will establish connection to every known server and route requests to primary nodes for cache operations.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="enableClusterDiscovery" type="xs:boolean">
+                <xs:annotation>
+                    <xs:documentation>Enables cluster discovery: client will maintain an actual list of all server nodes and connect to all of them.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="userName" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>Username to be used to connect to secured cluster.</xs:documentation>


### PR DESCRIPTION
* Add `IgniteClientConfiguration.EnableClusterDiscovery`.
* Allow any combinations of `EnableClusterDiscovery` and `EnablePartitionAwareness`:
  * Only `EnablePartitionAwareness`: use configured endpoints to route requests.
  * Only `EnableClusterDiscovery`: use discovered endpoints for failover, but maintain only one connection.
  * Both enabled: discover all, connect to all.
  * Both disabled: maintain one connection, use only configured endpoints for failover.