### PR TITLE
IGNITE-23472 Fix JavaLogger

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
@@ -117,6 +117,7 @@ public class JavaLogger implements IgniteLoggerEx {
 
     /** Path to configuration file. */
     @GridToStringExclude
+    @SuppressWarnings("FieldAccessedSynchronizedAndUnsynchronized")
     private String cfg;
 
     /** Quiet flag. */
@@ -209,13 +210,12 @@ public class JavaLogger implements IgniteLoggerEx {
      * Creates new logger with given parameters.
      *
      * @param impl Java Logging implementation to use.
-     * @param quiet Quiet mode.
      * @param cfg Path to configuration.
      */
-    private JavaLogger(Logger impl, boolean quiet, String cfg) {
-        this.impl = impl;
-        this.quiet = quiet;
-        this.cfg = cfg;
+    private JavaLogger(Logger impl, String cfg) {
+        this(impl, true);
+        if (cfg != null)
+            this.cfg = cfg;
     }
 
     /** {@inheritDoc} */
@@ -224,7 +224,7 @@ public class JavaLogger implements IgniteLoggerEx {
             ? Logger.getLogger("")
             : Logger.getLogger(ctgr instanceof Class
                 ? ((Class<?>)ctgr).getName()
-                : String.valueOf(ctgr)), quiet, cfg);
+                : String.valueOf(ctgr)), cfg);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
@@ -134,7 +134,7 @@ public class JavaLogger implements IgniteLoggerEx {
      * Creates new logger.
      */
     public JavaLogger() {
-        this(!isConfigured());
+        this(true);
     }
 
     /**
@@ -192,15 +192,6 @@ public class JavaLogger implements IgniteLoggerEx {
      * Creates new logger with given implementation.
      *
      * @param impl Java Logging implementation to use.
-     */
-    public JavaLogger(final Logger impl) {
-        this(impl, true);
-    }
-
-    /**
-     * Creates new logger with given implementation.
-     *
-     * @param impl Java Logging implementation to use.
      * @param configure Configure logger.
      */
     public JavaLogger(final Logger impl, boolean configure) {
@@ -214,13 +205,26 @@ public class JavaLogger implements IgniteLoggerEx {
         quiet = quiet0;
     }
 
+    /**
+     * Creates new logger with given parameters.
+     *
+     * @param impl Java Logging implementation to use.
+     * @param quiet Quiet mode.
+     * @param cfg Path to configuration.
+     */
+    private JavaLogger(Logger impl, boolean quiet, String cfg) {
+        this.impl = impl;
+        this.quiet = quiet;
+        this.cfg = cfg;
+    }
+
     /** {@inheritDoc} */
     @Override public IgniteLogger getLogger(Object ctgr) {
         return new JavaLogger(ctgr == null
             ? Logger.getLogger("")
             : Logger.getLogger(ctgr instanceof Class
                 ? ((Class<?>)ctgr).getName()
-                : String.valueOf(ctgr)));
+                : String.valueOf(ctgr)), quiet, cfg);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
+++ b/modules/core/src/main/java/org/apache/ignite/logger/java/JavaLogger.java
@@ -214,6 +214,7 @@ public class JavaLogger implements IgniteLoggerEx {
      */
     private JavaLogger(Logger impl, String cfg) {
         this(impl, true);
+
         if (cfg != null)
             this.cfg = cfg;
     }

--- a/modules/core/src/test/config/jul-debug.properties
+++ b/modules/core/src/test/config/jul-debug.properties
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Comma-separated list of logging "handlers". Note that some of them may be
+# reconfigured (or even removed) at runtime according to system properties.
+#
+# By default all messages will be passed to console and file.
+#
+handlers=java.util.logging.ConsoleHandler, org.apache.ignite.logger.java.JavaLoggerFileHandler
+
+#
+# Default global logging level.
+# This specifies which kinds of events are logged across all loggers.
+# For any given category this global level can be overriden by a category
+# specific level.
+# Note that handlers also have a separate level setting to limit messages
+# printed through it.
+#
+.level=FINE
+
+#
+# Console handler logs all messages with importance level `INFO` and above
+# into standard error stream (`System.err`).
+#
+java.util.logging.ConsoleHandler.formatter=org.apache.ignite.logger.java.JavaLoggerFormatter
+java.util.logging.ConsoleHandler.level=INFO
+
+#
+# File handler logs all messages into files with pattern `ignite-%{id8}.%g.log`
+# under `$IGNITE_HOME/work/log/` directory. The placeholder `%{id8}` is a truncated node ID.
+#
+org.apache.ignite.logger.java.JavaLoggerFileHandler.formatter=org.apache.ignite.logger.java.JavaLoggerFormatter
+org.apache.ignite.logger.java.JavaLoggerFileHandler.pattern=%{app}%{id8}.%g.log
+org.apache.ignite.logger.java.JavaLoggerFileHandler.level=INFO
+org.apache.ignite.logger.java.JavaLoggerFileHandler.limit=10485760
+org.apache.ignite.logger.java.JavaLoggerFileHandler.count=10

--- a/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
@@ -17,31 +17,102 @@
 
 package org.apache.ignite.logger.java;
 
+import java.io.File;
 import java.util.UUID;
+import java.util.logging.LogManager;
 import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.logger.IgniteLoggerEx;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.testframework.junits.common.GridCommonTest;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.apache.ignite.logger.java.JavaLogger.DFLT_CONFIG_PATH;
 
 /**
  * Java logger test.
  */
 @GridCommonTest(group = "Logger")
-public class JavaLoggerTest {
-    /** */
-    @SuppressWarnings({"FieldCanBeLocal"})
-    private IgniteLogger log;
+public class JavaLoggerTest extends GridCommonAbstractTest {
+    /**
+     * Path to jul configuration with DEBUG enabled.
+     */
+    private static final String LOG_CONFIG_DEBUG = "modules/core/src/test/config/jul-debug.properties";
+
+    /**
+     * Reset JavaLogger.
+     */
+    @Override protected void afterTest() throws Exception {
+        GridTestUtils.setFieldValue(JavaLogger.class, JavaLogger.class, "inited", false);
+    }
+
+
+    /**
+     * Check JavaLogger default constructor.
+     */
+    @Test
+    public void testDefaultConstructorWithDefaultConfig() {
+        IgniteLogger log1 = new JavaLogger();
+        IgniteLogger log2 = log1.getLogger(getClass());
+
+        assertTrue(log1.toString().contains("JavaLogger"));
+        assertTrue(log1.toString().contains(DFLT_CONFIG_PATH));
+
+        assertTrue(log2.toString().contains("JavaLogger"));
+        assertTrue(log2.toString().contains(DFLT_CONFIG_PATH));
+    }
+
+    /**
+     * Check JavaLogger constructor from java.util.logging.config.file property.
+     */
+    @Test
+    public void testDefaultConstructorWithProperty() throws Exception {
+        File file = new File(U.getIgniteHome(), LOG_CONFIG_DEBUG);
+        System.setProperty("java.util.logging.config.file", file.getPath());
+        // Call readConfiguration explicitly because Logger.getLogger was already called during IgniteUtils initialization
+        LogManager.getLogManager().readConfiguration();
+
+        IgniteLogger log1 = new JavaLogger();
+        assertTrue(log1.toString().contains("JavaLogger"));
+        assertTrue(log1.toString().contains(LOG_CONFIG_DEBUG));
+        assertTrue(log1.isDebugEnabled());
+
+        IgniteLogger log2 = log1.getLogger(getClass());
+        assertTrue(log2.toString().contains("JavaLogger"));
+        assertTrue(log2.toString().contains(LOG_CONFIG_DEBUG));
+        assertTrue(log1.isDebugEnabled());
+
+        System.clearProperty("java.util.logging.config.file");
+    }
+
+    /**
+     * Check Grid logging.
+     */
+    @Test
+    public void testGridLoggingWithDefaultLogger() throws Exception {
+        LogListener lsn = LogListener.matches("JavaLogger [quiet=true,")
+            .andMatches(DFLT_CONFIG_PATH)
+            .build();
+        ListeningTestLogger log = new ListeningTestLogger(new JavaLogger(), lsn);
+
+        IgniteConfiguration cfg = getConfiguration(getTestIgniteInstanceName());
+        cfg.setGridLogger(log);
+        startGrid(cfg);
+
+        assertTrue(GridTestUtils.waitForCondition(lsn::check, 2_000));
+        stopAllGrids();
+    }
 
     /**
      * @throws Exception If failed.
      */
     @Test
     public void testLogInitialize() throws Exception {
-        log = new JavaLogger();
+        JavaLogger log = new JavaLogger();
 
         ((JavaLogger)log).setWorkDirectory(U.defaultWorkDirectory());
         ((IgniteLoggerEx)log).setApplicationAndNode(null, UUID.fromString("00000000-1111-2222-3333-444444444444"));
@@ -49,7 +120,7 @@ public class JavaLoggerTest {
         System.out.println(log.toString());
 
         assertTrue(log.toString().contains("JavaLogger"));
-        assertTrue(log.toString().contains(JavaLogger.DFLT_CONFIG_PATH));
+        assertTrue(log.toString().contains(DFLT_CONFIG_PATH));
 
         if (log.isDebugEnabled())
             log.debug("This is 'debug' message.");

--- a/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/logger/java/JavaLoggerTest.java
@@ -88,6 +88,7 @@ public class JavaLoggerTest extends GridCommonAbstractTest {
     public void testDefaultConstructorWithProperty() throws Exception {
         String cfgPathProp = "java.util.logging.config.file";
         String oldPropVal = System.getProperty(cfgPathProp);
+
         try {
             File file = new File(U.getIgniteHome(), LOG_CONFIG_DEBUG);
             System.setProperty(cfgPathProp, file.getPath());
@@ -102,7 +103,7 @@ public class JavaLoggerTest extends GridCommonAbstractTest {
             IgniteLogger log2 = log1.getLogger(getClass());
             assertTrue(log2.toString().contains("JavaLogger"));
             assertTrue(log2.toString().contains(LOG_CONFIG_DEBUG));
-            assertTrue(log1.isDebugEnabled());
+            assertTrue(log2.isDebugEnabled());
         }
         finally {
             if (oldPropVal == null)
@@ -120,11 +121,13 @@ public class JavaLoggerTest extends GridCommonAbstractTest {
         LogListener lsn = LogListener.matches("JavaLogger [quiet=true,")
             .andMatches(DFLT_CONFIG_PATH)
             .build();
+
         ListeningTestLogger log = new ListeningTestLogger(new JavaLogger(), lsn);
 
         IgniteConfiguration cfg = getConfiguration(getTestIgniteInstanceName());
         cfg.setGridLogger(log);
-        try (Ignite ign = startGrid(cfg)) {
+
+        try (Ignite ignore = startGrid(cfg)) {
             assertTrue(lsn.check());
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/ListeningTestLogger.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/ListeningTestLogger.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.testframework;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
 import org.apache.ignite.IgniteLogger;
@@ -207,6 +208,13 @@ public class ListeningTestLogger implements IgniteLogger {
     /** {@inheritDoc} */
     @Override public String fileName() {
         return null;
+    }
+
+    /**
+     * @return String representation of original logger.
+     */
+    @Override public String toString() {
+        return Objects.toString(echo);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
@@ -273,7 +273,6 @@ public class GridTestLog4jLogger implements IgniteLoggerEx {
 
     /**
      * Creates new logger with given implementation.
-     *
      */
     private GridTestLog4jLogger(final Logger impl, String cfg) {
         assert impl != null;
@@ -514,7 +513,7 @@ public class GridTestLog4jLogger implements IgniteLoggerEx {
         if (!impl.isTraceEnabled())
             warning("Logging at TRACE level without checking if TRACE level is enabled: " + msg);
 
-            assert impl.isTraceEnabled() : "Logging at TRACE level without checking if TRACE level is enabled: " + msg;
+        assert impl.isTraceEnabled() : "Logging at TRACE level without checking if TRACE level is enabled: " + msg;
 
         impl.trace(msg);
     }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLogger.java
@@ -272,6 +272,23 @@ public class GridTestLog4jLogger implements IgniteLoggerEx {
     }
 
     /**
+     * Creates new logger with given implementation.
+     *
+     */
+    private GridTestLog4jLogger(final Logger impl, String cfg) {
+        assert impl != null;
+
+        addConsoleAppenderIfNeeded(null, new C1<Boolean, Logger>() {
+            @Override public Logger apply(Boolean init) {
+                return impl;
+            }
+        });
+
+        quiet = quiet0;
+        this.cfg = cfg;
+    }
+
+    /**
      * Checks if Log4j is already configured within this VM or not.
      *
      * @return {@code True} if log4j was already configured, {@code false} otherwise.
@@ -489,7 +506,7 @@ public class GridTestLog4jLogger implements IgniteLoggerEx {
             ? LogManager.getRootLogger()
             : ctgr instanceof Class
                 ? LogManager.getLogger(((Class<?>)ctgr).getName())
-                : LogManager.getLogger(ctgr.toString()));
+                : LogManager.getLogger(ctgr.toString()), cfg);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLoggerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLoggerSelfTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.testframework.junits.logger;
 
 import java.io.File;
 import java.net.URL;
-import java.util.UUID;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.logger.IgniteLoggerEx;
 import org.apache.ignite.internal.util.lang.RunnableX;
@@ -59,8 +58,6 @@ public class GridTestLog4jLoggerSelfTest {
     /** */
     @Before
     public void beforeTest() {
-        System.clearProperty("appId");
-        LogManager.shutdown();
         GridTestUtils.setFieldValue(GridTestLog4jLogger.class, GridTestLog4jLogger.class, "inited", false);
         Configurator.setRootLevel(Level.WARN);
     }
@@ -69,6 +66,7 @@ public class GridTestLog4jLoggerSelfTest {
     @After
     public void afterTest() {
         Configurator.setRootLevel(defaultRootLevel);
+
         assertEquals(defaultRootLevel, LoggerContext.getContext(false).getConfiguration().getRootLogger().getLevel());
     }
 
@@ -83,8 +81,6 @@ public class GridTestLog4jLoggerSelfTest {
 
         assertTrue(log.toString().contains("GridTestLog4jLogger"));
         assertTrue(log.toString().contains(xml.getPath()));
-
-        log.setApplicationAndNode(null, UUID.randomUUID());
 
         checkLog(log);
     }
@@ -102,8 +98,6 @@ public class GridTestLog4jLoggerSelfTest {
         assertTrue(log.toString().contains("GridTestLog4jLogger"));
         assertTrue(log.toString().contains(url.getPath()));
 
-        log.setApplicationAndNode(null, UUID.randomUUID());
-
         checkLog(log);
     }
 
@@ -114,8 +108,6 @@ public class GridTestLog4jLoggerSelfTest {
 
         assertTrue(log.toString().contains("GridTestLog4jLogger"));
         assertTrue(log.toString().contains(LOG_PATH_TEST));
-
-        log.setApplicationAndNode(null, UUID.randomUUID());
 
         checkLog(log);
     }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLoggerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/logger/GridTestLog4jLoggerSelfTest.java
@@ -28,8 +28,8 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -57,16 +57,18 @@ public class GridTestLog4jLoggerSelfTest {
     private static final Level defaultRootLevel = LogManager.getRootLogger().getLevel();
 
     /** */
-    @BeforeClass
-    public static void beforeTests() {
+    @Before
+    public void beforeTest() {
+        System.clearProperty("appId");
+        LogManager.shutdown();
+        GridTestUtils.setFieldValue(GridTestLog4jLogger.class, GridTestLog4jLogger.class, "inited", false);
         Configurator.setRootLevel(Level.WARN);
     }
 
     /** */
-    @AfterClass
-    public static void afterTests() {
+    @After
+    public void afterTest() {
         Configurator.setRootLevel(defaultRootLevel);
-
         assertEquals(defaultRootLevel, LoggerContext.getContext(false).getConfiguration().getRootLogger().getLevel());
     }
 
@@ -76,16 +78,13 @@ public class GridTestLog4jLoggerSelfTest {
         File xml = GridTestUtils.resolveIgnitePath(LOG_PATH_TEST);
 
         assert xml != null;
-        assert xml.exists();
 
-        IgniteLogger log = new GridTestLog4jLogger(xml).getLogger(getClass());
-
-        System.out.println(log.toString());
+        IgniteLoggerEx log = new GridTestLog4jLogger(xml).getLogger(getClass());
 
         assertTrue(log.toString().contains("GridTestLog4jLogger"));
         assertTrue(log.toString().contains(xml.getPath()));
 
-        ((IgniteLoggerEx)log).setApplicationAndNode(null, UUID.randomUUID());
+        log.setApplicationAndNode(null, UUID.randomUUID());
 
         checkLog(log);
     }
@@ -96,17 +95,14 @@ public class GridTestLog4jLoggerSelfTest {
         File xml = GridTestUtils.resolveIgnitePath(LOG_PATH_TEST);
 
         assert xml != null;
-        assert xml.exists();
 
         URL url = xml.toURI().toURL();
-        IgniteLogger log = new GridTestLog4jLogger(url).getLogger(getClass());
-
-        System.out.println(log.toString());
+        IgniteLoggerEx log = new GridTestLog4jLogger(url).getLogger(getClass());
 
         assertTrue(log.toString().contains("GridTestLog4jLogger"));
         assertTrue(log.toString().contains(url.getPath()));
 
-        ((IgniteLoggerEx)log).setApplicationAndNode(null, UUID.randomUUID());
+        log.setApplicationAndNode(null, UUID.randomUUID());
 
         checkLog(log);
     }
@@ -114,14 +110,12 @@ public class GridTestLog4jLoggerSelfTest {
     /** */
     @Test
     public void testPathConstructor() throws Exception {
-        IgniteLogger log = new GridTestLog4jLogger(LOG_PATH_TEST).getLogger(getClass());
-
-        System.out.println(log.toString());
+        IgniteLoggerEx log = new GridTestLog4jLogger(LOG_PATH_TEST).getLogger(getClass());
 
         assertTrue(log.toString().contains("GridTestLog4jLogger"));
         assertTrue(log.toString().contains(LOG_PATH_TEST));
 
-        ((IgniteLoggerEx)log).setApplicationAndNode(null, UUID.randomUUID());
+        log.setApplicationAndNode(null, UUID.randomUUID());
 
         checkLog(log);
     }


### PR DESCRIPTION
JavaLogger.configure method is invoked only once for all instances and it configures cfg field which was not static. Because of that only one instance had correct value and other instances had cfg with null value

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [x] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
