### PR TITLE
IGNITE-15735 Ingite configuration log message improvements

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/DataStorageConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.internal.processors.cache.persistence.file.AsyncFileIOFactory;
 import org.apache.ignite.internal.processors.cache.persistence.file.FileIOFactory;
 import org.apache.ignite.internal.processors.cache.persistence.file.RandomAccessFileIOFactory;
+import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -301,6 +302,7 @@ public class DataStorageConfiguration implements Serializable {
     private boolean alwaysWriteFullPages = DFLT_WAL_ALWAYS_WRITE_FULL_PAGES;
 
     /** Factory to provide I/O interface for data storage files */
+    @GridToStringExclude
     private FileIOFactory fileIOFactory =
         IgniteSystemProperties.getBoolean(IGNITE_USE_ASYNC_FILE_IO_FACTORY, DFLT_USE_ASYNC_FILE_IO_FACTORY) ?
             new AsyncFileIOFactory() : new RandomAccessFileIOFactory();

--- a/modules/core/src/main/java/org/apache/ignite/configuration/EncryptionConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/EncryptionConfiguration.java
@@ -18,11 +18,14 @@
 package org.apache.ignite.configuration;
 
 import java.io.Serializable;
+
+import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.internal.A;
 
 /**
  * Encryption configuration.
  */
+@GridToStringExclude
 public class EncryptionConfiguration implements Serializable {
     /** */
     private static final long serialVersionUID = 0L;

--- a/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
@@ -391,31 +391,24 @@ public class IgniteConfiguration {
     private long segChkFreq = DFLT_SEG_CHK_FREQ;
 
     /** Communication SPI. */
-    @GridToStringExclude
     private CommunicationSpi commSpi;
 
     /** Event storage SPI. */
-    @GridToStringExclude
     private EventStorageSpi evtSpi;
 
     /** Collision SPI. */
-    @GridToStringExclude
     private CollisionSpi colSpi;
 
     /** Deployment SPI. */
-    @GridToStringExclude
     private DeploymentSpi deploySpi;
 
     /** Checkpoint SPI. */
-    @GridToStringExclude
     private CheckpointSpi[] cpSpi;
 
     /** Failover SPI. */
-    @GridToStringExclude
     private FailoverSpi[] failSpi;
 
     /** Load balancing SPI. */
-    @GridToStringExclude
     private LoadBalancingSpi[] loadBalancingSpi;
 
     /** Indexing SPI. */
@@ -426,19 +419,15 @@ public class IgniteConfiguration {
     private AddressResolver addrRslvr;
 
     /** Encryption SPI. */
-    @GridToStringExclude
     private EncryptionSpi encryptionSpi;
 
     /** Metric exporter SPI. */
-    @GridToStringExclude
     private MetricExporterSpi[] metricExporterSpi;
 
     /** System view exporter SPI. */
-    @GridToStringExclude
     private SystemViewExporterSpi[] sysViewExporterSpi;
 
     /** Tracing SPI. */
-    @GridToStringExclude
     private TracingSpi tracingSpi;
 
     /** Cache configurations. */

--- a/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/IgniteConfiguration.java
@@ -49,6 +49,7 @@ import org.apache.ignite.events.EventType;
 import org.apache.ignite.failure.FailureHandler;
 import org.apache.ignite.internal.managers.eventstorage.GridEventStorageManager;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
+import org.apache.ignite.internal.util.tostring.GridToStringExclude;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -326,6 +327,7 @@ public class IgniteConfiguration {
     private String igniteWorkDir;
 
     /** MBean server. */
+    @GridToStringExclude
     private MBeanServer mbeanSrv;
 
     /** Local node ID. */
@@ -389,42 +391,54 @@ public class IgniteConfiguration {
     private long segChkFreq = DFLT_SEG_CHK_FREQ;
 
     /** Communication SPI. */
+    @GridToStringExclude
     private CommunicationSpi commSpi;
 
     /** Event storage SPI. */
+    @GridToStringExclude
     private EventStorageSpi evtSpi;
 
     /** Collision SPI. */
+    @GridToStringExclude
     private CollisionSpi colSpi;
 
     /** Deployment SPI. */
+    @GridToStringExclude
     private DeploymentSpi deploySpi;
 
     /** Checkpoint SPI. */
+    @GridToStringExclude
     private CheckpointSpi[] cpSpi;
 
     /** Failover SPI. */
+    @GridToStringExclude
     private FailoverSpi[] failSpi;
 
     /** Load balancing SPI. */
+    @GridToStringExclude
     private LoadBalancingSpi[] loadBalancingSpi;
 
     /** Indexing SPI. */
+    @GridToStringExclude
     private IndexingSpi indexingSpi;
 
     /** Address resolver. */
     private AddressResolver addrRslvr;
 
     /** Encryption SPI. */
+    @GridToStringExclude
     private EncryptionSpi encryptionSpi;
 
     /** Metric exporter SPI. */
+    @GridToStringExclude
     private MetricExporterSpi[] metricExporterSpi;
 
     /** System view exporter SPI. */
+    @GridToStringExclude
     private SystemViewExporterSpi[] sysViewExporterSpi;
 
     /** Tracing SPI. */
+    @GridToStringExclude
     private TracingSpi tracingSpi;
 
     /** Cache configurations. */

--- a/modules/core/src/main/java/org/apache/ignite/configuration/SystemDataRegionConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/SystemDataRegionConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.ignite.configuration;
 
 import java.io.Serializable;
 import org.apache.ignite.internal.util.typedef.internal.A;
+import org.apache.ignite.internal.util.typedef.internal.S;
 
 /**
  * This class allows defining system data region configuration with various parameters for Apache Ignite
@@ -89,5 +90,10 @@ public class SystemDataRegionConfiguration implements Serializable {
         this.maxSize = maxSize;
 
         return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(SystemDataRegionConfiguration.class, this);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/marshaller/IgniteMarshallerClassFilter.java
+++ b/modules/core/src/main/java/org/apache/ignite/marshaller/IgniteMarshallerClassFilter.java
@@ -67,4 +67,9 @@ public class IgniteMarshallerClassFilter implements IgnitePredicate<String> {
     @Override public int hashCode() {
         return Objects.hash(whiteList, blackList);
     }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "IgniteMarshallerClassFilter";
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/noop/NoopCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/noop/NoopCollisionSpi.java
@@ -17,7 +17,6 @@
 
 package org.apache.ignite.spi.collision.noop;
 
-import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.spi.IgniteSpiAdapter;
 import org.apache.ignite.spi.IgniteSpiException;
 import org.apache.ignite.spi.IgniteSpiMultipleInstancesSupport;

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/noop/NoopCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/noop/NoopCollisionSpi.java
@@ -67,6 +67,6 @@ public class NoopCollisionSpi extends IgniteSpiAdapter implements CollisionSpi {
 
     /** {@inheritDoc} */
     @Override public String toString() {
-        return S.toString(NoopCollisionSpi.class, this);
+        return "NoopCollisionSpi";
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/TcpCommunicationSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/communication/tcp/TcpCommunicationSpi.java
@@ -54,7 +54,7 @@ import org.apache.ignite.internal.util.nio.GridNioRecoveryDescriptor;
 import org.apache.ignite.internal.util.nio.GridNioServer;
 import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.apache.ignite.internal.util.nio.GridNioSessionMetaKey;
-import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.worker.WorkersRegistry;
 import org.apache.ignite.lang.IgniteFuture;
@@ -194,6 +194,7 @@ import static org.apache.ignite.spi.communication.tcp.internal.TcpConnectionInde
  */
 @IgniteSpiMultipleInstancesSupport(true)
 @IgniteSpiConsistencyChecked(optional = false)
+@GridToStringInclude
 public class TcpCommunicationSpi extends TcpCommunicationConfigInitializer {
     /** Node attribute that is mapped to node IP addresses (value is <tt>comm.tcp.addrs</tt>). */
     public static final String ATTR_ADDRS = "comm.tcp.addrs";
@@ -1153,7 +1154,10 @@ public class TcpCommunicationSpi extends TcpCommunicationConfigInitializer {
 
     /** {@inheritDoc} */
     @Override public String toString() {
-        return S.toString(TcpCommunicationSpi.class, this);
+        return "TcpCommunicationSpi [" +
+                "ctxInitLatch=" + ctxInitLatch.getCount() +
+                ", stopping=" + stopping +
+                "]";
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/ServerImpl.java
@@ -255,6 +255,7 @@ class ServerImpl extends TcpDiscoveryImpl {
     private long connCheckTick;
 
     /** */
+    @GridToStringExclude
     private final IgniteThreadPoolExecutor utilityPool;
 
     /** Pool size to ping remote DC if a corner node loses the ring connection. */
@@ -292,6 +293,7 @@ class ServerImpl extends TcpDiscoveryImpl {
     private StatisticsPrinter statsPrinter;
 
     /** Metric for max message queue size. */
+    @GridToStringExclude
     private MaxValueMetric maxMsgQueueSizeMetric;
 
     /** Failed nodes (but still in topology). */
@@ -310,6 +312,7 @@ class ServerImpl extends TcpDiscoveryImpl {
     private Queue<TcpDiscoveryCustomEventMessage> pendingCustomMsgs = new ArrayDeque<>();
 
     /** Messages history used for client reconnect. */
+    @GridToStringExclude
     private final EnsuredMessageHistory msgHist = new EnsuredMessageHistory();
 
     /** If non-shared IP finder is used this flag shows whether IP finder contains local address. */

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -383,6 +383,7 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
     private Marshaller marsh;
 
     /** Statistics. */
+    @GridToStringExclude
     protected final TcpDiscoveryStatistics stats = new TcpDiscoveryStatistics();
 
     /** Local port which node uses. */

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -350,9 +350,11 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
     protected long connRecoveryTimeout = DFLT_CONNECTION_RECOVERY_TIMEOUT;
 
     /** Grid discovery listener. */
+    @GridToStringExclude
     protected volatile DiscoverySpiListener lsnr;
 
     /** Data exchange. */
+    @GridToStringExclude
     protected DiscoverySpiDataExchange exchange;
 
     /** Metrics provider. */
@@ -456,9 +458,11 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
     private IgniteBiTuple<Collection<String>, Collection<String>> addrs;
 
     /** */
+    @GridToStringExclude
     protected IgniteSpiContext spiCtx;
 
     /** Discovery messages factory. */
+    @GridToStringExclude
     private MessageFactory msgFactory;
 
     /** For test purposes. */

--- a/modules/core/src/main/java/org/apache/ignite/spi/encryption/keystore/KeystoreEncryptionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/encryption/keystore/KeystoreEncryptionSpi.java
@@ -546,4 +546,9 @@ public class KeystoreEncryptionSpi extends IgniteSpiAdapter implements Encryptio
             throw new IgniteSpiException(e);
         }
     }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "KeystoreEncryptionSpi";
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/encryption/noop/NoopEncryptionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/encryption/noop/NoopEncryptionSpi.java
@@ -124,4 +124,9 @@ public class NoopEncryptionSpi extends IgniteSpiAdapter implements EncryptionSpi
     @Override public void spiStop() throws IgniteSpiException {
         // No-op.
     }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "NoopEncryptionSpi";
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/tracing/NoopTracingSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/tracing/NoopTracingSpi.java
@@ -67,4 +67,9 @@ public class NoopTracingSpi extends IgniteSpiAdapter implements TracingSpi<NoopS
     @Override public byte type() {
         return TracingSpiType.NOOP_TRACING_SPI.index();
     }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "NoopTracingSpi";
+    }
 }

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -30,30 +30,37 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
 
 /**
  * Test covers cases where Ignite configuration,
- * or it's nested objects has default implementation of {@link Object#toString()}
+ * or it's nested objects have default implementation of {@link Object#toString()}
  */
 @WithSystemProperty(key = IGNITE_QUIET, value = "false")
 public class IgniteConfigurationTest extends GridCommonAbstractTest {
     /** Error message to be prompted for ignite configuration */
     private static final String ASSERTION_ERROR_MESSAGE =
-            "Ignite configuration log message contains objects with default toString implementation";
+            "Ignite configuration log message contains objects with default #toString() implementation";
 
     /** Error message to be prompted for node start log message */
     private static final String NODE_START_ASSERTION_ERROR_MESSAGE =
-            "Node start log message contains objects with default toString implementation";
+            "Node start log message contains objects with default #toString() implementation";
+
+    /** Contains not identity hash fragments ("@...") */
+    public static final String CONTAINS_NOT_DEFAULT_TO_STRING = "(?!.*@[a-fA-F0-9]+).*";
 
     /** Pattern to check any object has default {@link Object#toString()} implementation */
-    private static final Pattern ERROR_PATTERN = Pattern.compile("^(?=.*IgniteConfiguration \\[)(?!.*@[a-fA-F0-9]+).*$");
+    private static final Pattern ERROR_PATTERN =
+            Pattern.compile("^(?=.*IgniteConfiguration \\[)"
+                    + CONTAINS_NOT_DEFAULT_TO_STRING + "$");
 
     /** Pattern to check any object has default {@link Object#toString()} implementation */
-    private static final Pattern NODE_START_ERROR_PATTERN = Pattern.compile("^(?=.*Node started with the following configuration \\[id=)(?!.*@[a-fA-F0-9]+).*$");
+    private static final Pattern NODE_START_ERROR_PATTERN =
+            Pattern.compile("^(?=.*Node started with the following configuration \\[id=)"
+                    + CONTAINS_NOT_DEFAULT_TO_STRING + "$");
 
     /** */
     private final ListeningTestLogger listeningLog = new ListeningTestLogger(log);
 
     /**
-     * Check ignite configuration log message contains no @ letters
-     * It's a common way to ensure all objects in prompt has {@link Object#toString()} overriden
+     * Checks that Ignite configuration log message contains no identity hash fragments ("@...").
+     * This is a common heuristic to ensure all logged objects override {@link Object#toString()}.
      */
     @Test
     public void testIgniteConfigurationPrompt() throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -1,0 +1,52 @@
+package org.apache.ignite.configuration;
+
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
+import org.apache.ignite.testframework.junits.WithSystemProperty;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
+
+/**
+ * Test covers cases where Ignite configuration,
+ * or it's nested objects has default implementation of {@link Object#toString()}
+ */
+@WithSystemProperty(key = IGNITE_QUIET, value = "false")
+public class IgniteConfigurationTest extends GridCommonAbstractTest {
+    /** Error message to be prompted */
+    private static final String ASSERTION_ERROR_MESSAGE =
+            "Ignite configuration log message contains objects with default toString implementation!";
+
+    /** Pattern to check any object has default {@link Object#toString()} implementation */
+    private static final Pattern ERROR_PATTERN = Pattern.compile("^(?=.*IgniteConfiguration \\[)(?!.*@\\d+).*$");
+
+    /** */
+    private final ListeningTestLogger listeningLog = new ListeningTestLogger(log);
+
+    /**
+     * Check ignite configuration log message contains no @ letters
+     * It's a common way to ensure all objects in prompt has {@link Object#toString()} overriden
+     */
+    @Test
+    public void testIgniteConfigurationPrompt() throws Exception {
+        LogListener igniteConfigurationLogListener = LogListener
+                .matches(ERROR_PATTERN)
+                .atLeast(1)
+                .build();
+        listeningLog.registerListener(igniteConfigurationLogListener);
+        try (IgniteEx ignored = startGrid(0)){
+            Assert.assertTrue(ASSERTION_ERROR_MESSAGE, igniteConfigurationLogListener.check());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        return super.getConfiguration(igniteInstanceName)
+                .setGridLogger(listeningLog);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -39,7 +39,7 @@ public class IgniteConfigurationTest extends GridCommonAbstractTest {
             "Ignite configuration log message contains objects with default toString implementation!";
 
     /** Pattern to check any object has default {@link Object#toString()} implementation */
-    private static final Pattern ERROR_PATTERN = Pattern.compile("^(?=.*IgniteConfiguration \\[)(?!.*@\\d+).*$");
+    private static final Pattern ERROR_PATTERN = Pattern.compile("^(?=.*IgniteConfiguration \\[)(?!.*@[a-fA-F0-9]+).*$");
 
     /** */
     private final ListeningTestLogger listeningLog = new ListeningTestLogger(log);

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -74,7 +74,7 @@ public class IgniteConfigurationTest extends GridCommonAbstractTest {
         listeningLog.registerListener(nodeStartIgniteConfigurationLogListener);
         try (IgniteEx ignored = startGrid(0)) {
             Assert.assertTrue(ASSERTION_ERROR_MESSAGE, igniteConfigurationLogListener.check());
-            Assert.assertTrue(NODE_START_ASSERTION_ERROR_MESSAGE, nodeStartIgniteConfigurationLogListener.check(10_000));
+            Assert.assertTrue(NODE_START_ASSERTION_ERROR_MESSAGE, nodeStartIgniteConfigurationLogListener.check());
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.ignite.configuration;
 
 import java.util.regex.Pattern;

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.apache.ignite.configuration;
 
+import java.util.regex.Pattern;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.testframework.ListeningTestLogger;
 import org.apache.ignite.testframework.LogListener;
@@ -7,8 +8,6 @@ import org.apache.ignite.testframework.junits.WithSystemProperty;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.regex.Pattern;
 
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
 
@@ -39,7 +38,7 @@ public class IgniteConfigurationTest extends GridCommonAbstractTest {
                 .atLeast(1)
                 .build();
         listeningLog.registerListener(igniteConfigurationLogListener);
-        try (IgniteEx ignored = startGrid(0)){
+        try (IgniteEx ignored = startGrid(0)) {
             Assert.assertTrue(ASSERTION_ERROR_MESSAGE, igniteConfigurationLogListener.check());
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -34,12 +34,19 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
  */
 @WithSystemProperty(key = IGNITE_QUIET, value = "false")
 public class IgniteConfigurationTest extends GridCommonAbstractTest {
-    /** Error message to be prompted */
+    /** Error message to be prompted for ignite configuration */
     private static final String ASSERTION_ERROR_MESSAGE =
             "Ignite configuration log message contains objects with default toString implementation!";
 
+    /** Error message to be prompted for node start log message */
+    private static final String NODE_START_ASSERTION_ERROR_MESSAGE =
+            "Node start log message contains objects with default toString implementation!";
+
     /** Pattern to check any object has default {@link Object#toString()} implementation */
     private static final Pattern ERROR_PATTERN = Pattern.compile("^(?=.*IgniteConfiguration \\[)(?!.*@[a-fA-F0-9]+).*$");
+
+    /** Pattern to check any object has default {@link Object#toString()} implementation */
+    private static final Pattern NODE_START_ERROR_PATTERN = Pattern.compile("^(?=.*Node started with the following configuration \\[id=)(?!.*@[a-fA-F0-9]+).*$");
 
     /** */
     private final ListeningTestLogger listeningLog = new ListeningTestLogger(log);
@@ -54,9 +61,15 @@ public class IgniteConfigurationTest extends GridCommonAbstractTest {
                 .matches(ERROR_PATTERN)
                 .atLeast(1)
                 .build();
+        LogListener nodeStartIgniteConfigurationLogListener = LogListener
+                .matches(NODE_START_ERROR_PATTERN)
+                .atLeast(1)
+                .build();
         listeningLog.registerListener(igniteConfigurationLogListener);
+        listeningLog.registerListener(nodeStartIgniteConfigurationLogListener);
         try (IgniteEx ignored = startGrid(0)) {
             Assert.assertTrue(ASSERTION_ERROR_MESSAGE, igniteConfigurationLogListener.check());
+            Assert.assertTrue(NODE_START_ASSERTION_ERROR_MESSAGE, nodeStartIgniteConfigurationLogListener.check(10_000));
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/configuration/IgniteConfigurationTest.java
@@ -36,11 +36,11 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_QUIET;
 public class IgniteConfigurationTest extends GridCommonAbstractTest {
     /** Error message to be prompted for ignite configuration */
     private static final String ASSERTION_ERROR_MESSAGE =
-            "Ignite configuration log message contains objects with default toString implementation!";
+            "Ignite configuration log message contains objects with default toString implementation";
 
     /** Error message to be prompted for node start log message */
     private static final String NODE_START_ASSERTION_ERROR_MESSAGE =
-            "Node start log message contains objects with default toString implementation!";
+            "Node start log message contains objects with default toString implementation";
 
     /** Pattern to check any object has default {@link Object#toString()} implementation */
     private static final Pattern ERROR_PATTERN = Pattern.compile("^(?=.*IgniteConfiguration \\[)(?!.*@[a-fA-F0-9]+).*$");
@@ -59,11 +59,9 @@ public class IgniteConfigurationTest extends GridCommonAbstractTest {
     public void testIgniteConfigurationPrompt() throws Exception {
         LogListener igniteConfigurationLogListener = LogListener
                 .matches(ERROR_PATTERN)
-                .atLeast(1)
                 .build();
         LogListener nodeStartIgniteConfigurationLogListener = LogListener
                 .matches(NODE_START_ERROR_PATTERN)
-                .atLeast(1)
                 .build();
         listeningLog.registerListener(igniteConfigurationLogListener);
         listeningLog.registerListener(nodeStartIgniteConfigurationLogListener);

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -1324,7 +1324,7 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
 
                 IgniteConfiguration nodeCfg = node.configuration();
 
-                log.info("Node started with the following configuration [id=" + node.cluster().localNode().id()
+                nodeCfg.getGridLogger().getLogger(getClass().getName()).info("Node started with the following configuration [id=" + node.cluster().localNode().id()
                     + ", discovery=" + nodeCfg.getDiscoverySpi()
                     + ", binaryCfg=" + nodeCfg.getBinaryConfiguration()
                     + ", lateAff=" + nodeCfg.isLateAffinityAssignment() + "]");

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -1324,10 +1324,12 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
 
                 IgniteConfiguration nodeCfg = node.configuration();
 
-                nodeCfg.getGridLogger().getLogger(getClass().getName()).info("Node started with the following configuration [id=" + node.cluster().localNode().id()
-                    + ", discovery=" + nodeCfg.getDiscoverySpi()
-                    + ", binaryCfg=" + nodeCfg.getBinaryConfiguration()
-                    + ", lateAff=" + nodeCfg.isLateAffinityAssignment() + "]");
+                nodeCfg.getGridLogger().getLogger(getClass().getName())
+                        .info("Node started with the following configuration ["
+                                + "id=" + node.cluster().localNode().id()
+                                + ", discovery=" + nodeCfg.getDiscoverySpi()
+                                + ", binaryCfg=" + nodeCfg.getBinaryConfiguration()
+                                + ", lateAff=" + nodeCfg.isLateAffinityAssignment() + "]");
 
                 return node;
             }

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite2.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite2.java
@@ -19,6 +19,7 @@ package org.apache.ignite.testsuites;
 
 import org.apache.ignite.ClassPathContentLoggingTest;
 import org.apache.ignite.cache.RemoveAllDeadlockTest;
+import org.apache.ignite.configuration.IgniteConfigurationTest;
 import org.apache.ignite.events.ClusterActivationStartedEventTest;
 import org.apache.ignite.failure.ExchangeTaskHandlerWaitingForTasksTest;
 import org.apache.ignite.failure.FailureHandlerTriggeredTest;
@@ -227,6 +228,8 @@ import org.junit.runners.Suite;
 
     FreeListCutTailDifferentGcTest.class,
     MdcCacheReadRequestsRoutingTest.class,
+
+    IgniteConfigurationTest.class,
 })
 public class IgniteBasicTestSuite2 {
 }

--- a/modules/opencensus/src/main/java/org/apache/ignite/spi/tracing/opencensus/OpenCensusTracingSpi.java
+++ b/modules/opencensus/src/main/java/org/apache/ignite/spi/tracing/opencensus/OpenCensusTracingSpi.java
@@ -152,7 +152,6 @@ public class OpenCensusTracingSpi extends IgniteSpiAdapter implements TracingSpi
         return TracingSpiType.OPEN_CENSUS_TRACING_SPI.index();
     }
 
-
     /** {@inheritDoc} */
     @Override public String toString() {
         return "OpenCensusTracingSpi";

--- a/modules/opencensus/src/main/java/org/apache/ignite/spi/tracing/opencensus/OpenCensusTracingSpi.java
+++ b/modules/opencensus/src/main/java/org/apache/ignite/spi/tracing/opencensus/OpenCensusTracingSpi.java
@@ -151,4 +151,10 @@ public class OpenCensusTracingSpi extends IgniteSpiAdapter implements TracingSpi
     @Override public byte type() {
         return TracingSpiType.OPEN_CENSUS_TRACING_SPI.index();
     }
+
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return "OpenCensusTracingSpi";
+    }
 }


### PR DESCRIPTION
Added some log output improvements:
1) Removed output of SPI instances, because it might be provided by third party components and contain sensitive data
2) Removed output of Management Beans instance because it gives nothing
3) Removed output of Encryption Configuration, FileIOFactory because it may produce security issues
4) Added output of nested configurations
5) Added test to ensure all logged nested objects have custom toString method imlementation
