### PR TITLE
IGNITE-13286 Support Java records in binary marshaller

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
@@ -202,7 +202,7 @@ public class BinaryClassDescriptor {
         initialSerializer = serializer;
 
         // If serializer is not defined at this point, then we have to use OptimizedMarshaller.
-        useOptMarshaller = serializer == null || isGeometryClass(cls);
+        useOptMarshaller = serializer == null || isGeometryClass(cls) || isRecord(cls);
 
         // Reset reflective serializer so that we rely on existing reflection-based serialization.
         if (serializer instanceof BinaryReflectiveSerializer)
@@ -1094,6 +1094,21 @@ public class BinaryClassDescriptor {
     /** */
     Constructor<?> ctor() {
         return ctor;
+    }
+
+    /**
+     * Checks whether a class is a Java record without requiring a Java 16 runtime at compile time.
+     *
+     * Records are immutable and the binary marshaller cannot restore their final fields. Java serialization,
+     * used by the optimized marshaller, supports serializable records starting with Java 16.
+     *
+     * @param cls Class to check.
+     * @return {@code True} if the class is a record.
+     */
+    private static boolean isRecord(Class<?> cls) {
+        Class<?> superCls = cls.getSuperclass();
+
+        return superCls != null && "java.lang.Record".equals(superCls.getName());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
@@ -235,8 +235,8 @@ public class BinaryClassDescriptor {
 
         if (useOptMarshaller && userType && !U.isIgnite(cls) && !U.isJdk(cls) && !QueryUtils.isGeometryClass(cls)) {
             U.warnDevOnly(ctx.log(), "Class \"" + cls.getName() + "\" cannot be serialized using " +
-                BinaryMarshaller.class.getSimpleName() + " because it either implements Externalizable interface " +
-                "or have writeObject/readObject methods. " + OptimizedMarshaller.class.getSimpleName() + " will be " +
+                BinaryMarshaller.class.getSimpleName() + " because it is a record, implements Externalizable, or " +
+                "has writeObject/readObject methods. " + OptimizedMarshaller.class.getSimpleName() + " will be " +
                 "used instead and class instances will be deserialized on the server. Please ensure that all nodes " +
                 "have this class in classpath. To enable binary serialization either implement " +
                 Binarylizable.class.getSimpleName() + " interface or set explicit serializer using " +

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -30,6 +30,11 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.AbstractQueue;
@@ -56,6 +61,8 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 import com.google.common.collect.ImmutableList;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
@@ -110,6 +117,7 @@ import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.ignite.internal.binary.streams.BinaryMemoryAllocator.THREAD_LOCAL;
+import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -124,6 +132,46 @@ public class BinaryMarshallerSelfTest extends AbstractBinaryArraysTest {
     @Test
     public void testNull() throws Exception {
         assertNull(marshalUnmarshal(null));
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testSerializableRecord() throws Exception {
+        assumeTrue("Records require Java 16 or later.", U.majorJavaVersion(U.jdkVersion()) >= 16);
+
+        Path tmpDir = Files.createTempDirectory("ignite-record-test");
+        Path srcDir = tmpDir.resolve("test");
+        Path srcFile = srcDir.resolve("TestRecord.java");
+
+        try {
+            Files.createDirectories(srcDir);
+            String src = "package test; " +
+                "public record TestRecord(String value, long timestamp) implements java.io.Serializable {}";
+
+            Files.write(srcFile, src.getBytes(StandardCharsets.UTF_8));
+
+            JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+            assertNotNull(compiler);
+            assertEquals(0, compiler.run(null, null, null, "-d", tmpDir.toString(), srcFile.toString()));
+
+            URL[] urls = {tmpDir.toUri().toURL()};
+
+            try (URLClassLoader clsLdr = new URLClassLoader(urls, getClass().getClassLoader())) {
+                Class<?> recordCls = clsLdr.loadClass("test.TestRecord");
+                Object record = recordCls.getConstructor(String.class, long.class).newInstance("value", 42L);
+                BinaryMarshaller marsh = binaryMarshaller();
+                Object restored = marsh.unmarshal(marsh.marshal(record), clsLdr);
+
+                assertEquals("value", recordCls.getMethod("value").invoke(restored));
+                assertEquals(42L, recordCls.getMethod("timestamp").invoke(restored));
+            }
+        }
+        finally {
+            U.delete(tmpDir.toFile());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary`n`nRoutes Java records through Ignite's optimized Java-serialization path, avoiding `Unsafe.objectFieldOffset()` on immutable record fields.`n`n## Root cause`n`nHibernate 7 uses a serializable record for `QueryResultsCacheImpl.CacheItem`. Ignite's reflective binary marshaller attempts to obtain unsafe offsets for record fields, which modern JDKs reject.`n`n## Changes`n`n- Detect records without introducing a Java 16 compile-time dependency.`n- Use `OptimizedMarshaller` for records.`n- Make the developer warning accurately include records.`n- Add a runtime-compiled serializable-record round-trip regression test; it runs on JDK 16+ and skips on older JDKs.`n`n## Verification`n`n- Rebased on current `ignite-2.17` and `git diff --check` passes.`n- All 4,531 `ignite-core` production sources compile successfully on JDK 25.`n- Focused test execution is blocked during unrelated full test compilation because JDK 25 removed `Thread.suspend()` and `Thread.resume()`, which legacy Ignite tests still reference. A supported JDK 17 is not installed locally.`n- Existing GitHub check failures are fork checkout-security refusals before code execution, not test failures.`n`nFixes #13286