### PR TITLE
Fix 'ssl.KeyManagerFactory.algorithm' security property retrieving

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/ssl/SslContextFactory.java
+++ b/modules/core/src/main/java/org/apache/ignite/ssl/SslContextFactory.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
+import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -62,7 +63,7 @@ public class SslContextFactory extends AbstractSslContextFactory {
     public static final String DFLT_SSL_PROTOCOL = AbstractSslContextFactory.DFLT_SSL_PROTOCOL;
 
     /** Default key manager / trust manager algorithm. Specifying different trust manager algorithm is not supported. */
-    public static final String DFLT_KEY_ALGORITHM = System.getProperty("ssl.KeyManagerFactory.algorithm", "SunX509");
+    public static final String DFLT_KEY_ALGORITHM = System.getProperty("ssl.KeyManagerFactory.algorithm", getSecurityProperty("ssl.KeyManagerFactory.algorithm", "SunX509"));
 
     /** Key manager algorithm. */
     protected String keyAlgorithm = DFLT_KEY_ALGORITHM;
@@ -382,6 +383,20 @@ public class SslContextFactory extends AbstractSslContextFactory {
         catch (IOException e) {
             throw new SSLException("Failed to initialize key store (I/O error occurred): " + storeFilePath, e);
         }
+    }
+
+    /**
+     * Get java security property
+     * @param property property name
+     * @param defaultValue default value
+     * @return Returns security property retrieved by name or defaultValue if not found
+     */
+    private static String getSecurityProperty(String property, String defaultValue) {
+        String value = Security.getProperty(property);
+        if (value != null) {
+            return value;
+        }
+        return defaultValue;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
### Fix 'ssl.KeyManagerFactory.algorithm' security property retrieving

### Issue
SslContextFactory has DFLT_KEY_ALGORITHM constant which by default tries to retrieve 'ssl.KeyManagerFactory.algorithm' value from the system property. But, according to Java specification (https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/net/ssl/KeyManagerFactory.html, https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/KeyManagerFactory.html), this is a **security** property. It can be specified in java.security file, therefore in order to get its value in code, Security.getProperty(..) method should be used.

### Fix
The proposed fix keeps backward compatibility with the scenarios when this property for some reason specified as a system property