### PR TITLE
IGNITE-29017 Document Java thin client sizeLong API

### DIFF
--- a/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/JavaThinClient.java
+++ b/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/JavaThinClient.java
@@ -190,11 +190,12 @@ public class JavaThinClient {
         cache.put(101, "101");
 
         cache.removeAll(data.keySet());
-        assert cache.size() == 1;
+        long cacheSize = cache.sizeLong();
+        assert cacheSize == 1;
         assert "101".equals(cache.get(101));
 
         cache.removeAll();
-        assert 0 == cache.size();
+        assert cache.sizeLong() == 0;
         // end::key-value-operations[]
         System.out.println("done");
     }
@@ -495,6 +496,9 @@ public class JavaThinClient {
 
         IgniteClientFuture<String> getFut = cache.getAsync(1);
         getFut.thenAccept(val -> System.out.println(val)); // Non-blocking continuation.
+
+        IgniteClientFuture<Long> sizeFut = cache.sizeLongAsync();
+        sizeFut.thenAccept(size -> System.out.println("Cache size: " + size));
         //end::async-api[]
     }
 

--- a/docs/_docs/thin-clients/java-thin-client.adoc
+++ b/docs/_docs/thin-clients/java-thin-client.adoc
@@ -180,6 +180,8 @@ include::{sourceCodeFile}[tag=getOrCreateCache,indent=0]
 === Basic Cache Operations
 
 The following code snippet demonstrates how to execute basic cache operations from the thin client.
+Use `ClientCache.sizeLong(...)` to get the cache size as a `long`.
+The older `ClientCache.size(...)` method returns `int` and is deprecated.
 
 [source, java]
 -------------------------------------------------------------------------------
@@ -446,6 +448,7 @@ include::{sourceCodeFile}[tag=client-authentication,indent=0]
 == Async APIs
 
 Most network-bound thin client APIs have an async counterpart, for example, `ClientCache.get` and `ClientCache.getAsync`.
+For cache size operations, prefer `ClientCache.sizeLongAsync(...)`; the older `ClientCache.sizeAsync(...)` method returns `IgniteClientFuture<Integer>` and is deprecated.
 
 [source, java]
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Thank you for submitting the pull request.

This patch documents the Java thin client long cache size API added in IGNITE-27816:

* mention ClientCache.sizeLong(...) in basic cache operations;
* mention ClientCache.sizeLongAsync(...) in the async API section;
* update Java thin client snippets to use the long-returning size API instead of deprecated int-returning methods.

Verification performed locally:

* git diff --check
* checked that ClientCache declares sizeLong(...) and sizeLongAsync(...)

Maven snippet compile was not run in the local environment because mvn / Maven wrapper was not available.