### PR TITLE
IGNITE-29020 Document SQL query initiator ID

### DIFF
--- a/docs/_docs/SQL/sql-api.adoc
+++ b/docs/_docs/SQL/sql-api.adoc
@@ -129,8 +129,11 @@ include::{javaSourceFile}[tag=query-initiator-id,indent=0]
 Ignite exposes this value in the `INITIATOR_ID` column of the
 link:monitoring-metrics/system-views#sql_queries[SQL_QUERIES] and
 link:monitoring-metrics/system-views#sql_queries_history[SQL_QUERIES_HISTORY]
-system views. Server-side SQL diagnostics, such as long query warning messages,
-also include the `initiatorId` value.
+system views. Query history aggregates executions of the same query, so the
+`INITIATOR_ID` column in `SQL_QUERIES_HISTORY` contains the value from the latest
+execution and does not preserve initiator IDs from earlier executions.
+Server-side SQL diagnostics, such as long query warning messages, also include
+the `initiatorId` value.
 
 === Local Execution
 

--- a/docs/_docs/SQL/sql-api.adoc
+++ b/docs/_docs/SQL/sql-api.adoc
@@ -116,6 +116,22 @@ include::code-snippets/cpp/src/sql.cpp[tag=sql-fields-query,indent=0]
 
 `SqlFieldsQuery` returns a cursor that iterates through the results that match the SQL query.
 
+=== Query Initiator ID
+
+To correlate SQL queries with server-side diagnostics, set a query initiator ID
+with `SqlFieldsQuery.setQueryInitiatorId(...)` before executing the query.
+
+[source,java]
+----
+include::{javaSourceFile}[tag=query-initiator-id,indent=0]
+----
+
+Ignite exposes this value in the `INITIATOR_ID` column of the
+link:monitoring-metrics/system-views#sql_queries[SQL_QUERIES] and
+link:monitoring-metrics/system-views#sql_queries_history[SQL_QUERIES_HISTORY]
+system views. Server-side SQL diagnostics, such as long query warning messages,
+also include the `initiatorId` value.
+
 === Local Execution
 
 To force local execution of a query, use `SqlFieldsQuery.setLocal(true)`. In this case, the query is executed against the data stored on the node where the query is run. It means that the results of the query are almost always incomplete. Use the local mode only if you are confident you understand this limitation.

--- a/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/SqlAPI.java
+++ b/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/SqlAPI.java
@@ -100,6 +100,18 @@ public class SqlAPI {
         // end::simple-query[]
     }
 
+    void queryInitiatorId(Ignite ignite) {
+        // tag::query-initiator-id[]
+        IgniteCache<Long, Person> cache = ignite.cache("Person");
+
+        SqlFieldsQuery sql = new SqlFieldsQuery(
+                "select concat(firstName, ' ', lastName) from Person")
+                .setQueryInitiatorId("person-report-job");
+
+        cache.query(sql).getAll();
+        // end::query-initiator-id[]
+    }
+
     void insert(Ignite ignite) {
         // tag::insert[]
         IgniteCache<Long, Person> cache = ignite.cache("personCache");

--- a/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/SqlAPI.java
+++ b/docs/_docs/code-snippets/java/src/main/java/org/apache/ignite/snippets/SqlAPI.java
@@ -105,7 +105,7 @@ public class SqlAPI {
         IgniteCache<Long, Person> cache = ignite.cache("Person");
 
         SqlFieldsQuery sql = new SqlFieldsQuery(
-                "select concat(firstName, ' ', lastName) from Person")
+                "select name from Person")
                 .setQueryInitiatorId("person-report-job");
 
         cache.query(sql).getAll();

--- a/docs/_docs/thin-clients/java-thin-client.adoc
+++ b/docs/_docs/thin-clients/java-thin-client.adoc
@@ -308,8 +308,6 @@ The `query(SqlFieldsQuery)` method returns an instance of `FieldsQueryCursor`, w
 NOTE: The `getAll()` method retrieves the results from the cursor and closes it.
 
 Read more about using `SqlFieldsQuery` and SQL API in the link:SQL/sql-api[Using SQL API] section.
-This section also describes how to use `SqlFieldsQuery.setQueryInitiatorId(...)`
-to correlate Java thin client SQL requests with SQL system views and server logs.
 
 == Using Cluster APIs
 

--- a/docs/_docs/thin-clients/java-thin-client.adoc
+++ b/docs/_docs/thin-clients/java-thin-client.adoc
@@ -308,6 +308,8 @@ The `query(SqlFieldsQuery)` method returns an instance of `FieldsQueryCursor`, w
 NOTE: The `getAll()` method retrieves the results from the cursor and closes it.
 
 Read more about using `SqlFieldsQuery` and SQL API in the link:SQL/sql-api[Using SQL API] section.
+This section also describes how to use `SqlFieldsQuery.setQueryInitiatorId(...)`
+to correlate Java thin client SQL requests with SQL system views and server logs.
 
 == Using Cluster APIs
 


### PR DESCRIPTION
Document practical usage of SqlFieldsQuery.setQueryInitiatorId(...).

The patch explains how to correlate SQL requests with SQL system views and server-side diagnostics, and notes that Java thin client SQL requests use the same SqlFieldsQuery mechanism.