### PR TITLE
IGNITE-28842 Restore parallel codestyle build (-T 1C) and report compilation failures clearly

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -97,7 +97,21 @@ jobs:
 
       - name: Run codestyle and licenses checks
         run: |
-          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V
+          set -o pipefail
+          rc=0
+          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V -T 1C 2>&1 | tee mvn-codestyle.log || rc=$?
+          if [ "$rc" -ne 0 ] && grep -q "COMPILATION ERROR" mvn-codestyle.log; then
+            echo "::error title=Compilation failed::Java compilation failed - this is a compile error, not a checkstyle violation. The flood of 'cannot find symbol' for generated *Walker/*Serializer/*Factory classes is a cascade: javac drops annotation-processor output when compilation fails. Fix the real error(s) listed in the build log group below first."
+            echo "::group::Likely root-cause compile errors (generated-class cascade filtered out)"
+            awk '
+              /^\[ERROR\].*cannot find symbol/ { loc=$0; getline s; gsub(/^[[:space:]]*(\[ERROR\][[:space:]]*)?/, "", s);
+                if (s !~ /(Walker|Serializer|Factory)([^A-Za-z]|$)/) print loc "  ->  " s; next }
+              /^\[ERROR\].*\.java:\[[0-9]+,[0-9]+\]/ {
+                if ($0 !~ /codegen\.idto|internal\.systemview/) print $0 }
+            ' mvn-codestyle.log | sed -E 's#^.*/modules/#modules/#; s/^\[ERROR\] //' | sort -u | head -n 40
+            echo "::endgroup::"
+          fi
+          exit "$rc"
 
       - name: Run abandoned tests checks.
         # Reuse classes from the previous step; the differing profiles otherwise trigger a full reactor recompile.


### PR DESCRIPTION
## [IGNITE-28842](https://issues.apache.org/jira/browse/IGNITE-28842)

### Background

The *Check java code* codestyle job intermittently looked broken with ~288 `cannot find symbol` errors for annotation-processor-generated classes (`*ViewWalker`, `*MessageSerializer`, `IDTOSerializerFactory`). Root cause: a single **real** compile error in a stale PR branch (a removed method still referenced after a clean text merge). javac drops all annotation-processor output when a compilation round has errors, so one real error cascades into hundreds of generated-class `cannot find symbol` errors that bury it.

[IGNITE-28840](https://github.com/apache/ignite/pull/13299) and [IGNITE-28841](https://github.com/apache/ignite/pull/13300) chased this as a build-infra / parallelism problem; both were misdiagnoses. IGNITE-28841 in particular dropped the `-T 1C` parallel build added by [IGNITE-28823](https://github.com/apache/ignite/pull/13281). `-T 1C` was never the cause — the failure reproduces single-threaded.

### Change

1. Restore `-T 1C` on the codestyle / `test-compile` step (re-applies the IGNITE-28823 speed-up).
2. On compilation failure, make the job state it plainly and surface the real error: a GitHub `::error::` annotation ("compilation failed, not a checkstyle violation"), plus a collapsible group listing likely root-cause errors with the generated-class cascade (`*Walker`/`*Serializer`/`*Factory`, `internal.systemview`, `codegen.idto`) filtered out. Checkstyle-only failures are unaffected.

### Verification

Filtering validated against a real failing build log (PR #13298 merge): from 288 errors it surfaces exactly the real one — `IgniteTxManager.java:[148,1] cannot find symbol: static deriveSyncMode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)