### PR TITLE
fix violations of Sonarqube rule java:S2111

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinResultSet.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinResultSet.java
@@ -786,7 +786,7 @@ public class JdbcThinResultSet implements ResultSet {
         if (cls == BigDecimal.class)
             return (BigDecimal)val;
         else if (val instanceof Number)
-            return new BigDecimal(((Number)val).doubleValue());
+            return BigDecimal.valueOf(((Number) val).doubleValue());
         else if (cls == Boolean.class)
             return new BigDecimal((Boolean)val ? 1 : 0);
         else if (cls == String.class || cls == Character.class) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcResultSet.java
@@ -789,7 +789,7 @@ public class JdbcResultSet implements ResultSet {
         if (cls == BigDecimal.class)
             return (BigDecimal)val;
         else if (val instanceof Number)
-            return new BigDecimal(((Number)val).doubleValue());
+            return BigDecimal.valueOf(((Number) val).doubleValue());
         else if (cls == Boolean.class)
             return new BigDecimal((Boolean)val ? 1 : 0);
         else if (cls == String.class || cls == Character.class) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -1507,7 +1507,7 @@ public abstract class IgniteUtils {
      * @return Rounded heap size.
      */
     private static double roundedHeapSize(double heap, int precision) {
-        double rounded = new BigDecimal(heap / (1024 * 1024 * 1024d)).round(new MathContext(precision)).doubleValue();
+        double rounded = BigDecimal.valueOf(heap / (1024 * 1024 * 1024d)).round(new MathContext(precision)).doubleValue();
 
         return rounded < 0.1 ? 0.1 : rounded;
     }


### PR DESCRIPTION
Hello,

This PR fixes 3 violations of Sonarqube Rule java:S2111 : ['"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111).
For more details, please see [CERT, NUM10-J.](https://wiki.sei.cmu.edu/confluence/x/kzdGBQ)

The patch was automatically generated using the ViolationFixer tool.