### PR TITLE
IGNITE-20026 Java thin: Remove port range limitation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -686,12 +686,6 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
         if (F.isEmpty(addrs))
             error = "At least one Ignite server node must be specified in the Ignite client configuration";
-        else {
-            for (InetSocketAddress addr : addrs) {
-                if (addr.getPort() < 1024 || addr.getPort() > 49151)
-                    error = String.format("Ignite client port %s is out of valid ports range 1024...49151", addr.getPort());
-            }
-        }
 
         if (error == null && cfg.getHeartbeatInterval() <= 0)
             error = "heartbeatInterval cannot be zero or less.";


### PR DESCRIPTION
Remove the port limitation to support other dynamic port reverse proxys. Like testcontainers[1]

[1]
https://stackoverflow.com/questions/76746998/why-ignite-tcpclientchannel-port-can-not-larger-than-49151