### PR TITLE
IGNITE-28271 Use the generated marshalling for GridJobExecuteResponse

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/GridJobExecuteResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/GridJobExecuteResponse.java
@@ -19,25 +19,18 @@ package org.apache.ignite.internal;
 
 import java.util.Map;
 import java.util.UUID;
-import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
-import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.util.tostring.GridToStringExclude;
-import org.apache.ignite.internal.util.typedef.F;
-import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.S;
-import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteUuid;
-import org.apache.ignite.marshaller.Marshaller;
-import org.apache.ignite.plugin.extensions.communication.Message;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Job execution response.
  */
 @UseBinaryMarshaller
-public class GridJobExecuteResponse implements Message {
+public class GridJobExecuteResponse implements DeferredUnmarshalMessage {
     /** */
     @Order(0)
     UUID nodeId;
@@ -50,27 +43,32 @@ public class GridJobExecuteResponse implements Message {
     @Order(2)
     IgniteUuid jobId;
 
-    /** Job result exception call holder. */
+    /** */
+    @GridToStringExclude
+    @Marshalled("gridExBytes")
+    @Nullable IgniteException gridEx;
+
+    /** */
     @Order(3)
     @Nullable byte[] gridExBytes;
 
     /** */
-    private IgniteException gridEx;
+    @GridToStringExclude
+    @Marshalled("resBytes")
+    @Nullable Object res;
 
-    /** Job result serialization call holder. */
+    /** */
     @Order(4)
     @Nullable byte[] resBytes;
 
     /** */
-    private @Nullable Object res;
+    @GridToStringExclude
+    @Marshalled("jobAttrsBytes")
+    Map<Object, Object> jobAttrs;
 
     /** */
-    /** Job attributes serialization call holder. */
     @Order(5)
     byte[] jobAttrsBytes;
-
-    /** */
-    private Map<Object, Object> jobAttrs;
 
     /** */
     @Order(6)
@@ -145,21 +143,9 @@ public class GridJobExecuteResponse implements Message {
         return res;
     }
 
-    /**
-     * @return Job exception.
-     */
+    /** @return Job exception. */
     @Nullable public IgniteException exception() {
         return gridEx;
-    }
-
-    /** */
-    public void exceptionBytes(@Nullable byte[] gridExBytes) {
-        this.gridExBytes = gridExBytes;
-    }
-
-    /** */
-    public @Nullable byte[] exceptionBytes() {
-        return gridExBytes;
     }
 
     /**
@@ -212,100 +198,10 @@ public class GridJobExecuteResponse implements Message {
         return retry;
     }
 
-    /**
-     * Serializes user data to byte[] with provided marshaller.
-     * Erases non-marshalled data like {@link #getJobAttributes()} or {@link #getJobResult()}.
-     */
-    public void marshallUserData(Marshaller marsh, @Nullable IgniteLogger log) throws IgniteCheckedException {
-        if (res != null) {
-            try {
-                resBytes = U.marshal(marsh, res);
-            }
-            catch (IgniteCheckedException e) {
-                resBytes = null;
-
-                String msg = "Failed to serialize job response [nodeId=" + nodeId +
-                    ", ses=" + sesId + ", jobId=" + jobId +
-                    ", resCls=" + (res == null ? null : res.getClass()) + ']';
-
-                wrapSerializationError(e, msg, log);
-            }
-
-            res = null;
-        }
-
-        if (!F.isEmpty(jobAttrs)) {
-            try {
-                jobAttrsBytes = U.marshal(marsh, jobAttrs);
-            }
-            catch (IgniteCheckedException e) {
-                jobAttrsBytes = null;
-
-                String msg = "Failed to serialize job attributes [nodeId=" + nodeId +
-                    ", ses=" + sesId + ", jobId=" + jobId +
-                    ", attrs=" + jobAttrs + ']';
-
-                wrapSerializationError(e, msg, log);
-            }
-
-            jobAttrs = null;
-        }
-
-        if (gridEx != null) {
-            try {
-                gridExBytes = U.marshal(marsh, gridEx);
-            }
-            catch (IgniteCheckedException e) {
-                String msg = "Failed to serialize job exception [nodeId=" + nodeId +
-                    ", ses=" + sesId + ", jobId=" + jobId +
-                    ", msg=\"" + e.getMessage() + "\"]";
-
-                gridEx = new IgniteException(msg);
-
-                U.error(log, msg, e);
-
-                gridExBytes = U.marshal(marsh, gridEx);
-            }
-
-            gridEx = null;
-        }
+    /** @return A copy carrying {@code err} and no payload. */
+    public GridJobExecuteResponse withError(IgniteException err) {
+        return new GridJobExecuteResponse(nodeId, sesId, jobId, err, null, null, isCancelled, retry);
     }
-
-    /**
-     * Deserializes user data from byte[] with provided marshaller and class loader.
-     * Erases marshalled data like {@link #jobAttrubutesBytes()} or {@link #jobResultBytes()}.
-     */
-    public void unmarshallUserData(Marshaller marshaller, ClassLoader clsLdr) throws IgniteCheckedException {
-        if (jobAttrsBytes != null) {
-            jobAttrs = U.unmarshal(marshaller, jobAttrsBytes, clsLdr);
-
-            jobAttrsBytes = null;
-        }
-
-        if (resBytes != null) {
-            res = U.unmarshal(marshaller, resBytes, clsLdr);
-
-            resBytes = null;
-        }
-
-        if (gridExBytes != null) {
-            gridEx = U.unmarshal(marshaller, gridExBytes, clsLdr);
-
-            gridExBytes = null;
-        }
-    }
-
-    /** */
-    private void wrapSerializationError(IgniteCheckedException e, String msg, @Nullable IgniteLogger log) {
-        if (gridEx != null)
-            gridEx.addSuppressed(e);
-        else
-            gridEx = U.convertException(e);
-
-        if (log != null && (log.isDebugEnabled() || !X.hasCause(e, NodeStoppingException.class)))
-            U.error(log, msg, e);
-    }
-
 
     /** {@inheritDoc} */
     @Override public String toString() {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
@@ -1617,8 +1617,22 @@ public class GridJobProcessor extends GridProcessorAdapter {
                 false,
                 null);
 
-            if (!loc)
-                jobRes.marshallUserData(marsh, log);
+            if (!loc) {
+                try {
+                    MessageMarshalling.marshal(jobRes, ctx, null);
+                }
+                catch (IgniteCheckedException e) {
+                    // The exception is the only payload of this response, so it is what could not be written.
+                    String errMsg = "Failed to serialize job exception [nodeId=" + sndNode.id() +
+                        ", ses=" + req.sessionId() + ", jobId=" + req.jobId() + ']';
+
+                    U.error(log, errMsg, e);
+
+                    jobRes = jobRes.withError(new IgniteException(errMsg));
+
+                    MessageMarshalling.marshal(jobRes, ctx, null);
+                }
+            }
 
             if (req.sessionFullSupport()) {
                 // Send response to designated job topic.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobWorker.java
@@ -46,6 +46,7 @@ import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.NodeStoppingException;
 import org.apache.ignite.internal.cluster.ClusterTopologyCheckedException;
+import org.apache.ignite.internal.managers.communication.MessageMarshalling;
 import org.apache.ignite.internal.managers.deployment.GridDeployment;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.processors.cache.distributed.dht.GridReservable;
@@ -64,7 +65,6 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.util.worker.GridWorker;
 import org.apache.ignite.lang.IgniteBiTuple;
 import org.apache.ignite.lang.IgniteUuid;
-import org.apache.ignite.marshaller.Marshaller;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.events.EventType.EVT_JOB_CANCELLED;
@@ -121,9 +121,6 @@ public class GridJobWorker extends GridWorker implements GridTimeoutObject {
 
     /** */
     private final IgniteLogger log;
-
-    /** */
-    private final Marshaller marsh;
 
     /** */
     private final GridJobSessionImpl ses;
@@ -244,8 +241,6 @@ public class GridJobWorker extends GridWorker implements GridTimeoutObject {
         this.job = job;
 
         log = U.logger(ctx, logRef, this);
-
-        marsh = ctx.marshaller();
 
         UUID locNodeId = ctx.discovery().localNode().id();
 
@@ -887,8 +882,36 @@ public class GridJobWorker extends GridWorker implements GridTimeoutObject {
                                 isCancelled(),
                                 retry ? ctx.cache().context().exchange().readyAffinityVersion() : null);
 
-                            if (!loc)
-                                jobRes.marshallUserData(marsh, log);
+                            if (!loc) {
+                                try {
+                                    MessageMarshalling.marshal(jobRes, ctx, null);
+                                }
+                                catch (IgniteCheckedException e) {
+                                    String ids = "[nodeId=" + sndNode.id() + ", ses=" + ses.getId() +
+                                        ", jobId=" + ses.getJobId() + ']';
+
+                                    logError("Failed to serialize job response " + ids, e);
+
+                                    // Drop the payload, keeping the job exception when there is one.
+                                    jobRes = jobRes.withError(jobRes.exception() != null
+                                        ? jobRes.exception()
+                                        : U.convertException(e));
+
+                                    try {
+                                        MessageMarshalling.marshal(jobRes, ctx, null);
+                                    }
+                                    catch (IgniteCheckedException e0) {
+                                        // Then the exception itself is what could not be written.
+                                        String errMsg = "Failed to serialize job exception " + ids;
+
+                                        logError(errMsg, e0);
+
+                                        jobRes = jobRes.withError(new IgniteException(errMsg));
+
+                                        MessageMarshalling.marshal(jobRes, ctx, null);
+                                    }
+                                }
+                            }
 
                             long timeout = ses.getEndTime() - U.currentTimeMillis();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/task/GridTaskWorker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/task/GridTaskWorker.java
@@ -68,6 +68,7 @@ import org.apache.ignite.internal.cluster.ClusterGroupEmptyCheckedException;
 import org.apache.ignite.internal.cluster.ClusterTopologyCheckedException;
 import org.apache.ignite.internal.compute.ComputeTaskCancelledCheckedException;
 import org.apache.ignite.internal.compute.ComputeTaskTimeoutCheckedException;
+import org.apache.ignite.internal.managers.communication.MessageMarshalling;
 import org.apache.ignite.internal.managers.deployment.GridDeployment;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.processors.closure.AffinityTask;
@@ -87,7 +88,6 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.util.worker.GridWorker;
 import org.apache.ignite.lang.IgniteInClosure;
 import org.apache.ignite.lang.IgniteUuid;
-import org.apache.ignite.marshaller.Marshaller;
 import org.apache.ignite.plugin.security.SecurityException;
 import org.apache.ignite.resources.TaskContinuousMapperResource;
 import org.jetbrains.annotations.Nullable;
@@ -155,9 +155,6 @@ public class GridTaskWorker<T, R> extends GridWorker implements GridTimeoutObjec
 
     /** */
     private final IgniteLogger log;
-
-    /** */
-    private final Marshaller marsh;
 
     /** */
     private final GridTaskSessionImpl ses;
@@ -324,8 +321,6 @@ public class GridTaskWorker<T, R> extends GridWorker implements GridTimeoutObjec
         this.subjId = subjId;
 
         log = U.logger(ctx, logRef, this);
-
-        marsh = ctx.marshaller();
 
         boolean noResCacheAnnotation = dep.annotation(taskCls, ComputeTaskNoResultCache.class) != null;
 
@@ -829,7 +824,7 @@ public class GridTaskWorker<T, R> extends GridWorker implements GridTimeoutObjec
                         boolean loc = ctx.localNodeId().equals(res.nodeId()) && !ctx.config().isMarshalLocalJobs();
 
                         if (!loc)
-                            res.unmarshallUserData(marsh, U.resolveClassLoader(dep.classLoader(), ctx.config()));
+                            MessageMarshalling.unmarshal(res, ctx, null, U.resolveClassLoader(dep.classLoader(), ctx.config()));
 
                         jobRes.onResponse(res.getJobResult(), res.exception(), res.getJobAttributes(), res.cancelled());
 


### PR DESCRIPTION
[IGNITE-28271](https://issues.apache.org/jira/browse/IGNITE-28271)

`GridJobExecuteResponse` carried three hand-written pairs of "object + bytes" — the job exception, the job result and the job attributes — served by `marshallUserData` and `unmarshallUserData`, which the callers invoked with an explicit `Marshaller`. All three become normal `@Marshalled` fields, and the message becomes a `DeferredUnmarshalMessage`, the way `GridJobExecuteRequest` works since IGNITE-28356.

### Not through `ErrorMessage`, and this is the point

The summary of the ticket asks to send the exception as an `ErrorMessage`. That is what breaks it, and it is very likely why the earlier attempt (IGNITE-26817) was reverted in IGNITE-26890.

`ErrorMessage` never fails: when it cannot write or read its payload it substitutes a wrapper. `GridP2PComputeExceptionTest` pins the opposite contract — an exception that cannot be deserialized must reach the caller as a `BinaryObjectException`, not as a wrapped `IgniteException`. With `ErrorMessage` two of its four tests fail.

A plain `@Marshalled("gridExBytes") IgniteException gridEx` reaches the goal of the ticket — no hand-written marshalling — while the generated code does the same `U.unmarshal` the old code did, so the failure semantics are untouched.

Worth noting for the record: the revert was not about the peer-deployment class loader. The two tests that cover a peer-deployed exception class pass here, because the message is deferred.

### Where the failure policy went

`marshallUserData` was not only marshalling: a payload that could not be serialized was turned into an exception for the caller, so a job never failed silently. That stays, in the same place and the same shape — before the send, one message going out. Only the marshalling under it is the generated one now.

`GridJobProcessor` builds a response that carries nothing but the exception, so there is only one thing that can fail there:

```java
if (!loc) {
    try {
        MessageMarshalling.marshal(jobRes, ctx, null);
    }
    catch (IgniteCheckedException e) {
        // The exception is the only payload of this response, so it is what could not be written.
        ...
        jobRes = jobRes.withError(new IgniteException(errMsg));

        MessageMarshalling.marshal(jobRes, ctx, null);
    }
}
```

`GridJobWorker` also carries the job result and the job attributes, so it drops the payload first and keeps the job exception — a broken result should not hide why the job actually failed — and only substitutes the exception when that too cannot be written. This is what `wrapSerializationError` did.

The message keeps one pure method for this, `withError(IgniteException)`, which copies the identity fields and drops the payload. No kernal context, no logger, no marshalling on the message any more.

Pre-marshalling does not double the work: the generated code writes a `@Marshalled` field only when its companion is still empty (`if (obj != null && bytes == null)`), so the later pass over the `GridIoMessage` wrapper finds nothing to do. The old code relied on the same thing.

One thing is not preserved: a second failure is no longer chained onto the first with `addSuppressed` when both the result and the attributes are broken.

`res` and `jobAttrs` get `@GridToStringExclude`, as in `GridJobExecuteRequest` — the old code erased the objects after marshalling, the generated code keeps them, and without the exclusion `toString()` would print a user payload into the log.

The `marsh` field of `GridJobWorker` and `GridTaskWorker` is unused after this and is removed.

### Wire format

This changes it: the three payloads keep their `@Order` slots and their bytes, but the message is no longer unmarshalled by the generic inbound pass. It has to be merged before 2.19 is released.

### Checks

* `GridP2PComputeExceptionTest` - 4 of 4. This is the suite the earlier attempt was reverted over;
* `GridP2PTimeoutSelfTest` - 8 of 8, `GridP2PMissedResourceCacheSizeSelfTest` - 8 of 8;
* `GridJobStealingSelfTest` - 11, `GridTaskFailoverSelfTest`, `IgniteCoreMessagesSerializationTest` - green;
* checkstyle with `-Pcheckstyle` - no violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


