### PR TITLE
IGNITE-20904 Fix Messaging SystemView code.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/GridMessageListenHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/GridMessageListenHandler.java
@@ -113,7 +113,7 @@ public class GridMessageListenHandler implements GridContinuousHandler {
 
     /** {@inheritDoc} */
     @Override public String cacheName() {
-        throw new IllegalStateException();
+        return null;
     }
 
     /** {@inheritDoc} */
@@ -222,8 +222,8 @@ public class GridMessageListenHandler implements GridContinuousHandler {
     }
 
     /** {@inheritDoc} */
-    @Nullable @Override public Object orderedTopic() {
-        return null;
+    @Override public Object orderedTopic() {
+        return this.topic;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
GridMessageListenHandler.cacheName() caused an IllegalStateException when querying the SystemView with SQL. I made it return null, and I adjusted the GridMessageListenHandler.orderedTopic() method so that the SystemView can return topicName.