### PR TITLE
IGNITE-28841 Drop parallel build (-T 1C) from the codestyle check

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run codestyle and licenses checks
         run: |
-          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V -T 1C -Dmaven.compiler.useIncrementalCompilation=false
+          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V
 
       - name: Run abandoned tests checks.
         # Reuse classes from the previous step; the differing profiles otherwise trigger a full reactor recompile.


### PR DESCRIPTION
## [IGNITE-28841](https://issues.apache.org/jira/browse/IGNITE-28841)

### Problem

[IGNITE-28840](https://github.com/apache/ignite/pull/13299) tried to fix the intermittent codestyle `test-compile` failure by adding `-Dmaven.compiler.useIncrementalCompilation=false`, but the job still fails the same way:

```
[ERROR] IgniteKernal.java:[176,45] cannot find symbol
  symbol:   class ConfigurationViewWalker
  location: package org.apache.ignite.internal.systemview
[ERROR] IgniteDataTransferObject.java:[27,47] package org.apache.ignite.internal.codegen.idto does not exist
```

Example with the IGNITE-28840 flag already in place: [run 28435576909](https://github.com/apache/ignite/actions/runs/28435576909/job/84260595716).

### Root cause

The trigger is `-T 1C` (introduced in [IGNITE-28823](https://github.com/apache/ignite/pull/13281)), not incremental compilation.

`maven-compiler-plugin` runs the compiler **in-process** (`fork` is not enabled), so javac executes inside the Maven JVM. The `ignite-core` annotation processors — `MessageProcessor`, `SystemViewRowAttributeWalkerProcessor`, `IgniteDataTransferObjectProcessor` — reach into `com.sun.tools.javac` internals (which is why `MAVEN_OPTS` and the surefire `argLine` open `jdk.compiler/com.sun.tools.javac.*`).

Under `-T 1C` several reactor modules compile concurrently in that single JVM. The shared in-process javac / `com.sun.tools.javac` machinery is not thread-safe, so generation of the Walker / Factory sources for `ignite-core` is intermittently dropped while the files referencing them are compiled — hence `cannot find symbol`. Single-threaded there is no concurrent compilation and the issue does not occur.

Forking the compiler is not viable here: a forked javac would not inherit the `--add-opens=jdk.compiler/...` that `MAVEN_OPTS` grants the in-process compiler, breaking the processors outright.

### Change

Run the codestyle / `test-compile` step single-threaded again (drop `-T 1C`) and remove the ineffective `-Dmaven.compiler.useIncrementalCompilation=false` from this step. The primary IGNITE-28823 improvement — avoiding the second full reactor recompile on the *abandoned tests* step — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)