### PR TITLE
IGNITE-27380 Document extra snapshot paths

### DIFF
--- a/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/Snapshots.java
+++ b/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/Snapshots.java
@@ -22,6 +22,7 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.spi.encryption.keystore.KeystoreEncryptionSpi;
 
@@ -35,6 +36,17 @@ public class Snapshots {
         File exSnpDir = new File("work", "ex_snapshots");
 
         cfg.setSnapshotPath(exSnpDir.getAbsolutePath());
+
+        cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+            .setExtraStoragePaths(
+                new File("work", "persistence-a").getAbsolutePath(),
+                new File("work", "persistence-b").getAbsolutePath()
+            )
+            .setExtraSnapshotPaths(
+                new File("work", "snapshots-a").getAbsolutePath(),
+                new File("work", "snapshots-b").getAbsolutePath()
+            )
+        );
         //end::config[]
 
         Ignite ignite = Ignition.start(cfg);

--- a/docs/_docs/code-snippets/xml/snapshots.xml
+++ b/docs/_docs/code-snippets/xml/snapshots.xml
@@ -24,6 +24,24 @@
         -->
         <property name="snapshotPath" value="/snapshots"/>
 
+        <property name="dataStorageConfiguration">
+            <bean class="org.apache.ignite.configuration.DataStorageConfiguration">
+                <property name="extraStoragePaths">
+                    <array>
+                        <value>/ignite/persistence-a</value>
+                        <value>/ignite/persistence-b</value>
+                    </array>
+                </property>
+
+                <property name="extraSnapshotPaths">
+                    <array>
+                        <value>/snapshots/persistence-a</value>
+                        <value>/snapshots/persistence-b</value>
+                    </array>
+                </property>
+            </bean>
+        </property>
+
         <!-- tag::cache[] -->
         <property name="cacheConfiguration">
             <bean class="org.apache.ignite.configuration.CacheConfiguration">

--- a/docs/_docs/persistence/snapshot-directory.adoc
+++ b/docs/_docs/persistence/snapshot-directory.adoc
@@ -37,3 +37,13 @@ tab:Java[]
 include::{javaCodeDir}/Snapshots.java[tags=config, indent=0]
 ----
 --
+
+If persistence data is distributed across several storage directories with
+`DataStorageConfiguration.extraStoragePaths`, you can also configure
+`DataStorageConfiguration.extraSnapshotPaths`. Each extra snapshot path is used
+for snapshot files that correspond to the matching extra storage path.
+
+The `extraSnapshotPaths` array must have the same number of entries as
+`extraStoragePaths`, and all extra snapshot paths must be unique. If an absolute
+`IgniteConfiguration.snapshotPath` is configured without `extraSnapshotPaths`,
+Ignite stores snapshot files only under the configured snapshot path.


### PR DESCRIPTION
Document DataStorageConfiguration.extraSnapshotPaths in the snapshot directory guide.

The patch explains how extra snapshot paths map to extra storage paths and adds XML and Java snippets.