### PR TITLE
IGNITE-25322 Fix defaultSerializer in BinaryContext to take into consideration the user passed binary config.

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryContextUserDefinedTypesTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryContextUserDefinedTypesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.binary;
+
+import java.util.List;
+
+import org.apache.ignite.binary.BinaryObjectException;
+import org.apache.ignite.binary.BinaryReader;
+import org.apache.ignite.binary.BinaryReflectiveSerializer;
+import org.apache.ignite.binary.BinarySerializer;
+import org.apache.ignite.binary.BinaryTypeConfiguration;
+import org.apache.ignite.binary.BinaryWriter;
+import org.apache.ignite.configuration.BinaryConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.binary.test.subpackage.GridBinaryTestClass3;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+
+/**
+ *
+ */
+public class BinaryContextUserDefinedTypesTest extends GridCommonAbstractTest {
+    /**
+     * Tests that user defined types have get the correct serializer.
+     */
+    @Test
+    public void testDefaultConstructor() {
+        IgniteConfiguration igniteCfg = new IgniteConfiguration();
+        List<BinaryTypeConfiguration> binaryTypeCfgs = List.of(
+            new BinaryTypeConfiguration(UserDefinedTypeWithBinarySerializer.class.getCanonicalName()).setSerializer(new BinaryReflectiveSerializer()),
+            new BinaryTypeConfiguration(GridBinaryTestClass3.class.getPackageName() + ".*").setSerializer(new BinaryReflectiveSerializer())
+        );
+        igniteCfg.setBinaryConfiguration(new BinaryConfiguration()
+            .setSerializer(new DefaultSerializer())
+            .setTypeConfigurations(binaryTypeCfgs)
+        );
+
+        BinaryContext binCtx = new BinaryContext(BinaryNoopMetadataHandler.instance(), igniteCfg, log);
+
+        // Validate that if a serializer is provided in the configuration, it is used instead of the default one.
+        assertEquals(BinaryReflectiveSerializer.class, binCtx.serializerForClass(UserDefinedTypeWithBinarySerializer.class));
+        assertEquals(BinaryReflectiveSerializer.class, binCtx.serializerForClass(GridBinaryTestClass3.class));
+        assertEquals(DefaultSerializer.class, binCtx.serializerForClass(UserDefinedTypeWithDefaultSerializer.class));
+    }
+
+    static class UserDefinedTypeWithDefaultSerializer {
+        // No-op.
+    }
+
+    static class UserDefinedTypeWithBinarySerializer {
+        // No-op.
+    }
+
+    private static class DefaultSerializer implements BinarySerializer {
+        @Override
+        public void writeBinary(Object obj, BinaryWriter writer) throws BinaryObjectException {
+            // No-op.
+        }
+
+        @Override
+        public void readBinary(Object obj, BinaryReader reader) throws BinaryObjectException {
+            // No-op.
+        }
+    }
+}


### PR DESCRIPTION
Ignite thin client has a seemingly incoherent behavior for determining the serializer of a user defined type.
On thin client startup, the passed binary configuration, is taken into account when registering the type descriptors.
For each binary type configuration, the type is registered along with its specified serializer, rather than the default serializer being chosen for it.

This is not what is happening, however, in the following case:
A thin client is connected to 2 servers. One of the servers crashes (chaos testing). The reliable channel fail listener is invoked which cleans up registered type descriptors. When a type that was initially configured in the binary config along with its serializer is used, the type descriptor will be recreated, passing through the method defaultSerializer, which only returns the default serializer if defined, ignoring whether or not a specific config has been specified for the class.

In this pr, I align the behavior at startup with the behavior after a server crash.

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
