### PR TITLE
IGNITE-24619 Describe regexPattern in cache list help

### DIFF
--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerParsingTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerParsingTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
@@ -93,6 +94,8 @@ import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
 import org.apache.ignite.testframework.junits.SystemPropertiesRule;
 import org.apache.ignite.testframework.junits.WithSystemProperty;
 import org.jetbrains.annotations.Nullable;
@@ -110,6 +113,7 @@ import static org.apache.ignite.internal.QueryMXBeanImpl.EXPECTED_GLOBAL_QRY_ID_
 import static org.apache.ignite.internal.commandline.ArgumentParser.CMD_VERBOSE;
 import static org.apache.ignite.internal.commandline.CommandHandler.DFLT_HOST;
 import static org.apache.ignite.internal.commandline.CommandHandler.DFLT_PORT;
+import static org.apache.ignite.internal.commandline.CommandHandler.EXIT_CODE_OK;
 import static org.apache.ignite.internal.management.api.CommandUtils.cmdText;
 import static org.apache.ignite.internal.management.api.CommandUtils.executable;
 import static org.apache.ignite.internal.management.api.CommandUtils.visitCommandParams;
@@ -130,6 +134,20 @@ import static org.junit.Assert.fail;
  */
 @WithSystemProperty(key = IGNITE_ENABLE_EXPERIMENTAL_COMMAND, value = "true")
 public class CommandHandlerParsingTest {
+    /** */
+    @Test
+    public void testCacheListHelpDescribesRegexPattern() {
+        ListeningTestLogger testLog = new ListeningTestLogger();
+        LogListener regexDescription = LogListener.matches(Pattern.compile(
+            "regexPattern\\s+- Java regular expression for filtering cache, group, or sequence names"
+        )).build();
+
+        testLog.registerListener(regexDescription);
+
+        assertEquals(EXIT_CODE_OK, new CommandHandler(testLog).execute(asList("--cache", "help")));
+        assertTrue(regexDescription.check());
+    }
+
     /** */
     @ClassRule public static final TestRule classRule = new SystemPropertiesRule();
 

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerParsingTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerParsingTest.java
@@ -139,7 +139,8 @@ public class CommandHandlerParsingTest {
     public void testCacheListHelpDescribesRegexPattern() {
         ListeningTestLogger testLog = new ListeningTestLogger();
         LogListener regexDescription = LogListener.matches(Pattern.compile(
-            "regexPattern\\s+- Java regular expression for filtering cache, group, or sequence names"
+            "regexPattern\\s+- Java regular expression for filtering cache, group, or sequence names.*" +
+                "'\\^account-\\.\\*' matches names starting with 'account-'"
         )).build();
 
         testLog.registerListener(regexDescription);

--- a/modules/core/src/main/java/org/apache/ignite/internal/management/cache/CacheListCommandArg.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/cache/CacheListCommandArg.java
@@ -33,7 +33,8 @@ public class CacheListCommandArg extends IgniteDataTransferObject {
     /** */
     @Order(0)
     @Positional
-    @Argument(example = "regexPattern")
+    @Argument(description = "Java regular expression for filtering cache, group, or sequence names. " +
+        "Examples: '.' matches all names, 'account-.*' matches names starting with 'account-'", example = "regexPattern")
     String regex;
 
     /** */

--- a/modules/core/src/main/java/org/apache/ignite/internal/management/cache/CacheListCommandArg.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/management/cache/CacheListCommandArg.java
@@ -34,7 +34,7 @@ public class CacheListCommandArg extends IgniteDataTransferObject {
     @Order(0)
     @Positional
     @Argument(description = "Java regular expression for filtering cache, group, or sequence names. " +
-        "Examples: '.' matches all names, 'account-.*' matches names starting with 'account-'", example = "regexPattern")
+        "Examples: '.' matches all names, '^account-.*' matches names starting with 'account-'", example = "regexPattern")
     String regex;
 
     /** */

--- a/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
+++ b/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
@@ -50,7 +50,7 @@ Arguments: --cache help --yes
     control.(sh|bat) --cache list regexPattern [nodeId] [--config] [--output-format multi-line] [--groups|--seq]
 
     Parameters:
-      regexPattern                - Java regular expression for filtering cache, group, or sequence names. Examples: '.' matches all names, 'account-.*' matches names starting with 'account-'.
+      regexPattern                - Java regular expression for filtering cache, group, or sequence names. Examples: '.' matches all names, '^account-.*' matches names starting with 'account-'.
       --config                    - print all configuration parameters for each cache.
       --output-format multi-line  - print configuration parameters per line. This option has effect only when used with --config and without [--groups|--seq].
       --groups                    - print information about groups.

--- a/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
+++ b/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
@@ -50,6 +50,7 @@ Arguments: --cache help --yes
     control.(sh|bat) --cache list regexPattern [nodeId] [--config] [--output-format multi-line] [--groups|--seq]
 
     Parameters:
+      regexPattern                - Java regular expression for filtering cache, group, or sequence names. Examples: '.' matches all names, 'account-.*' matches names starting with 'account-'.
       --config                    - print all configuration parameters for each cache.
       --output-format multi-line  - print configuration parameters per line. This option has effect only when used with --config and without [--groups|--seq].
       --groups                    - print information about groups.

--- a/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassWithSSLTest_cache_help.output
+++ b/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassWithSSLTest_cache_help.output
@@ -50,7 +50,7 @@ Arguments: --cache help --yes
     control.(sh|bat) --cache list regexPattern [nodeId] [--config] [--output-format multi-line] [--groups|--seq]
 
     Parameters:
-      regexPattern                - Java regular expression for filtering cache, group, or sequence names. Examples: '.' matches all names, 'account-.*' matches names starting with 'account-'.
+      regexPattern                - Java regular expression for filtering cache, group, or sequence names. Examples: '.' matches all names, '^account-.*' matches names starting with 'account-'.
       --config                    - print all configuration parameters for each cache.
       --output-format multi-line  - print configuration parameters per line. This option has effect only when used with --config and without [--groups|--seq].
       --groups                    - print information about groups.

--- a/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassWithSSLTest_cache_help.output
+++ b/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassWithSSLTest_cache_help.output
@@ -50,6 +50,7 @@ Arguments: --cache help --yes
     control.(sh|bat) --cache list regexPattern [nodeId] [--config] [--output-format multi-line] [--groups|--seq]
 
     Parameters:
+      regexPattern                - Java regular expression for filtering cache, group, or sequence names. Examples: '.' matches all names, 'account-.*' matches names starting with 'account-'.
       --config                    - print all configuration parameters for each cache.
       --output-format multi-line  - print configuration parameters per line. This option has effect only when used with --config and without [--groups|--seq].
       --groups                    - print information about groups.


### PR DESCRIPTION
## Summary

- describe the regexPattern argument in control.sh --cache help
- include examples for matching all names and names with a prefix
- cover the generated help output with a focused test and golden files

## Tests

- CommandHandlerParsingTest#testCacheListHelpDescribesRegexPattern
- Checkstyle for modules/core and modules/control-utility