### PR TITLE
IGNITE-21660 ClientQueryCursor is not closed in getAll

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientQueryCursor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientQueryCursor.java
@@ -40,19 +40,24 @@ class ClientQueryCursor<T> implements QueryCursor<T> {
 
     /** {@inheritDoc} */
     @Override public List<T> getAll() {
-        while (true) {
-            try {
-                List<T> res = new ArrayList<>();
+        try {
+            while (true) {
+                try {
+                    List<T> res = new ArrayList<>();
 
-                for (T ent : this)
-                    res.add(ent);
+                    for (T ent : this)
+                        res.add(ent);
 
-                return res;
+                    return res;
+                }
+                catch (ClientReconnectedException ex) {
+                    // If we were reconnected to a new server we can retry entire query to failover.
+                    pager.reset();
+                }
             }
-            catch (ClientReconnectedException ex) {
-                // If we were reconnected to a new server we can retry entire query to failover.
-                pager.reset();
-            }
+        }
+        finally {
+            close();
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/projects/IGNITE/issues/IGNITE-21660

ClientQueryCursor is not closed in `getAll()` method. According to the annotation, it should be closed.

Annotation:
Since all the results will be fetched, all the resources will be closed automatically after this call, e.g. there is no need to call {@link #close()} method in this case.
