### PR TITLE
IGNITE-28822 Protected Classes CI check: reduce cognitive complexity of the detection script

### DIFF
--- a/.github/workflows/check-protected-classes.yml
+++ b/.github/workflows/check-protected-classes.yml
@@ -39,26 +39,35 @@ jobs:
         run: |
           BASE_SHA=${{ github.event.pull_request.base.sha }}
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          ANNOTATION='org.apache.ignite.internal.Order'
+          HITS_FILE=/tmp/protected-hits.txt
 
-          HITS=""
+          # Added/deleted/modified .java files in the PR as "<status>\t<path>" lines.
+          changed_java_files() {
+            git diff --name-status --no-renames --diff-filter=ADM "$BASE_SHA"..."$HEAD_SHA" -- '*.java'
+          }
 
-          # New and deleted files: check diff content for @Order annotation.
-          for file in $(git diff --name-only --no-renames --diff-filter=AD "$BASE_SHA"..."$HEAD_SHA" -- '*.java'); do
-            if git diff "$BASE_SHA"..."$HEAD_SHA" -- "$file" | grep -q 'org.apache.ignite.internal.Order'; then
-              HITS="${HITS}${file}\n"
-            fi
-          done
+          # A protected class carries the @Order annotation; an added file is
+          # defined by the new revision, a deleted/modified one by the base.
+          is_protected_class() {
+            local status=$1 file=$2 ref=$BASE_SHA
+            [ "$status" = A ] && ref=$HEAD_SHA
+            git show "$ref:$file" 2>/dev/null | grep -q "$ANNOTATION"
+          }
 
-          # Modified files: check base version content for @Order annotation.
-          for file in $(git diff --name-only --no-renames --diff-filter=M "$BASE_SHA"..."$HEAD_SHA" -- '*.java'); do
-            if git show "${BASE_SHA}:${file}" 2>/dev/null | grep -q 'org.apache.ignite.internal.Order'; then
-              HITS="${HITS}${file}\n"
-            fi
-          done
+          # Read "<status>\t<path>" lines, emit the paths that are protected.
+          filter_protected() {
+            while IFS=$'\t' read -r status file; do
+              if is_protected_class "$status" "$file"; then
+                echo "$file"
+              fi
+            done
+          }
 
-          if [ -n "$HITS" ]; then
+          changed_java_files | filter_protected > "$HITS_FILE"
+
+          if [ -s "$HITS_FILE" ]; then
             echo "affected=true" >> "$GITHUB_OUTPUT"
-            printf '%b' "$HITS" > /tmp/protected-hits.txt
           fi
 
       - name: Comment on PR


### PR DESCRIPTION
## What
Simplify the detection logic in the `Rolling Upgrade check` step so it reads as a sequence of named steps:
- Split it into small functions — `changed_java_files`, `is_protected_class`, `filter_protected` — with a top-level `changed_java_files | filter_protected > "$HITS_FILE"`.
- Collapse the two near-identical loops (added/deleted vs modified files) into that single pass; the revision inspected per file status is `A` → head, `D`/`M` → base.
- Drop the string accumulation with literal `\n` + `printf '%b'`, the process substitution and the parallel `HITS` variable; matches go straight to the output file, detected with `[ -s ]`.

## Why
The two loops differed only in the diff filter and the grepped revision (duplication); the `\n`/`%b` and process-substitution idioms add reader friction. The named functions make the top level read as intent, halve the cyclomatic/cognitive complexity and remove the duplication.

## Behaviour
Verified equivalent to the previous logic on add / modify / delete / rename scenarios, and that a PR with no hits still exits 0 under `set -eo pipefail`. One intentional difference: the content-based grep no longer flags add/delete of the annotation's own definition file `org/apache/ignite/internal/Order*.java` — the previous diff-based grep matched the file *path* in diff headers (the regex dots match slashes), a false positive, since that file is the `@Order` definition, not a protected class.

## Notes
- Independent of [#13279](https://github.com/apache/ignite/pull/13279) (different hunk of the same file); no conflict expected.

Jira: https://issues.apache.org/jira/browse/IGNITE-28822

🤖 Generated with [Claude Code](https://claude.com/claude-code)
