### PR TITLE
IGNITE-26356 Clarify recommendations for -XX:MaxDirectMemorySize in docs

### DIFF
--- a/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
+++ b/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
@@ -122,10 +122,8 @@ Note that 10GB heap is used as an example and a smaller heap can be enough for y
 
 [NOTE]
 ====
-//TODO: Is this still valid? What does it do?
-If you use link:persistence/native-persistence[Ignite native persistence], we recommend that you set the
-`MaxDirectMemorySize` JVM parameter to `walSegmentSize * 4`.
-With the default WAL settings, this value is equal to 256MB.
+If you use link:persistence/native-persistence[Ignite native persistence], we recommend relying on the JVM default for direct memory. By default, the JVM allows direct buffers grow up to the Java heap size (-Xmx), which is sufficient in most cases.
+If you need an explicit limit, set `-XX:MaxDirectMemorySize` to at least `walSegmentSize * 4` (256 MB with the default WAL settings).
 ====
 
 === Advanced Memory Tuning

--- a/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
+++ b/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
@@ -123,7 +123,7 @@ Note that 10GB heap is used as an example and a smaller heap can be enough for y
 [NOTE]
 ====
 If you use link:persistence/native-persistence[Ignite native persistence], we recommend relying on the JVM default configuration of direct memory. By default, the JVM allows direct buffers grow up to the Java heap size (-Xmx), which is sufficient in most cases.
-If you need to override default limit for direct memory size, you should set `-XX:MaxDirectMemorySize` to at least `walSegmentSize * 4` (256 MB with the default WAL settings).
+If you need to override the default limit for direct memory size, you should set `-XX:MaxDirectMemorySize` to at least `walSegmentSize * 4` (256 MB with the default WAL settings).
 ====
 
 === Advanced Memory Tuning

--- a/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
+++ b/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
@@ -122,7 +122,7 @@ Note that 10GB heap is used as an example and a smaller heap can be enough for y
 
 [NOTE]
 ====
-If you use link:persistence/native-persistence[Ignite native persistence], we recommend relying on the JVM default for direct memory. By default, the JVM allows direct buffers grow up to the Java heap size (-Xmx), which is sufficient in most cases.
+If you use link:persistence/native-persistence[Ignite native persistence], we recommend relying on the JVM default configuration of direct memory. By default, the JVM allows direct buffers grow up to the Java heap size (-Xmx), which is sufficient in most cases.
 If you need an explicit limit, set `-XX:MaxDirectMemorySize` to at least `walSegmentSize * 4` (256 MB with the default WAL settings).
 ====
 

--- a/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
+++ b/docs/_docs/perf-and-troubleshooting/memory-tuning.adoc
@@ -123,7 +123,7 @@ Note that 10GB heap is used as an example and a smaller heap can be enough for y
 [NOTE]
 ====
 If you use link:persistence/native-persistence[Ignite native persistence], we recommend relying on the JVM default configuration of direct memory. By default, the JVM allows direct buffers grow up to the Java heap size (-Xmx), which is sufficient in most cases.
-If you need an explicit limit, set `-XX:MaxDirectMemorySize` to at least `walSegmentSize * 4` (256 MB with the default WAL settings).
+If you need to override default limit for direct memory size, you should set `-XX:MaxDirectMemorySize` to at least `walSegmentSize * 4` (256 MB with the default WAL settings).
 ====
 
 === Advanced Memory Tuning


### PR DESCRIPTION
### What was made
- Fixed documentation: the tuning advice was misleading, since the default limit for direct buffers is already equal to -Xmx.
---
Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [x] There is a single JIRA ticket related to the pull request. 
- [x] The web-link to the pull request is attached to the JIRA ticket.
- [x] The JIRA ticket has the _Patch Available_ state.
- [x] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [x] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [x] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
