### PR TITLE
IGNITE-26219 Move in-field init to constructors for serialized fields in Messages

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/authentication/UserAuthenticateRequestMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/authentication/UserAuthenticateRequestMessage.java
@@ -36,7 +36,7 @@ public class UserAuthenticateRequestMessage implements Message {
 
     /** Request ID. */
     @Order(2)
-    private IgniteUuid id = IgniteUuid.randomUuid();
+    private IgniteUuid id;
 
     /**
      *
@@ -52,6 +52,7 @@ public class UserAuthenticateRequestMessage implements Message {
     public UserAuthenticateRequestMessage(String name, String passwd) {
         this.name = name;
         this.passwd = passwd;
+        id = IgniteUuid.randomUuid();
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/KeyCacheObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/KeyCacheObjectImpl.java
@@ -34,7 +34,7 @@ public class KeyCacheObjectImpl extends CacheObjectAdapter implements KeyCacheOb
     private static final long serialVersionUID = 0L;
 
     /** */
-    private int part = -1;
+    private int part;
 
     /**
      *

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionSupplyMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionSupplyMessage.java
@@ -75,7 +75,7 @@ public class GridDhtPartitionSupplyMessage extends GridCacheGroupIdMessage imple
     private int msgSize;
 
     /** Estimated keys count. */
-    private long estimatedKeysCnt = -1;
+    private long estimatedKeysCnt;
 
     /** Estimated keys count per cache in case the message is for shared group. */
     @GridDirectMap(keyType = int.class, valueType = long.class)
@@ -97,6 +97,7 @@ public class GridDhtPartitionSupplyMessage extends GridCacheGroupIdMessage imple
         this.rebalanceId = rebalanceId;
         this.topVer = topVer;
         this.addDepInfo = addDepInfo;
+        estimatedKeysCnt = -1L;
     }
 
     /**
@@ -446,7 +447,7 @@ public class GridDhtPartitionSupplyMessage extends GridCacheGroupIdMessage imple
      * @param cnt Keys count to add.
      */
     public void addEstimatedKeysCount(long cnt) {
-        this.estimatedKeysCnt += cnt;
+        estimatedKeysCnt += cnt;
     }
 
     /**


### PR DESCRIPTION
Fields with @GridDirectTransient were ignored. 
removed  unnecessary 'this' in following boy scout rule

---

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
