### PR TITLE
Support Java records in binary marshaller

### DIFF
--- a/modules/binary/api/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
+++ b/modules/binary/api/src/main/java/org/apache/ignite/internal/binary/BinaryClassDescriptor.java
@@ -198,7 +198,7 @@ class BinaryClassDescriptor {
         initialSerializer = serializer;
 
         // If serializer is not defined at this point, then we have to use OptimizedMarshaller.
-        useOptMarshaller = serializer == null || CommonUtils.isGeometryClass(cls);
+        useOptMarshaller = serializer == null || CommonUtils.isGeometryClass(cls) || cls.isRecord();
 
         // Reset reflective serializer so that we rely on existing reflection-based serialization.
         if (serializer instanceof BinaryReflectiveSerializer)
@@ -231,8 +231,8 @@ class BinaryClassDescriptor {
 
         if (useOptMarshaller && userType && !CommonUtils.isIgnite(cls) && !CommonUtils.isJdk(cls) && !CommonUtils.isGeometryClass(cls)) {
             CommonUtils.warnDevOnly(ctx.log(), "Class \"" + cls.getName() + "\" cannot be serialized using " +
-                BinaryMarshaller.class.getSimpleName() + " because it either implements Externalizable interface " +
-                "or have writeObject/readObject methods. " + OptimizedMarshaller.class.getSimpleName() + " will be " +
+                BinaryMarshaller.class.getSimpleName() + " because it either implements Externalizable interface, " +
+                "have writeObject/readObject methods, or is a record. " + OptimizedMarshaller.class.getSimpleName() + " will be " +
                 "used instead and class instances will be deserialized on the server. Please ensure that all nodes " +
                 "have this class in classpath. To enable binary serialization either implement " +
                 Binarylizable.class.getSimpleName() + " interface or set explicit serializer using " +

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -131,6 +131,16 @@ public class BinaryMarshallerSelfTest extends AbstractBinaryArraysTest {
      * @throws Exception If failed.
      */
     @Test
+    public void testRecord() throws Exception {
+        TestRecord testRecord = new TestRecord("value", 42L);
+
+        assertEquals(testRecord, marshalUnmarshal(testRecord));
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
     public void testByte() throws Exception {
         assertEquals((byte)100, marshalUnmarshal((byte)100).byteValue());
     }
@@ -6277,4 +6287,9 @@ public class BinaryMarshallerSelfTest extends AbstractBinaryArraysTest {
             v = new Value(127);
         }
     }
+    /** */
+    private record TestRecord(String value, long timestamp) implements Serializable {
+        // No-op.
+    }
+
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/binary/BinaryMarshallerSelfTest.java
@@ -6287,6 +6287,7 @@ public class BinaryMarshallerSelfTest extends AbstractBinaryArraysTest {
             v = new Value(127);
         }
     }
+
     /** */
     private record TestRecord(String value, long timestamp) implements Serializable {
         // No-op.


### PR DESCRIPTION
## Summary

Routes Java records through Ignite's optimized Java-serialization path. This avoids attempting to obtain unsafe field offsets for immutable record components, which current JDKs reject.

## Changes

- Detect records with `Class.isRecord()`.
- Use `OptimizedMarshaller` for records.
- Include records in the fallback-serialization warning.
- Add a Java 17 serializable-record round-trip regression test.

## Verification

- Added `BinaryMarshallerSelfTest.testRecord`.
- CI pending; local execution was unavailable because the working drive is full.

Closes #13286