### PR TITLE
IGNITE-28854 CompressedMessageSerializer.readFrom() spins forever on a null chunk from a corrupted or incompatible peer

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/CompressedMessageSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/CompressedMessageSerializer.java
@@ -18,6 +18,7 @@
 package org.apache.ignite.internal.managers.communication;
 
 import java.nio.ByteBuffer;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.plugin.extensions.communication.MessageReader;
 import org.apache.ignite.plugin.extensions.communication.MessageSerializer;
 import org.apache.ignite.plugin.extensions.communication.MessageWriter;
@@ -110,23 +111,26 @@ public class CompressedMessageSerializer implements MessageSerializer<Compressed
                     if (!reader.isLastRead())
                         return false;
 
-                    if (msg.chunk != null) {
-                        if (msg.tmpBuf.remaining() <= CHUNK_SIZE) {
-                            ByteBuffer newTmpBuf = ByteBuffer.allocateDirect(msg.tmpBuf.capacity() * 2);
-
-                            msg.tmpBuf.flip();
-
-                            newTmpBuf.put(msg.tmpBuf);
-
-                            msg.tmpBuf = newTmpBuf;
-                        }
-
-                        msg.tmpBuf.put(msg.chunk);
-
-                        reader.decrementState();
-
-                        msg.chunk = null;
+                    if (msg.chunk == null) {
+                        throw new IgniteException("Failed to read compressed message: unexpected null chunk " +
+                            "(stream is corrupted or the sender is incompatible).");
                     }
+
+                    if (msg.tmpBuf.remaining() <= CHUNK_SIZE) {
+                        ByteBuffer newTmpBuf = ByteBuffer.allocateDirect(msg.tmpBuf.capacity() * 2);
+
+                        msg.tmpBuf.flip();
+
+                        newTmpBuf.put(msg.tmpBuf);
+
+                        msg.tmpBuf = newTmpBuf;
+                    }
+
+                    msg.tmpBuf.put(msg.chunk);
+
+                    reader.decrementState();
+
+                    msg.chunk = null;
             }
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/CompressedMessageTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/managers/communication/CompressedMessageTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.internal.CoreMessagesProvider;
 import org.apache.ignite.internal.direct.DirectMessageReader;
 import org.apache.ignite.internal.direct.DirectMessageWriter;
@@ -34,6 +35,7 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.plugin.extensions.communication.Message;
 import org.apache.ignite.plugin.extensions.communication.MessageFactory;
 import org.apache.ignite.plugin.extensions.communication.MessageFactoryProvider;
+import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.Test;
 
 import static org.apache.ignite.marshaller.Marshallers.jdk;
@@ -103,6 +105,36 @@ public class CompressedMessageTest {
         assertTrue(readMsg instanceof GridDhtPartitionsFullMessage);
 
         assertEqualsFullMsg(fullMsg, (GridDhtPartitionsFullMessage)readMsg);
+    }
+
+    /** Read must fail with an exception on a null chunk from the wire instead of looping forever. */
+    @Test
+    public void testReadFailsOnNullChunk() {
+        MessageFactory msgFactory = new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{
+            new CoreMessagesProvider(jdk(), jdk(), U.gridClassLoader())});
+
+        DirectMessageWriter writer = new DirectMessageWriter(msgFactory);
+
+        ByteBuffer buf = ByteBuffer.allocate(16);
+
+        writer.setBuffer(buf);
+
+        // Emulate a corrupted stream or an incompatible peer: dataSize > 0, non-final chunk, then the null-array
+        // marker (-1), which CompressedMessageSerializer.writeTo() never produces at the chunk position.
+        writer.writeInt(100);
+        writer.writeBoolean(false);
+        writer.writeByteArray(null);
+
+        buf.flip();
+
+        DirectMessageReader reader = new DirectMessageReader(msgFactory, null);
+
+        reader.setBuffer(buf);
+
+        GridTestUtils.assertThrows(null,
+            () -> new CompressedMessageSerializer().readFrom(new CompressedMessage(), reader),
+            IgniteException.class,
+            "unexpected null chunk");
     }
 
     /** */


### PR DESCRIPTION
In `CompressedMessageSerializer.readFrom()`, state 2 reads the next compressed chunk. `DirectByteBufferStream.readByteArray()` returns `null` (with `lastFinished == true`) when the wire contains the null-array marker (length `-1`). A well-behaved sender never writes `null` at this position (`writeTo()` only enters state 2 with a non-null chunk), but a corrupted stream or a malicious/incompatible peer can produce it: the `-1` length is accepted, the null branch does not advance the reader state, and the `while (true)` loop re-executes state 2 forever — the grid-nio worker thread spins at 100% CPU and its stripe stops processing messages, effectively degrading the whole node.

The fix treats a null chunk at this protocol position as a protocol violation: `IgniteException` with a descriptive message is thrown instead of silently looping. The exception propagates out of message decoding and the connection is closed.

Covered by a unit test that feeds the reader a buffer with the null-array marker at the chunk position and asserts the exception is thrown.

Note: this file is also touched by #13325 (IGNITE-28853, direct-buffer accumulator rework of the same method). The overlap is trivial (`case 2` is structurally identical in both versions), so the PRs can be merged in any order; whichever lands second resolves a one-hunk conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
