### PR TITLE
Fix 'occured' -> 'occurred' typos in MetricsMxBean @throws javadoc

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/mxbean/MetricsMxBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/mxbean/MetricsMxBean.java
@@ -46,7 +46,7 @@ public interface MetricsMxBean {
      *
      * @param name Metric name.
      * @param rateTimeInterval New rate time interval.
-     * @throws IgniteException If some error occured.
+     * @throws IgniteException If some error occurred.
      */
     @MXBeanDescription("Configure hitrate metric.")
     public void configureHitRateMetric(
@@ -60,7 +60,7 @@ public interface MetricsMxBean {
      *
      * @param name Metric name.
      * @param bounds New bounds.
-     * @throws IgniteException If some error occured.
+     * @throws IgniteException If some error occurred.
      */
     @MXBeanDescription("Configure histogram metric.")
     public void configureHistogramMetric(


### PR DESCRIPTION
Two `@throws IgniteException` javadoc entries on `MetricsMxBean` in `modules/core/src/main/java/org/apache/ignite/mxbean/MetricsMxBean.java` (lines 49 and 63) read `If some error occured`. Doc-only Java change.