### PR TITLE
IGNITE-26266: Mark IndexQuery#getCriteria with @Nullable

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/IndexQuery.java
@@ -138,6 +138,7 @@ public final class IndexQuery<K, V> extends Query<Cache.Entry<K, V>> {
      *
      * @return List of criteria for this index query.
      */
+    @Nullable
     public List<IndexQueryCriterion> getCriteria() {
         return criteria;
     }


### PR DESCRIPTION
Mark IndexQuery#getCriteria with @Nullable to avoid warning and highlight warning to a user.