### PR TITLE
IGNITE-627 Mute CacheNearReaderUpdateTest

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheNearReaderUpdateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheNearReaderUpdateTest.java
@@ -45,6 +45,7 @@ import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionConcurrency;
 import org.apache.ignite.transactions.TransactionIsolation;
 import org.apache.ignite.transactions.TransactionOptimisticException;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
@@ -58,6 +59,7 @@ import static org.apache.ignite.transactions.TransactionIsolation.SERIALIZABLE;
 /**
  *
  */
+@Ignore("https://issues.apache.org/jira/browse/IGNITE-627")
 public class CacheNearReaderUpdateTest extends GridCommonAbstractTest {
     /** */
     private static final int SRVS = 4;


### PR DESCRIPTION
## Summary

All four `@Test` methods in `CacheNearReaderUpdateTest` (`testNoBackups`, `testOneBackup`, `testOneBackupNearEnabled`, `testOneBackupStoreEnabled`) funnel into the shared private helper `runTestGetUpdateMultithreaded(...)`, whose first line is:

```java
fail("https://issues.apache.org/jira/browse/IGNITE-627");
```

As a result every test in the class fails 100% of the time by design — the class documents the unfixed bug [IGNITE-627](https://issues.apache.org/jira/browse/IGNITE-627). These are deterministic failures (not flaky) and are pure red noise in CI.

This mutes the whole class under the existing ticket via a class-level `@Ignore`, matching the existing precedent `GridCacheOnCopyFlagAtomicSelfTest`.

## Changes

- Add `import org.junit.Ignore;`
- Annotate the class with `@Ignore("https://issues.apache.org/jira/browse/IGNITE-627")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)