### PR TITLE
IGNITE-28953 Init CalciteMessageFactory with marshallers in Calcite tests

### DIFF
--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/exec/rel/ContinuousExecutionTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/exec/rel/ContinuousExecutionTest.java
@@ -40,6 +40,8 @@ import org.junit.Test;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import static org.apache.ignite.marshaller.Marshallers.jdk;
+
 /**
  *
  */
@@ -98,8 +100,12 @@ public class ContinuousExecutionTest extends AbstractExecutionTest {
         nodesCnt = remoteFragmentsCnt + 1;
         super.setup();
 
+        CalciteMessageFactory msgFactory = new CalciteMessageFactory();
+
+        msgFactory.init(jdk(), jdk());
+
         // Register messages in Message#REGISTRATIONS and avoids failure in Message#directType().
-        new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{new CalciteMessageFactory()});
+        new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{msgFactory});
     }
 
     /** */

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/exec/rel/ContinuousExecutionTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/exec/rel/ContinuousExecutionTest.java
@@ -34,13 +34,12 @@ import org.apache.ignite.internal.processors.query.calcite.message.CalciteMessag
 import org.apache.ignite.internal.processors.query.calcite.trait.AllNodes;
 import org.apache.ignite.internal.processors.query.calcite.type.IgniteTypeFactory;
 import org.apache.ignite.internal.processors.query.calcite.util.TypeUtils;
+import org.apache.ignite.marshaller.Marshallers;
 import org.apache.ignite.plugin.extensions.communication.MessageFactoryProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
-
-import static org.apache.ignite.marshaller.Marshallers.jdk;
 
 /**
  *
@@ -102,7 +101,7 @@ public class ContinuousExecutionTest extends AbstractExecutionTest {
 
         CalciteMessageFactory msgFactory = new CalciteMessageFactory();
 
-        msgFactory.init(jdk(), jdk());
+        msgFactory.init(Marshallers.jdk(), Marshallers.jdk());
 
         // Register messages in Message#REGISTRATIONS and avoids failure in Message#directType().
         new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{msgFactory});

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/message/CalciteCommunicationMessageSerializationTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/message/CalciteCommunicationMessageSerializationTest.java
@@ -18,9 +18,8 @@
 package org.apache.ignite.internal.processors.query.calcite.message;
 
 import org.apache.ignite.internal.managers.AbstractMessageSerializationTest;
+import org.apache.ignite.marshaller.Marshallers;
 import org.apache.ignite.plugin.extensions.communication.MessageFactoryProvider;
-
-import static org.apache.ignite.marshaller.Marshallers.jdk;
 
 /** */
 public class CalciteCommunicationMessageSerializationTest extends AbstractMessageSerializationTest {
@@ -28,7 +27,7 @@ public class CalciteCommunicationMessageSerializationTest extends AbstractMessag
     @Override protected MessageFactoryProvider messageFactory() {
         CalciteMessageFactory msgFactory = new CalciteMessageFactory();
 
-        msgFactory.init(jdk(), jdk());
+        msgFactory.init(Marshallers.jdk(), Marshallers.jdk());
 
         return msgFactory;
     }

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/message/CalciteCommunicationMessageSerializationTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/message/CalciteCommunicationMessageSerializationTest.java
@@ -20,10 +20,16 @@ package org.apache.ignite.internal.processors.query.calcite.message;
 import org.apache.ignite.internal.managers.AbstractMessageSerializationTest;
 import org.apache.ignite.plugin.extensions.communication.MessageFactoryProvider;
 
+import static org.apache.ignite.marshaller.Marshallers.jdk;
+
 /** */
 public class CalciteCommunicationMessageSerializationTest extends AbstractMessageSerializationTest {
     /** {@inheritDoc} */
     @Override protected MessageFactoryProvider messageFactory() {
-        return new CalciteMessageFactory();
+        CalciteMessageFactory msgFactory = new CalciteMessageFactory();
+
+        msgFactory.init(jdk(), jdk());
+
+        return msgFactory;
     }
 }

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/planner/PlanExecutionTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/planner/PlanExecutionTest.java
@@ -72,6 +72,7 @@ import org.junit.Test;
 
 import static org.apache.calcite.tools.Frameworks.createRootSchema;
 import static org.apache.ignite.configuration.IgniteConfiguration.DFLT_THREAD_KEEP_ALIVE_TIME;
+import static org.apache.ignite.marshaller.Marshallers.jdk;
 
 /**
  *
@@ -82,8 +83,12 @@ public class PlanExecutionTest extends AbstractPlannerTest {
     @Override protected void beforeTest() throws Exception {
         super.beforeTest();
 
+        CalciteMessageFactory msgFactory = new CalciteMessageFactory();
+
+        msgFactory.init(jdk(), jdk());
+
         // Register messages in Message#REGISTRATIONS and avoids failure in Message#directType().
-        new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{new CalciteMessageFactory()});
+        new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{msgFactory});
     }
 
     /**

--- a/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/planner/PlanExecutionTest.java
+++ b/modules/calcite/src/test/java/org/apache/ignite/internal/processors/query/calcite/planner/PlanExecutionTest.java
@@ -65,6 +65,7 @@ import org.apache.ignite.internal.processors.query.calcite.util.Commons;
 import org.apache.ignite.internal.processors.security.NoOpIgniteSecurityProcessor;
 import org.apache.ignite.internal.thread.pool.IgniteStripedThreadPoolExecutor;
 import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.marshaller.Marshallers;
 import org.apache.ignite.plugin.extensions.communication.MessageFactoryProvider;
 import org.apache.ignite.testframework.junits.GridTestKernalContext;
 import org.junit.Assert;
@@ -72,7 +73,6 @@ import org.junit.Test;
 
 import static org.apache.calcite.tools.Frameworks.createRootSchema;
 import static org.apache.ignite.configuration.IgniteConfiguration.DFLT_THREAD_KEEP_ALIVE_TIME;
-import static org.apache.ignite.marshaller.Marshallers.jdk;
 
 /**
  *
@@ -85,7 +85,7 @@ public class PlanExecutionTest extends AbstractPlannerTest {
 
         CalciteMessageFactory msgFactory = new CalciteMessageFactory();
 
-        msgFactory.init(jdk(), jdk());
+        msgFactory.init(Marshallers.jdk(), Marshallers.jdk());
 
         // Register messages in Message#REGISTRATIONS and avoids failure in Message#directType().
         new IgniteMessageFactoryImpl(new MessageFactoryProvider[]{msgFactory});

--- a/modules/core/src/main/java/org/apache/ignite/internal/plugin/AbstractMarshallableMessageFactoryProvider.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/plugin/AbstractMarshallableMessageFactoryProvider.java
@@ -68,6 +68,10 @@ public abstract class AbstractMarshallableMessageFactoryProvider implements Mess
 
     /** */
     private static <T extends Message> void register(IgniteMessageFactory factory, Class<T> cls, short id, Marshaller marsh) {
+        // Companions are instantiated right here, so a provider registering before init() would bind them to a null
+        // marshaller instead of picking the proper one up later.
+        assert marsh != null : "Provider is not initialized, see init(), while registering " + cls.getName();
+
         MessageSerializer<T> serializer = loadGenerated(cls, "Serializer", null, true);
 
         // A MarshallableMessage always gets a generated marshaller (the hook call alone is a statement), so its


### PR DESCRIPTION
IGNITE-28937 added an assert to `AbstractMarshallableMessageFactoryProvider#loadGenerated`: a generated companion constructor that takes a `Marshaller` requires the provider to be initialized via `init()`. In production `IgniteKernal#initProvider()` always does this.

`PlanExecutionTest` and `ContinuousExecutionTest` create `CalciteMessageFactory` without `init()` (they only need direct type registration), so 38 tests of the Calcite SQL 2 suite fail with:

```
java.lang.AssertionError: QueryStartRequestMarshaller takes a marshaller, but none was provided
```

The fix initializes the factory with jdk marshallers, the same way core tests do. Both tests pass locally (2 + 36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
