### PR TITLE
test: Replace LZ4FastDecompressor with LZ4SafeDecompressor in test

### DIFF
--- a/modules/compress/src/test/java/org/apache/ignite/internal/processors/cache/transform/AbstractCacheObjectCompressionTest.java
+++ b/modules/compress/src/test/java/org/apache/ignite/internal/processors/cache/transform/AbstractCacheObjectCompressionTest.java
@@ -22,8 +22,8 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 import com.github.luben.zstd.Zstd;
 import net.jpountz.lz4.LZ4Compressor;
-import net.jpountz.lz4.LZ4Decompressor;
 import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4SafeDecompressor;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.ThreadLocalDirectByteBuffer;
@@ -97,7 +97,7 @@ public abstract class AbstractCacheObjectCompressionTest extends AbstractCacheOb
         private static final LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
 
         /** */
-        static final LZ4Decompressor lz4Decompressor = lz4Factory.safeDecompressor();
+        static final LZ4SafeDecompressor lz4Decompressor = lz4Factory.safeDecompressor();
 
         /** */
         static final LZ4Compressor lz4Compressor = lz4Factory.highCompressor(1);


### PR DESCRIPTION
Tidy up test to not use unsafe decompressor implicated in [CVE-2025-12183](https://sites.google.com/sonatype.com/vulnerabilities/cve-2025-12183)