### PR TITLE
IGNITE-28634 Fix ClassCastException in IgniteTxManager.localTx when DHT remote tx is in thread context

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxManager.java
@@ -957,9 +957,9 @@ public class IgniteTxManager extends GridCacheSharedManagerAdapter {
      * @return Local transaction.
      */
     @Nullable public IgniteTxLocalAdapter localTx() {
-        IgniteTxLocalAdapter tx = tx();
+        IgniteInternalTx tx = tx();
 
-        return tx != null && tx.local() ? tx : null;
+        return tx instanceof IgniteTxLocalAdapter && tx.local() ? (IgniteTxLocalAdapter)tx : null;
     }
 
     /**


### PR DESCRIPTION
## Problem

`IgniteTxManager.localTx()` used the generic method `tx()` with an implicit unchecked cast to `IgniteTxLocalAdapter`:

```java
@Nullable public IgniteTxLocalAdapter localTx() {
    IgniteTxLocalAdapter tx = tx();  // Java infers T=IgniteTxLocalAdapter → implicit unchecked cast
    return tx != null && tx.local() ? tx : null;
}
```

`tx()` is declared as `public <T extends IgniteInternalTx> T tx()`. When assigning to `IgniteTxLocalAdapter tx`, the compiler inserts an implicit `(IgniteTxLocalAdapter)` cast that executes **before** the `tx.local()` check.

During the DHT commit phase, a `GridDhtTxRemote` can be present in the thread context. Since `GridDhtTxRemote` and `IgniteTxLocalAdapter` are unrelated branches of the type hierarchy (both extend `IgniteTxAdapter` but not each other), the cast throws `ClassCastException`:

```
Caused by: java.lang.ClassCastException: class GridDhtTxRemote cannot be cast to class IgniteTxLocalAdapter
    at IgniteTxManager.localTx(IgniteTxManager.java:960)
    at GridCacheMapEntry.currentTx(GridCacheMapEntry.java:3316)
    at GridCacheMapEntry.expireTime(GridCacheMapEntry.java:3268)
    at GridDistributedTxRemoteAdapter.commitIfLocked(GridDistributedTxRemoteAdapter.java:663)
```

This causes `commitIfLocked` to fail with `IgniteTxHeuristicCheckedException`, which can hang the Cache 6 test suite.

## Fix

Changed the variable type to `IgniteInternalTx` to eliminate the implicit generic cast, and added an explicit `instanceof` check before casting:

```java
@Nullable public IgniteTxLocalAdapter localTx() {
    IgniteInternalTx tx = tx();
    return tx instanceof IgniteTxLocalAdapter && tx.local() ? (IgniteTxLocalAdapter)tx : null;
}
```

## Testing

`GridCacheNearRemoveFailureTest` (part of `IgniteCacheFailoverTestSuite` / Cache 6):
- Without the fix: `ClassCastException` reproduced on the first run
- With the fix: `Tests run: 3, Failures: 0, Errors: 0`