### PR TITLE
IGNITE-28831 Fix DTO serializer codegen NPE on type-use annotated qualified types

### DIFF
--- a/modules/codegen/src/main/java/org/apache/ignite/internal/idto/IDTOSerializerGenerator.java
+++ b/modules/codegen/src/main/java/org/apache/ignite/internal/idto/IDTOSerializerGenerator.java
@@ -741,12 +741,11 @@ public class IDTOSerializerGenerator {
 
     /** @return FQN of {@code comp}. */
     private static String className(TypeMirror comp) {
-        String n = comp.toString();
-
-        int spaceIdx = n.indexOf(' ');
-
-        if (spaceIdx != -1)
-            n = n.substring(spaceIdx + 1);
+        // A type-use annotation (e.g. @Nullable, @NotNull) is rendered by the compiler either before the whole type
+        // ("@a.b.C java.util.Collection") or inline, right before the simple name of a qualified type
+        // ("java.util.@a.b.C Collection"). Strip such annotations wherever they appear so the package qualifier is
+        // preserved; otherwise only the simple name would remain and lookups by FQN (e.g. COLL_IMPL) would fail.
+        String n = comp.toString().replaceAll("@[^\\s()]+(?:\\([^)]*\\))?\\s*", "");
 
         int genIdx = n.indexOf('<');
 


### PR DESCRIPTION
## Description

[IGNITE-28831](https://issues.apache.org/jira/browse/IGNITE-28831)

`IgniteDataTransferObjectProcessor` throws a `NullPointerException` during annotation processing, which breaks compilation of `modules/core` from source:

```
mvn -o -q -pl modules/core -am test-compile -DskipTests -Dcheckstyle.skip=true
```

### Root cause

`IDTOSerializerGenerator.className(TypeMirror)` stripped everything before the first space to drop a *leading* type-use annotation (e.g. `@NotNull java.util.Collection`). But the compiler renders a type-use annotation (`@Nullable`/`@NotNull`) **inline, right before the simple name** of a qualified type:

```
java.util.@org.jetbrains.annotations.NotNull Collection<...>
```

The first-space heuristic discarded the `java.util.` qualifier and returned only `Collection`, which caused:

1. `COLL_IMPL.get("Collection")` → `null` → NPE in `simpleName()` for fields such as `BaselineNode.addrs` (`@NotNull Collection<ResolvedAddresses>`) and `IdleVerifyResult.txHashConflicts` (`@Nullable List<List<TransactionsHashRecord>>`).
2. Malformed `import String;` / `import Exception;` / `import IdleVerifyResult;` in the generated serializers for `DurableBackgroundCleanupIndexTreeTaskV2`, `SnapshotPartitionsVerifyResult`, `VisorTaskResult` (the `'.' expected` compile errors) for `@Nullable`-annotated fields.

The subsequent cascade of `cannot find symbol: class *ViewWalker` errors is a side effect: the processor's exception aborts the annotation-processing round, so the separate `SystemViewRowAttributeWalkerProcessor` output never gets compiled.

### Fix

Strip type-use annotations wherever they occur (preserving the package qualifier) instead of the first-space heuristic. The change is confined to the codegen module; DTO classes are not touched.

### Verification

`mvn -o -q -pl modules/core -am test-compile -DskipTests -Dcheckstyle.skip=true` completes with `BUILD SUCCESS`, and the serializers for `BaselineNode`, `IdleVerifyResult`, `DurableBackgroundCleanupIndexTreeTaskV2`, `SnapshotPartitionsVerifyResult`, `VisorTaskResult` are generated and compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)