### PR TITLE
IGNITE-28847 REST (memcached): eliminate intermediate buffer copies when encoding responses

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/protocols/tcp/GridTcpRestParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/protocols/tcp/GridTcpRestParser.java
@@ -37,6 +37,7 @@ import org.apache.ignite.internal.util.GridByteArrayList;
 import org.apache.ignite.internal.util.GridUnsafe;
 import org.apache.ignite.internal.util.nio.GridNioParser;
 import org.apache.ignite.internal.util.nio.GridNioSession;
+import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.marshaller.Marshaller;
@@ -659,40 +660,38 @@ public class GridTcpRestParser implements GridNioParser {
      * @throws IgniteCheckedException If serialization failed.
      */
     private ByteBuffer encodeMemcache(GridMemcachedMessage msg) throws IgniteCheckedException {
-        GridByteArrayList res = new GridByteArrayList(HDR_LEN);
-
-        int keyLen = 0;
+        byte[] key = null;
 
         int keyFlags = 0;
 
         if (msg.key() != null) {
-            ByteArrayOutputStream rawKey = new ByteArrayOutputStream();
+            T2<byte[], Integer> encKey = encodeObj(msg.key());
 
-            keyFlags = encodeObj(msg.key(), rawKey);
-
-            msg.key(rawKey.toByteArray());
-
-            keyLen = rawKey.size();
+            key = encKey.get1();
+            keyFlags = encKey.get2();
         }
 
-        int dataLen = 0;
+        byte[] val = null;
 
         int valFlags = 0;
 
         if (msg.value() != null) {
-            ByteArrayOutputStream rawVal = new ByteArrayOutputStream();
+            T2<byte[], Integer> encVal = encodeObj(msg.value());
 
-            valFlags = encodeObj(msg.value(), rawVal);
-
-            msg.value(rawVal.toByteArray());
-
-            dataLen = rawVal.size();
+            val = encVal.get1();
+            valFlags = encVal.get2();
         }
+
+        int keyLen = key != null ? key.length : 0;
+
+        int dataLen = val != null ? val.length : 0;
 
         int flagsLen = 0;
 
         if (msg.addFlags())// || keyFlags > 0 || valFlags > 0)
             flagsLen = FLAGS_LENGTH;
+
+        GridByteArrayList res = new GridByteArrayList(HDR_LEN + flagsLen + keyLen + dataLen);
 
         res.add(MEMCACHE_RES_FLAG);
 
@@ -723,14 +722,11 @@ public class GridTcpRestParser implements GridNioParser {
             res.add((short)valFlags);
         }
 
-        assert msg.key() == null || msg.key() instanceof byte[];
-        assert msg.value() == null || msg.value() instanceof byte[];
-
         if (keyLen > 0)
-            res.add((byte[])msg.key(), 0, ((byte[])msg.key()).length);
+            res.add(key, 0, keyLen);
 
         if (dataLen > 0)
-            res.add((byte[])msg.value(), 0, ((byte[])msg.value()).length);
+            res.add(val, 0, dataLen);
 
         return ByteBuffer.wrap(res.entireArray());
     }
@@ -871,67 +867,30 @@ public class GridTcpRestParser implements GridNioParser {
      * Encodes given object to a byte array and returns flags that describe the type of serialized object.
      *
      * @param obj Object to serialize.
-     * @param out Output stream to which object should be written.
-     * @return Serialization flags.
+     * @return Tuple of encoded object bytes and serialization flags.
      * @throws IgniteCheckedException If JDK serialization failed.
      */
-    private int encodeObj(Object obj, ByteArrayOutputStream out) throws IgniteCheckedException {
-        int flags = 0;
-
-        byte[] data = null;
-
+    private T2<byte[], Integer> encodeObj(Object obj) throws IgniteCheckedException {
         if (obj instanceof String)
-            data = ((String)obj).getBytes(UTF_8);
-        else if (obj instanceof Boolean) {
-            data = new byte[] {(byte)((Boolean)obj ? '1' : '0')};
-
-            flags |= BOOLEAN_FLAG;
-        }
-        else if (obj instanceof Integer) {
-            data = U.intToBytes((Integer)obj);
-
-            flags |= INT_FLAG;
-        }
-        else if (obj instanceof Long) {
-            data = U.longToBytes((Long)obj);
-
-            flags |= LONG_FLAG;
-        }
-        else if (obj instanceof Date) {
-            data = U.longToBytes(((Date)obj).getTime());
-
-            flags |= DATE_FLAG;
-        }
-        else if (obj instanceof Byte) {
-            data = new byte[] {(Byte)obj};
-
-            flags |= BYTE_FLAG;
-        }
-        else if (obj instanceof Float) {
-            data = U.intToBytes(Float.floatToIntBits((Float)obj));
-
-            flags |= FLOAT_FLAG;
-        }
-        else if (obj instanceof Double) {
-            data = U.longToBytes(Double.doubleToLongBits((Double)obj));
-
-            flags |= DOUBLE_FLAG;
-        }
-        else if (obj instanceof byte[]) {
-            data = (byte[])obj;
-
-            flags |= BYTE_ARR_FLAG;
-        }
-        else {
-            U.marshal(marsh, obj, out);
-
-            flags |= SERIALIZED_FLAG;
-        }
-
-        if (data != null)
-            out.write(data, 0, data.length);
-
-        return flags;
+            return new T2<>(((String)obj).getBytes(UTF_8), 0);
+        else if (obj instanceof Boolean)
+            return new T2<>(new byte[] {(byte)((Boolean)obj ? '1' : '0')}, BOOLEAN_FLAG);
+        else if (obj instanceof Integer)
+            return new T2<>(U.intToBytes((Integer)obj), INT_FLAG);
+        else if (obj instanceof Long)
+            return new T2<>(U.longToBytes((Long)obj), LONG_FLAG);
+        else if (obj instanceof Date)
+            return new T2<>(U.longToBytes(((Date)obj).getTime()), DATE_FLAG);
+        else if (obj instanceof Byte)
+            return new T2<>(new byte[] {(Byte)obj}, BYTE_FLAG);
+        else if (obj instanceof Float)
+            return new T2<>(U.intToBytes(Float.floatToIntBits((Float)obj)), FLOAT_FLAG);
+        else if (obj instanceof Double)
+            return new T2<>(U.longToBytes(Double.doubleToLongBits((Double)obj)), DOUBLE_FLAG);
+        else if (obj instanceof byte[])
+            return new T2<>((byte[])obj, BYTE_ARR_FLAG);
+        else
+            return new T2<>(U.marshal(marsh, obj), SERIALIZED_FLAG);
     }
 
     /**


### PR DESCRIPTION
## Description

[IGNITE-28847](https://issues.apache.org/jira/browse/IGNITE-28847)

`GridTcpRestParser#encodeMemcache` copies each response key/value payload up to 4 times before it reaches the wire:

1. `encodeObj` writes the encoded bytes into an intermediate `ByteArrayOutputStream` (copy into the BAOS internal buffer, with growth reallocations on the way);
2. `ByteArrayOutputStream#toByteArray()` produces another full copy;
3. that array is appended to a `GridByteArrayList` created with capacity `HDR_LEN` (24 bytes) only, so the list keeps doubling and re-copying its internal array while the payload is appended;
4. `GridByteArrayList#entireArray()` makes a final trimming copy because the internal array is larger than the actual packet.

As a side effect, `encodeMemcache` also mutates the message being encoded (`msg.key(...)`/`msg.value(...)` are overwritten with the serialized `byte[]`).

## Change

- `encodeObj` returns `T2<byte[], Integer>` (encoded bytes + type flags) instead of writing into a caller-provided `ByteArrayOutputStream`; for JDK-serialized objects `U.marshal(marsh, obj)` is used instead of marshalling into a BAOS.
- `encodeMemcache` computes the exact packet size up front and allocates `GridByteArrayList(HDR_LEN + flagsLen + keyLen + dataLen)`. The list never grows, so `entireArray()` returns its internal array without copying. The only remaining copy is the single append of key/value bytes into the packet buffer.
- The side-effecting mutation of `msg.key()`/`msg.value()` during encoding is removed.

Net effect for `String`/`byte[]` payloads: 4 full payload copies → 1.

## Benchmark

JMH (AverageTime, 1 fork, 3×1s warmup, 5×1s measurement, `-prof gc`; JDK 17; key = short `String`):

| Payload | old, ns/op | new, ns/op | time | old, B/op | new, B/op | alloc |
|---|---:|---:|---:|---:|---:|---:|
| 64 B `String` | 50.6 ± 0.8 | 21.3 ± 1.9 | −58% | 872 | 240 | −72% |
| 1 KiB `String` | 208.9 ± 20.2 | 73.8 ± 9.4 | −65% | 6632 | 2160 | −67% |
| 8 KiB `byte[]` | 1596.0 ± 110.4 | 433.0 ± 9.1 | −73% | 41432 | 8352 | −80% |
| `HashMap` (JDK-serialized) | 962.3 ± 138.8 | 1094.3 ± 194.1 | parity¹ | 5528 | 4184 | −24% |

¹ dominated by JDK serialization itself; the time difference is within the error bars, per-op allocations still drop.

## Checklist

- [x] Wire format is unchanged — byte-for-byte identical packets, verified in benchmark setup (old and new encoders replicated verbatim, outputs compared with `Arrays.equals`).
- [x] No public API change (internal `GridTcpRestParser` only).
- [x] `TcpRestParserSelfTest`, `RestMemcacheProtocolSelfTest`, `ClientMemcachedProtocolSelfTest` — 38/38 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
