### PR TITLE
IGNITE-26630 Separate the stripe key from the cache partition

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/StripedMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/StripedMessage.java
@@ -19,9 +19,7 @@ package org.apache.ignite.internal;
 
 import org.apache.ignite.plugin.extensions.communication.Message;
 
-/**
- * Message that chooses the stripe it is processed in.
- */
+/** Message that chooses the stripe it is processed in. */
 public interface StripedMessage extends Message {
     /** Process in any stripe. */
     public static final int ANY_STRIPE = -1;

--- a/modules/core/src/main/java/org/apache/ignite/internal/StripedMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/StripedMessage.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import org.apache.ignite.plugin.extensions.communication.Message;
+
+/**
+ * Message that chooses the stripe it is processed in.
+ */
+public interface StripedMessage extends Message {
+    /** Process in any stripe. */
+    public static final int ANY_STRIPE = -1;
+
+    /** Process in the pool itself, not in a stripe. */
+    public static final int NO_STRIPE = Integer.MIN_VALUE;
+
+    /**
+     * The value is an index, not a cache partition: messages sharing it are processed one after another
+     * by the same thread.
+     *
+     * @return Stripe index, {@link #ANY_STRIPE} or {@link #NO_STRIPE}.
+     */
+    public int stripeIdx();
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoManager.java
@@ -142,6 +142,8 @@ import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
 import static org.apache.ignite.internal.GridTopic.TOPIC_COMM_SYSTEM;
 import static org.apache.ignite.internal.GridTopic.TOPIC_COMM_USER;
 import static org.apache.ignite.internal.GridTopic.TOPIC_IO_TEST;
+import static org.apache.ignite.internal.StripedMessage.ANY_STRIPE;
+import static org.apache.ignite.internal.StripedMessage.NO_STRIPE;
 import static org.apache.ignite.internal.managers.communication.GridIoPolicy.AFFINITY_POOL;
 import static org.apache.ignite.internal.managers.communication.GridIoPolicy.CALLER_THREAD;
 import static org.apache.ignite.internal.managers.communication.GridIoPolicy.DATA_STREAMER_POOL;
@@ -1384,21 +1386,21 @@ public class GridIoManager extends GridManagerAdapter<CommunicationSpi<Object>> 
             if (msg0.processFromNioThread())
                 c.run();
             else
-                ctx.pools().getStripedExecutorService().execute(-1, c);
+                ctx.pools().getStripedExecutorService().execute(ANY_STRIPE, c);
 
             return;
         }
 
-        final int part = msg.partition(); // Store partition to avoid possible recalculation.
+        final int stripeIdx = msg.stripeIdx(); // Store to avoid possible recalculation.
 
-        if (plc == GridIoPolicy.SYSTEM_POOL && part != GridIoMessage.STRIPE_DISABLED_PART) {
-            ctx.pools().getStripedExecutorService().execute(part, c);
+        if (plc == GridIoPolicy.SYSTEM_POOL && stripeIdx != NO_STRIPE) {
+            ctx.pools().getStripedExecutorService().execute(stripeIdx, c);
 
             return;
         }
 
-        if (plc == GridIoPolicy.DATA_STREAMER_POOL && part != GridIoMessage.STRIPE_DISABLED_PART) {
-            ctx.pools().getDataStreamerExecutorService().execute(part, c);
+        if (plc == GridIoPolicy.DATA_STREAMER_POOL && stripeIdx != NO_STRIPE) {
+            ctx.pools().getDataStreamerExecutorService().execute(stripeIdx, c);
 
             return;
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/communication/GridIoMessage.java
@@ -21,8 +21,7 @@ import org.apache.ignite.internal.ExecutorAwareMessage;
 import org.apache.ignite.internal.GridTopicMessage;
 import org.apache.ignite.internal.NioField;
 import org.apache.ignite.internal.Order;
-import org.apache.ignite.internal.processors.cache.GridCacheMessage;
-import org.apache.ignite.internal.processors.datastreamer.DataStreamerRequest;
+import org.apache.ignite.internal.StripedMessage;
 import org.apache.ignite.internal.thread.context.OperationContextSnapshotMessage;
 import org.apache.ignite.internal.util.nio.GridNioServer.MessageWrapper;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
@@ -33,10 +32,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Wrapper for all grid messages.
  */
-public class GridIoMessage implements Message, MessageWrapper {
-    /** */
-    public static final Integer STRIPE_DISABLED_PART = Integer.MIN_VALUE;
-
+public class GridIoMessage implements StripedMessage, MessageWrapper {
     /** Policy. */
     @Order(0)
     byte plc;
@@ -175,18 +171,9 @@ public class GridIoMessage implements Message, MessageWrapper {
         throw new AssertionError();
     }
 
-    /**
-     * Get single partition for this message (if applicable).
-     *
-     * @return Partition ID.
-     */
-    public int partition() {
-        if (msg instanceof GridCacheMessage)
-            return ((GridCacheMessage)msg).partition();
-        if (msg instanceof DataStreamerRequest)
-            return ((DataStreamerRequest)msg).partition();
-        else
-            return STRIPE_DISABLED_PART;
+    /** {@inheritDoc} */
+    @Override public int stripeIdx() {
+        return msg instanceof StripedMessage ? ((StripedMessage)msg).stripeIdx() : NO_STRIPE;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheIoManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheIoManager.java
@@ -445,7 +445,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
                     nearEvicted.add(req.nearKey(i));
 
                 GridDhtAtomicUpdateResponse dhtRes = new GridDhtAtomicUpdateResponse(req.cacheId(),
-                    req.partition(),
+                    req.stripeIdx(),
                     req.futureId());
 
                 dhtRes.nearEvicted(nearEvicted);
@@ -458,7 +458,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
                 if (req.nearNodeId() != null) {
                     GridDhtAtomicNearResponse nearRes = new GridDhtAtomicNearResponse(req.cacheId(),
-                        req.partition(),
+                        req.stripeIdx(),
                         req.nearFutureId(),
                         nodeId,
                         req.flags());
@@ -791,7 +791,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
             GridDhtTxPrepareRequest req = (GridDhtTxPrepareRequest)msg;
 
             GridDhtTxPrepareResponse res = new GridDhtTxPrepareResponse(
-                req.partition(),
+                req.stripeIdx(),
                 req.version(),
                 req.futureId(),
                 req.miniId(),
@@ -806,7 +806,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
             GridDhtAtomicUpdateResponse res = new GridDhtAtomicUpdateResponse(
                 req.cacheId(),
-                req.partition(),
+                req.stripeIdx(),
                 req.futureId());
 
             res.onError(req.classError());
@@ -815,7 +815,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
             if (req.nearNodeId() != null) {
                 GridDhtAtomicNearResponse nearRes = new GridDhtAtomicNearResponse(req.cacheId(),
-                    req.partition(),
+                    req.stripeIdx(),
                     req.nearFutureId(),
                     nodeId,
                     req.flags());
@@ -832,7 +832,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
                 req.cacheId(),
                 nodeId,
                 req.futureId(),
-                req.partition(),
+                req.stripeIdx(),
                 false);
 
             res.error(req.classError());
@@ -901,7 +901,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
             GridNearTxPrepareRequest req = (GridNearTxPrepareRequest)msg;
 
             GridNearTxPrepareResponse res = new GridNearTxPrepareResponse(
-                req.partition(),
+                req.stripeIdx(),
                 req.version(),
                 req.futureId(),
                 req.miniId(),
@@ -980,7 +980,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
                 req.cacheId(),
                 nodeId,
                 req.futureId(),
-                req.partition(),
+                req.stripeIdx(),
                 false);
 
             res.error(req.classError());
@@ -994,7 +994,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
                 req.cacheId(),
                 nodeId,
                 req.futureId(),
-                req.partition(),
+                req.stripeIdx(),
                 false);
 
             res.error(req.classError());
@@ -1008,7 +1008,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
                 req.cacheId(),
                 nodeId,
                 req.futureId(),
-                req.partition(),
+                req.stripeIdx(),
                 false);
 
             res.error(req.classError());
@@ -1020,7 +1020,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
             GridDhtAtomicUpdateResponse res = new GridDhtAtomicUpdateResponse(
                 req.cacheId(),
-                req.partition(),
+                req.stripeIdx(),
                 req.futureId());
 
             res.onError(req.classError());
@@ -1029,7 +1029,7 @@ public class GridCacheIoManager extends GridCacheSharedManagerAdapter {
 
             if (req.nearNodeId() != null) {
                 GridDhtAtomicNearResponse nearRes = new GridDhtAtomicNearResponse(req.cacheId(),
-                    req.partition(),
+                    req.stripeIdx(),
                     req.nearFutureId(),
                     nodeId,
                     req.flags());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMessage.java
@@ -26,6 +26,7 @@ import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.DeferredUnmarshalMessage;
 import org.apache.ignite.internal.Order;
+import org.apache.ignite.internal.StripedMessage;
 import org.apache.ignite.internal.managers.deployment.GridDeployment;
 import org.apache.ignite.internal.managers.deployment.GridDeploymentInfo;
 import org.apache.ignite.internal.managers.deployment.GridDeploymentInfoBean;
@@ -44,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @see DeployableMessage
  */
-public abstract class GridCacheMessage implements DeferredUnmarshalMessage {
+public abstract class GridCacheMessage implements DeferredUnmarshalMessage, StripedMessage {
     /** Maximum number of cache lookup indexes. */
     public static final int MAX_CACHE_MSG_LOOKUP_INDEX = 7;
 
@@ -123,11 +124,9 @@ public abstract class GridCacheMessage implements DeferredUnmarshalMessage {
         return -1;
     }
 
-    /**
-     * @return Partition ID this message is targeted to or {@code -1} if it cannot be determined.
-     */
-    public int partition() {
-        return -1;
+    /** {@inheritDoc} */
+    @Override public int stripeIdx() {
+        return ANY_STRIPE;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedLockRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedLockRequest.java
@@ -366,8 +366,8 @@ public class GridDistributedLockRequest extends GridDistributedBaseMessage {
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
-        return keys != null && !keys.isEmpty() ? keys.get(0).partition() : -1;
+    @Override public int stripeIdx() {
+        return keys != null && !keys.isEmpty() ? keys.get(0).partition() : ANY_STRIPE;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedTxFinishResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedTxFinishResponse.java
@@ -64,7 +64,7 @@ public class GridDistributedTxFinishResponse extends GridCacheMessage {
     }
 
     /** {@inheritDoc} */
-    @Override public final int partition() {
+    @Override public final int stripeIdx() {
         return part;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedTxPrepareResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridDistributedTxPrepareResponse.java
@@ -78,7 +78,7 @@ public class GridDistributedTxPrepareResponse extends GridDistributedBaseMessage
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return part;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridNearUnlockRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/GridNearUnlockRequest.java
@@ -90,8 +90,8 @@ public class GridNearUnlockRequest extends GridDistributedBaseMessage {
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
-        return keys != null && !keys.isEmpty() ? keys.get(0).partition() : -1;
+    @Override public int stripeIdx() {
+        return keys != null && !keys.isEmpty() ? keys.get(0).partition() : ANY_STRIPE;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxFinishRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxFinishRequest.java
@@ -200,7 +200,7 @@ public class GridDhtTxFinishRequest extends GridDistributedTxFinishRequest {
 
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return U.safeAbs(version().hashCode());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxPrepareRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/GridDhtTxPrepareRequest.java
@@ -320,7 +320,7 @@ public class GridDhtTxPrepareRequest extends GridDistributedTxPrepareRequest imp
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return U.safeAbs(version().hashCode());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicCache.java
@@ -1766,7 +1766,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
         GridNearAtomicUpdateResponse res = new GridNearAtomicUpdateResponse(ctx.cacheId(),
             nodeId,
             req.futureId(),
-            req.partition(),
+            req.stripeIdx(),
             false);
 
         res.addFailedKeys(req.keys(), e);
@@ -1789,7 +1789,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
         GridNearAtomicUpdateResponse res = new GridNearAtomicUpdateResponse(ctx.cacheId(),
             node.id(),
             req.futureId(),
-            req.partition(),
+            req.stripeIdx(),
             false);
 
         assert !req.returnValue() || (req.operation() == TRANSFORM || req.size() == 1);
@@ -3241,7 +3241,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
         GridNearAtomicUpdateResponse res = new GridNearAtomicUpdateResponse(ctx.cacheId(),
             nodeId,
             checkReq.futureId(),
-            checkReq.partition(),
+            checkReq.stripeIdx(),
             false);
 
         GridCacheReturn ret = new GridCacheReturn(false, true);
@@ -3263,7 +3263,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
                 ", writeVer=" + req.writeVersion() + ", node=" + nodeId + ']');
         }
 
-        assert req.partition() >= 0 : req;
+        assert req.stripeIdx() >= 0 : req;
 
         GridCacheVersion ver = req.writeVersion();
 
@@ -3273,7 +3273,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
 
         if (req.nearNodeId() != null) {
             nearRes = new GridDhtAtomicNearResponse(ctx.cacheId(),
-                req.partition(),
+                req.stripeIdx(),
                 req.nearFutureId(),
                 nodeId,
                 req.flags());
@@ -3407,7 +3407,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
 
             if (nearEvicted != null) {
                 dhtRes = new GridDhtAtomicUpdateResponse(ctx.cacheId(),
-                    req.partition(),
+                    req.stripeIdx(),
                     req.futureId());
 
                 dhtRes.nearEvicted(nearEvicted);
@@ -3441,7 +3441,7 @@ public class GridDhtAtomicCache<K, V> extends GridDhtCacheAdapter<K, V> {
         if (dhtRes != null)
             sendDhtPrimaryResponse(nodeId, req, dhtRes);
         else
-            sendDeferredUpdateResponse(req.partition(), nodeId, req.futureId());
+            sendDeferredUpdateResponse(req.stripeIdx(), nodeId, req.futureId());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicNearResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicNearResponse.java
@@ -112,7 +112,7 @@ public class GridDhtAtomicNearResponse extends GridCacheIdMessage {
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return partId;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicSingleUpdateRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicSingleUpdateRequest.java
@@ -210,7 +210,7 @@ public class GridDhtAtomicSingleUpdateRequest extends GridDhtAtomicAbstractUpdat
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         int p = key.partition();
 
         assert p >= 0;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicUpdateRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicUpdateRequest.java
@@ -345,7 +345,7 @@ public class GridDhtAtomicUpdateRequest extends GridDhtAtomicAbstractUpdateReque
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         assert !F.isEmpty(keys) || !F.isEmpty(nearKeys);
 
         int p = !keys.isEmpty() ? keys.get(0).partition() : nearKeys.get(0).partition();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicUpdateResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridDhtAtomicUpdateResponse.java
@@ -115,7 +115,7 @@ public class GridDhtAtomicUpdateResponse extends GridCacheIdMessage implements G
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return partId;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicAbstractUpdateFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicAbstractUpdateFuture.java
@@ -481,7 +481,7 @@ public abstract class GridNearAtomicAbstractUpdateFuture extends GridCacheFuture
         GridNearAtomicUpdateResponse res = new GridNearAtomicUpdateResponse(cctx.cacheId(),
             req.nodeId(),
             req.futureId(),
-            req.partition(),
+            req.stripeIdx(),
             true);
 
         ClusterTopologyCheckedException e = new ClusterTopologyCheckedException("Primary node left grid " +
@@ -502,7 +502,7 @@ public abstract class GridNearAtomicAbstractUpdateFuture extends GridCacheFuture
         GridNearAtomicUpdateResponse res = new GridNearAtomicUpdateResponse(cctx.cacheId(),
             req.nodeId(),
             req.futureId(),
-            req.partition(),
+            req.stripeIdx(),
             e instanceof ClusterTopologyCheckedException);
 
         res.addFailedKeys(req.keys(), e);
@@ -518,7 +518,7 @@ public abstract class GridNearAtomicAbstractUpdateFuture extends GridCacheFuture
         GridNearAtomicUpdateResponse res = new GridNearAtomicUpdateResponse(cctx.cacheId(),
             req.updateRequest().nodeId(),
             req.futureId(),
-            req.partition(),
+            req.stripeIdx(),
             e instanceof ClusterTopologyCheckedException);
 
         res.addFailedKeys(req.updateRequest().keys(), e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicCheckUpdateRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicCheckUpdateRequest.java
@@ -54,7 +54,7 @@ public class GridNearAtomicCheckUpdateRequest extends GridCacheIdMessage {
 
         this.updateReq = updateReq;
         this.cacheId = updateReq.cacheId();
-        this.partId = updateReq.partition();
+        this.partId = updateReq.stripeIdx();
         this.futId = updateReq.futureId();
 
         assert partId >= 0;
@@ -74,8 +74,12 @@ public class GridNearAtomicCheckUpdateRequest extends GridCacheIdMessage {
         return updateReq;
     }
 
-    /** {@inheritDoc} */
-    @Override public int partition() {
+    /**
+     * The value travels because the primary puts it into the response, it cannot restore it otherwise.
+     *
+     * {@inheritDoc}
+     */
+    @Override public int stripeIdx() {
         return partId;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicFullUpdateRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicFullUpdateRequest.java
@@ -335,7 +335,7 @@ public class GridNearAtomicFullUpdateRequest extends GridNearAtomicAbstractUpdat
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         assert !F.isEmpty(keys);
 
         return keys.get(0).partition();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicSingleUpdateRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicSingleUpdateRequest.java
@@ -96,7 +96,7 @@ public class GridNearAtomicSingleUpdateRequest extends GridNearAtomicAbstractUpd
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         assert key != null;
 
         return key.partition();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicUpdateResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicUpdateResponse.java
@@ -355,7 +355,7 @@ public class GridNearAtomicUpdateResponse extends GridCacheIdMessage implements 
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return partId;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicUpdateResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicUpdateResponse.java
@@ -359,13 +359,6 @@ public class GridNearAtomicUpdateResponse extends GridCacheIdMessage implements 
         return partId;
     }
 
-    /**
-     * @param partId New partition ID.
-     */
-    public void partition(int partId) {
-        this.partId = partId;
-    }
-
     /** {@inheritDoc} */
     @Override public boolean addDeploymentInfo() {
         return addDepInfo;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsAbstractMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/preloader/GridDhtPartitionsAbstractMessage.java
@@ -18,7 +18,6 @@
 package org.apache.ignite.internal.processors.cache.distributed.dht.preloader;
 
 import org.apache.ignite.internal.Order;
-import org.apache.ignite.internal.managers.communication.GridIoMessage;
 import org.apache.ignite.internal.processors.cache.GridCacheMessage;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -69,8 +68,8 @@ public abstract class GridDhtPartitionsAbstractMessage extends GridCacheMessage 
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
-        return GridIoMessage.STRIPE_DISABLED_PART;
+    @Override public int stripeIdx() {
+        return NO_STRIPE;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearGetRequest.java
@@ -251,10 +251,10 @@ public class GridNearGetRequest extends GridCacheIdMessage implements GridCacheD
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         Collection<KeyCacheObject> keys0 = keyMap != null ? keyMap.keySet() : keys;
 
-        return F.isEmpty(keys0) ? -1 : keys0.iterator().next().partition();
+        return F.isEmpty(keys0) ? ANY_STRIPE : keys0.iterator().next().partition();
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearSingleGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearSingleGetRequest.java
@@ -191,7 +191,7 @@ public class GridNearSingleGetRequest extends GridCacheIdMessage implements Grid
     }
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         assert key != null;
 
         return key.partition();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxFinishRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxFinishRequest.java
@@ -140,7 +140,7 @@ public class GridNearTxFinishRequest extends GridDistributedTxFinishRequest {
 
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return U.safeAbs(version().hashCode());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxPrepareRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/near/GridNearTxPrepareRequest.java
@@ -289,7 +289,7 @@ public class GridNearTxPrepareRequest extends GridDistributedTxPrepareRequest im
 
 
     /** {@inheritDoc} */
-    @Override public int partition() {
+    @Override public int stripeIdx() {
         return U.safeAbs(version().hashCode());
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryRequest.java
@@ -580,9 +580,14 @@ public class GridCacheQueryRequest extends GridCacheIdMessage implements GridCac
     }
 
     /**
-     * @return Partition.
+     * @return Partition to scan, {@code -1} to scan all of them.
      */
-    @Override public int partition() {
+    public int partition() {
+        return part;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int stripeIdx() {
         return part;
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/transactions/IgniteTxHandler.java
@@ -341,7 +341,7 @@ public class IgniteTxHandler {
                     U.error(log, "Failed to prepare DHT transaction: " + locTx, e);
 
                 return new GridNearTxPrepareResponse(
-                    req.partition(),
+                    req.stripeIdx(),
                     req.version(),
                     req.futureId(),
                     req.miniId(),
@@ -512,7 +512,7 @@ public class IgniteTxHandler {
 
                     if (retry) {
                         GridNearTxPrepareResponse res = new GridNearTxPrepareResponse(
-                            req.partition(),
+                            req.stripeIdx(),
                             req.version(),
                             req.futureId(),
                             req.miniId(),
@@ -720,7 +720,7 @@ public class IgniteTxHandler {
                 ", req=" + req + ']');
 
         GridNearTxPrepareResponse res = new GridNearTxPrepareResponse(
-            req.partition(),
+            req.stripeIdx(),
             req.version(),
             req.futureId(),
             req.miniId(),
@@ -1005,7 +1005,7 @@ public class IgniteTxHandler {
 
             // Always send finish response.
             GridCacheMessage res = new GridNearTxFinishResponse(
-                req.partition(),
+                req.stripeIdx(),
                 req.version(),
                 req.threadId(),
                 req.futureId(),
@@ -1184,7 +1184,7 @@ public class IgniteTxHandler {
 
         try {
             res = new GridDhtTxPrepareResponse(
-                req.partition(),
+                req.stripeIdx(),
                 req.version(),
                 req.futureId(),
                 req.miniId(),
@@ -1273,7 +1273,7 @@ public class IgniteTxHandler {
                 }
 
             res = new GridDhtTxPrepareResponse(
-                req.partition(),
+                req.stripeIdx(),
                 req.version(),
                 req.futureId(),
                 req.miniId(),
@@ -1590,7 +1590,7 @@ public class IgniteTxHandler {
     private void sendReply(UUID nodeId, GridDhtTxFinishRequest req, boolean committed, GridCacheVersion nearTxId) {
         if (req.replyRequired() || req.checkCommitted()) {
             GridDhtTxFinishResponse res = new GridDhtTxFinishResponse(
-                req.partition(),
+                req.stripeIdx(),
                 req.version(),
                 req.futureId(),
                 req.miniId());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
@@ -123,8 +123,8 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.events.EventType.EVT_NODE_FAILED;
 import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
-import static org.apache.ignite.internal.StripedMessage.NO_STRIPE;
 import static org.apache.ignite.internal.GridTopic.TOPIC_DATASTREAM;
+import static org.apache.ignite.internal.StripedMessage.NO_STRIPE;
 
 /**
  * Data streamer implementation.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
@@ -2007,8 +2007,7 @@ public class DataStreamerImpl<K, V> implements IgniteDataStreamer<K, V>, Delayed
                     dep != null ? dep.classLoaderId() : null,
                     dep == null,
                     topVer,
-                    (rcvr == ISOLATED_UPDATER) ?
-                        partId : NO_STRIPE);
+                    (rcvr == ISOLATED_UPDATER) ? partId : NO_STRIPE);
 
                 try {
                     ctx.io().sendToGridTopic(node, TOPIC_DATASTREAM, req, plc);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
@@ -66,7 +66,6 @@ import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.IgniteNodeAttributes;
 import org.apache.ignite.internal.cluster.ClusterTopologyCheckedException;
 import org.apache.ignite.internal.cluster.ClusterTopologyServerNotFoundException;
-import org.apache.ignite.internal.managers.communication.GridIoMessage;
 import org.apache.ignite.internal.managers.communication.GridMessageListener;
 import org.apache.ignite.internal.managers.deployment.GridDeployment;
 import org.apache.ignite.internal.managers.eventstorage.GridLocalEventListener;
@@ -124,6 +123,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.events.EventType.EVT_NODE_FAILED;
 import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
+import static org.apache.ignite.internal.StripedMessage.NO_STRIPE;
 import static org.apache.ignite.internal.GridTopic.TOPIC_DATASTREAM;
 
 /**
@@ -2003,7 +2003,7 @@ public class DataStreamerImpl<K, V> implements IgniteDataStreamer<K, V>, Delayed
                     dep == null,
                     topVer,
                     (rcvr == ISOLATED_UPDATER) ?
-                        partId : GridIoMessage.STRIPE_DISABLED_PART);
+                        partId : NO_STRIPE);
 
                 try {
                     ctx.io().sendToGridTopic(node, TOPIC_DATASTREAM, req, plc);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerRequest.java
@@ -24,6 +24,7 @@ import org.apache.ignite.configuration.DeploymentMode;
 import org.apache.ignite.internal.DeferredUnmarshalMessage;
 import org.apache.ignite.internal.GridTopicMessage;
 import org.apache.ignite.internal.Order;
+import org.apache.ignite.internal.StripedMessage;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.processors.cache.GridCacheUtils;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  *
  */
-public class DataStreamerRequest implements DeferredUnmarshalMessage, CacheIdAware {
+public class DataStreamerRequest implements DeferredUnmarshalMessage, CacheIdAware, StripedMessage {
     /** */
     @Order(0)
     long reqId;
@@ -271,10 +272,8 @@ public class DataStreamerRequest implements DeferredUnmarshalMessage, CacheIdAwa
         return topVer;
     }
 
-    /**
-     * @return Partition ID.
-     */
-    public int partition() {
+    /** {@inheritDoc} */
+    @Override public int stripeIdx() {
         return partId;
     }
 


### PR DESCRIPTION
Step 1 of IGNITE-26630. No wire change: only method names move, no message field is touched.

### Why

`GridCacheMessage#partition()` sounds like a data partition, but it is the key that picks a stripe. The name has already misled: the ticket asked to remove the method, and removing it would send every cache message from the striped pool to the plain system pool, because the base class returns `-1` while "do not stripe" is `Integer.MIN_VALUE`. No functional test would notice.

### What changed

A new `StripedMessage` interface, next to `ExecutorAwareMessage` and shaped like it:

```java
public interface StripedMessage extends Message {
    public static final int ANY_STRIPE = -1;
    public static final int NO_STRIPE = Integer.MIN_VALUE;

    public int stripeIdx();
}
```

`GridIoMessage` loses its chain:

```java
-    public int partition() {
-        if (msg instanceof GridCacheMessage)
-            return ((GridCacheMessage)msg).partition();
-        if (msg instanceof DataStreamerRequest)
-            return ((DataStreamerRequest)msg).partition();
-        else
-            return STRIPE_DISABLED_PART;
-    }
+    @Override public int stripeIdx() {
+        return msg instanceof StripedMessage ? ((StripedMessage)msg).stripeIdx() : NO_STRIPE;
+    }
```

`STRIPE_DISABLED_PART` moves into the interface as `NO_STRIPE` and stops being a boxed `Integer`, and the bare `-1` literals become `ANY_STRIPE`.

Two classes where the name and the meaning did not match are now explicit:

* `GridCacheQueryRequest` keeps `partition()` — that one really is the partition to scan, read in `GridCacheDistributedQueryManager` — and gets `stripeIdx()` alongside it.
* `GridNearAtomicCheckUpdateRequest` loses `partition()`. The value it carries is the stripe of the update request, which the primary copies into the stripe of the response; the handler says so itself: "Message is processed in the same stripe".

### What is deliberately left alone

The fields are still named `part` and `partId`, and so are the constructor parameters they feed. Step 2 of the ticket deletes those fields — six of them travel the wire only to pick a stripe and nothing reads them — so renaming them now would churn the generated serializers and their reference files for nothing.

### Checks

* the set of striped messages is unchanged: `StripedMessage` is implemented by `GridCacheMessage` and `DataStreamerRequest`, exactly the two arms of the old chain;
* no message class was left with an orphaned `partition()` that silently stopped overriding anything — the only such method left is the intentional one in `GridCacheQueryRequest`;
* `IgniteCacheAtomicProtocolTest` 26/26 with assertions enabled — this is the stripe-sensitive path, where the deferred response buffer is a `ThreadLocal` flushed back into its own stripe;
* `DataStreamerImplSelfTest`, `CacheScanQueryFailoverTest`, `GridCacheQueryTransformerSelfTest`: 61 run, 0 failed;
* full `test-compile` of all modules, and checkstyle under `-Pcheckstyle`.
