### PR TITLE
IGNITE-28840 Disable incremental compilation on the parallel codestyle build

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run codestyle and licenses checks
         run: |
-          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V -T 1C
+          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V -T 1C -Dmaven.compiler.useIncrementalCompilation=false
 
       - name: Run abandoned tests checks.
         # Reuse classes from the previous step; the differing profiles otherwise trigger a full reactor recompile.


### PR DESCRIPTION
## [IGNITE-28840](https://issues.apache.org/jira/browse/IGNITE-28840)

### Problem

After [IGNITE-28823](https://github.com/apache/ignite/pull/13281) parallelized the codestyle step of `commit-check.yml` with `-T 1C`, the *Check java code on JDK 17 / Run codestyle and licenses checks* job fails intermittently during `ignite-core` `test-compile`:

```
[ERROR] IgniteKernal.java:[176,45] cannot find symbol
  symbol:   class ConfigurationViewWalker
  location: package org.apache.ignite.internal.systemview
[ERROR] IgniteDataTransferObject.java:[27,47] package org.apache.ignite.internal.codegen.idto does not exist
```

The missing symbols (`*ViewWalker`, `IDTOSerializerFactory`) are sources produced by annotation processors (`SystemViewRowAttributeWalkerProcessor`, `IgniteDataTransferObjectProcessor`). Most runs pass, a minority fail — e.g. [run 28431196455](https://github.com/apache/ignite/actions/runs/28431196455/job/84246055611).

### Root cause

`maven-compiler-plugin` runs with incremental compilation enabled by default. Under the parallel reactor (`-T 1C`) it detects a changed reactor dependency and performs a *partial* recompile of `ignite-core`: the annotation processors run over the stale subset only, so the generated Walker/Factory classes are not regenerated, while the files referencing them are recompiled — hence `cannot find symbol`. Single-threaded the recompile set is consistent, so the issue did not surface before IGNITE-28823.

The same incremental-compilation pitfall was already worked around for the *abandoned tests* step in IGNITE-28823 via `-Dmaven.compiler.useIncrementalCompilation=false`; the codestyle step was left on incremental compilation.

### Change

Add `-Dmaven.compiler.useIncrementalCompilation=false` to the codestyle / `test-compile` step, forcing a full compile so annotation processors always regenerate all sources. The `-T 1C` speed-up is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)