### PR TITLE
IGNITE-26757 Fix incorrect instance name in GridNioServerWrapper

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/TcpCommunicationSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/TcpCommunicationSpi.java
@@ -659,7 +659,7 @@ public class TcpCommunicationSpi extends TcpCommunicationConfigInitializer {
             commWorker,
             ignite.configuration(),
             this.srvLsnr,
-            getName(),
+            igniteInstanceName,
             getWorkersRegistry(ignite),
             ignite instanceof IgniteEx ? ((IgniteEx)ignite).context().metric() : null,
             this::createTcpClient,


### PR DESCRIPTION
Fixed  serialization failures of .NET errors at list occurred in `Cache#Invoke`. Failures caused by incorrect instance name in `GridNioServerWrapper`.
Incorrect instance name in `GridNioServerWrapper` leads to propagation such name to `IgniteThread#igniteInstanceName` and to impocibillity to get `Ignite` instance by calling `IgniteEx#gridx`.

----

Thank you for submitting the pull request to the Apache Ignite.

In order to streamline the review of the contribution 
we ask you to ensure the following steps have been taken:

### The Contribution Checklist
- [ ] There is a single JIRA ticket related to the pull request. 
- [ ] The web-link to the pull request is attached to the JIRA ticket.
- [ ] The JIRA ticket has the _Patch Available_ state.
- [ ] The pull request body describes changes that have been made. 
The description explains _WHAT_ and _WHY_ was made instead of _HOW_.
- [ ] The pull request title is treated as the final commit message. 
The following pattern must be used: `IGNITE-XXXX Change summary` where `XXXX` - number of JIRA issue.
- [ ] A reviewer has been mentioned through the JIRA comments 
(see [the Maintainers list](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute#HowtoContribute-ReviewProcessandMaintainers)) 
- [ ] The pull request has been checked by the Teamcity Bot and 
the `green visa` attached to the JIRA ticket (see [TC.Bot: Check PR](https://mtcga.gridgain.com/prs.html))

### Notes
- [How to Contribute](https://cwiki.apache.org/confluence/display/IGNITE/How+to+Contribute)
- [Coding abbreviation rules](https://cwiki.apache.org/confluence/display/IGNITE/Abbreviation+Rules)
- [Coding Guidelines](https://cwiki.apache.org/confluence/display/IGNITE/Coding+Guidelines)
- [Apache Ignite Teamcity Bot](https://cwiki.apache.org/confluence/display/IGNITE/Apache+Ignite+Teamcity+Bot)

If you need any help, please email dev@ignite.apache.org or ask anу advice on http://asf.slack.com _#ignite_ channel.
