### PR TITLE
IGNITE-23732 .NET: Document CET crash on .NET 9 (#11677)

### DIFF
--- a/docs/_docs/net-specific/net-troubleshooting.adoc
+++ b/docs/_docs/net-specific/net-troubleshooting.adoc
@@ -178,3 +178,29 @@ NativeLibrary.SetDllImportResolver(
     (lib, _, _) => lib == "libcoreclr.so" ? (IntPtr) (-1) : IntPtr.Zero);
 ----
 --
+
+=== .NET 9: Process exited with code -1073740791 (0xc0000409)
+
+Caused by Intel CET (Control-flow Enforcement Technology) being link:https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support[enabled by default for .NET 9 assemblies].
+Ignite starts a JVM in-process, which is incompatible with CET.
+
+More details:
+
+* link:https://learn.microsoft.com/en-us/dotnet/core/compatibility/9.0[Breaking changes in .NET 9]
+* link:https://windows-internals.com/cet-on-windows/[CET Internals in Windows]
+* link:https://ptupitsyn.github.io/Ignite-on-NET-9/[Blog: Ignite on .NET 9]
+
+==== Workaround
+
+Disable CET for the application by adding the following to the main project file (csproj, vsproj, etc):
+
+[tabs]
+--
+tab:XML[]
+[source,xml]
+----
+<PropertyGroup>
+  <CETCompat>false</CETCompat>
+</PropertyGroup>
+----
+--


### PR DESCRIPTION
(cherry picked from commit 267862f5413983dbfd920cd6d123a78b5b43329a)