### PR TITLE
IGNITE-27274 Get rid of thread local usage during BO marshaling

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -1332,7 +1332,7 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
                 return node;
             }
             finally {
-                IgniteUtils.setCurrentIgniteName(null);
+                //IgniteUtils.setCurrentIgniteName(null);
             }
         }
         else
@@ -1587,7 +1587,7 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
                     IgnitionEx.stop(igniteInstanceName, cancel, null, stopNotStarted);
                 }
                 finally {
-                    IgniteUtils.setCurrentIgniteName(null);
+                    //IgniteUtils.setCurrentIgniteName(null);
                 }
             }
             else


### PR DESCRIPTION
with PR
Benchmark                               (mapType)  (size)  Mode  Cnt        Score        Error  Units
JmhMapSerdesBenchmark.mapSerialization    HashMap  100000  avgt   15  3551882.126 ± 371538.570  ns/op

master
Benchmark                               (mapType)  (size)  Mode  Cnt        Score        Error  Units
JmhMapSerdesBenchmark.mapSerialization    HashMap  100000  avgt   15  6658072.198 ± 614606.382  ns/op
