### PR TITLE
IGNITE-28877 .NET tests: fail fast when embedded node cannot join topology instead of hanging the suite

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.AspNet.Tests/App.config
+++ b/modules/platforms/dotnet/Apache.Ignite.AspNet.Tests/App.config
@@ -29,8 +29,8 @@
         <gcServer enabled="true"/>
     </runtime>
 
-    <igniteConfiguration xmlns="http://ignite.apache.org/schema/dotnet/IgniteConfigurationSection" igniteInstanceName="myGrid1">
-        <discoverySpi type="TcpDiscoverySpi">
+    <igniteConfiguration xmlns="http://ignite.apache.org/schema/dotnet/IgniteConfigurationSection" igniteInstanceName="myGrid1" localhost="127.0.0.1">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>
@@ -44,7 +44,7 @@
     </igniteConfiguration>
 
     <igniteConfiguration2 igniteInstanceName="myGrid2" localhost="127.0.0.1">
-        <discoverySpi type="TcpDiscoverySpi">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>
@@ -58,7 +58,7 @@
     </igniteConfiguration2>
 
     <igniteConfiguration3 igniteInstanceName="myGrid3" localhost="127.0.0.1">
-        <discoverySpi type="TcpDiscoverySpi">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeTaskSessionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeTaskSessionTest.cs
@@ -75,7 +75,8 @@ namespace Apache.Ignite.Core.Tests.Compute
                 ConsistentId = igniteName,
                 IgniteInstanceName = igniteName,
                 DiscoverySpi = GetStaticDiscovery(),
-                JvmOptions = TestJavaOptions()
+                JvmOptions = TestJavaOptions(),
+                Localhost = "127.0.0.1"
             };
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -371,7 +371,14 @@ namespace Apache.Ignite.Core.Tests
                 {
                     Endpoints = new[] { "127.0.0.1:47500" + (maxPort == null ? null : (".." + maxPort)) }
                 },
-                SocketTimeout = TimeSpan.FromSeconds(0.3)
+                SocketTimeout = TimeSpan.FromSeconds(0.3),
+                // If the finder port is squatted at bind time (e.g. lingering teardown of the previous
+                // fixture), the node binds the next port and the default infinite join retries the finder
+                // address forever, eating the whole suite execution timeout: fail the test fast instead.
+                // MaxAckTimeout caps the exponential handshake backoff, otherwise a single retry sweep
+                // takes up to 20 minutes and JoinTimeout, checked between sweeps, never gets a chance.
+                JoinTimeout = TimeSpan.FromMinutes(2),
+                MaxAckTimeout = TimeSpan.FromSeconds(10)
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/app.config
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/app.config
@@ -32,8 +32,8 @@
         <gcServer enabled="true"/>
     </runtime>
 
-    <igniteConfiguration xmlns="http://ignite.apache.org/schema/dotnet/IgniteConfigurationSection" igniteInstanceName="myGrid1">
-        <discoverySpi type="TcpDiscoverySpi">
+    <igniteConfiguration xmlns="http://ignite.apache.org/schema/dotnet/IgniteConfigurationSection" igniteInstanceName="myGrid1" localhost="127.0.0.1">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>
@@ -47,7 +47,7 @@
     </igniteConfiguration>
 
     <igniteConfiguration2 igniteInstanceName="myGrid2" localhost="127.0.0.1">
-        <discoverySpi type="TcpDiscoverySpi">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/custom_app.config
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/custom_app.config
@@ -27,7 +27,7 @@
     </configSections>
 
     <igniteConfiguration3 igniteInstanceName="myGrid3" localhost="127.0.0.1">
-        <discoverySpi type="TcpDiscoverySpi">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>

--- a/modules/platforms/dotnet/Apache.Ignite.EntityFramework.Tests/App.config
+++ b/modules/platforms/dotnet/Apache.Ignite.EntityFramework.Tests/App.config
@@ -25,8 +25,8 @@
         <gcServer enabled="true" />
     </runtime>
 
-    <igniteConfiguration xmlns="http://ignite.apache.org/schema/dotnet/IgniteConfigurationSection" igniteInstanceName="myGrid1">
-        <discoverySpi type="TcpDiscoverySpi">
+    <igniteConfiguration xmlns="http://ignite.apache.org/schema/dotnet/IgniteConfigurationSection" igniteInstanceName="myGrid1" localhost="127.0.0.1">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>
@@ -39,7 +39,7 @@
     </igniteConfiguration>
 
     <igniteConfiguration2 igniteInstanceName="myGrid2" localhost="127.0.0.1">
-        <discoverySpi type="TcpDiscoverySpi">
+        <discoverySpi type="TcpDiscoverySpi" joinTimeout="0:2:0">
             <ipFinder type="TcpDiscoveryStaticIpFinder">
                 <endpoints>
                     <string>127.0.0.1:47500</string>


### PR DESCRIPTION
### What

Since 2026-07-07 all three "Platform .NET (Windows)" TC suites intermittently die with a 120-minute "Execution timeout", each at a fixed position (1490/1342/78 passed tests). The captured stack of a stuck run shows the embedded JVM spinning forever in `ServerImpl.sendJoinRequestMessage` / `joinTopology` inside `Ignition.Start`: if discovery port 47500 is occupied at bind time (e.g. lingering teardown of the previous fixture, or a half-stopped node), the new node binds 47501+, while the single-port static IP finder of the test configs only knows 47500, and the default `joinTimeout=0` retries forever.

This is not a code regression: the same revision both passes and hangs (e.g. builds 9190207 vs 9191076 on ci2), and a hung and a clean run consumed the very same dependency-build artifacts (9193992 vs 9198016).

### Fix (test code only)

- `TestUtils.GetStaticDiscovery()`: set `JoinTimeout` = 2 min so a stuck join fails the single test with a clear `IgniteSpiException` instead of eating the whole suite timeout, and cap `MaxAckTimeout` at 10 s — otherwise the exponential handshake backoff (up to 600 s per attempt) delays the join-timeout check by ~20 minutes per retry sweep.
- Same `joinTimeout` for the XML-configured discovery in `app.config` / `custom_app.config` sections.
- Add the forgotten `Localhost = 127.0.0.1` in `ComputeTaskSessionTest` and the `myGrid1` app.config section (every other test config pins it).

### Verification

- All three previously hanging fixtures pass locally (macOS, net6.0 + corretto-17): `ComputeTaskSessionTest`, `IgniteConfigurationSectionTest`, `ClientClusterDiscoveryTestsNoLocalhost` — 12/12.
- Negative test reproducing the CI condition (a silent process squatting 127.0.0.1:47500): before the fix the node start spins forever (32+ min observed, jstack confirms the `sendJoinRequestMessage` loop); with the fix the test fails in 2 min 39 s with "Failed to connect to any address from IP finder within join timeout".

🤖 Generated with [Claude Code](https://claude.com/claude-code)