### PR TITLE
IGNITE-23820 Run privileged workflow against approved commit

### DIFF
--- a/.github/workflows/sonar-pr-from-fork-build.yml
+++ b/.github/workflows/sonar-pr-from-fork-build.yml
@@ -32,11 +32,6 @@ jobs:
     name: Build artifacts for Sonar Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
-          persist-credentials: false
-
       - name: Set up JDK11
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/sonar-pr-from-fork-scan.yml
+++ b/.github/workflows/sonar-pr-from-fork-scan.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Read pull request event
         shell: bash
         run: |
+          # We can trust these values because we use 'workflow approval' to
+          # review the PR before approving the workflow:
           echo "pr_number=$(sed '1q;d' pr-event.txt)" >> "$GITHUB_ENV"
           echo "pr_head_ref=$(sed '2q;d' pr-event.txt)" >> "$GITHUB_ENV"
           echo "pr_base_ref=$(sed '3q;d' pr-event.txt)" >> "$GITHUB_ENV"
@@ -83,18 +85,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
             # "fetch-depth: 0" is needed for Sonar's new code detection, blame information and issue backdating
             # see more details at https://community.sonarsource.com/t/git-fetch-depth-implications/75260
-
-      - name: Checkout PR base branch
-        run: |
-          git remote add upstream ${{ github.event.repository.clone_url }}
-          git fetch upstream
-          git checkout -B $pr_base_ref upstream/$pr_base_ref
-          git checkout ${{ github.event.workflow_run.head_branch }}
-          git clean -ffdx && git reset --hard HEAD
 
       - name: Download compiled classes artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
`sonar-pr-from-fork-build.yml` and `sonar-pr-from-fork-scan.yml` analyze PRs. `sonar-pr-from-fork-scan.yml` needs privileges to access the `SONARCLOUD_TOKEN` and to update the status of the PR check.

To avoid a malicious PR from accessing those privileges, Ignite requires approval for GitHub Actions, and reviews the PR to catch any malicious code before approving the workflow.

These changes makes sure the privileged workflow is ran against the commit that was approved, and does not pull in any changes that may have been added to the PR after approval.