### PR TITLE
IGNITE-24264 Replace Google Analytics with Matomo (Ignite-2.9-docs)

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -20,16 +20,6 @@
       
 <html lang="en">
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1382082-1"></script>
-    <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-61232409-1');
-    </script>
-
     {% if page.content == nil or page.content == ""  %}
 <META NAME="ROBOTS" CONTENT="NOINDEX">
 {% endif %}
@@ -54,6 +44,23 @@
     <script type="text/javascript" src="{{'assets/js/jquery.swiftype.autocomplete.js?' |append: timestamp |relative_url}}"></script>
     <script type="text/javascript" src="{{'assets/js/anchor.min.js?'|append: timestamp|relative_url}}"></script>
     
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["setDoNotTrack", true]);
+      _paq.push(["disableCookies"]);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '77']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
 
 </head>
 <body>


### PR DESCRIPTION
## Change
This is one of a number of PR's I'm submitting to remove  **_Google_** & **_Yandex_** analytics from the Ignite website as part of [IGNITE-24264](https://issues.apache.org/jira/browse/IGNITE-24264). I have also included replacing those analytics which are not permitted at the ASF with _**Matomo**_ (see [analytics.apache.org](https://analytics.apache.org/)).

From what I see, it looks like you sometimes re-generate your docs from the branches, so I've cherry picked the change across branches - hence the number of PRs

### Previous PR
I didn't have much idea how the docs/website were built when I submitted [PR #189](https://github.com/apache/ignite-website/pull/189) - so thanks for applying that, but it seems it had no effect. Hopefully this effort will yield better results.


## Review
Thank you for submitting the pull request.

To streamline the review process of the patch and ensure better code quality
we ask both an author and a reviewer to verify the following:

### The Review Checklist
- [X] **Formal criteria:** TC status, codestyle, mandatory documentation. Also make sure to complete the following:  
\- There is a single JIRA ticket related to the pull request.  
\- The web-link to the pull request is attached to the JIRA ticket.  
\- The JIRA ticket has the Patch Available state.  
\- The description of the JIRA ticket explains WHAT was made, WHY and HOW.  
\- The pull request title is treated as the final commit message. The following pattern must be used: IGNITE-XXXX Change summary where XXXX - number of JIRA issue.
- [X] **Design:** new code conforms with the design principles of the components it is added to.
- [X] **Patch quality:** patch cannot be split into smaller pieces, its size must be reasonable.
- [X] **Code quality:** code is clean and readable, necessary developer documentation is added if needed.
- [X] **Tests code quality:** test set covers positive/negative scenarios, happy/edge cases. Tests are effective in terms of execution time and resources.

### Notes
- [Apache Ignite Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Java+Code+Style+Guide)