### PR TITLE
[DO NOT MERGE] CI test: validate codestyle compilation-failure reporting (IGNITE-28842)

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -97,7 +97,21 @@ jobs:
 
       - name: Run codestyle and licenses checks
         run: |
-          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V
+          set -o pipefail
+          rc=0
+          ./mvnw test-compile -Pall-java,licenses,lgpl,checkstyle,examples,check-licenses -B -V -T 1C 2>&1 | tee mvn-codestyle.log || rc=$?
+          if [ "$rc" -ne 0 ] && grep -q "COMPILATION ERROR" mvn-codestyle.log; then
+            echo "::error title=Compilation failed::Java compilation failed - this is a compile error, not a checkstyle violation. The flood of 'cannot find symbol' for generated *Walker/*Serializer/*Factory classes is a cascade: javac drops annotation-processor output when compilation fails. Fix the real error(s) listed in the build log group below first."
+            echo "::group::Likely root-cause compile errors (generated-class cascade filtered out)"
+            awk '
+              /^\[ERROR\].*cannot find symbol/ { loc=$0; getline s; gsub(/^[[:space:]]*(\[ERROR\][[:space:]]*)?/, "", s);
+                if (s !~ /(Walker|Serializer|Factory)([^A-Za-z]|$)/) print loc "  ->  " s; next }
+              /^\[ERROR\].*\.java:\[[0-9]+,[0-9]+\]/ {
+                if ($0 !~ /codegen\.idto|internal\.systemview/) print $0 }
+            ' mvn-codestyle.log | sed -E 's#^.*/modules/#modules/#; s/^\[ERROR\] //' | sort -u | head -n 40
+            echo "::endgroup::"
+          fi
+          exit "$rc"
 
       - name: Run abandoned tests checks.
         # Reuse classes from the previous step; the differing profiles otherwise trigger a full reactor recompile.

--- a/modules/core/src/main/java/org/apache/ignite/internal/CiBrokenCompileProbe.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/CiBrokenCompileProbe.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+/** Temporary probe to verify the codestyle job reports compilation failures clearly. Must be reverted. */
+class CiBrokenCompileProbe {
+    void probe() {
+        nonexistentMethodForCiTest();
+    }
+}


### PR DESCRIPTION
**Draft / do not merge / will be closed.**

Validates the compilation-failure reporting added in [IGNITE-28842](https://github.com/apache/ignite/pull/13302). This branch = the IGNITE-28842 workflow change + a deliberate compile error (undefined symbol) in an `ignite-core` main source.

Expected on the *Check java code* job: it fails, prints a `::error:: Compilation failed` annotation, and a "Likely root-cause compile errors" group that surfaces the real `nonexistentMethodForCiTest` error while hiding the generated-class cascade.

Will be closed once the output is confirmed.