### PR TITLE
IGNITE-28821 Protected Classes CI check: report as warning instead of failing the PR build

### DIFF
--- a/.github/workflows/check-protected-classes.yml
+++ b/.github/workflows/check-protected-classes.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -114,7 +115,28 @@ jobs:
               labels: ['compatibility'],
             });
 
-      - name: Fail on affected check
+      - name: Warning check on affected
         if: steps.check.outputs.affected == 'true'
-        run: |
-          exit 1
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const hits = fs.readFileSync('/tmp/protected-hits.txt', 'utf8').trim();
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Rolling upgrade compatibility',
+              head_sha: context.payload.pull_request.head.sha,
+              status: 'completed',
+              conclusion: 'action_required',
+              output: {
+                title: 'Possible compatibility issues',
+                summary: [
+                  'This PR modifies protected classes (with **Order** annotation).',
+                  'Changes to these classes can break rolling upgrade compatibility.',
+                  '',
+                  '**Affected files:**',
+                  hits.split('\n').map(f => '- `' + f.trim() + '`').join('\n'),
+                ].join('\n'),
+              },
+            });

--- a/.github/workflows/check-protected-classes.yml
+++ b/.github/workflows/check-protected-classes.yml
@@ -128,7 +128,7 @@ jobs:
               name: 'Rolling upgrade compatibility',
               head_sha: context.payload.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'action_required',
+              conclusion: 'neutral',
               output: {
                 title: 'Possible compatibility issues',
                 summary: [


### PR DESCRIPTION
## What
The `Protected Classes` workflow no longer fails the PR build when a change touches `@Order`-annotated (protected) classes. Instead it publishes a separate, non-blocking check `Rolling upgrade compatibility` with the `neutral` conclusion, keeping the existing PR comment and `compatibility` label.

## Why
A hard failure (`exit 1`) red-flagged PRs even for intentional, compatible changes, creating friction (the check was disabled manually on 2026-05-27 for this reason). A non-blocking advisory check surfaces the rolling-upgrade risk for reviewer attention without failing the build.

## Why `neutral` (and not `action_required`)
GitHub's Checks API has no dedicated "warning" conclusion. `action_required` is intended for GitHub Apps that attach a remediation action: it renders as a red ✕ with a "Resolve" button in the Checks tab and is dropped from the PR merge-box rollup entirely (so the warning becomes invisible there). `neutral` is the proper primitive for an advisory result — it shows in its own non-blocking "neutral" group in the merge box and as a grey marker in the Checks tab, and it never blocks merging.

## Notes
- The `Rolling Upgrade check` job now always succeeds.
- The new check is non-blocking unless added to required status checks.
- `checks: write` permission added for the Checks API call.

Jira: https://issues.apache.org/jira/browse/IGNITE-28821

🤖 Generated with [Claude Code](https://claude.com/claude-code)