### PR TITLE
IGNITE-23794 Added root cause for thrown IgniteClientException on client compute task failure

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/IgniteClientException.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/IgniteClientException.java
@@ -47,7 +47,7 @@ public class IgniteClientException extends IgniteException {
      * @param msg Message.
      * @param cause Cause.
      */
-    public IgniteClientException(int statusCode, String msg, Exception cause) {
+    public IgniteClientException(int statusCode, String msg, Throwable cause) {
         super(msg, cause);
 
         this.statusCode = statusCode;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/compute/ClientComputeTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/compute/ClientComputeTask.java
@@ -114,7 +114,7 @@ class ClientComputeTask implements ClientCloseableResource {
 
         // Fail fast.
         if (taskFut.isDone() && taskFut.error() != null)
-            throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage());
+            throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage(), taskFut.error());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/compute/ClientComputeTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/compute/ClientComputeTask.java
@@ -113,11 +113,12 @@ class ClientComputeTask implements ClientCloseableResource {
         taskFut = task.execute(taskName, arg, opts);
 
         // Fail fast.
-        if (taskFut.isDone() && taskFut.error() != null)
+        if (taskFut.isDone() && taskFut.error() != null) {
             if (ctx.kernalContext().clientListener().sendServerExceptionStackTraceToClient())
                 throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage(), taskFut.error());
             else
                 throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage());
+        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/compute/ClientComputeTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/compute/ClientComputeTask.java
@@ -114,7 +114,10 @@ class ClientComputeTask implements ClientCloseableResource {
 
         // Fail fast.
         if (taskFut.isDone() && taskFut.error() != null)
-            throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage(), taskFut.error());
+            if (ctx.kernalContext().clientListener().sendServerExceptionStackTraceToClient())
+                throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage(), taskFut.error());
+            else
+                throw new IgniteClientException(ClientStatus.FAILED, taskFut.error().getMessage());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
@@ -249,6 +249,8 @@ public class ComputeTaskTest extends AbstractThinClientTest {
         }
         catch (Exception e) {
             assertNotContains(log, e.getMessage(), "Caused by: java.lang.ArithmeticException: Foo");
+            assertContains(log, e.getMessage(), "Failed to map task jobs to nodes due to undeclared user exception");
+            assertContains(log, e.getMessage(), "cause=Foo");
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
@@ -55,9 +55,8 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.apache.ignite.testframework.GridTestUtils.assertContains;
+import static org.apache.ignite.testframework.GridTestUtils.assertNotContains;
 
 /**
  * Checks compute grid functionality of thin client.
@@ -244,10 +243,12 @@ public class ComputeTaskTest extends AbstractThinClientTest {
     @Test
     public void testSendNoStackTraceOnTaskMapFail() throws Exception {
         try (IgniteClient client = startClient(0)) {
-            IgniteClientFuture<Object> fut = client.compute().executeAsync2(TestExceptionalTask.class.getName(), null);
+            client.compute().execute(TestExceptionalTask.class.getName(), null);
 
-            Throwable err = fut.handle((f, t) -> t).toCompletableFuture().get(2, TimeUnit.SECONDS);
-            assertThat(err.getMessage(), not(containsString("Caused by: java.lang.ArithmeticException: Foo")));
+            fail();
+        }
+        catch (Exception e) {
+            assertNotContains(log, e.getMessage(), "Caused by: java.lang.ArithmeticException: Foo");
         }
     }
 
@@ -257,10 +258,12 @@ public class ComputeTaskTest extends AbstractThinClientTest {
     @Test
     public void testSendStackTraceOnTaskMapFail() throws Exception {
         try (IgniteClient client = startClient(1)) {
-            IgniteClientFuture<Object> fut = client.compute().executeAsync2(TestExceptionalTask.class.getName(), null);
+            client.compute().execute(TestExceptionalTask.class.getName(), null);
 
-            Throwable err = fut.handle((f, t) -> t).toCompletableFuture().get(2, TimeUnit.SECONDS);
-            assertThat(err.getMessage(), containsString("Caused by: java.lang.ArithmeticException: Foo"));
+            fail();
+        }
+        catch (Exception e) {
+            assertContains(log, e.getMessage(), "Caused by: java.lang.ArithmeticException: Foo");
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
@@ -242,7 +242,7 @@ public class ComputeTaskTest extends AbstractThinClientTest {
      * Tests asynchronous task execution with an exception and no stacktrace in error message (by default).
      */
     @Test
-    public void testExecuteTaskAsync2WithExceptionInTaskAndNoStacktrace() throws Exception {
+    public void testSendNoStackTraceOnTaskMapFail() throws Exception {
         try (IgniteClient client = startClient(0)) {
             IgniteClientFuture<Object> fut = client.compute().executeAsync2(TestExceptionalTask.class.getName(), null);
 
@@ -255,7 +255,7 @@ public class ComputeTaskTest extends AbstractThinClientTest {
      * Tests asynchronous task execution with an exception and stacktrace in error message.
      */
     @Test
-    public void testExecuteTaskAsync2WithExceptionInTaskAndStacktrace() throws Exception {
+    public void testSendStackTraceOnTaskMapFail() throws Exception {
         try (IgniteClient client = startClient(1)) {
             IgniteClientFuture<Object> fut = client.compute().executeAsync2(TestExceptionalTask.class.getName(), null);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
@@ -238,7 +238,7 @@ public class ComputeTaskTest extends AbstractThinClientTest {
     }
 
     /**
-     * Tests asynchronous task execution with an exception and no stacktrace in error message (by default).
+     * Tests task execution with an exception and no stacktrace in error message (by default).
      */
     @Test
     public void testSendNoStackTraceOnTaskMapFail() throws Exception {
@@ -253,7 +253,7 @@ public class ComputeTaskTest extends AbstractThinClientTest {
     }
 
     /**
-     * Tests asynchronous task execution with an exception and stacktrace in error message.
+     * Tests task execution with an exception and full stacktrace in error message.
      */
     @Test
     public void testSendStackTraceOnTaskMapFail() throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ComputeTaskTest.java
@@ -239,7 +239,7 @@ public class ComputeTaskTest extends AbstractThinClientTest {
     }
 
     /**
-     * Tests asynchronous task execution with an exception.
+     * Tests asynchronous task execution with an exception and no stacktrace in error message (by default).
      */
     @Test
     public void testExecuteTaskAsync2WithExceptionInTaskAndNoStacktrace() throws Exception {
@@ -252,7 +252,7 @@ public class ComputeTaskTest extends AbstractThinClientTest {
     }
 
     /**
-     * Tests asynchronous task execution with an exception.
+     * Tests asynchronous task execution with an exception and stacktrace in error message.
      */
     @Test
     public void testExecuteTaskAsync2WithExceptionInTaskAndStacktrace() throws Exception {


### PR DESCRIPTION
Added root cause for thrown IgniteClientException when client compute task fails with error. This information was lost when task computation issue happened.

Enhanced IgniteClientException constructor with Throwable argument, which replaced Exception, since task error is Throwable object.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
