### PR TITLE
IGNITE-25322 defaultSerializer in BinaryContext should take into consideration the user passed binary config.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryContext.java
@@ -867,9 +867,11 @@ public class BinaryContext {
      *
      * @param cls Class.
      * @return Serializer for class or {@code null} if none exists.
+     *
+     * Note: visible for testing.
      */
-    @Nullable private BinarySerializer serializerForClass(Class cls) {
-        BinarySerializer serializer = defaultSerializer();
+    @Nullable BinarySerializer serializerForClass(Class cls) {
+        BinarySerializer serializer = defaultSerializer(cls);
 
         if (serializer == null && canUseReflectiveSerializer(cls))
             serializer = new BinaryReflectiveSerializer();
@@ -878,12 +880,25 @@ public class BinaryContext {
     }
 
     /**
+     * Gets the default serializer for the given class.
+     *
+     * @param cls Class.
      * @return Default serializer.
      */
-    private BinarySerializer defaultSerializer() {
+    private BinarySerializer defaultSerializer(Class cls) {
         BinaryConfiguration binCfg = igniteCfg.getBinaryConfiguration();
+        if (binCfg == null) {
+            return null;
+        }
 
-        return binCfg != null ? binCfg.getSerializer() : null;
+        for (BinaryTypeConfiguration typeCfg : binCfg.getTypeConfigurations()) {
+            // TODO(taouad): handle the case with .*
+            if (typeCfg.getTypeName().equals(cls.getName())) {
+                return typeCfg.getSerializer();
+            }
+        }
+
+        return binCfg.getSerializer();
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryContextUserDefinedTypesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryContextUserDefinedTypesTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.binary;
+
+import java.util.List;
+
+import org.apache.ignite.binary.BinaryObjectException;
+import org.apache.ignite.binary.BinaryReader;
+import org.apache.ignite.binary.BinaryReflectiveSerializer;
+import org.apache.ignite.binary.BinarySerializer;
+import org.apache.ignite.binary.BinaryTypeConfiguration;
+import org.apache.ignite.binary.BinaryWriter;
+import org.apache.ignite.configuration.BinaryConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+
+/**
+ *
+ */
+public class BinaryContextUserDefinedTypesTest extends GridCommonAbstractTest {
+    /**
+     * Tests that user defined types have get the correct serializer.
+     */
+    @Test
+    public void testDefaultConstructor() {
+        IgniteConfiguration igniteCfg = new IgniteConfiguration();
+        List<BinaryTypeConfiguration> binaryTypeCfgs = List.of(
+            new BinaryTypeConfiguration(UserDefinedTypeWithBinarySerializer.class.getCanonicalName()).setSerializer(new BinaryReflectiveSerializer()),
+            new BinaryTypeConfiguration(UserDefinedTypeWithBinarySerializer.class.getCanonicalName()).setSerializer(new BinaryReflectiveSerializer())
+        );
+        igniteCfg.setBinaryConfiguration(new BinaryConfiguration()
+            .setSerializer(new DefaultSerializer())
+            .setTypeConfigurations(binaryTypeCfgs)
+        );
+
+        BinaryContext binCtx = new BinaryContext(BinaryNoopMetadataHandler.instance(), igniteCfg, log);
+
+        // Validate that if a serializer is provided in the configuration, it is used instead of the default one.
+        // TODO(taouad): test the case with .*
+        assertEquals(BinaryReflectiveSerializer.class, binCtx.serializerForClass(UserDefinedTypeWithDefaultSerializer.class));
+        assertEquals(DefaultSerializer.class, binCtx.serializerForClass(UserDefinedTypeWithDefaultSerializer.class));
+    }
+
+    static class UserDefinedTypeWithDefaultSerializer {
+    }
+
+    static class UserDefinedTypeWithBinarySerializer {
+    }
+
+    private static class DefaultSerializer implements BinarySerializer {
+        @Override
+        public void writeBinary(Object obj, BinaryWriter writer) throws BinaryObjectException {
+        }
+
+        @Override
+        public void readBinary(Object obj, BinaryReader reader) throws BinaryObjectException {
+        }
+    }
+}


### PR DESCRIPTION
Ignite thin client has a seemingly incoherent behavior for determining the serializer of a user defined type.
On thin client startup, the passed binary configuration, is taken into account when registering the type descriptors.
For each binary type configuration, the type is registered along with its specified serializer, rather than the default serializer being chosen for it.

This is not what is happening, however, in the following case:
A thin client is connected to 2 servers. One of the servers crashes (chaos testing). The reliable channel fail listener is invoked which cleans up registered type descriptors. When a type that was initially configured in the binary config along with its serializer is used, the type descriptor will be recreated, passing through the method defaultSerializer, which only returns the default serializer if defined, ignoring whether or not a specific config has been specified for the class.

In this pr, I align the behavior at startup with the behavior after a server crash.
