### PR TITLE
Fix #13549: treat metadata result sets without a statement as open

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinResultSetSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinResultSetSelfTest.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.Date;
 import java.sql.DriverManager;
 import java.sql.NClob;
@@ -1880,6 +1881,31 @@ public class JdbcThinResultSetSelfTest extends JdbcThinAbstractSelfTest {
                 rs.getRow();
             }
         });
+    }
+
+    /**
+     * Tests that metadata result sets, which are created without an associated statement (stmt == null),
+     * report a usable (not closed) state, in line with {@link ResultSet#isClosed()} semantics.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testMetadataResultSetIsClosed() throws Exception {
+        DatabaseMetaData meta = stmt.getConnection().getMetaData();
+
+        ResultSet rs = meta.getTables(null, null, "%", null);
+
+        // Metadata result sets are created without a statement and must be usable, not reported as closed.
+        assertFalse("Metadata result set must not be reported as closed", rs.isClosed());
+
+        // The result set must be iterable/usable.
+        while (rs.next())
+            rs.getString("TABLE_NAME");
+
+        // Explicitly closing the metadata result set must mark it as closed.
+        rs.close();
+
+        assertTrue("Explicitly closed metadata result set must be reported as closed", rs.isClosed());
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinResultSet.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc/thin/JdbcThinResultSet.java
@@ -1487,7 +1487,7 @@ public class JdbcThinResultSet implements ResultSet {
 
     /** {@inheritDoc} */
     @Override public boolean isClosed() throws SQLException {
-        return closed || stmt == null || stmt.connection().isClosed();
+        return closed || (stmt != null && stmt.connection().isClosed());
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Fixes #13549