### PR TITLE
IGNITE-28853 CompressedMessage: excessive copying on send/receive and per-message direct buffer allocations on receive path

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/direct/DirectMessageReader.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/direct/DirectMessageReader.java
@@ -493,14 +493,9 @@ public class DirectMessageReader implements MessageReader {
 
         byte[] uncompressed = msg0.uncompressed();
 
-        ByteBuffer tmpBuf = ByteBuffer.allocateDirect(uncompressed.length);
-
-        tmpBuf.put(uncompressed);
-        tmpBuf.flip();
-
         DirectMessageReader tmpReader = new DirectMessageReader(msgFactory, cacheObjProc);
 
-        tmpReader.setBuffer(tmpBuf);
+        tmpReader.setBuffer(ByteBuffer.wrap(uncompressed));
 
         T res = fun.apply(tmpReader);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/CompressedMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/CompressedMessage.java
@@ -17,14 +17,13 @@
 
 package org.apache.ignite.internal.managers.communication;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Inflater;
-import java.util.zip.InflaterInputStream;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.plugin.extensions.communication.Message;
@@ -38,17 +37,14 @@ public class CompressedMessage implements Message {
     /** Chunk size. */
     static final int CHUNK_SIZE = 10 * 1024;
 
-    /** Reader buffer capacity. */
-    static final int BUFFER_CAPACITY = 10 * CHUNK_SIZE;
+    /** Compressed data chunks: filled by {@link #compress(ByteBuffer)} on send, by the serializer on receive. */
+    List<byte[]> chunks;
 
-    /** Temporary buffer for compressed data received over the network. */
-    ByteBuffer tmpBuf;
+    /** Index of the next chunk to send. */
+    private int chunkIdx;
 
     /** Raw data size. */
     int dataSize;
-
-    /** Chunked byte reader. */
-    ChunkedByteReader chunkedReader;
 
     /** Chunk. */
     byte[] chunk;
@@ -73,7 +69,7 @@ public class CompressedMessage implements Message {
         this.compressionLvl = compressionLvl;
 
         if (dataSize > 0)
-            chunkedReader = new ChunkedByteReader(compress(buf));
+            compress(buf);
     }
 
     /** @return Raw data size. */
@@ -90,99 +86,81 @@ public class CompressedMessage implements Message {
 
     /** @return Next chunk of data or null. */
     public byte[] nextChunk() {
-        return chunkedReader.nextChunk();
+        return chunkIdx < chunks.size() ? chunks.get(chunkIdx++) : null;
     }
 
-    /**
-     * @param buf Buffer.
-     * @return Compressed data.
-     */
-    private byte[] compress(ByteBuffer buf) {
-        byte[] data = new byte[dataSize];
-
-        buf.get(data);
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length);
+    /** @param buf Buffer. */
+    private void compress(ByteBuffer buf) {
         Deflater deflater = new Deflater(compressionLvl, true);
 
-        try (DeflaterOutputStream dos = new DeflaterOutputStream(baos, deflater)) {
-            dos.write(data);
-            dos.finish();
-        }
-        catch (IOException ex) {
-            throw new IgniteException(ex);
+        try {
+            deflater.setInput(buf);
+            deflater.finish();
+
+            chunks = new ArrayList<>(dataSize / CHUNK_SIZE + 1);
+
+            // Incompressible data may expand: raw-deflate worst case below CHUNK_SIZE is one stored block (~11 bytes overhead).
+            byte[] chunk0 = new byte[dataSize >= CHUNK_SIZE ? CHUNK_SIZE : dataSize + 16];
+
+            int len = 0;
+
+            while (!deflater.finished()) {
+                len += deflater.deflate(chunk0, len, chunk0.length - len);
+
+                if (len == chunk0.length && !deflater.finished()) {
+                    chunks.add(chunk0);
+
+                    chunk0 = new byte[CHUNK_SIZE];
+                    len = 0;
+                }
+            }
+
+            if (len > 0)
+                chunks.add(len == chunk0.length ? chunk0 : Arrays.copyOf(chunk0, len));
         }
         finally {
             deflater.end();
         }
-
-        return baos.toByteArray();
     }
 
     /** @return Uncompressed data. */
     private byte[] uncompress() {
-        if (tmpBuf == null)
+        if (chunks == null)
             return null;
 
-        byte[] uncompressedData;
+        byte[] data = new byte[dataSize];
 
         Inflater inflater = new Inflater(true);
 
-        byte[] bytes = new byte[tmpBuf.position()];
+        try {
+            int off = 0;
 
-        tmpBuf.flip();
-        tmpBuf.get(bytes);
+            for (int i = 0; i < chunks.size() && off < dataSize; i++) {
+                inflater.setInput(chunks.get(i));
 
-        try (InflaterInputStream iis = new InflaterInputStream(new ByteArrayInputStream(bytes), inflater)) {
-            uncompressedData = iis.readAllBytes();
+                int n;
+
+                while (off < dataSize && (n = inflater.inflate(data, off, dataSize - off)) > 0)
+                    off += n;
+            }
+
+            if (off != dataSize)
+                throw new IgniteException("Compressed stream is truncated [expected=" + dataSize + ", inflated=" + off + ']');
         }
-        catch (IOException ex) {
-            throw new IgniteException(ex);
+        catch (DataFormatException e) {
+            throw new IgniteException(e);
         }
         finally {
             inflater.end();
         }
 
-        assert uncompressedData != null;
-        assert uncompressedData.length == dataSize : "Expected=" + dataSize + ", actual=" + uncompressedData.length;
+        chunks = null;
 
-        tmpBuf = null;
-
-        return uncompressedData;
+        return data;
     }
 
     /** {@inheritDoc} */
     @Override public String toString() {
         return S.toString(CompressedMessage.class, this);
-    }
-
-    /** Byte reader returning data chunks of predefined size. */
-    private static class ChunkedByteReader {
-        /** Input data. */
-        private final byte[] inputData;
-
-        /** Current position. */
-        private int pos;
-
-        /** Constructor. */
-        ChunkedByteReader(byte[] inputData) {
-            this.inputData = inputData;
-        }
-
-        /** @return Next chunk of bytes or null. */
-        byte[] nextChunk() {
-            if (pos >= inputData.length)
-                return null;
-
-            int curChunkSize = Math.min(inputData.length - pos, CHUNK_SIZE);
-
-            byte[] chunk = new byte[curChunkSize];
-
-            System.arraycopy(inputData, pos, chunk, 0, curChunkSize);
-
-            pos += curChunkSize;
-
-            return chunk;
-        }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/CompressedMessageSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/CompressedMessageSerializer.java
@@ -17,12 +17,11 @@
 
 package org.apache.ignite.internal.managers.communication;
 
-import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import org.apache.ignite.plugin.extensions.communication.MessageReader;
 import org.apache.ignite.plugin.extensions.communication.MessageSerializer;
 import org.apache.ignite.plugin.extensions.communication.MessageWriter;
 
-import static org.apache.ignite.internal.managers.communication.CompressedMessage.BUFFER_CAPACITY;
 import static org.apache.ignite.internal.managers.communication.CompressedMessage.CHUNK_SIZE;
 
 /** Message serializer for compressed message. */
@@ -37,7 +36,7 @@ public class CompressedMessageSerializer implements MessageSerializer<Compressed
         }
 
         while (true) {
-            if (msg.chunk == null && msg.chunkedReader != null) {
+            if (msg.chunk == null && msg.chunks != null) {
                 msg.chunk = msg.nextChunk();
 
                 msg.finalChunk = (msg.chunk == null);
@@ -75,9 +74,6 @@ public class CompressedMessageSerializer implements MessageSerializer<Compressed
 
     /** {@inheritDoc} */
     @Override public boolean readFrom(CompressedMessage msg, MessageReader reader) {
-        if (msg.tmpBuf == null)
-            msg.tmpBuf = ByteBuffer.allocateDirect(BUFFER_CAPACITY);
-
         assert msg.chunk == null : msg.chunk;
 
         while (true) {
@@ -111,17 +107,10 @@ public class CompressedMessageSerializer implements MessageSerializer<Compressed
                         return false;
 
                     if (msg.chunk != null) {
-                        if (msg.tmpBuf.remaining() <= CHUNK_SIZE) {
-                            ByteBuffer newTmpBuf = ByteBuffer.allocateDirect(msg.tmpBuf.capacity() * 2);
+                        if (msg.chunks == null)
+                            msg.chunks = new ArrayList<>(msg.dataSize / CHUNK_SIZE + 1);
 
-                            msg.tmpBuf.flip();
-
-                            newTmpBuf.put(msg.tmpBuf);
-
-                            msg.tmpBuf = newTmpBuf;
-                        }
-
-                        msg.tmpBuf.put(msg.chunk);
+                        msg.chunks.add(msg.chunk);
 
                         reader.decrementState();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/CompressedMessageTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/CompressedMessageTest.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.managers.communication;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -74,9 +75,9 @@ public class CompressedMessageTest {
 
                 assertTrue(compressedMsg.dataSize() > 0);
 
-                byte[] compressedData = U.field((Object)U.field(compressedMsg, "chunkedReader"), "inputData");
+                List<byte[]> chunks = U.field(compressedMsg, "chunks");
 
-                assertTrue(compressedData.length > CompressedMessage.CHUNK_SIZE * 2);
+                assertTrue(chunks.size() > 2);
 
                 checkChunkCnt = false;
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IGNITE-28853

`CompressedMessage` moves the same bytes through memory 3-5 times on both send and receive paths, and on the receive path additionally allocates direct `ByteBuffer`s per message. Direct allocation is expensive (memory zeroing, Cleaner-based release, potential `System.gc()` inside `Bits.reserveMemory`), while no point of the path actually needs a direct buffer: data arrives in and leaves through heap arrays.

**Send path:** `compress()` copies the whole source buffer into a `byte[]`, deflates via `DeflaterOutputStream` (512-byte internal buffer → many small JNI calls) into a `ByteArrayOutputStream` pre-sized to the *uncompressed* length, then copies again via `toByteArray()`; `ChunkedByteReader` then copies every 10K chunk into a fresh array one more time. (The per-message direct scratch buffer on the send side lives in `DirectMessageWriter.writeCompressedMessage` and is addressed separately by IGNITE-28836 / #13296.)

**Receive path:** `CompressedMessageSerializer.readFrom()` accumulates incoming chunks into a 100KB direct `ByteBuffer` allocated per message (grown by doubling through another copy), although each chunk is already a fresh heap array returned by `readByteArray()`; `uncompress()` copies it all back into a heap array and inflates via `InflaterInputStream.readAllBytes()` (internal 8K buffers + final consolidation copy) despite the exact result size being known upfront; `DirectMessageReader.readCompressedMessageAndDeserialize()` then copies the whole uncompressed payload into yet another per-message direct buffer, although `DirectByteBufferStream` fully supports heap buffers.

**Fix (wire format unchanged):**
* Internal representation switched to `List<byte[]> chunks` for both directions (pre-sized from `dataSize`), `ChunkedByteReader` removed.
* `compress()`: raw `Deflater` with `setInput(ByteBuffer)` (no input copy), deflating straight into wire-ready chunks — compressed bytes are written exactly once.
* `readFrom()`: a received chunk is simply added to the list — zero copies, zero direct allocations.
* `uncompress()`: raw `Inflater` fed chunk by chunk into an exact-size `byte[dataSize]`; a truncated stream fails fast with `IgniteException` (matching the `EOFException` diagnostics `InflaterInputStream` used to provide).
* `readCompressedMessageAndDeserialize()`: `ByteBuffer.wrap(uncompressed)` instead of `allocateDirect`+`put`+`flip`.

**JMH** (`GridDhtPartitionsFullMessage` receive round-trip with two `@Compress` map fields, JDK 17, M-series; benchmark source attached in a comment below):

| entries | master | patched | heap alloc |
|---|---|---|---|
| 30 | 15.2K ± 34.8K ops/s | **90.7K ± 15.0K** (~6x) | 66.7K → 28.0K B/op (−58%) |
| 500 | 4.38K ± 0.3K ops/s | **6.13K ± 0.9K** (+40%) | 522K → 431K B/op (−18%) |

Master's huge variance at 30 entries is caused by the per-message direct allocations triggering GC storms. On top of the heap savings, all per-message direct buffer allocations (~365KB/op at 500 entries, invisible to `gc.alloc.rate`) are eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
