### PR TITLE
IGNITE-22844 control.sh --consistency repair permissions fixes

### DIFF
--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/SecurityCommandHandlerPermissionsTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/SecurityCommandHandlerPermissionsTest.java
@@ -53,13 +53,13 @@ import static org.apache.ignite.plugin.security.SecurityPermissionSetBuilder.sys
 /** */
 public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbstractTest {
     /** */
-    private static final String TEST_NO_PERMISSIONS_LOGIN = "no-permissions-login";
+    public static final String TEST_NO_PERMISSIONS_LOGIN = "no-permissions-login";
 
     /** */
-    private static final String TEST_LOGIN = "cli-admin-login";
+    public static final String TEST_LOGIN = "cli-admin-login";
 
     /** */
-    private static final String DEFAULT_PWD = "pwd";
+    public static final String DEFAULT_PWD = "pwd";
 
     /** */
     @Parameterized.Parameters(name = "cmdHnd={0}")
@@ -164,7 +164,7 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
     }
 
     /** */
-    List<String> enrichWithConnectionArguments(Collection<String> cmdArgs, String login) {
+    public static List<String> enrichWithConnectionArguments(Collection<String> cmdArgs, String login) {
         List<String> args = new ArrayList<>();
 
         args.add(CMD_USER);

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/SecurityCommandHandlerPermissionsTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/SecurityCommandHandlerPermissionsTest.java
@@ -24,24 +24,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.ignite.Ignite;
-import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
-import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
-import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
-import org.apache.ignite.internal.processors.cache.CacheObjectImpl;
-import org.apache.ignite.internal.processors.cache.GridCacheAdapter;
-import org.apache.ignite.internal.processors.cache.GridCacheEntryEx;
-import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
-import org.apache.ignite.internal.processors.cache.version.GridCacheVersionManager;
-import org.apache.ignite.internal.processors.dr.GridDrType;
 import org.apache.ignite.internal.processors.security.impl.TestSecurityData;
 import org.apache.ignite.internal.processors.security.impl.TestSecurityPluginProvider;
-import org.apache.ignite.internal.util.typedef.G;
-import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.plugin.security.SecurityPermission;
 import org.apache.ignite.plugin.security.SecurityPermissionSet;
 import org.apache.ignite.plugin.security.SecurityPermissionSetBuilder;
@@ -50,13 +37,11 @@ import org.junit.Test;
 import org.junit.runners.Parameterized;
 
 import static java.util.Arrays.asList;
-import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.internal.commandline.ArgumentParser.CMD_PASSWORD;
 import static org.apache.ignite.internal.commandline.ArgumentParser.CMD_USER;
 import static org.apache.ignite.internal.commandline.CommandHandler.EXIT_CODE_OK;
 import static org.apache.ignite.internal.commandline.CommandHandler.EXIT_CODE_UNEXPECTED_ERROR;
 import static org.apache.ignite.internal.util.IgniteUtils.resolveIgnitePath;
-import static org.apache.ignite.plugin.security.SecurityPermission.ADMIN_OPS;
 import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_CREATE;
 import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_DESTROY;
 import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_READ;
@@ -75,9 +60,6 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
 
     /** */
     private static final String DEFAULT_PWD = "pwd";
-
-    /** */
-    private static final int PARTITIONS = 8;
 
     /** */
     @Parameterized.Parameters(name = "cmdHnd={0}")
@@ -140,19 +122,6 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
 
     /** */
     @Test
-    public void testConsistencyRepair() throws Exception {
-        List<String> cmdArgs = asList(
-            "--consistency", "repair",
-            "--cache", DEFAULT_CACHE_NAME,
-            "--strategy", "LWW",
-            "--partitions", IntStream.range(0, PARTITIONS).mapToObj(Integer::toString).collect(Collectors.joining(","))
-        );
-
-        checkConsistencyCommandPermissions(cmdArgs, adminPermission(ADMIN_OPS));
-    }
-
-    /** */
-    @Test
     public void testCacheCreate() throws Exception {
         String ccfgPath = resolveIgnitePath(
             "modules/control-utility/src/test/resources/config/cache/cache-create-correct.xml"
@@ -177,7 +146,11 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
 
     /** */
     private void checkCommandPermissions(Collection<String> cmdArgs, SecurityPermissionSet reqPerms) throws Exception {
-        Ignite ignite = startNode(0, reqPerms);
+        Ignite ignite = startGrid(
+            0,
+            userData(TEST_NO_PERMISSIONS_LOGIN, NO_PERMISSIONS),
+            userData(TEST_LOGIN, reqPerms)
+        );
 
         ignite.createCache(DEFAULT_CACHE_NAME);
 
@@ -188,68 +161,6 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
             assertTrue(testOut.toString().contains("Authorization failed"));
 
         assertEquals(EXIT_CODE_OK, execute(enrichWithConnectionArguments(cmdArgs, TEST_LOGIN)));
-    }
-
-    /** */
-    private void checkConsistencyCommandPermissions(Collection<String> cmdArgs, SecurityPermissionSet reqPerms) throws Exception {
-        int nodes = 3;
-
-        Ignite ignite = startGrid(nodes, reqPerms);
-
-        String cacheName = createCache(nodes, ignite);
-
-        fillCache(cacheName);
-
-        assertEquals(EXIT_CODE_UNEXPECTED_ERROR, execute(enrichWithConnectionArguments(cmdArgs, TEST_NO_PERMISSIONS_LOGIN)));
-
-        // We are losing command failure cause for --cache clear commnad. See IGNITE-21023 for more details.
-        if (!cmdArgs.containsAll(Arrays.asList("--cache", "clear")))
-            assertTrue(testOut.toString().contains("Authorization failed"));
-
-        assertEquals(EXIT_CODE_OK, execute(enrichWithConnectionArguments(cmdArgs, TEST_LOGIN)));
-    }
-
-    /**
-     * @param nodes Number of nodes in cluster.
-     * @param reqPerms security permition set.
-     * @return {@link Ignite} instance of the first node in the grid.
-     */
-    private Ignite startGrid(int nodes, SecurityPermissionSet reqPerms) throws Exception {
-        assert nodes > 0;
-
-        Ignite ignite = startNode(0, reqPerms);
-
-        for (int i = 1; i < nodes; ++i)
-            startNode(i, reqPerms);
-
-        return ignite;
-    }
-
-    /**
-     * Starts a single node with specified user security parameters.
-     * @param idx node index.
-     * @param reqPerms {@link SecurityPermissionSet} with permissions.
-     */
-    private Ignite startNode(int idx, SecurityPermissionSet reqPerms) throws Exception {
-        return startGrid(
-            idx,
-            userData(TEST_NO_PERMISSIONS_LOGIN, NO_PERMISSIONS),
-            userData(TEST_LOGIN, reqPerms)
-        );
-    }
-
-    /**
-     * @param ignite Ignite instance.
-     * @param nodes Number for ignite instances.
-     */
-    private String createCache(int nodes, Ignite ignite) {
-        CacheConfiguration<Integer, Integer> cfg = new CacheConfiguration<>(DEFAULT_CACHE_NAME);
-
-        cfg.setAtomicityMode(TRANSACTIONAL);
-        cfg.setBackups(nodes - 1);
-        cfg.setAffinity(new RendezvousAffinityFunction().setPartitions(PARTITIONS));
-
-        return ignite.getOrCreateCache(cfg).getName();
     }
 
     /** */
@@ -275,14 +186,6 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
     }
 
     /** */
-    private SecurityPermissionSet adminPermission(SecurityPermission... perms) {
-        return SecurityPermissionSetBuilder.create()
-            .defaultAllowAll(false)
-            .appendSystemPermissions(perms)
-            .build();
-    }
-
-    /** */
     private TestSecurityData userData(String login, SecurityPermissionSet perms) {
         return new TestSecurityData(
             login,
@@ -290,53 +193,5 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
             perms,
             new Permissions()
         );
-    }
-
-    /**
-     *
-     */
-    private void fillCache(String name) throws Exception {
-        for (Ignite node : G.allGrids()) {
-            while (((IgniteEx)node).cachex(name) == null) // Waiting for cache internals to init.
-                U.sleep(1);
-        }
-
-        GridCacheVersionManager mgr =
-            ((GridCacheAdapter)(grid(1)).cachex(name).cache()).context().shared().versions();
-
-        for (int key = 0; key < PARTITIONS; key++) {
-            List<Ignite> nodes = new ArrayList<>();
-
-            nodes.add(primaryNode(key, name));
-            nodes.addAll(backupNodes(key, name));
-
-            Collections.shuffle(nodes);
-
-            int val = key;
-            Object obj;
-
-            for (Ignite node : nodes) {
-                IgniteInternalCache cache = ((IgniteEx)node).cachex(name);
-
-                GridCacheAdapter adapter = ((GridCacheAdapter)cache.cache());
-
-                GridCacheEntryEx entry = adapter.entryEx(key);
-
-                obj = ++val;
-
-                boolean init = entry.initialValue(
-                    new CacheObjectImpl(obj, null), // Incremental or same value.
-                    mgr.next(entry.context().kernalContext().discovery().topologyVersion()), // Incremental version.
-                    0,
-                    0,
-                    false,
-                    AffinityTopologyVersion.NONE,
-                    GridDrType.DR_NONE,
-                    false,
-                    false);
-
-                assertTrue("iterableKey " + key + " already inited", init);
-            }
-        }
     }
 }

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/SecurityCommandHandlerPermissionsTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/SecurityCommandHandlerPermissionsTest.java
@@ -219,7 +219,7 @@ public class SecurityCommandHandlerPermissionsTest extends GridCommandHandlerAbs
 
         Ignite ignite = startNode(0, reqPerms);
 
-        for(int i = 1; i < nodes; ++i)
+        for (int i = 1; i < nodes; ++i)
             startNode(i, reqPerms);
 
         return ignite;

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerConsistencyTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerConsistencyTest.java
@@ -142,7 +142,7 @@ public class GridCommandHandlerConsistencyTest extends GridCommandHandlerCluster
     public boolean callByGrp;
 
     /**
-     * True if security checks enabled
+     * True if security checks enabled.
      */
     @Parameterized.Parameter(4)
     public boolean withSecurityEnabled;
@@ -172,13 +172,17 @@ public class GridCommandHandlerConsistencyTest extends GridCommandHandlerCluster
 
         cfg.setGridLogger(listeningLog);
 
-        if (withSecurityEnabled)
+        if (withSecurityEnabled) {
             cfg.setPluginProviders(
                 new TestSecurityPluginProvider(
-                    igniteInstanceName, DEFAULT_PWD, ALL_PERMISSIONS, false,
+                    igniteInstanceName,
+                    DEFAULT_PWD,
+                    ALL_PERMISSIONS,
+                    false,
                     new TestSecurityData(TEST_NO_PERMISSIONS_LOGIN, DEFAULT_PWD, NO_PERMISSIONS, new Permissions()),
                     new TestSecurityData(TEST_LOGIN, DEFAULT_PWD, systemPermissions(ADMIN_OPS), new Permissions()))
             );
+        }
 
         return cfg;
     }

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerConsistencyTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerConsistencyTest.java
@@ -109,16 +109,20 @@ public class GridCommandHandlerConsistencyTest extends GridCommandHandlerCluster
     public static Iterable<Object[]> data() {
         List<Object[]> res = new ArrayList<>();
 
-        for (String invoker : commandHandlers())
-            for (ReadRepairStrategy strategy : ReadRepairStrategy.values())
-                for (boolean explicitGrp : new boolean[] {false, true})
-                    for (boolean callByGrp : new boolean[] {false, true})
+        for (String invoker : commandHandlers()) {
+            for (ReadRepairStrategy strategy : ReadRepairStrategy.values()) {
+                for (boolean explicitGrp : new boolean[] {false, true}) {
+                    for (boolean callByGrp : new boolean[] {false, true}) {
                         for (boolean withSecurityEnabled : new boolean[] {false, true}) {
                             if (!explicitGrp && callByGrp || invoker.equals(JMX_CMD_HND) && withSecurityEnabled)
                                 continue;
 
                             res.add(new Object[] {invoker, strategy, explicitGrp, callByGrp, withSecurityEnabled});
                         }
+                    }
+                }
+            }
+        }
 
         return res;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
@@ -274,8 +274,7 @@ public class ConsistencyRepairTask extends AbstractConsistencyTask<ConsistencyRe
          * @param keys Keys.
          */
         private void repair(IgniteCache<Object, Object> cache, Set<Object> keys) {
-            UUID nodeId = ignite.localNode().id();
-            try (OperationSecurityContext ignored = ignite.context().security().withContext(nodeId)) {
+            try (OperationSecurityContext ignored = ignite.context().security().withContext(ignite.localNode().id())) {
                 cache.getAll(keys); // Repair.
             }
             catch (CacheException e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;

--- a/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
@@ -274,8 +274,8 @@ public class ConsistencyRepairTask extends AbstractConsistencyTask<ConsistencyRe
          * @param keys Keys.
          */
         private void repair(IgniteCache<Object, Object> cache, Set<Object> keys) {
-            UUID randomNodeId = ignite.cluster().node().id();
-            try (OperationSecurityContext ignored = ignite.context().security().withContext(randomNodeId)) {
+            UUID nodeId = ignite.localNode().id();
+            try (OperationSecurityContext ignored = ignite.context().security().withContext(nodeId)) {
                 cache.getAll(keys); // Repair.
             }
             catch (CacheException e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/consistency/ConsistencyRepairTask.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,6 +41,7 @@ import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtLocalPartition;
 import org.apache.ignite.internal.processors.cache.distributed.near.consistency.IgniteIrreparableConsistencyViolationException;
 import org.apache.ignite.internal.processors.cache.persistence.CacheDataRow;
+import org.apache.ignite.internal.processors.security.OperationSecurityContext;
 import org.apache.ignite.internal.util.GridConcurrentHashSet;
 import org.apache.ignite.internal.util.lang.GridCursor;
 import org.apache.ignite.internal.util.typedef.F;
@@ -48,6 +50,7 @@ import org.apache.ignite.internal.visor.VisorJob;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.resources.LoggerResource;
+
 import static org.apache.ignite.events.EventType.EVT_CONSISTENCY_VIOLATION;
 
 /**
@@ -271,7 +274,8 @@ public class ConsistencyRepairTask extends AbstractConsistencyTask<ConsistencyRe
          * @param keys Keys.
          */
         private void repair(IgniteCache<Object, Object> cache, Set<Object> keys) {
-            try {
+            UUID randomNodeId = ignite.cluster().node().id();
+            try (OperationSecurityContext ignored = ignite.context().security().withContext(randomNodeId)) {
                 cache.getAll(keys); // Repair.
             }
             catch (CacheException e) {


### PR DESCRIPTION
_**Intro:**_
Currently 'Read Repair' task performed for the chosen partitions by control.sh requires CACHE_READ and CACHE PUT permissions in addition to ADMIN_OPS. Thus, to perform the comand `control.sh --consistency repair` the one needs all 3 permissions.

There is no point  to have additional CACHE_READ and CACHE_PUT permissions to perform the operation, as they are useless for the task itself, and introduces security risk, by allowing the user to manipulate the cache in parallel.

The solution would be to substitute user's security context with the context of the cluster node that performs the command. The former is used for the ADMIN_OPS permission check and the latter is used for cache. This will ease the requirement for the users to perform `control.sh --consistency repair` without introducing any additional security risk.

_**What have I changed:**_ 
- As the task logic proceeds with cache reads after initial authorization, we switch the user SecurityContext to a random node SecurityContext
- Additional tests for users with ADMIN_OPS only. Those should be able to start `control.sh --consistency repair` command with no authorization error relates to CACHE_READ and CACHE_PUT

----------------------------------------------------------------------------

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
