### PR TITLE
Fix broken Maven central badge in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/apache/ignite.svg?branch=master)](https://travis-ci.org/apache/ignite)
 [![GitHub](https://img.shields.io/github/license/apache/ignite?color=blue)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Maven Central](https://maven-badges.sml.io/maven-central/org.apache.ignite/ignite-core/badge.svg)](https://search.maven.org/search?q=org.apache.ignite)
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.ignite/ignite-core?label=Maven%20Central&versionPrefix=2)](https://search.maven.org/search?q=org.apache.ignite)
 [![GitHub release](https://img.shields.io/badge/release-download-brightgreen.svg)](https://ignite.apache.org/download.cgi)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/apache/ignite)
 [![Twitter Follow](https://img.shields.io/twitter/follow/ApacheIgnite?style=social)](https://twitter.com/ApacheIgnite)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/apache/ignite.svg?branch=master)](https://travis-ci.org/apache/ignite)
 [![GitHub](https://img.shields.io/github/license/apache/ignite?color=blue)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.ignite/ignite-core/badge.svg)](https://search.maven.org/search?q=org.apache.ignite)
+[![Maven Central](https://maven-badges.sml.io/maven-central/org.apache.ignite/ignite-core/badge.svg)](https://search.maven.org/search?q=org.apache.ignite)
 [![GitHub release](https://img.shields.io/badge/release-download-brightgreen.svg)](https://ignite.apache.org/download.cgi)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/apache/ignite)
 [![Twitter Follow](https://img.shields.io/twitter/follow/ApacheIgnite?style=social)](https://twitter.com/ApacheIgnite)


### PR DESCRIPTION
The Maven central badge in `README` does not load; the [URL to the badge has changed](https://github.com/softwaremill/maven-badges#a-new-dns-address).