### PR TITLE
IGNITE-28485 Fix 'illegal reflective access' during control utility startup

### DIFF
--- a/bin/include/jvmdefaults.bat
+++ b/bin/include/jvmdefaults.bat
@@ -32,6 +32,7 @@ if %java_version% GEQ 11 if %java_version% LSS 14 (
     --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
     --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
     --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED ^
+    --add-opens=java.base/java.nio=ALL-UNNAMED ^
     --illegal-access=permit ^
     %current_value%
 )
@@ -45,6 +46,7 @@ if %java_version% GEQ 14 if %java_version% LSS 15 (
     --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
     --add-opens=java.base/jdk.internal.access=ALL-UNNAMED ^
     --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED ^
+    --add-opens=java.base/java.nio=ALL-UNNAMED ^
     --illegal-access=permit ^
     %current_value%
 )

--- a/bin/include/jvmdefaults.sh
+++ b/bin/include/jvmdefaults.sh
@@ -32,6 +32,7 @@ getJavaSpecificOpts() {
           --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
           --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
           --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
+          --add-opens=java.base/java.nio=ALL-UNNAMED \
           --illegal-access=permit \
           ${current_value}"
 
@@ -44,6 +45,7 @@ getJavaSpecificOpts() {
             --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
             --add-opens=java.base/jdk.internal.access=ALL-UNNAMED \
             --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
+            --add-opens=java.base/java.nio=ALL-UNNAMED \
             --illegal-access=permit \
             ${current_value}"
 

--- a/docs/_docs/includes/java9.adoc
+++ b/docs/_docs/includes/java9.adoc
@@ -35,6 +35,7 @@ tab:Java 11[]
 --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
 --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
 --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED
+--add-opens=java.base/java.nio=ALL-UNNAMED
 --illegal-access=permit
 ----
 


### PR DESCRIPTION
before:
```
java -version
openjdk version "11.0.19" 2023-04-18

./control.sh  | grep illegal-access=warn
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.ignite.internal.util.GridUnsafe$2 (file:/home/apache-ignite-slim-2.18.0-bin/libs/ignite-core-2.18.0.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of org.apache.ignite.internal.util.GridUnsafe$2
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations

```

after - No warn found in logs.