### PR TITLE
IGNITE-28848 ZooKeeper discovery: stream marshalZip through DeflaterOutputStream to cut allocations and peak memory

### DIFF
--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
@@ -4074,7 +4074,8 @@ public class ZookeeperDiscoveryImpl {
 
         GridByteArrayOutputStream out = new GridByteArrayOutputStream();
 
-        // Buffer coalesces ~1KB ObjectOutputStream blocks into fewer JNI deflate calls.
+        // BufferedOutputStream's 8 KB buffer coalesces JdkMarshaller's ~1 KB ObjectOutputStream
+        // block-data writes into fewer Deflater JNI calls.
         try (BufferedOutputStream zipOut = new BufferedOutputStream(new DeflaterOutputStream(out))) {
             U.marshal(marsh, obj, zipOut);
         }

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
@@ -17,7 +17,9 @@
 
 package org.apache.ignite.spi.discovery.zk.internal;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +41,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.DataFormatException;
-import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import org.apache.ignite.Ignite;
@@ -4064,33 +4066,20 @@ public class ZookeeperDiscoveryImpl {
 
     /**
      * @param obj Object.
-     * @return Bytes.
+     * @return Zip-compressed marshalled bytes.
      * @throws IgniteCheckedException If failed.
      */
     byte[] marshalZip(Object obj) throws IgniteCheckedException {
         assert obj != null;
 
-        return zip(U.marshal(marsh, obj));
-    }
+        GridByteArrayOutputStream out = new GridByteArrayOutputStream();
 
-    /**
-     * @param bytes Bytes to compress.
-     * @return Zip-compressed bytes.
-     */
-    private static byte[] zip(byte[] bytes) {
-        Deflater deflater = new Deflater();
-
-        deflater.setInput(bytes);
-        deflater.finish();
-
-        GridByteArrayOutputStream out = new GridByteArrayOutputStream(bytes.length);
-
-        final byte[] buf = new byte[bytes.length];
-
-        while (!deflater.finished()) {
-            int cnt = deflater.deflate(buf);
-
-            out.write(buf, 0, cnt);
+        // Buffer coalesces ~1KB ObjectOutputStream blocks into fewer JNI deflate calls.
+        try (BufferedOutputStream zipOut = new BufferedOutputStream(new DeflaterOutputStream(out))) {
+            U.marshal(marsh, obj, zipOut);
+        }
+        catch (IOException e) {
+            throw new IgniteCheckedException("Failed to marshal object: " + obj, e);
         }
 
         return out.toByteArray();

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
@@ -4072,7 +4072,10 @@ public class ZookeeperDiscoveryImpl {
     byte[] marshalZip(Object obj) throws IgniteCheckedException {
         assert obj != null;
 
-        GridByteArrayOutputStream out = new GridByteArrayOutputStream();
+        // Seed the output buffer so the compressed stream doesn't grow through a chain of doubling
+        // reallocations; 8 KB matches the BufferedOutputStream buffer we already allocate below, so
+        // it stays cheap for small payloads.
+        GridByteArrayOutputStream out = new GridByteArrayOutputStream(8 * 1024);
 
         // BufferedOutputStream's 8 KB buffer coalesces JdkMarshaller's ~1 KB ObjectOutputStream
         // block-data writes into fewer Deflater JNI calls.

--- a/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
+++ b/modules/zookeeper/src/main/java/org/apache/ignite/spi/discovery/zk/internal/ZookeeperDiscoveryImpl.java
@@ -4072,10 +4072,7 @@ public class ZookeeperDiscoveryImpl {
     byte[] marshalZip(Object obj) throws IgniteCheckedException {
         assert obj != null;
 
-        // Seed the output buffer so the compressed stream doesn't grow through a chain of doubling
-        // reallocations; 8 KB matches the BufferedOutputStream buffer we already allocate below, so
-        // it stays cheap for small payloads.
-        GridByteArrayOutputStream out = new GridByteArrayOutputStream(8 * 1024);
+        GridByteArrayOutputStream out = new GridByteArrayOutputStream();
 
         // BufferedOutputStream's 8 KB buffer coalesces JdkMarshaller's ~1 KB ObjectOutputStream
         // block-data writes into fewer Deflater JNI calls.


### PR DESCRIPTION
JIRA: [IGNITE-28848](https://issues.apache.org/jira/browse/IGNITE-28848) (follow-up to IGNITE-28835)

**Why this matters.** `marshalZip()` sits on the two busiest control-plane paths of ZooKeeper discovery: the coordinator re-marshals the whole `ZkDiscoveryEventsData` on **every** discovery event (node joins/failures and every custom message — cache create/destroy, exchange, services, snapshots, ...), and join data / data-for-joined is megabytes in clusters with hundreds of caches (split across znodes by `jute.maxbuffer`). The current code materializes the uncompressed form before compressing: ~6x the uncompressed size in garbage and ~3x at peak **per call** — so a mass join, client reconnect storm or rolling restart hits the coordinator with GC pressure and heap spikes exactly when it is busiest, and the pauses land on the discovery critical path (events are processed sequentially, the whole cluster sees slower event propagation). `Deflater.end()` is never called either, so zlib native memory waits for the Cleaner.

**Change:** stream marshalling straight through `BufferedOutputStream -> DeflaterOutputStream`: the uncompressed form is never materialized, peak memory is bounded by the compressed output, and the deflater is released deterministically on close. The `BufferedOutputStream` is essential — `ObjectOutputStream` writes ~1 KB blocks, and unbuffered per-block JNI deflate calls cost +14–20% time. The private `zip()` helper is removed (`marshalZip` was its only caller); `unzip()` stays (still used for `ATTR_SECURITY_SUBJECT_V2`); the read side (`unmarshalZip`) already streams. Same pattern as `DiscoveryMessageParser.marshalZip` in the same package.

**Compatibility:** zlib format is unchanged (default `Deflater` settings in both versions) — old nodes inflate the bytes as is, rolling upgrade safe.

JMH (avgt, JDK 17, `-prof gc`), old vs new:

| payload (marshalled → zipped) | time old, us/op | time new, us/op | alloc old, B/op | alloc new, B/op |
|---|---|---|---|---|
| MAP_2K (1.6 KB → 0.7 KB) | 21.3 ± 11.5 | 15.4 ± 0.7 | 12,544 | 14,368 (+15%) |
| MAP_100K (132 KB → 40 KB) | 1,987 ± 512 | 1,931 ± 264 | 1,065,204 | 283,835 (−73%) |
| LIST_1M (1.66 MB → 318 KB) | 17,661 ± 3,433 | 16,825 ± 980 | 9,891,984 | 1,788,235 (−82%) |

Allocations drop 73–82% on realistic payloads; per-call time is on par or better. The small-payload trade-off (+15% B/op — bounded fixed overhead of the 8 KB buffer, break-even ~3 KB) is analyzed in the JIRA description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)