### PR TITLE
IGNITE-21395 .NET: Fix ClientServerCompatibilityTest on JDK 11

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
@@ -307,7 +307,7 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
             {
                 TestUtils.EnsureJvmCreated();
 
-                if (TestUtilsJni.GetJavaMajorVersion() <= 11)
+                if (TestUtilsJni.GetJavaMajorVersion() < 11)
                 {
                     // Old Ignite versions can't start on new JDKs (support was not yet added).
                     yield return new object[] { JavaServer.GroupIdIgnite, "2.4.0", 0 };

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -64,6 +64,8 @@ namespace Apache.Ignite.Core.Tests
 
             Console.WriteLine("Using maven at: " + MavenPath);
             Console.WriteLine("JAVA_HOME: " + Environment.GetEnvironmentVariable("JAVA_HOME"));
+            Console.WriteLine("IsJava9: " + Jvm.IsJava9());
+            Console.WriteLine("GetJavaMajorVersion: " + TestUtilsJni.GetJavaMajorVersion());
 
             var pomWrapper =
                 ReplaceIgniteVersionInPomFile(groupId, version, Path.Combine(JavaServerSourcePath, "pom.xml"));


### PR DESCRIPTION
Disable `ClientServerCompatibilityTest` test cases for Ignite 2.4.0 and 2.6.0 on JDK 11.