### PR TITLE
IGNITE-28843 Improve diagnostics when snapshot/dump directory creation fails

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/filename/SharedFileTree.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/filename/SharedFileTree.java
@@ -18,6 +18,8 @@
 package org.apache.ignite.internal.processors.cache.persistence.filename;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
@@ -195,8 +197,13 @@ public class SharedFileTree {
      * @param dir Directory to create.
      */
     public static File mkdir(File dir, String name) {
-        if (!U.mkdirs(dir))
-            throw new IgniteException("Could not create directory for " + name + ": " + dir);
+        try {
+            Files.createDirectories(dir.toPath());
+        }
+        catch (IOException e) {
+            throw new IgniteException("Could not create directory for " + name + ": " + dir +
+                ' ' + U.ioFailureDetails(e), e);
+        }
 
         if (!dir.canRead())
             throw new IgniteException("Cannot read from directory: " + dir);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/SnapshotFutureTask.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -633,8 +634,13 @@ class SnapshotFutureTask extends AbstractCreateSnapshotFutureTask implements Che
 
                 File cfgTmpRoot = sft.tempFileTree().cacheConfigurationFile(ccfg).getParentFile();
 
-                if (!U.mkdirs(cfgTmpRoot))
-                    throw new IOException("Unable to create temp directory to copy original configuration file: " + cfgTmpRoot);
+                try {
+                    Files.createDirectories(cfgTmpRoot.toPath());
+                }
+                catch (IOException e) {
+                    throw new IOException("Unable to create temp directory to copy original configuration file: " +
+                        cfgTmpRoot + ' ' + U.ioFailureDetails(e), e);
+                }
 
                 File newCcfgFile = new File(cfgTmpRoot, ccfgFile.getName());
                 newCcfgFile.createNewFile();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/dump/CreateDumpFutureTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/snapshot/dump/CreateDumpFutureTask.java
@@ -224,10 +224,8 @@ public class CreateDumpFutureTask extends AbstractCreateSnapshotFutureTask imple
         for (Map.Entry<Integer, Set<Integer>> e : processed.entrySet()) {
             int grp = e.getKey();
 
-            for (File grpDumpDir : sft.cacheStorages(cctx.cache().cacheGroup(grp).config())) {
-                if (!grpDumpDir.mkdirs())
-                    throw new IgniteCheckedException("Dump directory can't be created: " + grpDumpDir);
-            }
+            for (File grpDumpDir : sft.cacheStorages(cctx.cache().cacheGroup(grp).config()))
+                IgniteUtils.ensureDirectory(grpDumpDir, "dump directory", null);
 
             CacheGroupContext gctx = cctx.cache().cacheGroup(grp);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/IgniteUtils.java
@@ -6262,17 +6262,31 @@ public abstract class IgniteUtils extends CommonUtils {
      *      the same name already exists.
      */
     public static void ensureDirectory(File dir, String msg, IgniteLogger log) throws IgniteCheckedException {
-        if (!dir.exists()) {
-            if (!dir.mkdirs())
-                throw new IgniteCheckedException("Failed to create " + msg + ": " +
-                    dir.getAbsolutePath());
-        }
-        else if (!dir.isDirectory())
+        if (dir.exists() && !dir.isDirectory())
             throw new IgniteCheckedException("Failed to initialize " + msg +
                 " (a file with the same name already exists): " + dir.getAbsolutePath());
 
+        try {
+            Files.createDirectories(dir.toPath());
+        }
+        catch (IOException e) {
+            throw new IgniteCheckedException("Failed to create " + msg + ": " + dir.getAbsolutePath() +
+                ' ' + ioFailureDetails(e), e);
+        }
+
         if (log != null && log.isInfoEnabled())
             log.info("Resolved " + msg + ": " + dir.getAbsolutePath());
+    }
+
+    /**
+     * Renders the OS-level reason of an I/O failure so that a caller can append it to its own error message.
+     * The reason survives logging that prints only {@link Throwable#toString()} (without the cause chain).
+     *
+     * @param e I/O failure.
+     * @return Reason suffix, e.g. {@code [reason=AccessDeniedException, detail=/path: Permission denied]}.
+     */
+    public static String ioFailureDetails(IOException e) {
+        return "[reason=" + e.getClass().getSimpleName() + ", detail=" + e.getMessage() + ']';
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/util/IgniteUtilsUnitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/util/IgniteUtilsUnitTest.java
@@ -17,16 +17,29 @@
 
 package org.apache.ignite.internal.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.testframework.ListeningTestLogger;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Unit tests for {@link IgniteUtils}.
@@ -37,6 +50,9 @@ public class IgniteUtilsUnitTest {
 
     /***/
     private final List<String> logMessages = new CopyOnWriteArrayList<>();
+
+    /***/
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
     /***/
     @Test
@@ -54,6 +70,65 @@ public class IgniteUtilsUnitTest {
         }
 
         assertThat(logMessages, is(empty()));
+    }
+
+    /** Creating a directory that already exists must be a no-op, not an error. */
+    @Test
+    public void ensureDirectoryIsIdempotentForExistingDirectory() throws Exception {
+        File dir = tmp.newFolder("dump_dir");
+
+        IgniteUtils.ensureDirectory(dir, "dump directory", null);
+        IgniteUtils.ensureDirectory(dir, "dump directory", null);
+    }
+
+    /** On failure the OS-level reason and cause must be reported, not a bare "can't be created". */
+    @Test
+    public void ensureDirectorySurfacesReasonAndCauseWhenPathComponentIsFile() throws Exception {
+        File blocker = tmp.newFile("this_is_a_file");
+
+        File target = new File(blocker, "db/cell_2_node_2");
+
+        try {
+            IgniteUtils.ensureDirectory(target, "dump directory", null);
+
+            fail("Expected IgniteCheckedException");
+        }
+        catch (IgniteCheckedException e) {
+            assertThat(e.getMessage(), containsString("Failed to create dump directory"));
+            assertThat(e.getMessage(), containsString("reason="));
+            assertThat(e.getCause(), instanceOf(IOException.class));
+        }
+    }
+
+    /** A non-writable parent must yield an {@link AccessDeniedException}-backed message. */
+    @Test
+    public void ensureDirectoryReportsAccessDeniedWhenParentNotWritable() throws Exception {
+        assumeTrue("POSIX permissions required", FileSystems.getDefault()
+            .supportedFileAttributeViews().contains("posix"));
+
+        File parent = tmp.newFolder("nvme5_snapshot");
+
+        Files.setPosixFilePermissions(parent.toPath(), PosixFilePermissions.fromString("r-xr-xr-x"));
+
+        try {
+            // Skip when the current user can write regardless of the mode bits (e.g. running as root).
+            assumeFalse("parent is writable (running as root?)", new File(parent, "probe").mkdirs());
+
+            File target = new File(parent, "dump_x/db/cell_2_node_2");
+
+            try {
+                IgniteUtils.ensureDirectory(target, "dump directory", null);
+
+                fail("Expected IgniteCheckedException");
+            }
+            catch (IgniteCheckedException e) {
+                assertThat(e.getMessage(), containsString("AccessDeniedException"));
+                assertThat(e.getCause(), instanceOf(AccessDeniedException.class));
+            }
+        }
+        finally {
+            Files.setPosixFilePermissions(parent.toPath(), PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
     }
 
     /***/


### PR DESCRIPTION
## IGNITE-28843

https://issues.apache.org/jira/browse/IGNITE-28843

### Problem

Snapshot/dump directory creation failures reported only the target path with no OS-level cause:

```
class org.apache.ignite.IgniteCheckedException: Dump directory can't be created:
/opt/ignite/nvme5/snapshot/dump_.../db/cell_2_node_2/cache-replication.replications_v1
```

The reason (permissions, no space, read-only FS, a file where a directory is expected, a missing mount) is lost because the code uses `java.io.File.mkdirs()`, which returns a boolean and discards the cause. `mkdirs()` also returns `false` when the directory already exists, which can produce a misleading error on retry.

### Fix

Create directories via NIO `Files.createDirectories(Path)`. It is idempotent for existing directories and throws a typed `IOException` (`AccessDeniedException`; `FileSystemException` "No space left on device"; `ReadOnlyFileSystemException`; `NotDirectoryException` / `FileAlreadyExistsException`; `NoSuchFileException`) that carries the OS reason. The exception class and message are included in the thrown Ignite exception, and the original exception is attached as the cause.

Updated:
- `IgniteUtils.ensureDirectory(File, String, IgniteLogger)` — shared helper used by WAL, binary metadata, maintenance, snapshot and dump config.
- `CreateDumpFutureTask.prepare()` — the exact spot from the report; now routed through `ensureDirectory` (also removes the inconsistency with `saveCacheConfigs`, which already used it).
- `SnapshotFutureTask` — temp cache-configuration directory.
- `SharedFileTree.mkdir(File, String)` — remaining raw-mkdirs throwing site.

Not changed: `IgniteUtils.mkdirs(File)` keeps its boolean contract — a boolean cannot carry a reason, and 9 call-sites (3 of them ignoring the result) rely on it.

Resulting message example:

```
Failed to create dump directory: /opt/ignite/nvme5/snapshot/.../cell_2_node_2/cache-replication.replications_v1 [reason=AccessDeniedException, detail=/opt/ignite/.../cell_2_node_2: Permission denied]
```

### Testing

`IgniteUtilsUnitTest`, 3 new cases (plain JUnit, no grid started):
- `ensureDirectoryIsIdempotentForExistingDirectory` — an existing directory must not raise an error (guards the `mkdirs()`-returns-false regression).
- `ensureDirectorySurfacesReasonAndCauseWhenPathComponentIsFile` — the message contains `reason=` and the cause is an `IOException` (deterministic, independent of permissions or the running user).
- `ensureDirectoryReportsAccessDeniedWhenParentNotWritable` — a non-writable parent yields `AccessDeniedException` in both the message and the cause. Guarded with `assumeTrue(POSIX)` and an `assumeFalse` writable-probe so it self-skips on non-POSIX filesystems or when running as root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
