### PR TITLE
IGNITE: fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/management/cache/IdleVerifyException.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/cache/IdleVerifyException.java
@@ -23,7 +23,7 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.internal.util.typedef.F;
 
 /**
- * This exception is used to collect exceptions occured in {@link VerifyBackupPartitionsTask} execution.
+ * This exception is used to collect exceptions that occurred in {@link VerifyBackupPartitionsTask} execution.
  */
 public class IdleVerifyException extends IgniteException {
     /** */

--- a/modules/core/src/main/java/org/apache/ignite/mxbean/MetricsMxBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/mxbean/MetricsMxBean.java
@@ -46,7 +46,7 @@ public interface MetricsMxBean {
      *
      * @param name Metric name.
      * @param rateTimeInterval New rate time interval.
-     * @throws IgniteException If some error occured.
+     * @throws IgniteException If some error occurred.
      */
     @MXBeanDescription("Configure hitrate metric.")
     public void configureHitRateMetric(
@@ -60,7 +60,7 @@ public interface MetricsMxBean {
      *
      * @param name Metric name.
      * @param bounds New bounds.
-     * @throws IgniteException If some error occured.
+     * @throws IgniteException If some error occurred.
      */
     @MXBeanDescription("Configure histogram metric.")
     public void configureHistogramMetric(

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/ICache.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/ICache.cs
@@ -836,7 +836,7 @@ namespace Apache.Ignite.Core.Cache
         /// <param name="processor">The processor.</param>
         /// <param name="arg">The argument.</param>
         /// <returns>Result of the processing.</returns>
-        /// <exception cref="CacheEntryProcessorException">If an exception has occured during processing.</exception>
+        /// <exception cref="CacheEntryProcessorException">If an exception has occurred during processing.</exception>
         TRes Invoke<TArg, TRes>(TK key, ICacheEntryProcessor<TK, TV, TArg, TRes> processor, TArg arg);
 
         /// <summary>
@@ -851,7 +851,7 @@ namespace Apache.Ignite.Core.Cache
         /// <param name="processor">The processor.</param>
         /// <param name="arg">The argument.</param>
         /// <returns>Result of the processing.</returns>
-        /// <exception cref="CacheEntryProcessorException">If an exception has occured during processing.</exception>
+        /// <exception cref="CacheEntryProcessorException">If an exception has occurred during processing.</exception>
         Task<TRes> InvokeAsync<TArg, TRes>(TK key, ICacheEntryProcessor<TK, TV, TArg, TRes> processor, TArg arg);
 
         /// <summary>
@@ -878,7 +878,7 @@ namespace Apache.Ignite.Core.Cache
         /// defined by the <see cref="ICacheEntryProcessor{K,V,A,R}"/> implementation.
         /// No mappings will be returned for processors that return a null value for a key.
         /// </returns>
-        /// <exception cref="CacheEntryProcessorException">If an exception has occured during processing.</exception>
+        /// <exception cref="CacheEntryProcessorException">If an exception has occurred during processing.</exception>
         ICollection<ICacheEntryProcessorResult<TK, TRes>> InvokeAll<TArg, TRes>(IEnumerable<TK> keys,
             ICacheEntryProcessor<TK, TV, TArg, TRes> processor, TArg arg);
 
@@ -906,7 +906,7 @@ namespace Apache.Ignite.Core.Cache
         /// defined by the <see cref="ICacheEntryProcessor{K,V,A,R}"/> implementation.
         /// No mappings will be returned for processors that return a null value for a key.
         /// </returns>
-        /// <exception cref="CacheEntryProcessorException">If an exception has occured during processing.</exception>
+        /// <exception cref="CacheEntryProcessorException">If an exception has occurred during processing.</exception>
         Task<ICollection<ICacheEntryProcessorResult<TK, TRes>>> InvokeAllAsync<TArg, TRes>(IEnumerable<TK> keys,
             ICacheEntryProcessor<TK, TV, TArg, TRes> processor, TArg arg);
 


### PR DESCRIPTION
Trivial spelling fix in three source files — `occured` → `occurred`.

All three occurrences are in API documentation, where `/// <exception>` and `@throws` tags are rendered in the Javadoc / C# XML-doc output that users see:

- `modules/core/.../mxbean/MetricsMxBean.java` — `@throws IgniteException If some error occurred.` on `configureHitRateMetric` and `configureHistogramMetric`.
- `modules/core/.../management/cache/IdleVerifyException.java` — class Javadoc.
- `modules/platforms/dotnet/.../Cache/ICache.cs` — `<exception cref="CacheEntryProcessorException">If an exception has occurred during processing.</exception>` on `Invoke` / `InvokeAll` overloads.

No functional changes.