### PR TITLE
IGNITE-20758 Fix LongDestroyDurableBackgroundTaskTest

### DIFF
--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/LongDestroyDurableBackgroundTaskTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/LongDestroyDurableBackgroundTaskTest.java
@@ -371,7 +371,6 @@ public class LongDestroyDurableBackgroundTaskTest extends GridCommonAbstractTest
 
         taskArg.caches(new String[]{"SQL_PUBLIC_T"});
         taskArg.nodeIds(nodeIds.toArray(EMPTY_UUIDS));
-        taskArg.checkFirst(0);
         taskArg.checkThrough(1);
         taskArg.checkCrc(true);
         taskArg.checkSizes(true);


### PR DESCRIPTION
### Description

Removed setting up of `CacheValidateIndexesCommandArg` (former `VisorValidateIndexesTaskArg`) `checkFirst` parameter.

Before [IGNITE-15629](https://issues.apache.org/jira/browse/IGNITE-15629) `VisorValidateIndexesTaskArg` was initialized in `LongDestroyDurableBackgroundTaskTest` via constructor with zero argument for `checkFirst` [1]. Currently, a setter method `CacheValidateIndexesCommandArg#checkFirst` is used and it performs implicit validation, so value of `checkFirst` should be positive.


Under the hood, for `checkFirst` with values less or equal to zero processing is skipped in `ValidateIndexesClosure#processPartIterator`[2, 3] (and in `#processIndex`). Moreover, default value of `checkFirst` is `-1` [4], so we can remove explicit setting up of this parameter in order to pass the test.


Links:
1. https://github.com/apache/ignite/blob/098e09117934295c9314315dedf0eca1648022f5/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/LongDestroyDurableBackgroundTaskTest.java#L370
1. https://github.com/apache/ignite/blob/01a7d075a5f48016511f6a754538201f12aff4f7/modules/core/src/main/java/org/apache/ignite/internal/visor/verify/ValidateIndexesClosure.java#L594
1. https://github.com/apache/ignite/blob/41b0fa192b7a77c7574fe2d03eed295cf6cc2471/modules/core/src/main/java/org/apache/ignite/internal/management/cache/ValidateIndexesClosure.java#L573
1. https://github.com/apache/ignite/blob/abdfc99cd2a9fc37879fb9cef82aea9e0437bac1/modules/core/src/main/java/org/apache/ignite/internal/management/cache/CacheValidateIndexesCommandArg.java#L53

----
Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
