### PR TITLE
IGNITE-28834 Apply test load scaling (GridTestUtils.SF) to long-running tests

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/ConcurrentCheckpointAndUpdateTtlTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/ConcurrentCheckpointAndUpdateTtlTest.java
@@ -147,7 +147,7 @@ public class ConcurrentCheckpointAndUpdateTtlTest extends GridCommonAbstractTest
         }, 1, "touch");
 
         IgniteInternalFuture<?> cpFut = runMultiThreadedAsync(() -> {
-            for (int i = 0; i < 1_000; i++) {
+            for (int i = 0; i < GridTestUtils.SF.applyLB(1_000, 200); i++) {
                 try {
                     forceCheckpoint(F.asList(grid(0), grid(1)));
                 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CrossCacheTxRandomOperationsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CrossCacheTxRandomOperationsTest.java
@@ -34,6 +34,7 @@ import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.NearCacheConfiguration;
 import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionConcurrency;
@@ -263,7 +264,7 @@ public class CrossCacheTxRandomOperationsTest extends GridCommonAbstractTest {
 
             boolean checkData = fullSync && !optimistic;
 
-            long stopTime = System.currentTimeMillis() + 10_000;
+            long stopTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(10_000, 2_000);
 
             for (int i = 0; i < 10_000; i++) {
                 if (i % 100 == 0) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCachePutAllRestartTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCachePutAllRestartTest.java
@@ -125,7 +125,7 @@ public class IgniteCachePutAllRestartTest extends GridCommonAbstractTest {
         try {
             ThreadLocalRandom rnd = ThreadLocalRandom.current();
 
-            long endTime = System.currentTimeMillis() + 2 * 60_000;
+            long endTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(2 * 60_000, 20_000);
 
             while (System.currentTimeMillis() < endTime) {
                 int node = rnd.nextInt(1, NODES);
@@ -151,7 +151,7 @@ public class IgniteCachePutAllRestartTest extends GridCommonAbstractTest {
 
         ThreadLocalRandom rnd = ThreadLocalRandom.current();
 
-        long endTime = System.currentTimeMillis() + 2 * 60_000;
+        long endTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(2 * 60_000, 20_000);
 
         while (System.currentTimeMillis() < endTime) {
             int node = rnd.nextInt(0, NODES);
@@ -168,7 +168,7 @@ public class IgniteCachePutAllRestartTest extends GridCommonAbstractTest {
 
                     Random rnd = new Random();
 
-                    long endTime = System.currentTimeMillis() + 60_000;
+                    long endTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(60_000, 10_000);
 
                     try {
                         int iter = 0;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteCacheGetRestartTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteCacheGetRestartTest.java
@@ -47,7 +47,7 @@ import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
  */
 public class IgniteCacheGetRestartTest extends GridCommonAbstractTest {
     /** */
-    private static final long TEST_TIME = 60_000;
+    private static final long TEST_TIME = GridTestUtils.SF.applyLB(60_000, 10_000);
 
     /** */
     private static final int SRVS = 3;
@@ -56,7 +56,7 @@ public class IgniteCacheGetRestartTest extends GridCommonAbstractTest {
     private static final int CLIENTS = 1;
 
     /** */
-    private static final int KEYS = 100_000;
+    private static final int KEYS = GridTestUtils.SF.applyLB(100_000, 10_000);
 
     /** */
     private ThreadLocal<Boolean> client = new ThreadLocal<>();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxCacheWriteSynchronizationModesMultithreadedTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/IgniteTxCacheWriteSynchronizationModesMultithreadedTest.java
@@ -305,7 +305,7 @@ public class IgniteTxCacheWriteSynchronizationModesMultithreadedTest extends Gri
      * @throws Exception If failed.
      */
     private void commitMultithreaded(final IgniteBiInClosure<Ignite, IgniteCache<Integer, Integer>> c) throws Exception {
-        final long stopTime = System.currentTimeMillis() + 10_000;
+        final long stopTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(10_000, 2_000);
 
         GridTestUtils.runMultiThreaded(new IgniteInClosure<Integer>() {
             @Override public void apply(Integer idx) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgnitePdsTransactionsHangTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgnitePdsTransactionsHangTest.java
@@ -40,6 +40,7 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.TransactionConfiguration;
 import org.apache.ignite.internal.processors.cache.transactions.IgniteTxManager;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionIsolation;
@@ -68,7 +69,7 @@ public class IgnitePdsTransactionsHangTest extends GridCommonAbstractTest {
     public static final int WARM_UP_PERIOD = 20;
 
     /** Duration. */
-    public static final int DURATION = 180;
+    public static final int DURATION = GridTestUtils.SF.applyLB(180, 40);
 
     /** Maximum count of inserted keys. */
     public static final int MAX_KEY_COUNT = 500_000;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/wal/SegmentedRingByteBufferTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/wal/SegmentedRingByteBufferTest.java
@@ -384,7 +384,7 @@ public class SegmentedRingByteBufferTest extends GridCommonAbstractTest {
                 }
             }, producerCnt, "producer-thread");
 
-            long endTime = System.currentTimeMillis() + 60 * 1000L;
+            long endTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(60 * 1000, 10_000);
 
             while (System.currentTimeMillis() < endTime && ex.get() == null) {
                 while (restartBarrier.getNumberWaiting() != producerCnt && ex.get() == null)
@@ -487,7 +487,7 @@ public class SegmentedRingByteBufferTest extends GridCommonAbstractTest {
 
             Random rnd = new Random();
 
-            long endTime = System.currentTimeMillis() + 60 * 1000L;
+            long endTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(60 * 1000, 10_000);
 
             while (System.currentTimeMillis() < endTime && ex.get() == null) {
                 try {
@@ -591,7 +591,7 @@ public class SegmentedRingByteBufferTest extends GridCommonAbstractTest {
 
             Random rnd = new Random();
 
-            long endTime = System.currentTimeMillis() + 60 * 1000L;
+            long endTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(60 * 1000, 10_000);
 
             while (System.currentTimeMillis() < endTime && ex.get() == null) {
                 try {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxDeadlockDetectionNoHangsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxDeadlockDetectionNoHangsTest.java
@@ -182,7 +182,7 @@ public class TxDeadlockDetectionNoHangsTest extends GridCommonAbstractTest {
                 }
             }, 1, "restart-thread");
 
-            long stopTime = System.currentTimeMillis() + 2 * 60_000L;
+            long stopTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(2 * 60_000, 20_000);
 
             for (int i = 0; System.currentTimeMillis() < stopTime; i++) {
                 boolean detectionEnabled = grid(0).context().cache().context().tm().deadlockDetectionEnabled();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxDeadlockDetectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxDeadlockDetectionTest.java
@@ -131,7 +131,7 @@ public class TxDeadlockDetectionTest extends GridCommonAbstractTest {
                 }
             }, 1, "restart-thread");
 
-            long stopTime = System.currentTimeMillis() + 2 * 60_000L;
+            long stopTime = System.currentTimeMillis() + GridTestUtils.SF.applyLB(2 * 60_000, 20_000);
 
             for (int i = 0; System.currentTimeMillis() < stopTime; i++) {
                 log.info(">>> Iteration " + i);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxPartitionCounterStateConsistencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/transactions/TxPartitionCounterStateConsistencyTest.java
@@ -274,7 +274,7 @@ public class TxPartitionCounterStateConsistencyTest extends TxPartitionCounterSt
 
         List<Integer> primaryKeys = primaryKeys(prim.cache(DEFAULT_CACHE_NAME), 10_000);
 
-        long stop = U.currentTimeMillis() + 30_000;
+        long stop = U.currentTimeMillis() + GridTestUtils.SF.applyLB(30_000, 10_000);
 
         Random r = new Random();
 
@@ -326,7 +326,7 @@ public class TxPartitionCounterStateConsistencyTest extends TxPartitionCounterSt
 
         assertFalse(backups.contains(prim));
 
-        long stop = U.currentTimeMillis() + 30_000;
+        long stop = U.currentTimeMillis() + GridTestUtils.SF.applyLB(30_000, 10_000);
 
         long seed = System.nanoTime();
 
@@ -390,7 +390,7 @@ public class TxPartitionCounterStateConsistencyTest extends TxPartitionCounterSt
 
         assertFalse(backups.contains(prim));
 
-        long stop = U.currentTimeMillis() + 30_000;
+        long stop = U.currentTimeMillis() + GridTestUtils.SF.applyLB(30_000, 10_000);
 
         long seed = System.nanoTime();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/database/CacheFreeListSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/database/CacheFreeListSelfTest.java
@@ -294,7 +294,7 @@ public class CacheFreeListSelfTest extends GridCommonAbstractTest {
 
                 Random rnd = ThreadLocalRandom.current();
 
-                for (int i = 0; i < 200_000; i++) {
+                for (int i = 0; i < GridTestUtils.SF.applyLB(200_000, 50_000); i++) {
                     boolean grow0 = grow.get();
 
                     if (grow0) {


### PR DESCRIPTION
[IGNITE-28834](https://issues.apache.org/jira/browse/IGNITE-28834)

Wrap the load loops / time-boxed durations of the heaviest tests that were not honoring `TEST_SCALE_FACTOR` in `GridTestUtils.SF.applyLB(...)`, so they scale down on CI (where the factor is `0.1`) while keeping a safe lower bound at full scale.

### Scaled tests
- `IgniteTxCacheWriteSynchronizationModesMultithreadedTest` — 10s load window
- `TxDeadlockDetectionNoHangsTest` / `TxDeadlockDetectionTest` — 2-min run window
- `IgniteCacheGetRestartTest` — `TEST_TIME` / `KEYS`
- `CrossCacheTxRandomOperationsTest` — 10s window
- `SegmentedRingByteBufferTest` — 60s producer/consumer windows
- `TxPartitionCounterStateConsistencyTest` — 30s restart windows
- `IgnitePdsTransactionsHangTest` — `DURATION` (kept above warm-up)
- `CacheFreeListSelfTest` — grow/shrink load (200k → LB 50k)
- `ConcurrentCheckpointAndUpdateTtlTest` — checkpoint loop
- `IgniteCachePutAllRestartTest` — 2-min + 60s put windows

Lower bounds keep each scenario meaningful at factor `0.1` (e.g. ≥20s for deadlock detection, ≥10s for tx/restart windows, ≥50k entries for free-list grow/shrink).

Selection stopped where per-test saving drops below ~1 minute; the remaining heavy tests are topology/fan-out bound (no scalable load) and are out of scope.

### Validation
`mvn clean test-compile -pl modules/core` is green (JDK 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)